### PR TITLE
Remove unused mute toggle import

### DIFF
--- a/src/hooks/vocabulary/useVocabularyContainerState.tsx
+++ b/src/hooks/vocabulary/useVocabularyContainerState.tsx
@@ -1,6 +1,5 @@
 
 import { useVocabularyManager } from "@/hooks/vocabulary/useVocabularyManager";
-import { useMuteToggle } from "@/hooks/useMuteToggle";
 import { useVocabularyAudioSync } from "@/hooks/useVocabularyAudioSync";
 import { useModalState } from "./useModalState";
 import { useCategoryNavigation } from "./useCategoryNavigation";


### PR DESCRIPTION
## Summary
- fix linter by removing unused `useMuteToggle` import

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840501ece38832fa09265e63d063968