### PR TITLE
Fix timer cleanup in AddWordModal

### DIFF
--- a/src/components/vocabulary-app/AddWordModal.tsx
+++ b/src/components/vocabulary-app/AddWordModal.tsx
@@ -139,6 +139,7 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
       return;
     }
     
+    let timeoutId: number | undefined;
     try {
       setIsSearching(true);
       setSearchError('');
@@ -154,7 +155,7 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
       
       // Primary dictionary API call with timeout
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
+      timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
       
       const response = await fetch(apiUrl, {
         signal: controller.signal,
@@ -162,8 +163,6 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
           'Accept': 'application/json',
         }
       });
-      
-      clearTimeout(timeoutId);
       
       if (!response.ok) {
         throw new Error('Failed to fetch definition');
@@ -213,6 +212,9 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
         setSearchError('Search failed. Please try again or enter details manually.');
       }
     } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       setIsSearching(false);
     }
   };


### PR DESCRIPTION
## Summary
- ensure fetch timeout is cleared regardless of success or failure

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840509ab00c832fb4d59f3d7aaf2293