### PR TITLE
Fix stopSpeaking import

### DIFF
--- a/src/hooks/audio/useAudioCleanup.tsx
+++ b/src/hooks/audio/useAudioCleanup.tsx
@@ -1,6 +1,5 @@
 
 import { useEffect, useCallback } from 'react';
-import { stopSpeaking } from '@/utils/speech';
 
 export const useAudioCleanup = (
   clearAutoAdvanceTimer: () => void,


### PR DESCRIPTION
## Summary
- remove unused `stopSpeaking` import from `useAudioCleanup`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840537328b4832f9f084403db1e3c9f