### PR TITLE
Add vitest and convert validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -79,6 +80,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { validateVocabularyWord, validateMeaning, validateExample } from '../src/utils/security/validation';
+
+// Representative tests for vocabulary validation utilities
+
+describe('validateVocabularyWord', () => {
+  it('accepts simple words', () => {
+    const result = validateVocabularyWord('water');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('accepts words with IPA notation', () => {
+    const result = validateVocabularyWord('beautiful /ˈbjuːtɪfəl/');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects malicious input', () => {
+    const result = validateVocabularyWord('<script>alert(1)</script>');
+    expect(result.isValid).toBe(false);
+  });
+});
+
+describe('validateMeaning', () => {
+  it('accepts normal meanings', () => {
+    const result = validateMeaning('to stop working or functioning');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('accepts meanings with pronunciation', () => {
+    const result = validateMeaning('pronounced /ˈwɔːtər/ in American English');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects SQL injections', () => {
+    const result = validateMeaning('SELECT * FROM users');
+    expect(result.isValid).toBe(false);
+  });
+});
+
+describe('validateExample', () => {
+  it('accepts normal examples', () => {
+    const result = validateExample('The car broke down on the highway.');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('accepts examples with stress marks', () => {
+    const result = validateExample('Stress pattern: ˈbeautiful (primary stress on first syllable)');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects form tags', () => {
+    const result = validateExample('<form action="evil.com">');
+    expect(result.isValid).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- install Vitest in devDependencies and expose via `npm test`
- add basic Vitest configuration
- create `validation.test.ts` covering validation helpers

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840537ac5b0832f8c38f7fa4b4645e3