### PR TITLE
Fix toast hook effect dependencies

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure the toast listener is registered only once

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/top-notice-buddy/node_modules/@eslint/js/index.js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68405369febc832fb6ff85c668fb667f