### PR TITLE
Fix mute toggle to stop speech

### DIFF
--- a/src/hooks/useMuteToggle.tsx
+++ b/src/hooks/useMuteToggle.tsx
@@ -1,15 +1,14 @@
 
 import { useState, useCallback, useEffect } from 'react';
-import { stopSpeaking } from '@/utils/speech';
 import { VocabularyWord } from '@/types/vocabulary';
 
 export const useMuteToggle = (
-  isMuted: boolean, 
+  isMuted: boolean,
   handleToggleMute: () => void,
   currentWord: VocabularyWord | null,
   isPaused: boolean,
   clearAutoAdvanceTimer: () => void,
-  stopSpeaking: () => void,
+  stopSpeech: () => void,
   voiceRegion: 'US' | 'UK'
 ) => {
   const [mute, setMute] = useState(isMuted);
@@ -34,11 +33,12 @@ export const useMuteToggle = (
       console.error('Error updating mute state in localStorage:', error);
     }
     
-    // Clear timers when muting to prevent auto-advance
+    // Clear timers and stop any speech when muting to prevent auto-advance
     if (!mute) {
       clearAutoAdvanceTimer();
+      stopSpeech();
     }
-  }, [mute, handleToggleMute, clearAutoAdvanceTimer]);
+  }, [mute, handleToggleMute, clearAutoAdvanceTimer, stopSpeech]);
   
   return { mute, toggleMute };
 };


### PR DESCRIPTION
## Summary
- fix naming collision in `useMuteToggle`
- stop ongoing speech when muting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68404dbceb60832f8a555f28197363d2