### PR TITLE
Improve speech playback error handling and utilities

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
@@ -87,6 +87,9 @@ export const useSpeechExecution = (
           case 'network':
             handlePermissionError('network');
             break;
+          case 'canceled':
+            console.log('[SPEECH-EXECUTION] Speech was canceled');
+            return;
           case 'interrupted':
             console.log('[SPEECH-EXECUTION] Speech was interrupted, advancing without retry');
             setTimeout(() => goToNextWord(), 1000);

--- a/src/utils/speech/simpleSpeechController.ts
+++ b/src/utils/speech/simpleSpeechController.ts
@@ -80,6 +80,11 @@ class SimpleSpeechController {
 
   stop(): void {
     console.log('SimpleSpeechController: Stopping speech');
+    console.log('SimpleSpeechController: Current state before stop', {
+      isActive: this.isActive,
+      speaking: window.speechSynthesis?.speaking,
+      paused: window.speechSynthesis?.paused
+    });
     if (window.speechSynthesis) {
       window.speechSynthesis.cancel();
     }

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -80,3 +80,14 @@ export const getVoiceByRegion = (region: 'US' | 'UK', gender: 'male' | 'female' 
 export const getVoiceBySelection = (voiceSelection: VoiceSelection): SpeechSynthesisVoice | null => {
   return getVoiceByRegion(voiceSelection.region, voiceSelection.gender);
 };
+
+export const hasAvailableVoices = (): boolean => {
+  try {
+    if (typeof window === 'undefined' || !window.speechSynthesis) {
+      return false;
+    }
+    return window.speechSynthesis.getVoices().length > 0;
+  } catch {
+    return false;
+  }
+};

--- a/tests/voiceUtils.test.ts
+++ b/tests/voiceUtils.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { hasAvailableVoices } from '../src/utils/speech/voiceUtils';
+
+// Mock speechSynthesis
+beforeEach(() => {
+  (global as any).window = {
+    speechSynthesis: {
+      getVoices: () => []
+    }
+  };
+});
+
+describe('hasAvailableVoices', () => {
+  it('returns false when no voices are available', () => {
+    (window as any).speechSynthesis.getVoices = () => [];
+    expect(hasAvailableVoices()).toBe(false);
+  });
+
+  it('returns true when voices are available', () => {
+    (window as any).speechSynthesis.getVoices = () => [{ lang: 'en-US', name: 'A' }];
+    expect(hasAvailableVoices()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `hasAvailableVoices` utility
- handle `canceled` speech errors in execution hook
- log internal state when stopping speech
- test `hasAvailableVoices`

## Testing
- `npm exec vitest` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684055f228a4832f87118084f48b1555