### PR TITLE
Expose toast remove delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,9 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Time (ms) a dismissed toast stays mounted before it is removed.
+// Exported so consumers can override if necessary.
+export const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- tweak default toast removal delay to 5 seconds
- export the constant for consumers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68410a20a048832fac42c3ca2e92a7d1