### PR TITLE
Load VAPID key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+# Public VAPID key used for push notifications
+VITE_VAPID_PUBLIC_KEY=


### PR DESCRIPTION
## Summary
- inject VAPID key from environment variables
- add VITE_VAPID_PUBLIC_KEY to env example
- warn when trying to initialize or subscribe without VAPID key

## Testing
- `npm test` *(fails: validateMeaning rejects SQL injections)*

------
https://chatgpt.com/codex/tasks/task_e_68410a136d48832f803c4e8d35389213