### PR TITLE
Fix playback flag reset when speech cancelled

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
@@ -37,6 +37,7 @@ export const usePlaybackOrchestrator = (
   const { playInProgressRef, setPlayInProgress, isPlayInProgress } = usePlayInProgress();
 
   const resetPlayInProgress = useCallback(() => {
+    console.log('[PLAYBACK-ORCHESTRATOR] Resetting play in progress flag');
     playInProgressRef.current = false;
   }, [playInProgressRef]);
   const { validateAndPrepareContent } = useContentValidation();
@@ -87,6 +88,7 @@ export const usePlaybackOrchestrator = (
       muted,
       paused,
       isPlayInProgress,
+      resetPlayInProgress,
       wordTransitionRef
     );
 


### PR DESCRIPTION
## Summary
- reset play in progress flag when controller inactive
- log when resetting flag and when resetPlayInProgress is triggered
- pass `resetPlayInProgress` into `usePlaybackConditions`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841600dc6a0832fbb8a12f84955005a