### PR TITLE
Fix lint issues and add error handling

### DIFF
--- a/src/utils/security/sanitization.ts
+++ b/src/utils/security/sanitization.ts
@@ -35,9 +35,11 @@ export const sanitizeInput = (input: string): string => {
   });
   
   // Remove null bytes but preserve other characters that might be valid in linguistic notation
+  // eslint-disable-next-line no-control-regex
   sanitized = sanitized.replace(/\x00/g, '');
   
   // Only remove the most dangerous control characters, preserve others that might be linguistic
+  // eslint-disable-next-line no-control-regex
   sanitized = sanitized.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
   
   // Be much more selective about HTML entities - only remove clearly dangerous ones

--- a/src/utils/security/validationTest.ts
+++ b/src/utils/security/validationTest.ts
@@ -122,5 +122,8 @@ export const testValidationPatterns = () => {
 
 // Make it available globally for console testing
 if (typeof window !== 'undefined') {
-  (window as any).testValidationPatterns = testValidationPatterns;
+  interface WindowWithValidation extends Window {
+    testValidationPatterns: typeof testValidationPatterns;
+  }
+  (window as WindowWithValidation).testValidationPatterns = testValidationPatterns;
 }

--- a/src/utils/security/validationTypes.ts
+++ b/src/utils/security/validationTypes.ts
@@ -49,8 +49,8 @@ export const SQL_INJECTION_PATTERNS = [
   // SQL keywords with clear attack patterns (case-insensitive, word boundaries)
   /\b(SELECT\s+\*\s+FROM|INSERT\s+INTO|UPDATE\s+.*\s+SET|DELETE\s+FROM|DROP\s+TABLE|CREATE\s+TABLE|ALTER\s+TABLE|EXEC|UNION\s+SELECT)\b/gi,
   // SQL comment indicators at start of injection attempts
-  /^\s*(--|\#|\/\*)/g,
-  /;\s*(--|\#|\/\*)/g,
+  /^\s*(--|#|\/\*)/g,
+  /;\s*(--|#|\/\*)/g,
   // Clear injection patterns
   /'\s*(OR|AND)\s+.*[=<>]/gi,
   /"\s*(OR|AND)\s+.*[=<>]/gi,

--- a/src/utils/speech/core/speechEngine.ts
+++ b/src/utils/speech/core/speechEngine.ts
@@ -107,7 +107,12 @@ export const unlockAudio = (): Promise<boolean> => {
       console.log('[ENGINE] Attempting to unlock audio...');
       
       // Simple approach - just create an AudioContext if available
-      const AudioContext = window.AudioContext || (window as any).webkitAudioContext;
+      interface WindowWithWebAudio extends Window {
+        webkitAudioContext?: typeof AudioContext;
+      }
+
+      const AudioContext =
+        window.AudioContext || (window as WindowWithWebAudio).webkitAudioContext;
       if (!AudioContext) {
         console.log('[ENGINE] AudioContext not supported, using speech directly');
         resolve(true);

--- a/src/utils/speech/core/speechPlayer.ts
+++ b/src/utils/speech/core/speechPlayer.ts
@@ -15,23 +15,24 @@ export const speak = (
   region: 'US' | 'UK' = 'US', 
   pauseRequestedRef?: React.MutableRefObject<boolean>
 ): Promise<string> => {
-  return new Promise(async (resolve, reject) => {
-    if (isMutedFromLocalStorage()) {
-      console.log('Speech is muted, resolving immediately');
-      resolve('skipped');
-      return;
-    }
+  return new Promise((resolve, reject) => {
+    const run = async () => {
+      if (isMutedFromLocalStorage()) {
+        console.log('Speech is muted, resolving immediately');
+        resolve('skipped');
+        return;
+      }
 
-    if (!window.speechSynthesis) {
-      console.error('Speech synthesis not supported');
-      reject(new Error('Speech synthesis not supported'));
-      return;
-    }
+      if (!window.speechSynthesis) {
+        console.error('Speech synthesis not supported');
+        reject(new Error('Speech synthesis not supported'));
+        return;
+      }
 
-    try {
-      // Ensure we're not trying to speak multiple things at once
-      await ensureSpeechEngineReady();
-      stopSpeaking();
+      try {
+        // Ensure we're not trying to speak multiple things at once
+        await ensureSpeechEngineReady();
+        stopSpeaking();
 
       // Wait for DOM to update before continuing
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -86,9 +87,12 @@ export const speak = (
           reject(new Error('Could not load voices'));
         }
       }
-    } catch (err) {
-      console.error('Unexpected error in speak function:', err);
-      reject(err);
-    }
+      } catch (err) {
+        console.error('Unexpected error in speak function:', err);
+        reject(err);
+      }
+    };
+
+    void run();
   });
 };

--- a/src/utils/speech/core/speechPlayerUtils.ts
+++ b/src/utils/speech/core/speechPlayerUtils.ts
@@ -17,7 +17,9 @@ export function isMutedFromLocalStorage(): boolean {
       const parsedStates = JSON.parse(storedStates);
       return parsedStates.isMuted === true;
     }
-  } catch (error) {}
+  } catch (error) {
+    console.error('Error reading mute state from localStorage:', error);
+  }
   return false;
 }
 

--- a/src/utils/speech/debug/speechDebugHelper.ts
+++ b/src/utils/speech/debug/speechDebugHelper.ts
@@ -85,6 +85,9 @@ export const speechDebugHelper = {
 
 // Make it available globally for console testing
 if (typeof window !== 'undefined') {
-  (window as any).speechDebugHelper = speechDebugHelper;
+  interface WindowWithSpeechDebug extends Window {
+    speechDebugHelper: typeof speechDebugHelper;
+  }
+  (window as WindowWithSpeechDebug).speechDebugHelper = speechDebugHelper;
   console.log('Speech debug helper available as window.speechDebugHelper');
 }

--- a/src/utils/text/contentFilters.ts
+++ b/src/utils/text/contentFilters.ts
@@ -56,7 +56,7 @@ export const extractSpeechableContent = (text: string): string => {
   });
   
   // Remove content between forward slashes (phonetic transcription)
-  processedText = processedText.replace(/\/([^\/]*)\//g, '');
+  processedText = processedText.replace(/\/([^/]*)\//g, '');
   
   // Remove standalone IPA characters but preserve words containing them
   // Only remove if the entire word consists mainly of IPA characters

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;

--- a/tests/voiceUtils.test.ts
+++ b/tests/voiceUtils.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { hasAvailableVoices } from '../src/utils/speech/voiceUtils';
 
 // Mock speechSynthesis
+interface MockWindow {
+  speechSynthesis: {
+    getVoices: () => Array<{ lang: string; name: string }>;
+  };
+}
+
 beforeEach(() => {
-  (global as any).window = {
+  (global as { window: MockWindow }).window = {
     speechSynthesis: {
       getVoices: () => []
     }
@@ -12,12 +18,14 @@ beforeEach(() => {
 
 describe('hasAvailableVoices', () => {
   it('returns false when no voices are available', () => {
-    (window as any).speechSynthesis.getVoices = () => [];
+    (window as MockWindow).speechSynthesis.getVoices = () => [];
     expect(hasAvailableVoices()).toBe(false);
   });
 
   it('returns true when voices are available', () => {
-    (window as any).speechSynthesis.getVoices = () => [{ lang: 'en-US', name: 'A' }];
+    (window as MockWindow).speechSynthesis.getVoices = () => [
+      { lang: 'en-US', name: 'A' }
+    ];
     expect(hasAvailableVoices()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- improve localStorage error handling
- add window interface for speech debug helper
- fix regex escapes in content filters
- use ESM import for tailwind plugin
- refine regex rules for sanitization
- avoid `any` types in tests and speech engine helpers
- restructure `speak` to avoid async promise executor

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68424c8ff620832f9ad89f21eda650c5