### PR TITLE
Fix TS2352 error in validationTest

### DIFF
--- a/src/utils/security/validationTest.ts
+++ b/src/utils/security/validationTest.ts
@@ -125,5 +125,5 @@ if (typeof window !== 'undefined') {
   interface WindowWithValidation extends Window {
     testValidationPatterns: typeof testValidationPatterns;
   }
-  (window as WindowWithValidation).testValidationPatterns = testValidationPatterns;
+  (window as unknown as WindowWithValidation).testValidationPatterns = testValidationPatterns;
 }


### PR DESCRIPTION
## Summary
- fix cast syntax for testValidationPatterns assignment

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684277318334832f800a017363dad091