### PR TITLE
Fix speech debug helper cast

### DIFF
--- a/src/utils/speech/debug/speechDebugHelper.ts
+++ b/src/utils/speech/debug/speechDebugHelper.ts
@@ -88,6 +88,6 @@ if (typeof window !== 'undefined') {
   interface WindowWithSpeechDebug extends Window {
     speechDebugHelper: typeof speechDebugHelper;
   }
-  (window as WindowWithSpeechDebug).speechDebugHelper = speechDebugHelper;
+  (window as unknown as WindowWithSpeechDebug).speechDebugHelper = speechDebugHelper;
   console.log('Speech debug helper available as window.speechDebugHelper');
 }


### PR DESCRIPTION
## Summary
- resolve TypeScript cast error in speechDebugHelper

## Testing
- `npx tsc src/utils/speech/debug/speechDebugHelper.ts --lib ES2020,DOM --skipLibCheck --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68427735a5f0832f80bdfccb6c9f4172