### PR TITLE
Add setter export from word modal state hook

### DIFF
--- a/src/hooks/vocabulary/useWordModalState.tsx
+++ b/src/hooks/vocabulary/useWordModalState.tsx
@@ -31,6 +31,7 @@ export const useWordModalState = () => {
 
   return {
     isAddWordModalOpen,
+    setIsAddWordModalOpen,
     isEditMode,
     wordToEdit,
     handleOpenAddWordModal,


### PR DESCRIPTION
## Summary
- expose `setIsAddWordModalOpen` from `useWordModalState`

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: PASS waiting for file changes - all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842772ed6e8832f832ce1782eb33480