### PR TITLE
Fix audio playback initialization

### DIFF
--- a/src/utils/speech/simpleSpeechController.ts
+++ b/src/utils/speech/simpleSpeechController.ts
@@ -1,4 +1,6 @@
 
+import { unlockAudio, loadVoicesAndWait } from './core/speechEngine';
+
 /**
  * Simplified speech controller for reliable audio playback
  */
@@ -18,8 +20,12 @@ class SimpleSpeechController {
       onError?: (error: SpeechSynthesisErrorEvent) => void;
     } = {}
   ): Promise<boolean> {
-    return new Promise((resolve) => {
+    return new Promise(async (resolve) => {
       try {
+        // Ensure browser audio is unlocked and voices are available
+        await unlockAudio();
+        await loadVoicesAndWait();
+
         // Stop any current speech
         this.stop();
         


### PR DESCRIPTION
## Summary
- ensure `simpleSpeechController` unlocks audio and loads voices before speaking

## Testing
- `npm run lint` *(fails: no-empty, no-explicit-any, and other eslint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684276ac79e0832fb83ed77847a63909