### PR TITLE
Fix autoplayer delay

### DIFF
--- a/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
@@ -56,7 +56,7 @@ export const useAutoPlay = (
       } else {
         console.log('[AUTO-PLAY] Conditions changed, skipping execution');
       }
-    }, 300); // Longer delay to prevent race conditions
+    }, 400); // Longer delay to prevent race conditions
     
     return () => {
       if (autoPlayTimeoutRef.current) {


### PR DESCRIPTION
## Summary
- tweak autoplay delay to avoid race conditions

## Testing
- `npx vitest run`
- `npm run lint` *(fails: no-async-promise-executor and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684646449b94832f83f58ec93549fa7f