### PR TITLE
Update orchestrator for word transition

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
@@ -123,6 +123,8 @@ export const usePlaybackOrchestrator = (
       } else if (conditionCheck.reason === 'muted') {
         console.log('[PLAYBACK-ORCHESTRATOR] Speech is muted, auto-advancing after delay');
         setTimeout(() => goToNextWord(), 3000);
+      } else if (conditionCheck.reason === 'word-transition') {
+        setTimeout(playCurrentWord, 150);
       }
       return;
     }


### PR DESCRIPTION
## Summary
- improve playback orchestrator logic
  - when word transition is in progress, delay playback briefly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684646416dec832f85b6f0970527761b