### PR TITLE
Fix speech cancellation race

### DIFF
--- a/src/utils/speech/simpleSpeechController.ts
+++ b/src/utils/speech/simpleSpeechController.ts
@@ -26,8 +26,11 @@ class SimpleSpeechController {
         await unlockAudio();
         await loadVoicesAndWait();
 
-        // Stop any current speech
+        // Stop any current speech and wait briefly for the cancel
         this.stop();
+
+        // Allow the cancel operation to fully propagate
+        await new Promise(r => setTimeout(r, 50));
         
         // Create new utterance
         const utterance = new SpeechSynthesisUtterance(text);


### PR DESCRIPTION
## Summary
- delay after calling stop() inside `simpleSpeechController.speak`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684659888128832fb6681d49a1e35f95