### PR TITLE
Fix missing vocabulary export

### DIFF
--- a/public/defaultVocabulary.json
+++ b/public/defaultVocabulary.json
@@ -1,1 +1,13 @@
+{
+  "phrasal verbs": [
+    {
+      "word": "look up",
+      "meaning": "search for information",
+      "example": "I looked up the word in the dictionary",
+      "count": 0,
+      "category": "phrasal verbs"
+    }
+  ],
+  "idioms": [],
+  "advanced words": []
 }

--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -1,0 +1,16 @@
+import { SheetData } from '@/types/vocabulary';
+
+export const DEFAULT_VOCABULARY_DATA: SheetData = {
+  "phrasal verbs": [
+    {
+      word: "look up",
+      meaning: "search for information",
+      example: "I looked up the word in the dictionary",
+      count: 0,
+      category: "phrasal verbs"
+    }
+    // add more entries as needed
+  ],
+  idioms: [],
+  "advanced words": []
+};


### PR DESCRIPTION
## Summary
- restore the missing default vocabulary export
- keep a matching JSON copy for optional fetches

## Testing
- `npx vitest run`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and no-async-promise-executor)*

------
https://chatgpt.com/codex/tasks/task_e_68479fe34550832fb6487272e5ef4b16