### PR TITLE
Fix typing errors in vocabulary operations

### DIFF
--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -35,9 +35,9 @@ const VocabularyContainer: React.FC = () => {
   const { currentCategory, nextCategory } = useCategoryNavigation();
 
   // Optimized file upload handler that prevents excessive processing
-  const handleOptimizedFileUpload = (file: File) => {
+  const handleOptimizedFileUpload = async (file: File) => {
     console.log('[VOCAB-CONTAINER] Optimized file upload handler called');
-    containerState.handleFileUploaded(file);
+    await containerState.handleFileUploaded(file);
   };
 
   // Optimized category switch handler


### PR DESCRIPTION
## Summary
- return `Promise<void>` in file upload handler
- initialize `WordNavigation` with data and sheet options
- ensure Excel import includes `count`
- update calls to `getCurrentWord` and `getNextWord`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx vitest` *(fails: tries to install packages interactively)*

------
https://chatgpt.com/codex/tasks/task_e_6847d5fa4ed4832fb4843044728db489