### PR TITLE
Remove WelcomeScreen placeholder

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -1,7 +1,6 @@
 
 import React from "react";
 import VocabularyLayout from "@/components/VocabularyLayout";
-import WelcomeScreen from "@/components/WelcomeScreen";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithData from "./ContentWithData";
 import { useVocabularyContainerState } from "@/hooks/vocabulary/useVocabularyContainerState";
@@ -150,11 +149,6 @@ const VocabularyAppContainer: React.FC = () => {
     nextCategory
   });
 
-  // Create a wrapper function for file upload to match WelcomeScreen's expected signature
-  const handleFileUploadWrapper = () => {
-    // This is a no-op since WelcomeScreen will handle file selection internally
-    // The actual file processing will be handled by the FileUpload component
-  };
 
   return (
     <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
@@ -186,7 +180,7 @@ const VocabularyAppContainer: React.FC = () => {
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
       ) : (
-        <WelcomeScreen onFileUploaded={handleFileUploadWrapper} />
+        <p>Loading vocabulary…</p>
       )}
     </VocabularyLayout>
   );

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -1,7 +1,6 @@
 
 import React from "react";
 import VocabularyLayout from "@/components/VocabularyLayout";
-import WelcomeScreen from "@/components/WelcomeScreen";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithDataNew from "./ContentWithDataNew";
 import { useVocabularyContainerState } from "@/hooks/vocabulary/useVocabularyContainerState";
@@ -95,11 +94,6 @@ const VocabularyAppContainerNew: React.FC = () => {
     ? { word: currentWord.word, category: currentWord.category || currentCategory }
     : null;
 
-  // Create a wrapper function for file upload to match WelcomeScreen's expected signature
-  const handleFileUploadWrapper = () => {
-    // This is a no-op since WelcomeScreen will handle file selection internally
-    // The actual file processing will be handled by the FileUpload component
-  };
 
   return (
     <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
@@ -131,7 +125,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
       ) : (
-        <WelcomeScreen onFileUploaded={handleFileUploadWrapper} />
+        <p>Loading vocabulary…</p>
       )}
     </VocabularyLayout>
   );


### PR DESCRIPTION
## Summary
- clean out `WelcomeScreen` from vocabulary containers
- show a static placeholder when no data is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847d8c60410832fb1692878c5c684d8