### PR TITLE
Fix manual next after pause

### DIFF
--- a/src/hooks/vocabulary/useVocabularyActions.tsx
+++ b/src/hooks/vocabulary/useVocabularyActions.tsx
@@ -11,6 +11,7 @@ export const useVocabularyActions = (
   wordChangeInProgressRef: React.MutableRefObject<boolean>,
   lastManualActionTimeRef: React.MutableRefObject<number>,
   isChangingWordRef: React.MutableRefObject<boolean>,
+  pauseRequestedRef: React.MutableRefObject<boolean> | undefined,
   setIsPaused: React.Dispatch<React.SetStateAction<boolean>>,
   timerRef: React.MutableRefObject<number | null>,
   displayNextWord: () => void
@@ -24,7 +25,8 @@ export const useVocabularyActions = (
     clearTimer,
     wordChangeInProgressRef,
     lastManualActionTimeRef,
-    isChangingWordRef
+    isChangingWordRef,
+    pauseRequestedRef
   );
   
   // Use the category actions hook

--- a/src/hooks/vocabulary/useVocabularyManager.tsx
+++ b/src/hooks/vocabulary/useVocabularyManager.tsx
@@ -27,6 +27,7 @@ export const useVocabularyManager = () => {
   const isSpeakingRef = useRef<boolean>(false);
   const isChangingWordRef = useRef<boolean>(false);
   const wordChangeInProgressRef = useRef(false);
+  const pauseRequestedRef = useRef<boolean>(false);
 
   // Error handling
   const { jsonLoadError, handleVocabularyError } = useErrorHandling(
@@ -52,7 +53,7 @@ export const useVocabularyManager = () => {
   );
 
   // Vocabulary actions
-  const { 
+  const {
     handleTogglePause,
     handleManualNext,
     handleSwitchCategory
@@ -62,6 +63,7 @@ export const useVocabularyManager = () => {
     wordChangeInProgressRef,
     lastManualActionTimeRef,
     isChangingWordRef,
+    pauseRequestedRef,
     setIsPaused,
     timerRef,
     displayNextWord

--- a/src/hooks/vocabulary/useWordNavigation.tsx
+++ b/src/hooks/vocabulary/useWordNavigation.tsx
@@ -10,7 +10,8 @@ export const useWordNavigationActions = (
   clearTimer: () => void,
   wordChangeInProgressRef: React.MutableRefObject<boolean>,
   lastManualActionTimeRef: React.MutableRefObject<number>,
-  isChangingWordRef: React.MutableRefObject<boolean>
+  isChangingWordRef: React.MutableRefObject<boolean>,
+  pauseRequestedRef?: React.MutableRefObject<boolean>
 ) => {
   // Debounced next word handler to prevent rapid clicks
   const handleManualNext = useCallback(() => {
@@ -26,6 +27,10 @@ export const useWordNavigationActions = (
     console.log("Manual next word requested");
     lastManualActionTimeRef.current = Date.now();
     clearTimer();
+
+    if (pauseRequestedRef) {
+      pauseRequestedRef.current = false;
+    }
     
     // Set flags to prevent multiple concurrent word changes
     wordChangeInProgressRef.current = true;
@@ -51,7 +56,14 @@ export const useWordNavigationActions = (
         isChangingWordRef.current = false;
       }, 200);
     }
-  }, [clearTimer, setCurrentWord, wordChangeInProgressRef, lastManualActionTimeRef, isChangingWordRef]);
+  }, [
+    clearTimer,
+    setCurrentWord,
+    wordChangeInProgressRef,
+    lastManualActionTimeRef,
+    isChangingWordRef,
+    pauseRequestedRef
+  ]);
 
   return {
     handleManualNext


### PR DESCRIPTION
## Summary
- allow `useWordNavigationActions` to reset `pauseRequestedRef`
- plumb the new ref through `useVocabularyActions` and `useVocabularyManager`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e21eb8b4832f9372ac5c243a37a0