### PR TITLE
Fix conflict in useVocabularyActions

### DIFF
--- a/src/hooks/vocabulary/useVocabularyActions.tsx
+++ b/src/hooks/vocabulary/useVocabularyActions.tsx
@@ -1,5 +1,4 @@
 
-import { useCallback } from "react";
 import { usePauseActions } from "./usePauseActions";
 import { useWordNavigationActions } from "./useWordNavigation";
 import { useCategoryActions } from "./useCategoryActions";


### PR DESCRIPTION
## Summary
- resolve merge artifact in `useVocabularyActions`
- remove unused `useCallback` import

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e5f051b4832f84cee542d1dcd907