### PR TITLE
Add new vocabulary categories

### DIFF
--- a/public/defaultVocabulary.json
+++ b/public/defaultVocabulary.json
@@ -14201,5 +14201,21 @@
     "example": "She’s a consultant cardiologist.",
     "count": 0
     }
+  ],
+  "grammar": [
+    {
+      "word": "present perfect",
+      "meaning": "a tense used for actions that happened at an unspecified time",
+      "example": "I have visited France twice.",
+      "count": 0
+    }
+  ],
+  "phrases, collocations": [
+    {
+      "word": "make up one's mind",
+      "meaning": "decide after consideration",
+      "example": "She couldn't make up her mind about the dress.",
+      "count": 0
+    }
   ]
 }

--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -18,6 +18,7 @@ const VocabularyAppContainer: React.FC = () => {
   // Get base vocabulary state
   const {
     hasData,
+    hasAnyData,
     handleFileUploaded,
     jsonLoadError,
     handleSwitchCategory,
@@ -29,6 +30,7 @@ const VocabularyAppContainer: React.FC = () => {
 
   console.log('[VOCAB-CONTAINER] Container state:', {
     hasData,
+    hasAnyData,
     wordListLength: wordList?.length || 0,
     currentCategory
   });
@@ -180,7 +182,11 @@ const VocabularyAppContainer: React.FC = () => {
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
       ) : (
-        <p>Loading vocabulary…</p>
+        hasAnyData ? (
+          <p>No data for this category</p>
+        ) : (
+          <p>Loading vocabulary…</p>
+        )
       )}
     </VocabularyLayout>
   );

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -14,6 +14,7 @@ const VocabularyAppContainerNew: React.FC = () => {
   // Get base vocabulary state (file handling, categories, etc.)
   const {
     hasData,
+    hasAnyData,
     handleFileUploaded,
     jsonLoadError,
     handleSwitchCategory,
@@ -25,6 +26,7 @@ const VocabularyAppContainerNew: React.FC = () => {
 
   console.log('[VOCAB-CONTAINER-NEW] Container state:', {
     hasData,
+    hasAnyData,
     wordListLength: wordList?.length || 0,
     currentCategory
   });
@@ -125,7 +127,11 @@ const VocabularyAppContainerNew: React.FC = () => {
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
       ) : (
-        <p>Loading vocabulary…</p>
+        hasAnyData ? (
+          <p>No data for this category</p>
+        ) : (
+          <p>Loading vocabulary…</p>
+        )
       )}
     </VocabularyLayout>
   );

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -18,7 +18,9 @@ interface WordFormFieldsProps {
 const CATEGORY_OPTIONS = [
   { value: "phrasal verbs", label: "Phrasal Verbs" },
   { value: "idioms", label: "Idioms" },
-  { value: "advanced words", label: "Advanced Words" }
+  { value: "advanced words", label: "Advanced Words" },
+  { value: "grammar", label: "Grammar" },
+  { value: "phrases, collocations", label: "Phrases & Collocations" }
 ];
 
 const WordFormFields: React.FC<WordFormFieldsProps> = ({

--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -14,6 +14,7 @@ const VocabularyContainer: React.FC = () => {
   const containerState = useVocabularyContainerState();
   console.log('[VOCAB-CONTAINER] Container state:', {
     hasData: containerState.hasData,
+    hasAnyData: containerState.hasAnyData,
     currentCategory: containerState.currentCategory
   });
 
@@ -50,8 +51,8 @@ const VocabularyContainer: React.FC = () => {
     containerState.handleSwitchCategory();
   };
 
-  // Show file upload if no data
-  if (!containerState.hasData) {
+  // Show file upload if no data at all
+  if (!containerState.hasAnyData) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] space-y-6">
         <div className="text-center space-y-4">
@@ -61,6 +62,15 @@ const VocabularyContainer: React.FC = () => {
           </p>
         </div>
         <FileUpload onFileUploaded={handleOptimizedFileUpload} />
+      </div>
+    );
+  }
+
+  // Show message if category has no words
+  if (!containerState.hasData) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <p className="text-gray-600">No data for this category</p>
       </div>
     );
   }

--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -14204,5 +14204,21 @@ export const DEFAULT_VOCABULARY_DATA: SheetData = {
     "example": "She’s a consultant cardiologist.",
     "count": 0
     }
+  ],
+  "grammar": [
+    {
+      "word": "present perfect",
+      "meaning": "a tense used for actions that happened at an unspecified time",
+      "example": "I have visited France twice.",
+      "count": 0
+    }
+  ],
+  "phrases, collocations": [
+    {
+      "word": "make up one's mind",
+      "meaning": "decide after consideration",
+      "example": "She couldn't make up her mind about the dress.",
+      "count": 0
+    }
   ]
 }

--- a/src/hooks/vocabulary/useVocabularyContainerState.tsx
+++ b/src/hooks/vocabulary/useVocabularyContainerState.tsx
@@ -8,7 +8,8 @@ export const useVocabularyContainerState = () => {
   console.log('[VOCAB-CONTAINER-STATE] === Hook Initialization ===');
 
   // File and data loading state
-  const [hasData, setHasData] = useState(false);
+  const [hasData, setHasData] = useState(false); // data in current category
+  const [hasAnyData, setHasAnyData] = useState(false); // data in any category
   const [jsonLoadError, setJsonLoadError] = useState<string | null>(null);
   const [wordList, setWordList] = useState<VocabularyWord[]>([]);
 
@@ -32,11 +33,13 @@ export const useVocabularyContainerState = () => {
 
       setWordList(initialWordList);
       setHasData(initialWordList.length > 0);
+      setHasAnyData(vocabularyService.hasData());
       setJsonLoadError(null);
     } catch (error) {
       console.error('[VOCAB-CONTAINER-STATE] Error loading initial data:', error);
       setJsonLoadError('Failed to load vocabulary data');
       setHasData(false);
+      setHasAnyData(false);
       setWordList([]);
     }
   }, []);
@@ -52,6 +55,7 @@ export const useVocabularyContainerState = () => {
         
         setWordList(updatedWordList);
         setHasData(updatedWordList.length > 0);
+        setHasAnyData(vocabularyService.hasData());
         setJsonLoadError(null);
       } catch (error) {
         console.error('[VOCAB-CONTAINER-STATE] Error updating from service:', error);
@@ -81,14 +85,17 @@ export const useVocabularyContainerState = () => {
         console.log('[VOCAB-CONTAINER-STATE] File loaded successfully, words:', newWordList.length);
         setWordList(newWordList);
         setHasData(true);
+        setHasAnyData(vocabularyService.hasData());
       } else {
         setJsonLoadError('Failed to load vocabulary file');
         setHasData(false);
+        setHasAnyData(vocabularyService.hasData());
       }
     } catch (error) {
       console.error('[VOCAB-CONTAINER-STATE] File upload error:', error);
       setJsonLoadError(error instanceof Error ? error.message : 'Unknown error occurred');
       setHasData(false);
+      setHasAnyData(vocabularyService.hasData());
     }
   }, []);
 
@@ -108,16 +115,19 @@ export const useVocabularyContainerState = () => {
         
         setWordList(newWordList);
         setHasData(newWordList.length > 0);
+        setHasAnyData(vocabularyService.hasData());
         
         // Clear any previous errors since category switch was successful
         setJsonLoadError(null);
       } else {
         console.warn('[VOCAB-CONTAINER-STATE] Category switch failed');
         setJsonLoadError('Failed to switch category');
+        setHasAnyData(vocabularyService.hasData());
       }
     } catch (error) {
       console.error('[VOCAB-CONTAINER-STATE] Error switching category:', error);
       setJsonLoadError('Error switching category');
+      setHasAnyData(vocabularyService.hasData());
     }
   }, [currentCategory]);
 
@@ -142,6 +152,7 @@ export const useVocabularyContainerState = () => {
 
   return {
     hasData,
+    hasAnyData,
     handleFileUploaded,
     jsonLoadError,
     handleSwitchCategory,

--- a/src/services/sheet/SheetManager.ts
+++ b/src/services/sheet/SheetManager.ts
@@ -5,7 +5,13 @@ import { SheetProcessor } from "./SheetProcessor";
 import { SheetNormalizer } from "./SheetNormalizer";
 
 export class SheetManager {
-  readonly sheetOptions = ["phrasal verbs", "idioms", "advanced words"];
+  readonly sheetOptions = [
+    "phrasal verbs",
+    "idioms",
+    "advanced words",
+    "grammar",
+    "phrases, collocations"
+  ];
   private sheetProcessor: SheetProcessor;
   private sheetNormalizer: SheetNormalizer;
 

--- a/src/services/sheet/SheetNormalizer.ts
+++ b/src/services/sheet/SheetNormalizer.ts
@@ -13,6 +13,8 @@ export class SheetNormalizer {
     if (normalized.includes("phrasal") || normalized.includes("verb")) return "phrasal verbs";
     if (normalized.includes("idiom")) return "idioms";
     if (normalized.includes("advanced")) return "advanced words";
+    if (normalized.includes("grammar")) return "grammar";
+    if (normalized.includes("phrase") || normalized.includes("collocation")) return "phrases, collocations";
     
     // Default to "phrasal verbs" if no match (instead of original name)
     return "phrasal verbs";

--- a/src/services/vocabulary/VocabularyDataManager.ts
+++ b/src/services/vocabulary/VocabularyDataManager.ts
@@ -98,7 +98,9 @@ export class VocabularyDataManager {
           const fallbackData: SheetData = {
             "phrasal verbs": [],
             "idioms": [],
-            "advanced words": []
+            "advanced words": [],
+            "grammar": [],
+            "phrases, collocations": []
           };
           this.data = this.dataProcessor.processDataTypes(fallbackData);
           this.storage.saveData(this.data);

--- a/src/services/vocabulary/VocabularyService.ts
+++ b/src/services/vocabulary/VocabularyService.ts
@@ -16,7 +16,13 @@ export class VocabularyService {
   
   constructor() {
     // Updated sheet options without "All words"
-    this.sheetOptions = ["phrasal verbs", "idioms", "advanced words"];
+    this.sheetOptions = [
+      "phrasal verbs",
+      "idioms",
+      "advanced words",
+      "grammar",
+      "phrases, collocations"
+    ];
     
     // Initialize the components
     this.dataManager = new VocabularyDataManager();


### PR DESCRIPTION
## Summary
- add `grammar` and `phrases, collocations` categories to default data
- recognise the new categories when importing or switching sheets
- show a warning when a category has no data
- update vocabulary state hook to track whether any data exists

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint package)*

------
https://chatgpt.com/codex/tasks/task_e_6847e569ec50832f8f25f1689bbc6999