### PR TITLE
Allow manual speech while paused

### DIFF
--- a/src/components/vocabulary-app/useAudioPlayback.tsx
+++ b/src/components/vocabulary-app/useAudioPlayback.tsx
@@ -25,7 +25,8 @@ export const useAudioPlayback = (
   speechAttemptsRef: React.MutableRefObject<number>,
   stopSpeaking: () => void,
   displayTime: number,
-  pauseRequestedRef?: React.MutableRefObject<boolean>
+  pauseRequestedRef?: React.MutableRefObject<boolean>,
+  manualOverrideRef?: React.MutableRefObject<boolean>
 ) => {
   // Use our extracted hooks for different aspects of audio playback
   const { clearAllAudioState } = useAudioCleanup(
@@ -50,7 +51,8 @@ export const useAudioPlayback = (
     speechAttemptsRef,
     stopSpeaking,
     displayTime,
-    pauseRequestedRef
+    pauseRequestedRef,
+    manualOverrideRef
   );
   
   // Pause/unpause effect

--- a/src/hooks/audio/useAudioEffect.tsx
+++ b/src/hooks/audio/useAudioEffect.tsx
@@ -18,17 +18,23 @@ export const useAudioEffect = (
   speechAttemptsRef: React.MutableRefObject<number>,
   stopSpeaking: () => void,
   displayTime: number,
-  pauseRequestedRef?: React.MutableRefObject<boolean>
+  pauseRequestedRef?: React.MutableRefObject<boolean>,
+  manualOverrideRef?: React.MutableRefObject<boolean>
 ) => {
   // Handle playing audio when the current word changes - with debouncing
   useEffect(() => {
+    // Capture manual override state and reset it immediately
+    const manualOverride = manualOverrideRef?.current;
+    if (manualOverrideRef) {
+      manualOverrideRef.current = false;
+    }
     if (!currentWord) {
       console.log('[APP] No current word, nothing to speak');
       return;
     }
     
-    // Skip playback when muted or paused
-    if (isPaused) {
+    // Skip playback when muted or paused unless manual override is active
+    if (isPaused && !manualOverride) {
       console.log('[APP] App is paused, not speaking');
       return;
     }
@@ -144,6 +150,7 @@ export const useAudioEffect = (
     speechAttemptsRef,
     handleManualNext,
     pauseRequestedRef,
-    isSoundPlaying
+    isSoundPlaying,
+    manualOverrideRef
   ]);
 };

--- a/src/hooks/vocabulary/useVocabularyActions.tsx
+++ b/src/hooks/vocabulary/useVocabularyActions.tsx
@@ -13,7 +13,8 @@ export const useVocabularyActions = (
   isChangingWordRef: React.MutableRefObject<boolean>,
   setIsPaused: React.Dispatch<React.SetStateAction<boolean>>,
   timerRef: React.MutableRefObject<number | null>,
-  displayNextWord: () => void
+  displayNextWord: () => void,
+  manualOverrideRef?: React.MutableRefObject<boolean>
 ) => {
   // Use the pause actions hook
   const { handleTogglePause } = usePauseActions(setIsPaused);
@@ -24,7 +25,8 @@ export const useVocabularyActions = (
     clearTimer,
     wordChangeInProgressRef,
     lastManualActionTimeRef,
-    isChangingWordRef
+    isChangingWordRef,
+    manualOverrideRef
   );
   
   // Use the category actions hook

--- a/src/hooks/vocabulary/useVocabularyManager.tsx
+++ b/src/hooks/vocabulary/useVocabularyManager.tsx
@@ -27,6 +27,7 @@ export const useVocabularyManager = () => {
   const isSpeakingRef = useRef<boolean>(false);
   const isChangingWordRef = useRef<boolean>(false);
   const wordChangeInProgressRef = useRef(false);
+  const manualOverrideRef = useRef(false);
 
   // Error handling
   const { jsonLoadError, handleVocabularyError } = useErrorHandling(
@@ -64,7 +65,8 @@ export const useVocabularyManager = () => {
     isChangingWordRef,
     setIsPaused,
     timerRef,
-    displayNextWord
+    displayNextWord,
+    manualOverrideRef
   );
 
   // File handler

--- a/src/hooks/vocabulary/useWordNavigation.tsx
+++ b/src/hooks/vocabulary/useWordNavigation.tsx
@@ -10,7 +10,8 @@ export const useWordNavigationActions = (
   clearTimer: () => void,
   wordChangeInProgressRef: React.MutableRefObject<boolean>,
   lastManualActionTimeRef: React.MutableRefObject<number>,
-  isChangingWordRef: React.MutableRefObject<boolean>
+  isChangingWordRef: React.MutableRefObject<boolean>,
+  manualOverrideRef?: React.MutableRefObject<boolean>
 ) => {
   // Debounced next word handler to prevent rapid clicks
   const handleManualNext = useCallback(() => {
@@ -24,6 +25,9 @@ export const useWordNavigationActions = (
     }
 
     console.log("Manual next word requested");
+    if (manualOverrideRef) {
+      manualOverrideRef.current = true;
+    }
     lastManualActionTimeRef.current = Date.now();
     clearTimer();
     
@@ -51,7 +55,7 @@ export const useWordNavigationActions = (
         isChangingWordRef.current = false;
       }, 200);
     }
-  }, [clearTimer, setCurrentWord, wordChangeInProgressRef, lastManualActionTimeRef, isChangingWordRef]);
+  }, [clearTimer, setCurrentWord, wordChangeInProgressRef, lastManualActionTimeRef, isChangingWordRef, manualOverrideRef]);
 
   return {
     handleManualNext


### PR DESCRIPTION
## Summary
- extend `useAudioEffect` with a `manualOverrideRef` flag
- mark manual overrides on manual word changes
- thread the flag through vocabulary helpers
- pass the flag into the audio effect

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 29 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847e21d6d00832facb07e7f87a29405