### PR TITLE
Fix category message not blocking controls

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import VocabularyLayout from "@/components/VocabularyLayout";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithData from "./ContentWithData";
+import VocabularyCard from "./VocabularyCard";
 import { useVocabularyContainerState } from "@/hooks/vocabulary/useVocabularyContainerState";
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { useWordModalState } from "@/hooks/vocabulary/useWordModalState";
@@ -181,12 +182,27 @@ const VocabularyAppContainer: React.FC = () => {
           handleOpenAddWordModal={handleOpenAddWordModal}
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
+      ) : hasAnyData ? (
+        <VocabularyCard
+          word="No data for this category"
+          meaning=""
+          example=""
+          backgroundColor="#F0F8FF"
+          isMuted={muted}
+          isPaused={paused}
+          onToggleMute={handleToggleMuteWithInteraction}
+          onTogglePause={handleTogglePauseWithInteraction}
+          onCycleVoice={handleCycleVoiceWithInteraction}
+          onSwitchCategory={handleCategorySwitchDirect}
+          onNextWord={() => {}}
+          currentCategory={currentCategory}
+          nextCategory={nextCategory || 'Next'}
+          isSpeaking={false}
+          category={currentCategory}
+          selectedVoice={selectedVoice}
+        />
       ) : (
-        hasAnyData ? (
-          <p>No data for this category</p>
-        ) : (
-          <p>Loading vocabulary…</p>
-        )
+        <p>Loading vocabulary…</p>
       )}
     </VocabularyLayout>
   );

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import VocabularyLayout from "@/components/VocabularyLayout";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithDataNew from "./ContentWithDataNew";
+import VocabularyCardNew from "./VocabularyCardNew";
 import { useVocabularyContainerState } from "@/hooks/vocabulary/useVocabularyContainerState";
 import { useWordModalState } from "@/hooks/vocabulary/useWordModalState";
 import { useVocabularyController } from "@/hooks/vocabulary-controller/useVocabularyController";
@@ -126,12 +127,27 @@ const VocabularyAppContainerNew: React.FC = () => {
           handleOpenAddWordModal={handleOpenAddWordModal}
           handleOpenEditWordModal={handleOpenEditWordModal}
         />
+      ) : hasAnyData ? (
+        <VocabularyCardNew
+          word="No data for this category"
+          meaning=""
+          example=""
+          backgroundColor="#F0F8FF"
+          isMuted={isMuted}
+          isPaused={isPaused}
+          onToggleMute={toggleMute}
+          onTogglePause={togglePause}
+          onCycleVoice={toggleVoice}
+          onSwitchCategory={handleSwitchCategoryWithState}
+          onNextWord={() => {}}
+          currentCategory={currentCategory}
+          nextCategory={nextCategory || 'Next'}
+          isSpeaking={false}
+          category={currentCategory}
+          voiceRegion={voiceRegion}
+        />
       ) : (
-        hasAnyData ? (
-          <p>No data for this category</p>
-        ) : (
-          <p>Loading vocabulary…</p>
-        )
+        <p>Loading vocabulary…</p>
       )}
     </VocabularyLayout>
   );


### PR DESCRIPTION
## Summary
- keep controls active when a category has no data
- show "No data for this category" inside the vocabulary card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e91b1e38832fa5b297d8d76fa84c