### PR TITLE
Allow manual speech while paused

### DIFF
--- a/src/hooks/useWordSpeechSync.tsx
+++ b/src/hooks/useWordSpeechSync.tsx
@@ -98,7 +98,7 @@ export const useWordSpeechSync = (
         localStorage.setItem('currentDisplayedWord', wordToSpeak.word);
       } catch {}
       const fullText = `${wordToSpeak.word}. ${wordToSpeak.meaning}. ${wordToSpeak.example}`;
-      if (isPaused || isMuted) {
+      if ((isPaused && !forceSpeak) || isMuted) {
         console.log("App was paused/muted while preparing, aborting");
         isSpeakingRef.current = false;
         speechLockRef.current = false;

--- a/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
@@ -47,10 +47,15 @@ export const useSimpleVocabularyController = () => {
   }, []);
 
   // Play current word function
-  const playCurrentWord = useCallback(async () => {
+  const playCurrentWord = useCallback(async (allowWhenPaused = false) => {
     const word = currentWord || refreshCurrentWord();
     
-    if (!word || isMuted || isPaused || speechInProgressRef.current) {
+    if (
+      !word ||
+      isMuted ||
+      (isPaused && !allowWhenPaused) ||
+      speechInProgressRef.current
+    ) {
       debug('[SIMPLE-VOCAB-CONTROLLER] Cannot play:', {
         hasWord: !!word,
         isMuted,

--- a/src/hooks/vocabulary-controller/useVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useVocabularyController.ts
@@ -50,9 +50,14 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   }, [clearTimeouts]);
 
   // Play current word function
-  const playCurrentWord = useCallback(async () => {
+  const playCurrentWord = useCallback(async (allowWhenPaused = false) => {
     // Prevent multiple simultaneous speech attempts
-    if (speechInProgressRef.current || !currentWord || isMuted || isPaused) {
+    if (
+      speechInProgressRef.current ||
+      !currentWord ||
+      isMuted ||
+      (isPaused && !allowWhenPaused)
+    ) {
       debug('[VOCAB-CONTROLLER] Skipping speech:', {
         speechInProgress: speechInProgressRef.current,
         hasWord: !!currentWord,


### PR DESCRIPTION
## Summary
- allow playCurrentWord while app is paused
- support paused playback override in simple controller
- permit forced speech even when paused

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea0ffd58832f981d9f0032c406e8