### PR TITLE
Add Australian voice option

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -4,7 +4,7 @@ import { vocabularyService } from '@/services/vocabularyService';
 
 interface DebugPanelProps {
   isMuted: boolean;
-  voiceRegion: 'US' | 'UK';
+  voiceRegion: 'US' | 'UK' | 'AU';
   isPaused: boolean;
   currentWord?: {
     word: string;

--- a/src/components/NotificationManager.tsx
+++ b/src/components/NotificationManager.tsx
@@ -26,7 +26,7 @@ const requestNotificationPermission = async () => {
 interface NotificationManagerProps {
   onNotificationsEnabled: () => void;
   currentWord?: VocabularyWord | null;
-  voiceRegion?: 'US' | 'UK';
+  voiceRegion?: 'US' | 'UK' | 'AU';
 }
 
 const NotificationManager: React.FC<NotificationManagerProps> = ({ 

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -19,7 +19,7 @@ interface ContentWithDataNewProps {
   isSpeaking: boolean;
   handleManualNext: () => void;
   displayTime: number;
-  voiceRegion: 'US' | 'UK';
+  voiceRegion: 'US' | 'UK' | 'AU';
   debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -22,7 +22,7 @@ interface VocabularyCardNewProps {
   isSpeaking?: boolean;
   displayTime?: number;
   category?: string;
-  voiceRegion: 'US' | 'UK';
+  voiceRegion: 'US' | 'UK' | 'AU';
 }
 
 const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -17,7 +17,7 @@ interface VocabularyMainNewProps {
   nextCategory: string | null;
   isSoundPlaying: boolean;
   displayTime: number;
-  voiceRegion: 'US' | 'UK';
+  voiceRegion: 'US' | 'UK' | 'AU';
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({

--- a/src/components/vocabulary-app/useAudioPlayback.tsx
+++ b/src/components/vocabulary-app/useAudioPlayback.tsx
@@ -14,7 +14,7 @@ export const useAudioPlayback = (
   currentWord: VocabularyWord | null,
   isPaused: boolean,
   mute: boolean,
-  voiceRegion: 'US' | 'UK',
+  voiceRegion: 'US' | 'UK' | 'AU',
   handleManualNext: () => void,
   isSoundPlaying: boolean,
   setIsSoundPlaying: (playing: boolean) => void,

--- a/src/hooks/audio/useAudioEffect.tsx
+++ b/src/hooks/audio/useAudioEffect.tsx
@@ -7,7 +7,7 @@ export const useAudioEffect = (
   currentWord: VocabularyWord | null,
   isPaused: boolean,
   mute: boolean,
-  voiceRegion: 'US' | 'UK',
+  voiceRegion: 'US' | 'UK' | 'AU',
   handleManualNext: () => void,
   isSoundPlaying: boolean,
   setIsSoundPlaying: (playing: boolean) => void,

--- a/src/hooks/speech/useChunkSequencer.tsx
+++ b/src/hooks/speech/useChunkSequencer.tsx
@@ -6,7 +6,7 @@ export const useChunkSequencer = () => {
   const speakChunksSequentially = useCallback(
     async (
       chunks: string[], 
-      voiceRegion: 'US' | 'UK', 
+      voiceRegion: 'US' | 'UK' | 'AU', 
       startIndex: number = 0,
       pauseRequestedRef?: React.MutableRefObject<boolean>
     ): Promise<string> => {

--- a/src/hooks/speech/useSpeechSynthesis.tsx
+++ b/src/hooks/speech/useSpeechSynthesis.tsx
@@ -45,7 +45,7 @@ export const useSpeechSynthesis = () => {
   
   // Function to change voice region
   const handleChangeVoice = useCallback(() => {
-    const newRegion = voiceRegion === 'US' ? 'UK' : 'US';
+    const newRegion = voiceRegion === 'US' ? 'UK' : voiceRegion === 'UK' ? 'AU' : 'US';
     setVoiceRegion(newRegion);
     console.log(`Voice changed to ${newRegion}`);
   }, [voiceRegion, setVoiceRegion]);

--- a/src/hooks/speech/useVoiceLoading.tsx
+++ b/src/hooks/speech/useVoiceLoading.tsx
@@ -2,11 +2,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getVoiceByRegion } from '@/utils/speech';
 
-export const useVoiceLoading = (voiceRegion: 'US' | 'UK') => {
+export const useVoiceLoading = (voiceRegion: 'US' | 'UK' | 'AU') => {
   const [isVoicesLoaded, setIsVoicesLoaded] = useState(false);
   const voicesLoadedTimeoutRef = useRef<number | null>(null);
   const currentVoiceRef = useRef<SpeechSynthesisVoice | null>(null);
-  const lastVoiceRegionRef = useRef<'US' | 'UK'>(voiceRegion);
+  const lastVoiceRegionRef = useRef<'US' | 'UK' | 'AU'>(voiceRegion);
   const pendingSpeechRef = useRef<{text: string, forceSpeak: boolean} | null>(null);
 
   // Initialize voice loading

--- a/src/hooks/speech/useVoiceSettings.tsx
+++ b/src/hooks/speech/useVoiceSettings.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 
 interface VoiceSettings {
   isMuted: boolean;
-  voiceRegion: 'US' | 'UK';
+  voiceRegion: 'US' | 'UK' | 'AU';
 }
 
 export const useVoiceSettings = () => {
@@ -20,7 +20,7 @@ export const useVoiceSettings = () => {
         
         return {
           isMuted: parsedStates.isMuted === true,
-          voiceRegion: (parsedStates.voiceRegion === 'UK' ? 'UK' : 'US') as 'US' | 'UK'
+          voiceRegion: (parsedStates.voiceRegion === 'UK' ? 'UK' : 'US') as 'US' | 'UK' | 'AU'
         };
       }
     } catch (error) {
@@ -31,7 +31,7 @@ export const useVoiceSettings = () => {
 
   const { isMuted: initialMuted, voiceRegion: initialVoiceRegion } = getInitialStates();
   const [isMuted, setIsMuted] = useState(initialMuted);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK'>(initialVoiceRegion);
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>(initialVoiceRegion);
 
   // Update mute state in localStorage when it changes
   useEffect(() => {

--- a/src/hooks/useMuteToggle.tsx
+++ b/src/hooks/useMuteToggle.tsx
@@ -9,7 +9,7 @@ export const useMuteToggle = (
   isPaused: boolean,
   clearAutoAdvanceTimer: () => void,
   stopSpeech: () => void,
-  voiceRegion: 'US' | 'UK'
+  voiceRegion: 'US' | 'UK' | 'AU'
 ) => {
   const [mute, setMute] = useState(isMuted);
   

--- a/src/hooks/useVocabularyAudioSync.tsx
+++ b/src/hooks/useVocabularyAudioSync.tsx
@@ -7,7 +7,7 @@ export const useVocabularyAudioSync = (
   currentWord: VocabularyWord | null, 
   isPaused: boolean, 
   isMuted: boolean, 
-  voiceRegion: 'US' | 'UK'
+  voiceRegion: 'US' | 'UK' | 'AU'
 ) => {
   const [isSoundPlaying, setIsSoundPlaying] = useState(false);
   const autoAdvanceTimerRef = useRef<number | null>(null);

--- a/src/hooks/useVoiceManager.tsx
+++ b/src/hooks/useVoiceManager.tsx
@@ -60,7 +60,7 @@ export const useVoiceManager = () => {
     };
   }, [loadVoices]);
 
-  const selectVoiceByRegion = useCallback((voiceRegion: 'US' | 'UK'): SpeechSynthesisVoice | null => {
+  const selectVoiceByRegion = useCallback((voiceRegion: 'US' | 'UK' | 'AU'): SpeechSynthesisVoice | null => {
     if (availableVoices.length === 0) {
       console.log("No voices available, cannot select by region");
       return null;
@@ -76,14 +76,23 @@ export const useVoiceManager = () => {
       if (!voice) {
         voice = availableVoices.find(v => v.lang === 'en-US');
       }
-    } else {
+    } else if (voiceRegion === 'UK') {
       // Try to find UK voice - be more specific
-      voice = availableVoices.find(v => 
+      voice = availableVoices.find(v =>
         v.lang === 'en-GB' && (v.name.includes('Google') || v.name.includes('Microsoft'))
       );
-      
+
       if (!voice) {
         voice = availableVoices.find(v => v.lang === 'en-GB');
+      }
+    } else {
+      // AU voice selection
+      voice = availableVoices.find(v =>
+        v.lang === 'en-AU' && (v.name.includes('Google') || v.name.includes('Microsoft'))
+      );
+
+      if (!voice) {
+        voice = availableVoices.find(v => v.lang === 'en-AU');
       }
     }
     

--- a/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
@@ -13,7 +13,7 @@ export const useSimpleVocabularyController = () => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
   
   // Refs to track state and prevent race conditions
   const speechInProgressRef = useRef(false);
@@ -162,7 +162,7 @@ export const useSimpleVocabularyController = () => {
   }, [isMuted, stopSpeech]);
 
   const toggleVoice = useCallback(() => {
-    const newRegion = voiceRegion === 'US' ? 'UK' : 'US';
+    const newRegion = voiceRegion === 'US' ? 'UK' : voiceRegion === 'UK' ? 'AU' : 'US';
     debug('[SIMPLE-VOCAB-CONTROLLER] Toggle voice to:', newRegion);
     setVoiceRegion(newRegion);
   }, [voiceRegion]);

--- a/src/hooks/vocabulary-controller/useVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useVocabularyController.ts
@@ -14,7 +14,7 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
   
   // Refs to prevent unnecessary effects and manage state
   const lastWordRef = useRef<string | null>(null);
@@ -164,7 +164,7 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   }, [isMuted, stopSpeech, goToNext]);
 
   const toggleVoice = useCallback(() => {
-    const newRegion = voiceRegion === 'US' ? 'UK' : 'US';
+    const newRegion = voiceRegion === 'US' ? 'UK' : voiceRegion === 'UK' ? 'AU' : 'US';
     debug('[VOCAB-CONTROLLER] Toggle voice to:', newRegion);
     setVoiceRegion(newRegion);
   }, [voiceRegion]);

--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -74,7 +74,7 @@ export const useVoiceManagement = () => {
   }, [allVoiceOptions]);
   
   // Function to find the appropriate voice with hardcoded names
-  const findVoice = useCallback((region: 'US' | 'UK'): SpeechSynthesisVoice | null => {
+  const findVoice = useCallback((region: 'US' | 'UK' | 'AU'): SpeechSynthesisVoice | null => {
     console.log(`Looking for ${region} voice`);
     
     // Always get fresh voices

--- a/src/hooks/vocabulary-playback/core/useWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/core/useWordPlayback.ts
@@ -14,7 +14,7 @@ export const useWordPlayback = (
   muted: boolean,
   paused: boolean,
   cancelSpeech: () => void,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   userInteractionRef: React.MutableRefObject<boolean>,
   setIsSpeaking: (isSpeaking: boolean) => void,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
@@ -8,7 +8,7 @@ import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
  * Hook for controlling speech synthesis execution
  */
 export const useSpeechController = (
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection
 ) => {
   const executeSpeechSynthesis = useCallback(async (

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
@@ -15,7 +15,7 @@ export const useOrchestratorCore = (
   currentIndex: number,
   muted: boolean,
   paused: boolean,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: any,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackCoordination.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackCoordination.ts
@@ -7,7 +7,7 @@ import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
  * Hook for coordinating the playback execution with all the required dependencies
  */
 export const usePlaybackCoordination = (
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
@@ -12,7 +12,7 @@ import { toast } from 'sonner';
  * Hook for executing the playback process
  */
 export const usePlaybackExecution = (
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackFlow.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackFlow.ts
@@ -12,7 +12,7 @@ export const usePlaybackFlow = (
   currentIndex: number,
   muted: boolean,
   paused: boolean,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
@@ -11,7 +11,7 @@ export const usePlaybackOrchestrator = (
   currentIndex: number,
   muted: boolean,
   paused: boolean,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
@@ -11,7 +11,7 @@ import { useSpeechController } from './speech-execution/useSpeechController';
  * Refactored speech execution hook with modular components
  */
 export const useSpeechExecution = (
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
@@ -14,7 +14,7 @@ export const useUtteranceManager = () => {
   const createUtterance = useCallback((
     word: VocabularyWord, 
     selectedVoice: VoiceSelection,
-    findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+    findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
     onStart: () => void,
     onEnd: () => void,
     onError: (e: SpeechSynthesisErrorEvent) => void

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useWordPlaybackLogic.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useWordPlaybackLogic.ts
@@ -13,7 +13,7 @@ export const useWordPlaybackLogic = (
   muted: boolean,
   paused: boolean,
   cancelSpeech: () => void,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   userInteractionRef: React.MutableRefObject<boolean>,
   setIsSpeaking: (isSpeaking: boolean) => void,
@@ -30,7 +30,7 @@ export const useWordPlaybackLogic = (
   createUtterance: (
     word: VocabularyWord, 
     selectedVoice: VoiceSelection,
-    findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+    findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
     onStart: () => void,
     onEnd: () => void,
     onError: (e: SpeechSynthesisErrorEvent) => void

--- a/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
@@ -22,7 +22,7 @@ export const useWordPlaybackCore = (
   muted: boolean,
   paused: boolean,
   cancelSpeech: () => void,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   userInteractionRef: React.MutableRefObject<boolean>,
   setIsSpeaking: (isSpeaking: boolean) => void,

--- a/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
@@ -9,7 +9,7 @@ import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
  */
 export const useSpeechExecution = (
   selectedVoice: VoiceSelection,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   setIsSpeaking: (isSpeaking: boolean) => void,
   isPlayingRef: React.MutableRefObject<boolean>,
   advanceToNext: () => void,

--- a/src/hooks/vocabulary-playback/speech-playback/core/useVoiceManager.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useVoiceManager.ts
@@ -7,7 +7,7 @@ import { VoiceSelection } from '../../useVoiceSelection';
  */
 export const useVoiceManager = (selectedVoice: VoiceSelection) => {
   // Find voice by region
-  const findVoice = useCallback((region: 'US' | 'UK') => {
+  const findVoice = useCallback((region: 'US' | 'UK' | 'AU') => {
     const voices = window.speechSynthesis?.getVoices() || [];
     const lang = region === 'US' ? 'en-US' : 'en-GB';
     return voices.find(voice => voice.lang.startsWith(lang)) || null;

--- a/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
@@ -17,7 +17,7 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
   const { selectedVoice, cycleVoice, voices } = useVoiceSelection();
   
   // Find voice function
-  const findVoice = useCallback((region: 'US' | 'UK') => {
+  const findVoice = useCallback((region: 'US' | 'UK' | 'AU') => {
     return voices.find(voice => voice.region === region)?.voice || null;
   }, [voices]);
   

--- a/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
@@ -10,7 +10,7 @@ import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
  */
 export const useSimpleWordPlayback = (
   selectedVoice: VoiceSelection,
-  findVoice: (region: 'US' | 'UK') => SpeechSynthesisVoice | null,
+  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   goToNextWord: () => void,
   muted: boolean,
   paused: boolean

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect } from 'react';
 // Hard-coded voice names from previously working version
 const US_VOICE_NAME = "Samantha";
 const UK_VOICE_NAME = "Google UK English Female";
+const AU_VOICE_NAME = "Google AU English Female";
 
 export type VoiceOption = {
   label: string;
-  region: 'US' | 'UK';
+  region: 'US' | 'UK' | 'AU';
   gender: 'male' | 'female';
   voice: SpeechSynthesisVoice | null;
 };
@@ -15,7 +16,7 @@ export type VoiceOption = {
 // Define voice types with consistent structure
 export interface VoiceSelection {
   label: string;
-  region: 'US' | 'UK';
+  region: 'US' | 'UK' | 'AU';
   gender: 'male' | 'female';
   index: number;
 }
@@ -24,6 +25,7 @@ export interface VoiceSelection {
 const VOICE_OPTIONS: VoiceSelection[] = [
   { label: "US", region: "US", gender: "female", index: 0 },
   { label: "UK", region: "UK", gender: "female", index: 1 },
+  { label: "AU", region: "AU", gender: "female", index: 2 },
 ];
 
 const DEFAULT_VOICE_OPTION: VoiceSelection = VOICE_OPTIONS[0];
@@ -64,9 +66,13 @@ export const useVoiceSelection = () => {
                        availableVoices.find(v => v.name.includes(US_VOICE_NAME)) ||
                        availableVoices.find(v => v.lang === 'en-US');
                        
-        const ukVoice = availableVoices.find(v => v.name === UK_VOICE_NAME) || 
+        const ukVoice = availableVoices.find(v => v.name === UK_VOICE_NAME) ||
                        availableVoices.find(v => v.name.includes(UK_VOICE_NAME)) ||
                        availableVoices.find(v => v.lang === 'en-GB');
+
+        const auVoice = availableVoices.find(v => v.name === AU_VOICE_NAME) ||
+                       availableVoices.find(v => v.name.includes(AU_VOICE_NAME)) ||
+                       availableVoices.find(v => v.lang === 'en-AU');
         
         // Create simplified voice options
         const voiceOptions: VoiceOption[] = [
@@ -81,12 +87,19 @@ export const useVoiceSelection = () => {
             region: "UK" as const,
             gender: "female" as const,
             voice: ukVoice || null
+          },
+          {
+            label: "AU",
+            region: "AU" as const,
+            gender: "female" as const,
+            voice: auVoice || null
           }
         ];
         
         console.log('Voice options created:');
         console.log(`US voice: ${voiceOptions[0].voice?.name || 'not found'}`);
         console.log(`UK voice: ${voiceOptions[1].voice?.name || 'not found'}`);
+        console.log(`AU voice: ${voiceOptions[2].voice?.name || 'not found'}`);
         
         setVoices(voiceOptions);
         
@@ -126,9 +139,9 @@ export const useVoiceSelection = () => {
     };
   }, []);
   
-  // Function to change voice selection - toggle between US and UK
+  // Function to cycle through available voices
   const cycleVoice = () => {
-    const nextIndex = voiceIndex === 0 ? 1 : 0;  // Toggle between 0 and 1
+    const nextIndex = (voiceIndex + 1) % VOICE_OPTIONS.length;
     const nextVoice = VOICE_OPTIONS[nextIndex];
     
     console.log(`Cycling voice from ${selectedVoice.label} to ${nextVoice.label}`);

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -10,7 +10,7 @@ class DirectSpeechService {
   private completionTimeoutId: number | null = null;
 
   // Region-specific speech settings
-  private getRegionSettings(region: 'US' | 'UK') {
+  private getRegionSettings(region: 'US' | 'UK' | 'AU') {
     return {
       US: {
         rate: 0.75, // Slightly slower for better comprehension
@@ -19,6 +19,12 @@ class DirectSpeechService {
         pauseDuration: 600
       },
       UK: {
+        rate: 0.8,
+        pitch: 1.0,
+        volume: 1.0,
+        pauseDuration: 500
+      },
+      AU: {
         rate: 0.8,
         pitch: 1.0,
         volume: 1.0,
@@ -51,7 +57,7 @@ class DirectSpeechService {
   async speak(
     text: string, 
     options: {
-      voiceRegion?: 'US' | 'UK';
+      voiceRegion?: 'US' | 'UK' | 'AU';
       word?: string;
       meaning?: string;
       example?: string;

--- a/src/utils/speech/core/engineManager.ts
+++ b/src/utils/speech/core/engineManager.ts
@@ -3,8 +3,8 @@ import { SpeechSynthesisVoice } from '@/types/speech';
 import { getVoiceByRegion } from '../voiceUtils';
 import { getSpeechRate, getSpeechPitch, getSpeechVolume } from './speechSettings';
 
-export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 'US' | 'UK'): void => {
-  const langCode = region === 'US' ? 'en-US' : 'en-GB';
+export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 'US' | 'UK' | 'AU'): void => {
+  const langCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
   const voice = getVoiceByRegion(region);
   
   if (voice) {

--- a/src/utils/speech/core/speakWithVoice.ts
+++ b/src/utils/speech/core/speakWithVoice.ts
@@ -8,7 +8,7 @@ import { createSpeechMonitor, clearSpeechMonitor, SpeechMonitorRefs } from './sp
 
 interface SpeakWithVoiceParams {
   utterance: SpeechSynthesisUtterance;
-  region: 'US' | 'UK';
+  region: 'US' | 'UK' | 'AU';
   text: string;
   processedText: string;
   onComplete: () => void;
@@ -37,7 +37,7 @@ export async function speakWithVoice({
   await new Promise(resolve => setTimeout(resolve, domUpdateDelay));
   
   // Use the correct language code based on the selected region
-  const langCode = region === 'US' ? 'en-US' : 'en-GB';
+  const langCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
   console.log(`[VOICE] Using ${region} voice (${langCode})`);
   
   // First wait for voices to load (addressing the not-allowed error)

--- a/src/utils/speech/core/speechPlayer.ts
+++ b/src/utils/speech/core/speechPlayer.ts
@@ -12,7 +12,7 @@ import {
 
 export const speak = (
   text: string, 
-  region: 'US' | 'UK' = 'US', 
+  region: 'US' | 'UK' | 'AU' = 'US', 
   pauseRequestedRef?: React.MutableRefObject<boolean>
 ): Promise<string> => {
   return new Promise((resolve, reject) => {

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,10 +1,13 @@
 
-export const getVoiceRegionFromStorage = (): 'US' | 'UK' => {
+export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
   try {
     const storedStates = localStorage.getItem('buttonStates');
     if (storedStates) {
       const parsedStates = JSON.parse(storedStates);
-      return parsedStates.voiceRegion === 'UK' ? 'UK' : 'US';
+      if (parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU') {
+        return parsedStates.voiceRegion;
+      }
+      return 'US';
     }
   } catch (error) {
     console.error('Error reading voice region from localStorage:', error);

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -1,6 +1,6 @@
 import { VoiceSelection } from "@/hooks/vocabulary-playback/useVoiceSelection";
 
-// Updated voice names with better UK options
+// Updated voice names with better UK and AU options
 const US_VOICE_NAME = "Samantha"; // For US voice
 const UK_VOICE_NAMES = [
   "Google UK English Female", // Primary option
@@ -8,6 +8,12 @@ const UK_VOICE_NAMES = [
   "Kate", // Another backup
   "Susan", // Microsoft UK voice
   "Hazel" // Additional UK option
+];
+const AU_VOICE_NAMES = [
+  "Google AU English Female", // Primary option for AU
+  "Karen", // macOS AU voice
+  "Catherine", // Additional AU option
+  "Hayley" // Backup AU option
 ];
 
 export const findFallbackVoice = (voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {
@@ -26,7 +32,7 @@ export const findFallbackVoice = (voices: SpeechSynthesisVoice[]): SpeechSynthes
 };
 
 // Enhanced function to get voice by region with better UK voice selection
-export const getVoiceByRegion = (region: 'US' | 'UK', gender: 'male' | 'female' = 'female'): SpeechSynthesisVoice | null => {
+export const getVoiceByRegion = (region: 'US' | 'UK' | 'AU', gender: 'male' | 'female' = 'female'): SpeechSynthesisVoice | null => {
   const voices = window.speechSynthesis.getVoices();
   
   if (!voices || voices.length === 0) {
@@ -52,7 +58,7 @@ export const getVoiceByRegion = (region: 'US' | 'UK', gender: 'male' | 'female' 
       console.log(`Fallback US voice by language: ${voice.name} (${voice.lang})`);
       return voice;
     }
-  } else {
+  } else if (region === 'UK') {
     // Enhanced UK voice selection
     console.log('Searching for UK voice with enhanced selection...');
     
@@ -105,6 +111,43 @@ export const getVoiceByRegion = (region: 'US' | 'UK', gender: 'male' | 'female' 
         console.log(`Found UK voice by indicator "${indicator}": ${voice.name} (${voice.lang})`);
         return voice;
       }
+    }
+  }
+
+  else if (region === 'AU') {
+    console.log('Searching for AU voice...');
+
+    for (const auVoiceName of AU_VOICE_NAMES) {
+      let voice = voices.find(v => v.name === auVoiceName);
+
+      if (voice) {
+        console.log(`Found exact AU voice match: ${voice.name} (${voice.lang})`);
+        return voice;
+      }
+
+      voice = voices.find(v => v.name.includes(auVoiceName));
+
+      if (voice) {
+        console.log(`Found partial AU voice match: ${voice.name} (${voice.lang})`);
+        return voice;
+      }
+    }
+
+    let voice = voices.find(v =>
+      v.lang === 'en-AU' &&
+      (gender === 'female' ? !v.name.toLowerCase().includes('male') : v.name.toLowerCase().includes('male'))
+    );
+
+    if (voice) {
+      console.log(`Found AU voice by language and gender: ${voice.name} (${voice.lang})`);
+      return voice;
+    }
+
+    voice = voices.find(v => v.lang === 'en-AU');
+
+    if (voice) {
+      console.log(`Fallback AU voice by language: ${voice.name} (${voice.lang})`);
+      return voice;
     }
   }
   


### PR DESCRIPTION
## Summary
- add AU voice option to available voices
- update voice selection logic and region handling
- expand union types to support `AU` region
- support AU voice in speech utilities and controllers

## Testing
- `npm test`
- `npm run lint` *(fails: 41 errors, 30 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847ebf269b4832f9c15c84232a672b8