### PR TITLE
Add AU voice options and slower rates

### DIFF
--- a/src/hooks/speech/useVoiceSettings.tsx
+++ b/src/hooks/speech/useVoiceSettings.tsx
@@ -20,7 +20,10 @@ export const useVoiceSettings = () => {
         
         return {
           isMuted: parsedStates.isMuted === true,
-          voiceRegion: (parsedStates.voiceRegion === 'UK' ? 'UK' : 'US') as 'US' | 'UK' | 'AU'
+          voiceRegion:
+            parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU'
+              ? parsedStates.voiceRegion
+              : 'US'
         };
       }
     } catch (error) {

--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 // Hard-coded voice names from previously working version
 const US_VOICE_NAME = "Samantha";
 const UK_VOICE_NAME = "Google UK English Female";
+const AU_VOICE_NAME = "Google AU English Female";
 
 /**
  * Hook for managing voice selection and finding appropriate voices
@@ -14,7 +15,8 @@ export const useVoiceManagement = () => {
   // Define voice options with consistent structure
   const allVoiceOptions: VoiceSelection[] = [
     { label: "US", region: "US", gender: "female", index: 0 },
-    { label: "UK", region: "UK", gender: "female", index: 1 }
+    { label: "UK", region: "UK", gender: "female", index: 1 },
+    { label: "AU", region: "AU", gender: "female", index: 2 }
   ];
   
   const [voiceIndex, setVoiceIndex] = useState(0);
@@ -23,7 +25,8 @@ export const useVoiceManagement = () => {
   // Create voice options array for UI - compatibility format
   const voices = [
     { label: "US", region: "US" as const, gender: "female" as const, voice: null },
-    { label: "UK", region: "UK" as const, gender: "female" as const, voice: null }
+    { label: "UK", region: "UK" as const, gender: "female" as const, voice: null },
+    { label: "AU", region: "AU" as const, gender: "female" as const, voice: null }
   ];
   
   // Load initial voice settings from localStorage
@@ -87,7 +90,8 @@ export const useVoiceManagement = () => {
     }
     
     // Use hardcoded voice names
-    const targetVoiceName = region === 'US' ? US_VOICE_NAME : UK_VOICE_NAME;
+    const targetVoiceName =
+      region === 'US' ? US_VOICE_NAME : region === 'UK' ? UK_VOICE_NAME : AU_VOICE_NAME;
     
     // Strategy 1: Find exact name match
     let voice = allVoices.find(v => v.name === targetVoiceName);
@@ -108,7 +112,8 @@ export const useVoiceManagement = () => {
     // Fallback strategies
     
     // Strategy 3: Match by language code
-    voice = allVoices.find(v => v.lang === (region === 'US' ? 'en-US' : 'en-GB'));
+    const langCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
+    voice = allVoices.find(v => v.lang === langCode);
     
     if (voice) {
       console.log(`Selected ${region} voice by language code: ${voice.name} (${voice.lang})`);
@@ -133,10 +138,10 @@ export const useVoiceManagement = () => {
     return null;
   }, []);
   
-  // Function to cycle through voices (simplified to just toggle between US and UK)
+  // Function to cycle through voices including AU
   const cycleVoice = useCallback(() => {
     setVoiceIndex(prevIndex => {
-      const nextIndex = prevIndex === 0 ? 1 : 0;  // Toggle between 0 (US) and 1 (UK)
+      const nextIndex = (prevIndex + 1) % allVoiceOptions.length;
       console.log(`Cycling voice from ${allVoiceOptions[prevIndex].label} to ${allVoiceOptions[nextIndex].label}`);
       
       // Save to localStorage

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -4,7 +4,11 @@ import { useState, useEffect } from 'react';
 // Hard-coded voice names from previously working version
 const US_VOICE_NAME = "Samantha";
 const UK_VOICE_NAME = "Google UK English Female";
-const AU_VOICE_NAME = "Google AU English Female";
+const AU_VOICE_NAMES = [
+  "Google AU English Female",
+  "Google AU English Male",
+  "Karen"
+];
 
 export type VoiceOption = {
   label: string;
@@ -70,9 +74,16 @@ export const useVoiceSelection = () => {
                        availableVoices.find(v => v.name.includes(UK_VOICE_NAME)) ||
                        availableVoices.find(v => v.lang === 'en-GB');
 
-        const auVoice = availableVoices.find(v => v.name === AU_VOICE_NAME) ||
-                       availableVoices.find(v => v.name.includes(AU_VOICE_NAME)) ||
-                       availableVoices.find(v => v.lang === 'en-AU');
+        let auVoice: SpeechSynthesisVoice | undefined;
+        for (const auName of AU_VOICE_NAMES) {
+          auVoice =
+            availableVoices.find(v => v.name === auName) ||
+            availableVoices.find(v => v.name.includes(auName));
+          if (auVoice) break;
+        }
+        if (!auVoice) {
+          auVoice = availableVoices.find(v => v.lang === 'en-AU');
+        }
         
         // Create simplified voice options
         const voiceOptions: VoiceOption[] = [

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -13,7 +13,7 @@ class DirectSpeechService {
   private getRegionSettings(region: 'US' | 'UK' | 'AU') {
     return {
       US: {
-        rate: 0.75, // Slightly slower for better comprehension
+        rate: 0.7, // Slower for better comprehension
         pitch: 1.0,
         volume: 1.0,
         pauseDuration: 600
@@ -25,7 +25,7 @@ class DirectSpeechService {
         pauseDuration: 500
       },
       AU: {
-        rate: 0.8,
+        rate: 0.7,
         pitch: 1.0,
         volume: 1.0,
         pauseDuration: 500

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -17,7 +17,10 @@ export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
 
 export const getSpeechRate = (): number => {
   const region = getVoiceRegionFromStorage();
-  return region === 'US' ? 0.8 : 1.0;
+  if (region === 'US' || region === 'AU') {
+    return 0.7;
+  }
+  return 1.0;
 };
 
 export const getSpeechPitch = (): number => {

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -11,6 +11,7 @@ const UK_VOICE_NAMES = [
 ];
 const AU_VOICE_NAMES = [
   "Google AU English Female", // Primary option for AU
+  "Google AU English Male", // New male AU option
   "Karen", // macOS AU voice
   "Catherine", // Additional AU option
   "Hayley" // Backup AU option


### PR DESCRIPTION
## Summary
- support AU voice in voice management and voice selection
- include new Google AU English Male voice
- slow down US and AU speech rates
- remember AU voice region when loading saved settings
- cycle through US/UK/AU voices

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6847f82c1f2c832f9f995c570d8672ae