### PR TITLE
Fix incorrect string in vocabulary

### DIFF
--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -2764,7 +2764,7 @@ export const DEFAULT_VOCABULARY_DATA: SheetData = {
     },
     {
       "word": "get/catch sb’s drift",
-      "meaning": "understand the basic "meaning": nắm được ý chính.",
+      "meaning": "understand the basic meaning: nắm được ý chính.",
       "example": "Doreen and I have been having some problems recently, if you catch my drift.",
       "count": 0
     },


### PR DESCRIPTION
## Summary
- correct the `meaning` text for "get/catch sb’s drift" in defaultVocabulary.ts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847fe07e6a8832f9376fd29d6e03bdf