### PR TITLE
Fix speech filter for word type notes

### DIFF
--- a/src/utils/text/contentFilters.ts
+++ b/src/utils/text/contentFilters.ts
@@ -46,14 +46,12 @@ export const extractSpeechableContent = (text: string): string => {
   
   let processedText = text;
   
-  // Remove content in square brackets (often IPA notation)
-  processedText = processedText.replace(/\[([^\]]*)\]/g, (match, content) => {
-    // If the bracketed content is short and looks like a word type, keep it
-    if (content.length < 20 && /^[a-zA-Z\s]+$/.test(content)) {
-      return `(${content})`;
-    }
-    return ''; // Remove IPA notation in brackets
-  });
+  // Remove content in square brackets (often IPA notation or word type)
+  // Always strip this content from the spoken text
+  processedText = processedText.replace(/\[[^\]]*\]/g, '');
+
+  // Remove short parenthetical word type labels like "(adj)" or "(noun)"
+  processedText = processedText.replace(/\([a-zA-Z.\s]{1,20}\)/g, '');
   
   // Remove content between forward slashes (phonetic transcription)
   processedText = processedText.replace(/\/([^/]*)\//g, '');

--- a/tests/contentFilters.test.ts
+++ b/tests/contentFilters.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { extractSpeechableContent } from '../src/utils/text/contentFilters';
+
+describe('extractSpeechableContent', () => {
+  it('removes IPA and word type annotations', () => {
+    const input = 'quick (adj) [kwiːk]';
+    const result = extractSpeechableContent(input);
+    expect(result).toBe('quick');
+  });
+});


### PR DESCRIPTION
## Summary
- strip bracketed IPA/word type text from spoken output
- remove short parenthetical word type labels like `(adj)`
- test content filter behavior

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_684802a7b358832fb47e43807dbcfa6b