### PR TITLE
Update AU voice preference to more energetic option

### DIFF
--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -5,9 +5,11 @@ import { useState, useEffect } from 'react';
 const US_VOICE_NAME = "Samantha";
 const UK_VOICE_NAME = "Google UK English Female";
 const AU_VOICE_NAMES = [
-  "Google AU English Female",
+  "Hayley",
   "Google AU English Male",
-  "Karen"
+  "Google AU English Female",
+  "Karen",
+  "Catherine"
 ];
 
 export type VoiceOption = {

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -10,11 +10,11 @@ const UK_VOICE_NAMES = [
   "Hazel" // Additional UK option
 ];
 const AU_VOICE_NAMES = [
-  "Google AU English Female", // Primary option for AU
-  "Google AU English Male", // New male AU option
+  "Hayley", // Energetic AU voice
+  "Google AU English Male", // Younger male AU option
+  "Google AU English Female", // Original female option
   "Karen", // macOS AU voice
-  "Catherine", // Additional AU option
-  "Hayley" // Backup AU option
+  "Catherine" // Additional AU option
 ];
 
 export const findFallbackVoice = (voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {


### PR DESCRIPTION
## Summary
- reorder AU voice list to prioritize `Hayley` then `Google AU English Male` for a younger, more animated sound
- keep original voice options as fallbacks

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684808343a24832fb16db28f40a58e29