### PR TITLE
Set UK as default voice region

### DIFF
--- a/src/hooks/speech/useVoiceSettings.tsx
+++ b/src/hooks/speech/useVoiceSettings.tsx
@@ -20,16 +20,16 @@ export const useVoiceSettings = () => {
         
         return {
           isMuted: parsedStates.isMuted === true,
-          voiceRegion:
-            parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU'
-              ? parsedStates.voiceRegion
-              : 'US'
+            voiceRegion:
+              parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU'
+                ? parsedStates.voiceRegion
+                : 'UK'
         };
       }
     } catch (error) {
       console.error('Error reading button states from localStorage:', error);
     }
-    return { isMuted: false, voiceRegion: 'US' };
+    return { isMuted: false, voiceRegion: 'UK' };
   };
 
   const { isMuted: initialMuted, voiceRegion: initialVoiceRegion } = getInitialStates();

--- a/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
@@ -13,7 +13,7 @@ export const useSimpleVocabularyController = () => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('UK');
   
   // Refs to track state and prevent race conditions
   const speechInProgressRef = useRef(false);

--- a/src/hooks/vocabulary-controller/useVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useVocabularyController.ts
@@ -14,7 +14,7 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('UK');
   
   // Refs to prevent unnecessary effects and manage state
   const lastWordRef = useRef<string | null>(null);

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -34,12 +34,12 @@ const VOICE_OPTIONS: VoiceSelection[] = [
   { label: "AU", region: "AU", gender: "female", index: 2 },
 ];
 
-const DEFAULT_VOICE_OPTION: VoiceSelection = VOICE_OPTIONS[0];
+const DEFAULT_VOICE_OPTION: VoiceSelection = VOICE_OPTIONS[1];
 
 export const useVoiceSelection = () => {
   const [voices, setVoices] = useState<VoiceOption[]>([]);
   const [selectedVoice, setSelectedVoice] = useState<VoiceSelection>(DEFAULT_VOICE_OPTION);
-  const [voiceIndex, setVoiceIndex] = useState<number>(0);
+  const [voiceIndex, setVoiceIndex] = useState<number>(1);
   
   // Load available voices when the component mounts
   useEffect(() => {

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -2,17 +2,17 @@
 export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
   try {
     const storedStates = localStorage.getItem('buttonStates');
-    if (storedStates) {
-      const parsedStates = JSON.parse(storedStates);
-      if (parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU') {
-        return parsedStates.voiceRegion;
+      if (storedStates) {
+        const parsedStates = JSON.parse(storedStates);
+        if (parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU') {
+          return parsedStates.voiceRegion;
+        }
+        return 'UK';
       }
-      return 'US';
-    }
   } catch (error) {
     console.error('Error reading voice region from localStorage:', error);
   }
-  return 'US'; // Default to US if not found or error
+  return 'UK'; // Default to UK if not found or error
 };
 
 export const getSpeechRate = (): number => {

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -13,7 +13,7 @@ const controllerState = {
   isPaused: false,
   isMuted: false,
   isSpeaking: false,
-  voiceRegion: 'US' as const,
+  voiceRegion: 'UK' as const,
   togglePause: vi.fn(),
   toggleMute: vi.fn(),
   goToNext: vi.fn(),
@@ -32,10 +32,10 @@ vi.mock('../src/hooks/vocabulary-playback/useVoiceSelection', () => {
   return {
     useVoiceSelection: () => {
       const [selectedVoice, setSelectedVoice] = React.useState({
-        label: 'US',
-        region: 'US' as const,
+        label: 'UK',
+        region: 'UK' as const,
         gender: 'female' as const,
-        index: 0,
+        index: 1,
       });
 
       const cycleVoice = () => {
@@ -72,12 +72,12 @@ describe('VocabularyContainer voice toggle', () => {
   it('keeps label and controller.voiceRegion in sync', async () => {
     render(<VocabularyContainer />);
 
-    const toggleBtn = screen.getByRole('button', { name: 'US' });
-    expect(controllerState.voiceRegion).toBe('US');
+    const toggleBtn = screen.getByRole('button', { name: 'UK' });
+    expect(controllerState.voiceRegion).toBe('UK');
 
     await userEvent.click(toggleBtn);
 
-    expect(screen.getByRole('button', { name: 'UK' })).toBeInTheDocument();
-    expect(controllerState.voiceRegion).toBe('UK');
+    expect(screen.getByRole('button', { name: 'AU' })).toBeInTheDocument();
+    expect(controllerState.voiceRegion).toBe('AU');
   });
 });


### PR DESCRIPTION
## Summary
- default region is UK for vocabulary controllers and voice settings hooks
- update initial voice selection to UK
- update fallback region from storage to UK
- adjust tests for new default region

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482357d414832f8994dc4991786f0c