### PR TITLE
Lower US and AU speech rate

### DIFF
--- a/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
@@ -64,7 +64,7 @@ export const createUtterance = (
     }
     
     // Configure speech properties for much slower, clearer speech
-    utterance.rate = 0.7;   // Much slower rate for better comprehension
+    utterance.rate = 0.6;   // Much slower rate for better comprehension
     utterance.pitch = 1.0;  // Default pitch
     utterance.volume = 1.0; // Full volume
     

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -15,7 +15,7 @@ class DirectSpeechService {
   private getRegionSettings(region: 'US' | 'UK' | 'AU') {
     return {
       US: {
-        rate: 0.7, // Slower for better comprehension
+        rate: 0.6, // Slower for better comprehension
         pitch: 1.0,
         volume: 1.0,
         pauseDuration: 600
@@ -27,7 +27,7 @@ class DirectSpeechService {
         pauseDuration: 500
       },
       AU: {
-        rate: 0.7,
+        rate: 0.6,
         pitch: 1.0,
         volume: 1.0,
         pauseDuration: 500

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -18,7 +18,7 @@ export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
 export const getSpeechRate = (): number => {
   const region = getVoiceRegionFromStorage();
   if (region === 'US' || region === 'AU') {
-    return 0.7;
+    return 0.6;
   }
   return 1.0;
 };


### PR DESCRIPTION
## Summary
- reduce default speaking rate for US/AU voices
- update direct speech service settings
- update vocabulary playback utterance setup

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684823534d5c832f8d89827578994b70