### PR TITLE
Update tests for UK default voice

### DIFF
--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -13,7 +13,7 @@ const controllerState = {
   isPaused: false,
   isMuted: false,
   isSpeaking: false,
-  voiceRegion: 'US' as const,
+  voiceRegion: 'UK' as const,
   togglePause: vi.fn(),
   toggleMute: vi.fn(),
   goToNext: vi.fn(),
@@ -32,15 +32,19 @@ vi.mock('../src/hooks/vocabulary-playback/useVoiceSelection', () => {
   return {
     useVoiceSelection: () => {
       const [selectedVoice, setSelectedVoice] = React.useState({
-        label: 'US',
-        region: 'US' as const,
+        label: 'UK',
+        region: 'UK' as const,
         gender: 'female' as const,
         index: 0,
       });
 
       const cycleVoice = () => {
-        controllerState.toggleVoice();
-        const region = controllerState.voiceRegion;
+        const region =
+          selectedVoice.region === 'US'
+            ? 'UK'
+            : selectedVoice.region === 'UK'
+            ? 'AU'
+            : 'US';
         setSelectedVoice({ label: region, region, gender: 'female', index: 0 });
       };
 
@@ -72,12 +76,12 @@ describe('VocabularyContainer voice toggle', () => {
   it('keeps label and controller.voiceRegion in sync', async () => {
     render(<VocabularyContainer />);
 
-    const toggleBtn = screen.getByRole('button', { name: 'US' });
-    expect(controllerState.voiceRegion).toBe('US');
+    const toggleBtn = screen.getByRole('button', { name: 'UK' });
+    expect(controllerState.voiceRegion).toBe('UK');
 
     await userEvent.click(toggleBtn);
 
-    expect(screen.getByRole('button', { name: 'UK' })).toBeInTheDocument();
-    expect(controllerState.voiceRegion).toBe('UK');
+    expect(screen.getByRole('button', { name: 'AU' })).toBeInTheDocument();
+    expect(controllerState.voiceRegion).toBe('AU');
   });
 });

--- a/tests/voiceUtils.test.ts
+++ b/tests/voiceUtils.test.ts
@@ -24,7 +24,7 @@ describe('hasAvailableVoices', () => {
 
   it('returns true when voices are available', () => {
     (window as MockWindow).speechSynthesis.getVoices = () => [
-      { lang: 'en-US', name: 'A' }
+      { lang: 'en-GB', name: 'Google UK English Female' }
     ];
     expect(hasAvailableVoices()).toBe(true);
   });


### PR DESCRIPTION
## Summary
- adjust mocks in `vocabularyContainerVoiceToggle.test.tsx` to start with the UK voice
- update expectations to reflect the new UK->AU cycle
- update `voiceUtils` test with new UK voice name

## Testing
- `npx vitest run tests/vocabularyContainerVoiceToggle.test.tsx --maxWorkers=1 --reporter basic` *(fails: RangeError: options.minThreads and options.maxThreads must not conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6848236b893c832f9533b500d43acb8d