### PR TITLE
Add direct voice region buttons and default UK region

### DIFF
--- a/src/components/NotificationManager.tsx
+++ b/src/components/NotificationManager.tsx
@@ -32,7 +32,7 @@ interface NotificationManagerProps {
 const NotificationManager: React.FC<NotificationManagerProps> = ({ 
   onNotificationsEnabled,
   currentWord,
-  voiceRegion = 'US'
+  voiceRegion = 'UK'
 }) => {
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [permissionState, setPermissionState] = useState<string>('default');

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -13,6 +13,7 @@ interface ContentWithDataNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
+  handleSetVoiceRegion: (region: 'US' | 'UK' | 'AU') => void;
   handleSwitchCategory: () => void;
   currentCategory: string;
   nextCategory: string | null;
@@ -37,6 +38,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
+  handleSetVoiceRegion,
   handleSwitchCategory,
   currentCategory,
   nextCategory,
@@ -63,6 +65,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         toggleMute={toggleMute}
         handleTogglePause={handleTogglePause}
         handleCycleVoice={handleCycleVoice}
+        handleSetVoiceRegion={handleSetVoiceRegion}
         handleSwitchCategory={handleSwitchCategory}
         currentCategory={currentCategory}
         nextCategory={nextCategory}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -45,6 +45,7 @@ const VocabularyAppContainerNew: React.FC = () => {
     togglePause,
     toggleMute,
     toggleVoice,
+    setVoiceRegion,
     playCurrentWord,
     wordCount
   } = useVocabularyController(wordList || []);
@@ -111,6 +112,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           toggleMute={toggleMute}
           handleTogglePause={togglePause}
           handleCycleVoice={toggleVoice}
+          handleSetVoiceRegion={setVoiceRegion}
           handleSwitchCategory={handleSwitchCategoryWithState}
           currentCategory={currentCategory}
           nextCategory={nextCategory}
@@ -138,6 +140,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           onToggleMute={toggleMute}
           onTogglePause={togglePause}
           onCycleVoice={toggleVoice}
+          onSetVoiceRegion={setVoiceRegion}
           onSwitchCategory={handleSwitchCategoryWithState}
           onNextWord={() => {}}
           currentCategory={currentCategory}

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -15,6 +15,7 @@ interface VocabularyCardNewProps {
   onToggleMute: () => void;
   onTogglePause: () => void;
   onCycleVoice: () => void;
+  onSetVoiceRegion: (region: 'US' | 'UK' | 'AU') => void;
   onSwitchCategory: () => void;
   onNextWord: () => void;
   currentCategory: string;
@@ -35,6 +36,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   onToggleMute,
   onTogglePause,
   onCycleVoice,
+  onSetVoiceRegion,
   onSwitchCategory,
   onNextWord,
   currentCategory,
@@ -148,10 +150,35 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
                 'Next'}
             </Button>
             
-            {/* Voice toggle button with simplified region display */}
+            {/* Voice selection buttons */}
             <Button
-              variant="outline" 
-              size="sm" 
+              variant="outline"
+              size="sm"
+              onClick={() => onSetVoiceRegion('US')}
+              className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
+            >
+              US
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onSetVoiceRegion('UK')}
+              className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
+            >
+              UK
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onSetVoiceRegion('AU')}
+              className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
+            >
+              AU
+            </Button>
+            {/* Existing cycle button for convenience */}
+            <Button
+              variant="outline"
+              size="sm"
               onClick={onCycleVoice}
               className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
             >

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -11,6 +11,7 @@ interface VocabularyMainNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
+  handleSetVoiceRegion: (region: 'US' | 'UK' | 'AU') => void;
   handleSwitchCategory: () => void;
   handleManualNext: () => void;
   currentCategory: string;
@@ -27,6 +28,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
+  handleSetVoiceRegion,
   handleSwitchCategory,
   currentCategory,
   nextCategory,
@@ -49,6 +51,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
         onToggleMute={toggleMute}
         onTogglePause={handleTogglePause}
         onCycleVoice={handleCycleVoice}
+        onSetVoiceRegion={handleSetVoiceRegion}
         onSwitchCategory={handleSwitchCategory}
         onNextWord={handleManualNext}
         currentCategory={currentCategory}

--- a/src/hooks/speech/useVoiceSettings.tsx
+++ b/src/hooks/speech/useVoiceSettings.tsx
@@ -21,15 +21,15 @@ export const useVoiceSettings = () => {
         return {
           isMuted: parsedStates.isMuted === true,
           voiceRegion:
-            parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU'
+            parsedStates.voiceRegion === 'US' || parsedStates.voiceRegion === 'AU'
               ? parsedStates.voiceRegion
-              : 'US'
+              : 'UK'
         };
       }
     } catch (error) {
       console.error('Error reading button states from localStorage:', error);
     }
-    return { isMuted: false, voiceRegion: 'US' };
+    return { isMuted: false, voiceRegion: 'UK' };
   };
 
   const { isMuted: initialMuted, voiceRegion: initialVoiceRegion } = getInitialStates();

--- a/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
@@ -13,7 +13,7 @@ export const useSimpleVocabularyController = () => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('UK');
   
   // Refs to track state and prevent race conditions
   const speechInProgressRef = useRef(false);
@@ -229,6 +229,7 @@ export const useSimpleVocabularyController = () => {
     togglePause,
     toggleMute,
     toggleVoice,
+    setVoiceRegion,
     playCurrentWord
   };
 };

--- a/src/hooks/vocabulary-controller/useVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useVocabularyController.ts
@@ -14,7 +14,7 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('US');
+  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>('UK');
   
   // Refs to prevent unnecessary effects and manage state
   const lastWordRef = useRef<string | null>(null);
@@ -223,6 +223,7 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
     togglePause,
     toggleMute,
     toggleVoice,
+    setVoiceRegion,
     playCurrentWord,
     wordCount: wordList.length
   };

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -4,15 +4,15 @@ export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
     const storedStates = localStorage.getItem('buttonStates');
     if (storedStates) {
       const parsedStates = JSON.parse(storedStates);
-      if (parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU') {
+      if (parsedStates.voiceRegion === 'US' || parsedStates.voiceRegion === 'AU') {
         return parsedStates.voiceRegion;
       }
-      return 'US';
+      return 'UK';
     }
   } catch (error) {
     console.error('Error reading voice region from localStorage:', error);
   }
-  return 'US'; // Default to US if not found or error
+  return 'UK'; // Default to UK if not found or error
 };
 
 export const getSpeechRate = (): number => {

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -13,7 +13,7 @@ const controllerState = {
   isPaused: false,
   isMuted: false,
   isSpeaking: false,
-  voiceRegion: 'US' as const,
+  voiceRegion: 'UK' as const,
   togglePause: vi.fn(),
   toggleMute: vi.fn(),
   goToNext: vi.fn(),
@@ -32,16 +32,21 @@ vi.mock('../src/hooks/vocabulary-playback/useVoiceSelection', () => {
   return {
     useVoiceSelection: () => {
       const [selectedVoice, setSelectedVoice] = React.useState({
-        label: 'US',
-        region: 'US' as const,
+        label: 'UK',
+        region: 'UK' as const,
         gender: 'female' as const,
-        index: 0,
+        index: 1,
       });
 
       const cycleVoice = () => {
-        controllerState.toggleVoice();
-        const region = controllerState.voiceRegion;
-        setSelectedVoice({ label: region, region, gender: 'female', index: 0 });
+        const options = [
+          { label: 'US', region: 'US' as const },
+          { label: 'UK', region: 'UK' as const },
+          { label: 'AU', region: 'AU' as const }
+        ];
+        const next =
+          options[(selectedVoice.index + 1) % options.length];
+        setSelectedVoice({ ...next, gender: 'female', index: (selectedVoice.index + 1) % options.length });
       };
 
       return { selectedVoice, cycleVoice };
@@ -72,12 +77,12 @@ describe('VocabularyContainer voice toggle', () => {
   it('keeps label and controller.voiceRegion in sync', async () => {
     render(<VocabularyContainer />);
 
-    const toggleBtn = screen.getByRole('button', { name: 'US' });
-    expect(controllerState.voiceRegion).toBe('US');
+    const toggleBtn = screen.getByRole('button', { name: 'UK' });
+    expect(controllerState.voiceRegion).toBe('UK');
 
     await userEvent.click(toggleBtn);
 
-    expect(screen.getByRole('button', { name: 'UK' })).toBeInTheDocument();
-    expect(controllerState.voiceRegion).toBe('UK');
+    expect(screen.getByRole('button', { name: 'AU' })).toBeInTheDocument();
+    expect(controllerState.voiceRegion).toBe('AU');
   });
 });


### PR DESCRIPTION
## Summary
- add dedicated US/UK/AU voice region buttons in `VocabularyCardNew`
- pass new voice region setter through app container components
- default all voice settings to "UK"
- update tests for new default and selection logic

## Testing
- `npx vitest run tests/vocabularyContainerVoiceToggle.test.tsx`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68482357de9c832f8248b97b800062e4