### PR TITLE
Update default speech voice names

### DIFF
--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -4,9 +4,9 @@ import { VoiceSelection } from '../useVoiceSelection';
 import { toast } from 'sonner';
 
 // Hard-coded voice names from previously working version
-const US_VOICE_NAME = "Samantha";
+const US_VOICE_NAME = "en-US-Standard-G";
 const UK_VOICE_NAME = "Google UK English Female";
-const AU_VOICE_NAME = "Google AU English Female";
+const AU_VOICE_NAME = "en-AU-Standard-C";
 
 /**
  * Hook for managing voice selection and finding appropriate voices

--- a/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
@@ -2,7 +2,7 @@
 import { VoiceSelection } from '../useVoiceSelection';
 
 // Hard-coded voice names based on previously working version
-const US_VOICE_NAME = "Samantha"; // For US voice
+const US_VOICE_NAME = "en-US-Standard-G"; // For US voice
 const UK_VOICE_NAME = "Google UK English Female"; // For UK voice
 
 // Backup voice names in case primary ones aren't found

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -2,10 +2,10 @@
 import { useState, useEffect } from 'react';
 
 // Hard-coded voice names from previously working version
-const US_VOICE_NAME = "Samantha";
+const US_VOICE_NAME = "en-US-Standard-G";
 const UK_VOICE_NAME = "Google UK English Female";
 const AU_VOICE_NAMES = [
-  "Hayley",
+  "en-AU-Standard-C",
   "Google AU English Male",
   "Google AU English Female",
   "Karen",

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -1,7 +1,7 @@
 import { VoiceSelection } from "@/hooks/vocabulary-playback/useVoiceSelection";
 
 // Updated voice names with better UK and AU options
-const US_VOICE_NAME = "Samantha"; // For US voice
+const US_VOICE_NAME = "en-US-Standard-G"; // For US voice
 const UK_VOICE_NAMES = [
   "Google UK English Female", // Primary option
   "Daniel", // Backup UK voice
@@ -10,7 +10,7 @@ const UK_VOICE_NAMES = [
   "Hazel" // Additional UK option
 ];
 const AU_VOICE_NAMES = [
-  "Hayley", // Energetic AU voice
+  "en-AU-Standard-C", // Energetic AU voice
   "Google AU English Male", // Younger male AU option
   "Google AU English Female", // Original female option
   "Karen", // macOS AU voice


### PR DESCRIPTION
## Summary
- adjust US default voice to `en-US-Standard-G`
- update AU fallback arrays to start with `en-AU-Standard-C`
- keep the same fallback ordering across all voice utilities and hooks

## Testing
- `npx vitest --run`

------
https://chatgpt.com/codex/tasks/task_e_6848290d815c832fa8bc05bcfca74210