### PR TITLE
Fix speech interruptions and refine phonetic filtering

### DIFF
--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -74,7 +74,7 @@ class DirectSpeechService {
   }
 
   async speak(
-    text: string, 
+    text: string,
     options: {
       voiceRegion?: 'US' | 'UK' | 'AU';
       word?: string;
@@ -88,8 +88,13 @@ class DirectSpeechService {
     const region = options.voiceRegion || 'US';
     console.log(`[DIRECT-SPEECH] speak() called - Region: ${region}, Word: ${options.word || 'N/A'}`);
 
-    // Stop any existing speech
-    this.stop();
+    // Ensure any existing speech has fully stopped before starting a new one
+    if (this.isActive) {
+      this.stop();
+      // Brief pause allows the speech engine to settle and prevents
+      // immediate 'interrupted' errors when starting the next utterance
+      await new Promise((r) => setTimeout(r, 150));
+    }
     this.wasManuallyStopped = false;
     
     return new Promise((resolve) => {

--- a/src/utils/text/contentFilters.ts
+++ b/src/utils/text/contentFilters.ts
@@ -55,6 +55,10 @@ export const extractSpeechableContent = (text: string): string => {
   
   // Remove content between forward slashes (phonetic transcription)
   processedText = processedText.replace(/\/([^/]*)\//g, '');
+
+  // Remove any leading or trailing forward slash segments that might remain
+  // after earlier filtering (e.g. /ˈbjuːtɪfəl/)
+  processedText = processedText.replace(/^\s*\/[^/]*\/\s*|\s*\/[^/]*\/\s*$/g, '');
   
   // Remove standalone IPA characters but preserve words containing them
   // Only remove if the entire word consists mainly of IPA characters


### PR DESCRIPTION
## Summary
- prevent new utterances from starting before the previous one stops
- strip leading or trailing phonetic notation before speech

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68482ab7ac28832f89524497f9c23cbc