### PR TITLE
Improve voice toggle cycling

### DIFF
--- a/src/components/VocabularyCard.tsx
+++ b/src/components/VocabularyCard.tsx
@@ -24,6 +24,7 @@ interface VocabularyCardProps {
   displayTime?: number;
   category?: string;
   selectedVoice: VoiceSelection;
+  nextVoiceLabel: string;
 }
 
 const VocabularyCard: React.FC<VocabularyCardProps> = ({
@@ -43,7 +44,8 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   isSpeaking = false,
   displayTime,
   category,
-  selectedVoice
+  selectedVoice,
+  nextVoiceLabel
 }) => {
   // Store current word in localStorage to help track sync issues
   useEffect(() => {
@@ -152,12 +154,12 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             
             {/* Single voice toggle button */}
             <Button
-              variant="outline" 
-              size="sm" 
+              variant="outline"
+              size="sm"
               onClick={onCycleVoice}
               className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
             >
-              {selectedVoice.label}
+              {nextVoiceLabel}
             </Button>
           </div>
         </div>

--- a/src/components/vocabulary-app/ContentWithData.tsx
+++ b/src/components/vocabulary-app/ContentWithData.tsx
@@ -21,6 +21,7 @@ interface ContentWithDataProps {
   handleManualNext: () => void;
   displayTime: number;
   selectedVoice: VoiceSelection;
+  nextVoiceLabel: string;
   debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
@@ -45,6 +46,7 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
   handleManualNext,
   displayTime,
   selectedVoice,
+  nextVoiceLabel,
   debugPanelData,
   isAddWordModalOpen,
   handleCloseModal,
@@ -71,6 +73,7 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
         handleManualNext={handleManualNext}
         displayTime={displayTime}
         selectedVoice={selectedVoice}
+        nextVoiceLabel={nextVoiceLabel}
       />
       
       {/* Action buttons container */}

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -13,6 +13,7 @@ interface ContentWithDataNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
+  nextVoiceLabel: string;
   handleSwitchCategory: () => void;
   currentCategory: string;
   nextCategory: string | null;
@@ -20,6 +21,7 @@ interface ContentWithDataNewProps {
   handleManualNext: () => void;
   displayTime: number;
   voiceRegion: 'US' | 'UK' | 'AU';
+  nextVoiceLabel: string;
   debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
@@ -37,6 +39,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
+  nextVoiceLabel,
   handleSwitchCategory,
   currentCategory,
   nextCategory,
@@ -44,6 +47,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleManualNext,
   displayTime,
   voiceRegion,
+  nextVoiceLabel,
   debugPanelData,
   isAddWordModalOpen,
   handleCloseModal,
@@ -70,6 +74,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         handleManualNext={handleManualNext}
         displayTime={displayTime}
         voiceRegion={voiceRegion}
+        nextVoiceLabel={nextVoiceLabel}
       />
       
       {/* Action buttons container */}

--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -53,6 +53,13 @@ const VocabularyAppContainer: React.FC = () => {
     allVoiceOptions
   } = useVocabularyPlayback(wordList || []);
 
+  const nextVoiceLabel =
+    selectedVoice.region === 'UK'
+      ? 'US'
+      : selectedVoice.region === 'US'
+      ? 'AU'
+      : 'US';
+
   console.log('[VOCAB-CONTAINER] Playback state:', {
     playbackCurrentWord: playbackCurrentWord?.word,
     muted,
@@ -166,6 +173,7 @@ const VocabularyAppContainer: React.FC = () => {
           toggleMute={handleToggleMuteWithInteraction}
           handleTogglePause={handleTogglePauseWithInteraction}
           handleCycleVoice={handleCycleVoiceWithInteraction}
+          nextVoiceLabel={nextVoiceLabel}
           handleSwitchCategory={handleCategorySwitchDirect}
           currentCategory={currentCategory}
           nextCategory={nextCategory}
@@ -173,6 +181,7 @@ const VocabularyAppContainer: React.FC = () => {
           handleManualNext={handleManualNext}
           displayTime={displayTime}
           selectedVoice={selectedVoice}
+          nextVoiceLabel={nextVoiceLabel}
           debugPanelData={debugData}
           isAddWordModalOpen={isAddWordModalOpen}
           handleCloseModal={handleCloseModal}
@@ -200,6 +209,7 @@ const VocabularyAppContainer: React.FC = () => {
           isSpeaking={false}
           category={currentCategory}
           selectedVoice={selectedVoice}
+          nextVoiceLabel={nextVoiceLabel}
         />
       ) : (
         <p>Loading vocabulary…</p>

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -49,6 +49,9 @@ const VocabularyAppContainerNew: React.FC = () => {
     wordCount
   } = useVocabularyController(wordList || []);
 
+  const nextVoiceLabel =
+    voiceRegion === 'UK' ? 'US' : voiceRegion === 'US' ? 'AU' : 'US';
+
   console.log('[VOCAB-CONTAINER-NEW] Controller state:', {
     currentWord: currentWord?.word,
     currentIndex,
@@ -111,6 +114,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           toggleMute={toggleMute}
           handleTogglePause={togglePause}
           handleCycleVoice={toggleVoice}
+          nextVoiceLabel={nextVoiceLabel}
           handleSwitchCategory={handleSwitchCategoryWithState}
           currentCategory={currentCategory}
           nextCategory={nextCategory}
@@ -118,6 +122,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           handleManualNext={handleManualNext}
           displayTime={displayTime}
           voiceRegion={voiceRegion}
+          nextVoiceLabel={nextVoiceLabel}
           debugPanelData={debugData}
           isAddWordModalOpen={isAddWordModalOpen}
           handleCloseModal={handleCloseModal}
@@ -145,6 +150,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           isSpeaking={false}
           category={currentCategory}
           voiceRegion={voiceRegion}
+          nextVoiceLabel={nextVoiceLabel}
         />
       ) : (
         <p>Loading vocabulary…</p>

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -24,6 +24,7 @@ interface VocabularyCardProps {
   displayTime?: number;
   category?: string;
   selectedVoice: VoiceSelection;
+  nextVoiceLabel: string;
 }
 
 const VocabularyCard: React.FC<VocabularyCardProps> = ({
@@ -42,7 +43,8 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   nextCategory,
   isSpeaking = false,
   category,
-  selectedVoice
+  selectedVoice,
+  nextVoiceLabel
 }) => {
   // Store current word in localStorage to help track sync issues
   useEffect(() => {
@@ -151,12 +153,12 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             
             {/* Single voice toggle button */}
             <Button
-              variant="outline" 
-              size="sm" 
+              variant="outline"
+              size="sm"
               onClick={onCycleVoice}
               className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
             >
-              {selectedVoice.label}
+              {nextVoiceLabel}
             </Button>
           </div>
         </div>

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -23,6 +23,7 @@ interface VocabularyCardNewProps {
   displayTime?: number;
   category?: string;
   voiceRegion: 'US' | 'UK' | 'AU';
+  nextVoiceLabel: string;
 }
 
 const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
@@ -41,7 +42,8 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   nextCategory,
   isSpeaking = false,
   category,
-  voiceRegion
+  voiceRegion,
+  nextVoiceLabel
 }) => {
   // Store current word in localStorage to help track sync issues
   useEffect(() => {
@@ -150,12 +152,12 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
             
             {/* Voice toggle button with simplified region display */}
             <Button
-              variant="outline" 
-              size="sm" 
+              variant="outline"
+              size="sm"
               onClick={onCycleVoice}
               className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
             >
-              {voiceRegion}
+              {nextVoiceLabel}
             </Button>
           </div>
         </div>

--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -19,6 +19,7 @@ interface VocabularyMainProps {
   isSoundPlaying: boolean;
   displayTime: number;
   selectedVoice: VoiceSelection;
+  nextVoiceLabel: string;
 }
 
 const VocabularyMain: React.FC<VocabularyMainProps> = ({
@@ -35,6 +36,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
   handleManualNext,
   displayTime,
   selectedVoice,
+  nextVoiceLabel,
 }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -57,6 +59,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
         isSpeaking={isSoundPlaying}
         category={currentWord.category || currentCategory}
         selectedVoice={selectedVoice}
+        nextVoiceLabel={nextVoiceLabel}
       />
     </div>
   );

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -18,6 +18,7 @@ interface VocabularyMainNewProps {
   isSoundPlaying: boolean;
   displayTime: number;
   voiceRegion: 'US' | 'UK' | 'AU';
+  nextVoiceLabel: string;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -34,6 +35,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   handleManualNext,
   displayTime,
   voiceRegion,
+  nextVoiceLabel,
 }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -56,6 +58,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
         isSpeaking={isSoundPlaying}
         category={currentWord.category || currentCategory}
         voiceRegion={voiceRegion}
+        nextVoiceLabel={nextVoiceLabel}
       />
     </div>
   );

--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -20,6 +20,12 @@ const VocabularyContainer: React.FC = () => {
 
   // Voice selection
   const { selectedVoice, cycleVoice } = useVoiceSelection();
+  const nextVoiceLabel =
+    selectedVoice.region === 'UK'
+      ? 'US'
+      : selectedVoice.region === 'US'
+      ? 'AU'
+      : 'US';
 
   // Get controller state (simplified version)
   const controllerState = useSimpleVocabularyController();
@@ -111,6 +117,7 @@ const VocabularyContainer: React.FC = () => {
         currentCategory={currentCategory}
         nextCategory={nextCategory}
         selectedVoice={selectedVoice}
+        nextVoiceLabel={nextVoiceLabel}
         category={controllerState.currentWord.category}
       />
     </div>

--- a/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useSimpleVocabularyController.ts
@@ -167,7 +167,12 @@ export const useSimpleVocabularyController = () => {
   }, [isMuted, stopSpeech]);
 
   const toggleVoice = useCallback(() => {
-    const newRegion = voiceRegion === 'US' ? 'UK' : voiceRegion === 'UK' ? 'AU' : 'US';
+    const newRegion =
+      voiceRegion === 'UK'
+        ? 'US'
+        : voiceRegion === 'US'
+        ? 'AU'
+        : 'US';
     debug('[SIMPLE-VOCAB-CONTROLLER] Toggle voice to:', newRegion);
     setVoiceRegion(newRegion);
   }, [voiceRegion]);

--- a/src/hooks/vocabulary-controller/useVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useVocabularyController.ts
@@ -169,7 +169,12 @@ export const useVocabularyController = (wordList: VocabularyWord[]) => {
   }, [isMuted, stopSpeech, goToNext]);
 
   const toggleVoice = useCallback(() => {
-    const newRegion = voiceRegion === 'US' ? 'UK' : voiceRegion === 'UK' ? 'AU' : 'US';
+    const newRegion =
+      voiceRegion === 'UK'
+        ? 'US'
+        : voiceRegion === 'US'
+        ? 'AU'
+        : 'US';
     debug('[VOCAB-CONTROLLER] Toggle voice to:', newRegion);
     setVoiceRegion(newRegion);
   }, [voiceRegion]);

--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -138,11 +138,17 @@ export const useVoiceManagement = () => {
     return null;
   }, []);
   
-  // Function to cycle through voices including AU
+  // Function to cycle through voices in the desired order
   const cycleVoice = useCallback(() => {
     setVoiceIndex(prevIndex => {
-      const nextIndex = (prevIndex + 1) % allVoiceOptions.length;
-      console.log(`Cycling voice from ${allVoiceOptions[prevIndex].label} to ${allVoiceOptions[nextIndex].label}`);
+      const currentRegion = allVoiceOptions[prevIndex].region;
+      const nextRegion =
+        currentRegion === 'UK' ? 'US' : currentRegion === 'US' ? 'AU' : 'US';
+      const nextIndex = allVoiceOptions.findIndex(v => v.region === nextRegion);
+
+      console.log(
+        `Cycling voice from ${allVoiceOptions[prevIndex].label} to ${allVoiceOptions[nextIndex].label}`
+      );
       
       // Save to localStorage
       try {

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -152,22 +152,26 @@ export const useVoiceSelection = () => {
     };
   }, []);
   
-  // Function to cycle through available voices
+  // Function to cycle through available voices in the desired order
   const cycleVoice = () => {
-    const nextIndex = (voiceIndex + 1) % VOICE_OPTIONS.length;
-    const nextVoice = VOICE_OPTIONS[nextIndex];
-    
-    console.log(`Cycling voice from ${selectedVoice.label} to ${nextVoice.label}`);
-    setVoiceIndex(nextIndex);
+    const currentRegion = selectedVoice.region;
+    const nextRegion =
+      currentRegion === 'UK' ? 'US' : currentRegion === 'US' ? 'AU' : 'US';
+    const nextVoice = VOICE_OPTIONS.find(v => v.region === nextRegion)!;
+
+    console.log(
+      `Cycling voice from ${selectedVoice.label} to ${nextVoice.label}`
+    );
+    setVoiceIndex(nextVoice.index);
     setSelectedVoice(nextVoice);
-    
+
     // Save the preference
     try {
       const savedSettings = localStorage.getItem('vocabularySettings');
       const settings = savedSettings ? JSON.parse(savedSettings) : {};
       localStorage.setItem('vocabularySettings', JSON.stringify({
         ...settings,
-        voiceIndex: nextIndex
+        voiceIndex: nextVoice.index
       }));
     } catch (error) {
       console.error('Error saving voice preference:', error);

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -18,7 +18,12 @@ const controllerState = {
   toggleMute: vi.fn(),
   goToNext: vi.fn(),
   toggleVoice: vi.fn(() => {
-    controllerState.voiceRegion = controllerState.voiceRegion === 'US' ? 'UK' : controllerState.voiceRegion === 'UK' ? 'AU' : 'US';
+    controllerState.voiceRegion =
+      controllerState.voiceRegion === 'UK'
+        ? 'US'
+        : controllerState.voiceRegion === 'US'
+        ? 'AU'
+        : 'US';
   }),
   playCurrentWord: vi.fn(),
 };
@@ -40,9 +45,9 @@ vi.mock('../src/hooks/vocabulary-playback/useVoiceSelection', () => {
 
       const cycleVoice = () => {
         const region =
-          selectedVoice.region === 'US'
-            ? 'UK'
-            : selectedVoice.region === 'UK'
+          selectedVoice.region === 'UK'
+            ? 'US'
+            : selectedVoice.region === 'US'
             ? 'AU'
             : 'US';
         setSelectedVoice({ label: region, region, gender: 'female', index: 0 });
@@ -76,12 +81,12 @@ describe('VocabularyContainer voice toggle', () => {
   it('keeps label and controller.voiceRegion in sync', async () => {
     render(<VocabularyContainer />);
 
-    const toggleBtn = screen.getByRole('button', { name: 'UK' });
+    const toggleBtn = screen.getByRole('button', { name: 'US' });
     expect(controllerState.voiceRegion).toBe('UK');
 
     await userEvent.click(toggleBtn);
 
     expect(screen.getByRole('button', { name: 'AU' })).toBeInTheDocument();
-    expect(controllerState.voiceRegion).toBe('AU');
+    expect(controllerState.voiceRegion).toBe('US');
   });
 });


### PR DESCRIPTION
## Summary
- show next accent on the voice button
- cycle voices in order UK → US → AU → US …
- adjust components and tests for new toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483dc21d24832fae1ae37a920f6b05