### PR TITLE
Add overlay to enable audio

### DIFF
--- a/src/components/VocabularyApp.tsx
+++ b/src/components/VocabularyApp.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import VocabularyAppContainerNew from "./vocabulary-app/VocabularyAppContainerNew";
 import { vocabularyService } from '@/services/vocabularyService';
 import ToastProvider from './vocabulary-app/ToastProvider';
+import AudioPermissionPrompt from './vocabulary-app/AudioPermissionPrompt';
 
 const VocabularyApp = () => {
   // Force reload of default vocabulary when app loads
@@ -14,6 +15,7 @@ const VocabularyApp = () => {
   return (
     <>
       <ToastProvider />
+      <AudioPermissionPrompt />
       <VocabularyAppContainerNew />
     </>
   );

--- a/src/components/vocabulary-app/AudioPermissionPrompt.tsx
+++ b/src/components/vocabulary-app/AudioPermissionPrompt.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+const AudioPermissionPrompt: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const hadInteraction = localStorage.getItem('hadUserInteraction') === 'true';
+    if (!hadInteraction) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleInteraction = () => {
+    localStorage.setItem('hadUserInteraction', 'true');
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    if (!visible) return;
+    document.addEventListener('click', handleInteraction);
+    document.addEventListener('touchstart', handleInteraction);
+    document.addEventListener('keydown', handleInteraction);
+    return () => {
+      document.removeEventListener('click', handleInteraction);
+      document.removeEventListener('touchstart', handleInteraction);
+      document.removeEventListener('keydown', handleInteraction);
+    };
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded text-center">
+        <p className="text-lg mb-2">Click anywhere to enable audio playback</p>
+        <p className="text-sm text-muted-foreground">This is required by your browser</p>
+      </div>
+    </div>
+  );
+};
+
+export default AudioPermissionPrompt;


### PR DESCRIPTION
## Summary
- show a simple overlay prompting the user to interact before audio can play
- use the overlay in the main app component

## Testing
- `npm test`
- `npm run lint` *(fails: 32 errors, 33 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684841d7bd6c832fa844b1781a357f5a