### PR TITLE
Update speech unlock logic

### DIFF
--- a/src/hooks/vocabulary-playback/speech-playback/ensureVoices.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/ensureVoices.ts
@@ -1,6 +1,4 @@
 
-import { unlockAudio } from '@/utils/speech/core/speechEngine';
-
 // Maximum number of attempts to load voices
 const MAX_VOICE_LOAD_ATTEMPTS = 10;
 
@@ -8,9 +6,6 @@ const MAX_VOICE_LOAD_ATTEMPTS = 10;
 export const ensureVoicesLoaded = (): Promise<SpeechSynthesisVoice[]> => {
   return new Promise(async (resolve) => {
     console.log('Ensuring voices are loaded...');
-    
-    // First try to unlock audio to ensure proper browser permissions
-    await unlockAudio();
     
     // Helper function to check if voices are available
     const checkVoices = (): SpeechSynthesisVoice[] => {

--- a/src/utils/speech/controller/speechExecutor.ts
+++ b/src/utils/speech/controller/speechExecutor.ts
@@ -1,5 +1,5 @@
 
-import { unlockAudio, loadVoicesAndWait } from '../core/speechEngine';
+import { loadVoicesAndWait } from '../core/speechEngine';
 import { 
   registerSpeechRequest, 
   unregisterSpeechRequest, 
@@ -37,8 +37,7 @@ export class SpeechExecutor {
           return;
         }
         
-        // Ensure browser audio is unlocked and voices are available
-        await unlockAudio();
+        // Ensure voices are available
         await loadVoicesAndWait();
 
         // Double-check pause state after async operations

--- a/src/utils/speech/core/modules/speechSynthesis.ts
+++ b/src/utils/speech/core/modules/speechSynthesis.ts
@@ -1,5 +1,4 @@
 
-import { unlockAudio } from './speechUnlock';
 import { loadVoicesAndWait } from './speechVoiceLoader';
 
 // Enhanced speech function with comprehensive monitoring
@@ -8,9 +7,6 @@ export const speakWithRetry = async (
   maxRetries: number = 2
 ): Promise<boolean> => {
   console.log('[ENGINE] === Starting Enhanced Speech Process ===');
-  
-  // Ensure audio is unlocked
-  await unlockAudio();
   
   // Ensure voices are loaded
   const voices = await loadVoicesAndWait();

--- a/src/utils/speech/core/modules/speechUnlock.ts
+++ b/src/utils/speech/core/modules/speechUnlock.ts
@@ -1,47 +1,6 @@
 
-// Enhanced unlockAudio function with better error handling
+// Audio unlocking is no longer required. The function now immediately resolves.
 export const unlockAudio = (): Promise<boolean> => {
-  return new Promise((resolve) => {
-    try {
-      console.log('[ENGINE] Attempting to unlock audio context...');
-      
-      interface WindowWithWebAudio extends Window {
-        webkitAudioContext?: typeof globalThis.AudioContext;
-      }
-
-      const AudioContext =
-        window.AudioContext || (window as WindowWithWebAudio).webkitAudioContext;
-      
-      if (!AudioContext) {
-        console.log('[ENGINE] AudioContext not supported, proceeding with speech synthesis');
-        resolve(true);
-        return;
-      }
-      
-      try {
-        const context = new AudioContext();
-        
-        console.log('[ENGINE] AudioContext created, state:', context.state);
-        
-        if (context.state === 'suspended') {
-          context.resume().then(() => {
-            console.log('[ENGINE] ✓ AudioContext resumed successfully');
-            resolve(true);
-          }).catch(err => {
-            console.warn('[ENGINE] Failed to resume AudioContext:', err);
-            resolve(true); // Still allow speech synthesis to try
-          });
-        } else {
-          console.log('[ENGINE] ✓ AudioContext already ready');
-          resolve(true);
-        }
-      } catch (e) {
-        console.warn('[ENGINE] AudioContext creation failed:', e);
-        resolve(true); // Still allow speech synthesis to try
-      }
-    } catch (e) {
-      console.warn('[ENGINE] Audio unlock failed, continuing anyway:', e);
-      resolve(true);
-    }
-  });
+  console.log('[ENGINE] Audio unlock skipped');
+  return Promise.resolve(true);
 };


### PR DESCRIPTION
## Summary
- simplify `unlockAudio` so it always resolves immediately
- drop unnecessary `unlockAudio` calls in speech modules and hooks

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6848468ac7a0832f81868c3285bbd467