### PR TITLE
Simplify permission manager

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechErrorHandler.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechErrorHandler.ts
@@ -5,8 +5,6 @@ import { useCallback } from 'react';
  * Hook for handling speech synthesis errors with appropriate recovery strategies
  */
 export const useSpeechErrorHandler = (
-  setHasSpeechPermission: (hasPermission: boolean) => void,
-  handlePermissionError: (errorType: string) => void,
   incrementRetryAttempts: () => boolean,
   goToNextWord: (fromUser?: boolean) => void,
   scheduleAutoAdvance: (delay: number) => void,
@@ -39,13 +37,13 @@ export const useSpeechErrorHandler = (
     switch (event.error) {
       case 'not-allowed':
         console.log(`[SPEECH-ERROR-${sessionId}] Permission denied`);
-        setHasSpeechPermission(false);
-        handlePermissionError('not-allowed');
+        if (!paused && !muted) {
+          scheduleAutoAdvance(2000);
+        }
         break;
         
       case 'network':
         console.log(`[SPEECH-ERROR-${sessionId}] Network error`);
-        handlePermissionError('network');
         if (!paused && !muted) {
           scheduleAutoAdvance(2000);
         }
@@ -84,8 +82,6 @@ export const useSpeechErrorHandler = (
       }
     }
   }, [
-    setHasSpeechPermission,
-    handlePermissionError,
     incrementRetryAttempts,
     goToNextWord,
     paused,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
@@ -28,8 +28,7 @@ export const useOrchestratorCore = (
   lastManualActionTimeRef: React.MutableRefObject<number>,
   autoAdvanceTimerRef: React.MutableRefObject<number | null>,
   voicesLoadedRef: React.MutableRefObject<boolean>,
-  ensureVoicesLoaded: () => Promise<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>
+  ensureVoicesLoaded: () => Promise<boolean>
 ) => {
   // Calculate current word using dedicated hook
   const { currentWord } = useCurrentWordCalculation(wordList, currentIndex);
@@ -58,7 +57,6 @@ export const useOrchestratorCore = (
     goToNextWord,
     voicesLoadedRef,
     ensureVoicesLoaded,
-    permissionErrorShownRef,
     paused,
     muted
   );
@@ -78,7 +76,6 @@ export const useOrchestratorCore = (
     paused,
     muted,
     wordTransitionRef,
-    permissionErrorShownRef,
     checkSpeechSupport,
     voicesLoadedRef,
     ensureVoicesLoaded

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackCoordination.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackCoordination.ts
@@ -18,7 +18,6 @@ export const usePlaybackCoordination = (
   goToNextWord: () => void,
   voicesLoadedRef: React.MutableRefObject<boolean>,
   ensureVoicesLoaded: () => Promise<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>,
   paused: boolean,
   muted: boolean
 ) => {
@@ -35,7 +34,6 @@ export const usePlaybackCoordination = (
       goToNextWord,
       voicesLoadedRef,
       ensureVoicesLoaded,
-      permissionErrorShownRef,
       paused,
       muted
     };
@@ -51,7 +49,6 @@ export const usePlaybackCoordination = (
     goToNextWord,
     voicesLoadedRef,
     ensureVoicesLoaded,
-    permissionErrorShownRef,
     paused,
     muted
   ]);

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
@@ -5,7 +5,6 @@ import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 import { useContentValidation } from './useContentValidation';
 import { usePlaybackConditions } from './usePlaybackConditions';
 import { useSpeechExecution } from './useSpeechExecution';
-import { useSpeechPermissionManager } from './useSpeechPermissionManager';
 import { toast } from 'sonner';
 
 /**
@@ -25,7 +24,6 @@ export const usePlaybackExecution = (
   paused: boolean,
   muted: boolean,
   wordTransitionRef: React.MutableRefObject<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>,
   checkSpeechSupport: () => boolean,
   voicesLoadedRef: React.MutableRefObject<boolean>,
   ensureVoicesLoaded: () => Promise<boolean>
@@ -33,12 +31,7 @@ export const usePlaybackExecution = (
   const { validateAndPrepareContent } = useContentValidation();
   const { checkPlaybackConditions, handleControllerReset } = usePlaybackConditions();
   
-  // Use the permission manager for speech permissions
-  const { 
-    setHasSpeechPermission,
-    checkSpeechPermissions,
-    handlePermissionError 
-  } = useSpeechPermissionManager();
+  // Permissions are always granted in this simplified setup
   
   const { executeSpeech } = useSpeechExecution(
     findVoice,
@@ -53,11 +46,7 @@ export const usePlaybackExecution = (
     autoAdvanceTimerRef,
     paused,
     muted,
-    wordTransitionRef,
-    permissionErrorShownRef,
-    setHasSpeechPermission,
-    handlePermissionError,
-    checkSpeechPermissions
+    wordTransitionRef
   );
 
   const executePlayback = useCallback(async (
@@ -114,10 +103,7 @@ export const usePlaybackExecution = (
       
       // Ensure speech synthesis is available
       if (!checkSpeechSupport()) {
-        if (!permissionErrorShownRef.current) {
-          toast.error("Your browser doesn't support speech synthesis");
-          permissionErrorShownRef.current = true;
-        }
+        toast.error("Your browser doesn't support speech synthesis");
         scheduleAutoAdvance(3000);
         setPlayInProgress(false);
         return;
@@ -164,7 +150,6 @@ export const usePlaybackExecution = (
     voicesLoadedRef,
     ensureVoicesLoaded,
     checkSpeechSupport,
-    permissionErrorShownRef,
     validateAndPrepareContent,
     executeSpeech,
     setIsSpeaking,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackFlow.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackFlow.ts
@@ -25,8 +25,7 @@ export const usePlaybackFlow = (
   lastManualActionTimeRef: React.MutableRefObject<number>,
   autoAdvanceTimerRef: React.MutableRefObject<number | null>,
   voicesLoadedRef: React.MutableRefObject<boolean>,
-  ensureVoicesLoaded: () => Promise<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>
+  ensureVoicesLoaded: () => Promise<boolean>
 ) => {
   // Use the orchestrator hook that handles all the complex logic
   return usePlaybackOrchestrator(
@@ -47,7 +46,6 @@ export const usePlaybackFlow = (
     lastManualActionTimeRef,
     autoAdvanceTimerRef,
     voicesLoadedRef,
-    ensureVoicesLoaded,
-    permissionErrorShownRef
+    ensureVoicesLoaded
   );
 };

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackOrchestrator.ts
@@ -24,8 +24,7 @@ export const usePlaybackOrchestrator = (
   lastManualActionTimeRef: React.MutableRefObject<number>,
   autoAdvanceTimerRef: React.MutableRefObject<number | null>,
   voicesLoadedRef: React.MutableRefObject<boolean>,
-  ensureVoicesLoaded: () => Promise<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>
+  ensureVoicesLoaded: () => Promise<boolean>
 ) => {
   // Use the core orchestrator that handles all the complex logic
   return useOrchestratorCore(
@@ -46,7 +45,6 @@ export const usePlaybackOrchestrator = (
     lastManualActionTimeRef,
     autoAdvanceTimerRef,
     voicesLoadedRef,
-    ensureVoicesLoaded,
-    permissionErrorShownRef
+    ensureVoicesLoaded
   );
 };

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechExecution.ts
@@ -23,18 +23,12 @@ export const useSpeechExecution = (
   autoAdvanceTimerRef: React.MutableRefObject<number | null>,
   paused: boolean,
   muted: boolean,
-  wordTransitionRef: React.MutableRefObject<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>,
-  setHasSpeechPermission: (hasPermission: boolean) => void,
-  handlePermissionError: (errorType: string) => void,
-  checkSpeechPermissions: () => Promise<boolean>
+  wordTransitionRef: React.MutableRefObject<boolean>
 ) => {
   // Initialize modular hooks
   const { validatePreConditions, validateSpeechContent } = useSpeechValidation();
   
   const { handleSpeechError } = useSpeechErrorHandler(
-    setHasSpeechPermission,
-    handlePermissionError,
     incrementRetryAttempts,
     goToNextWord,
     paused,
@@ -73,15 +67,6 @@ export const useSpeechExecution = (
     }
 
     try {
-      // Check permissions
-      console.log(`[SPEECH-EXECUTION-${sessionId}] Checking speech permissions`);
-      const hasPermission = await checkSpeechPermissions();
-      if (!hasPermission) {
-        console.log(`[SPEECH-EXECUTION-${sessionId}] Permission check failed`);
-        setPlayInProgress(false);
-        handlePermissionError('not-allowed');
-        return false;
-      }
 
       // Validate speech content
       if (!validateSpeechContent(sessionId, speechableText, setPlayInProgress, goToNextWord)) {
@@ -129,8 +114,6 @@ export const useSpeechExecution = (
     createOnEndCallback,
     handleSpeechError,
     executeSpeechSynthesis,
-    checkSpeechPermissions,
-    handlePermissionError,
     goToNextWord,
     scheduleAutoAdvance,
     paused,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechPermissionManager.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useSpeechPermissionManager.ts
@@ -1,94 +1,19 @@
 
-import { useState, useCallback, useRef } from 'react';
-import { toast } from 'sonner';
+import { useCallback } from 'react';
 
 /**
  * Hook for managing speech permissions and providing user feedback
  */
 export const useSpeechPermissionManager = () => {
-  const [hasSpeechPermission, setHasSpeechPermission] = useState(true);
-  const [permissionErrorShown, setPermissionErrorShown] = useState(false);
-  const permissionCheckAttempts = useRef(0);
-  const maxPermissionAttempts = 3;
+  // Permission is always granted in this simplified implementation
+  const hasSpeechPermission = true;
 
-  // Check if speech synthesis is available and permissions are granted
   const checkSpeechPermissions = useCallback(async (): Promise<boolean> => {
-    console.log('[PERMISSION-MANAGER] Checking speech permissions');
-    
-    if (!window.speechSynthesis) {
-      console.error('[PERMISSION-MANAGER] Speech synthesis not supported');
-      if (!permissionErrorShown) {
-        toast.error("Your browser doesn't support speech synthesis");
-        setPermissionErrorShown(true);
-      }
-      setHasSpeechPermission(false);
-      return false;
-    }
-
-    // Check if user has interacted with the page
-    const hadUserInteraction = localStorage.getItem('hadUserInteraction') === 'true';
-    if (!hadUserInteraction) {
-      console.log('[PERMISSION-MANAGER] No user interaction detected');
-      if (!permissionErrorShown) {
-        toast.error("Please click anywhere on the page to enable audio playback");
-        setPermissionErrorShown(true);
-      }
-      setHasSpeechPermission(false);
-      return false;
-    }
-
-    // Simple permission check - just try to speak
-    try {
-      console.log('[PERMISSION-MANAGER] Permission check successful');
-      setHasSpeechPermission(true);
-      return true;
-    } catch (error) {
-      console.error('[PERMISSION-MANAGER] Error during permission check:', error);
-      setHasSpeechPermission(false);
-      return false;
-    }
-  }, [permissionErrorShown]);
-
-  // Reset permission state for retry
-  const resetPermissionState = useCallback(() => {
-    console.log('[PERMISSION-MANAGER] Resetting permission state');
-    setHasSpeechPermission(true);
-    setPermissionErrorShown(false);
-    permissionCheckAttempts.current = 0;
+    return true;
   }, []);
-
-  // Handle permission errors with user-friendly messages
-  const handlePermissionError = useCallback((errorType: string) => {
-    console.log('[PERMISSION-MANAGER] Handling permission error:', errorType);
-    
-    switch (errorType) {
-      case 'not-allowed':
-        setHasSpeechPermission(false);
-        if (!permissionErrorShown) {
-          toast.error("Audio playback blocked. Please click anywhere to enable it.");
-          setPermissionErrorShown(true);
-        }
-        break;
-      case 'network':
-        if (!permissionErrorShown) {
-          toast.error("Network connection required for speech synthesis");
-          setPermissionErrorShown(true);
-        }
-        break;
-      default:
-        if (!permissionErrorShown) {
-          toast.error("Speech synthesis encountered an error");
-          setPermissionErrorShown(true);
-        }
-    }
-  }, [permissionErrorShown]);
 
   return {
     hasSpeechPermission,
-    setHasSpeechPermission,
-    permissionErrorShown,
-    checkSpeechPermissions,
-    resetPermissionState,
-    handlePermissionError
+    checkSpeechPermissions
   };
 };

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useWordPlaybackLogic.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useWordPlaybackLogic.ts
@@ -28,7 +28,6 @@ export const useWordPlaybackLogic = (
   autoAdvanceTimerRef: React.MutableRefObject<number | null>,
   voicesLoadedRef: React.MutableRefObject<boolean>,
   ensureVoicesLoaded: () => Promise<boolean>,
-  permissionErrorShownRef: React.MutableRefObject<boolean>,
   utteranceRef: React.MutableRefObject<SpeechSynthesisUtterance | null>,
   createUtterance: (
     word: VocabularyWord, 
@@ -58,8 +57,7 @@ export const useWordPlaybackLogic = (
     lastManualActionTimeRef,
     autoAdvanceTimerRef,
     voicesLoadedRef,
-    ensureVoicesLoaded,
-    permissionErrorShownRef
+    ensureVoicesLoaded
   );
   
   return {

--- a/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
@@ -70,7 +70,6 @@ export const useWordPlaybackCore = (
     autoAdvanceTimerRef,
     voicesLoadedRef,
     ensureVoicesLoaded,
-    permissionErrorShownRef,
     utteranceRef,
     createUtterance
   );


### PR DESCRIPTION
## Summary
- strip permission checks from `useSpeechPermissionManager`
- update playback hooks to use simplified permission logic
- remove permission handling branches in speech execution

## Testing
- `npx vitest run` *(fails: Need to install the following packages: vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68484687a190832f894cefadb17cb9e8