### PR TITLE
Fix autoplay state sync

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -25,9 +25,10 @@ const VocabularyAppContainer: React.FC = () => {
     handleSwitchCategory,
     currentCategory,
     nextCategory,
-    displayTime,
-    wordList
+    displayTime
   } = useVocabularyContainerState();
+
+  const wordList = vocabularyService.getWordList();
 
   console.log('[VOCAB-CONTAINER] Container state:', {
     hasData,
@@ -82,7 +83,7 @@ const VocabularyAppContainer: React.FC = () => {
   
   useAutoPlayOnDataLoad({
     hasData,
-    wordList,
+    currentWord: playbackCurrentWord,
     userInteractionRef,
     playCurrentWord
   });

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -24,8 +24,7 @@ const VocabularyAppContainerNew: React.FC = () => {
     handleSwitchCategory,
     currentCategory,
     nextCategory,
-    displayTime,
-    wordList
+    displayTime
   } = useVocabularyContainerState();
 
   // Track whether the user has interacted to enable audio playback
@@ -34,7 +33,6 @@ const VocabularyAppContainerNew: React.FC = () => {
   console.log('[VOCAB-CONTAINER-NEW] Container state:', {
     hasData,
     hasAnyData,
-    wordListLength: wordList?.length || 0,
     currentCategory
   });
 
@@ -68,7 +66,7 @@ const VocabularyAppContainerNew: React.FC = () => {
 
   useAutoPlayOnDataLoad({
     hasData,
-    wordList,
+    currentWord,
     userInteractionRef,
     playCurrentWord,
   });

--- a/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
+++ b/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
@@ -3,14 +3,14 @@ import { useEffect, useState } from 'react';
 
 interface AutoPlayProps {
   hasData: boolean;
-  wordList: any[] | null;
+  currentWord: any | null;
   userInteractionRef: React.MutableRefObject<boolean>;
   playCurrentWord: () => void;
 }
 
 export const useAutoPlayOnDataLoad = ({
   hasData,
-  wordList,
+  currentWord,
   userInteractionRef,
   playCurrentWord,
 }: AutoPlayProps) => {
@@ -23,7 +23,7 @@ export const useAutoPlayOnDataLoad = ({
 
   // Force audio to play when data becomes available
   useEffect(() => {
-    if (hasData && wordList && wordList.length > 0 && hasUserInteracted) {
+    if (hasData && currentWord && hasUserInteracted) {
       console.log('Data loaded and user has interacted, triggering playback');
       // Small delay to ensure rendering completes
       const timerId = setTimeout(() => {
@@ -31,5 +31,5 @@ export const useAutoPlayOnDataLoad = ({
       }, 500);
       return () => clearTimeout(timerId);
     }
-  }, [hasData, wordList, hasUserInteracted, playCurrentWord]);
+  }, [hasData, currentWord, hasUserInteracted, playCurrentWord]);
 };

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -46,7 +46,10 @@ export const useUnifiedVocabularyController = () => {
       return;
     }
 
-    console.log(`[UNIFIED-CONTROLLER] Scheduling auto-advance in ${delay}ms`);
+    console.log(`[UNIFIED-CONTROLLER] Scheduling auto-advance in ${delay}ms`, {
+      word: currentWord?.word,
+      index: currentIndex
+    });
     autoAdvanceTimerRef.current = window.setTimeout(() => {
       autoAdvanceTimerRef.current = null;
       if (!isPaused && !isMuted && !isTransitioningRef.current) {
@@ -54,7 +57,7 @@ export const useUnifiedVocabularyController = () => {
         goToNext();
       }
     }, delay);
-  }, [isPaused, isMuted]);
+  }, [isPaused, isMuted, currentWord, currentIndex]);
 
   // Subscribe to speech controller state changes
   useEffect(() => {
@@ -129,7 +132,11 @@ export const useUnifiedVocabularyController = () => {
       return;
     }
 
-    console.log('[UNIFIED-CONTROLLER] Going to next word');
+    console.log('[UNIFIED-CONTROLLER] Going to next word', {
+      from: currentWord?.word,
+      index: currentIndex,
+      total: wordList.length
+    });
     isTransitioningRef.current = true;
     lastWordChangeRef.current = Date.now();
 

--- a/src/hooks/vocabulary/useVocabularyContainerState.tsx
+++ b/src/hooks/vocabulary/useVocabularyContainerState.tsx
@@ -1,6 +1,5 @@
 
 import { useState, useEffect, useCallback } from 'react';
-import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { useCategoryNavigation } from './useCategoryNavigation';
 
@@ -11,7 +10,6 @@ export const useVocabularyContainerState = () => {
   const [hasData, setHasData] = useState(false); // data in current category
   const [hasAnyData, setHasAnyData] = useState(false); // data in any category
   const [jsonLoadError, setJsonLoadError] = useState<string | null>(null);
-  const [wordList, setWordList] = useState<VocabularyWord[]>([]);
 
   // Category navigation
   const { currentCategory, nextCategory } = useCategoryNavigation();
@@ -19,20 +17,14 @@ export const useVocabularyContainerState = () => {
   // Display time for UI (can be customized later)
   const displayTime = 5000;
 
-  // Load initial vocabulary data
+  // Load initial vocabulary info
   useEffect(() => {
-    console.log('[VOCAB-CONTAINER-STATE] Loading initial vocabulary data');
-    
-    try {
-      const initialWordList = vocabularyService.getWordList();
-      console.log('[VOCAB-CONTAINER-STATE] Initial word list:', {
-        length: initialWordList.length,
-        firstWord: initialWordList[0]?.word || 'none',
-        sample: initialWordList.slice(0, 3).map(w => w.word)
-      });
+    console.log('[VOCAB-CONTAINER-STATE] Loading initial vocabulary info');
 
-      setWordList(initialWordList);
-      setHasData(initialWordList.length > 0);
+    try {
+      const list = vocabularyService.getWordList();
+      console.log('[VOCAB-CONTAINER-STATE] Initial word count:', list.length);
+      setHasData(list.length > 0);
       setHasAnyData(vocabularyService.hasData());
       setJsonLoadError(null);
     } catch (error) {
@@ -40,21 +32,19 @@ export const useVocabularyContainerState = () => {
       setJsonLoadError('Failed to load vocabulary data');
       setHasData(false);
       setHasAnyData(false);
-      setWordList([]);
     }
   }, []);
 
-  // Subscribe to vocabulary service changes using the correct methods
+  // Subscribe to vocabulary service changes
   useEffect(() => {
     const handleVocabularyChange = () => {
       console.log('[VOCAB-CONTAINER-STATE] Vocabulary service updated');
-      
+
       try {
-        const updatedWordList = vocabularyService.getWordList();
-        console.log('[VOCAB-CONTAINER-STATE] Updated word list length:', updatedWordList.length);
-        
-        setWordList(updatedWordList);
-        setHasData(updatedWordList.length > 0);
+        const list = vocabularyService.getWordList();
+        console.log('[VOCAB-CONTAINER-STATE] Updated word count:', list.length);
+
+        setHasData(list.length > 0);
         setHasAnyData(vocabularyService.hasData());
         setJsonLoadError(null);
       } catch (error) {
@@ -81,10 +71,9 @@ export const useVocabularyContainerState = () => {
       const success = await vocabularyService.processExcelFile(file);
       
       if (success) {
-        const newWordList = vocabularyService.getWordList();
-        console.log('[VOCAB-CONTAINER-STATE] File loaded successfully, words:', newWordList.length);
-        setWordList(newWordList);
-        setHasData(true);
+        const list = vocabularyService.getWordList();
+        console.log('[VOCAB-CONTAINER-STATE] File loaded successfully, words:', list.length);
+        setHasData(list.length > 0);
         setHasAnyData(vocabularyService.hasData());
       } else {
         setJsonLoadError('Failed to load vocabulary file');
@@ -108,13 +97,12 @@ export const useVocabularyContainerState = () => {
       const newCategory = vocabularyService.nextSheet();
       
       if (newCategory) {
-        const newWordList = vocabularyService.getWordList();
-        
+        const list = vocabularyService.getWordList();
+
         console.log('[VOCAB-CONTAINER-STATE] ✓ Category switched to:', newCategory);
-        console.log('[VOCAB-CONTAINER-STATE] New word list length:', newWordList.length);
-        
-        setWordList(newWordList);
-        setHasData(newWordList.length > 0);
+        console.log('[VOCAB-CONTAINER-STATE] New word count:', list.length);
+
+        setHasData(list.length > 0);
         setHasAnyData(vocabularyService.hasData());
         
         // Clear any previous errors since category switch was successful
@@ -144,7 +132,6 @@ export const useVocabularyContainerState = () => {
   console.log('[VOCAB-CONTAINER-STATE] Final state summary:', {
     hasData,
     currentWord: vocabularyManagerState.currentWord?.word || 'none',
-    wordListLength: wordList.length,
     currentCategory,
     isPaused: vocabularyManagerState.isPaused,
     isSoundPlaying: false
@@ -158,7 +145,6 @@ export const useVocabularyContainerState = () => {
     handleSwitchCategory,
     currentCategory,
     nextCategory,
-    displayTime,
-    wordList
+    displayTime
   };
 };

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -68,7 +68,6 @@ vi.mock('../src/hooks/vocabulary/useVocabularyContainerState', () => ({
     currentCategory: 'general',
     nextCategory: 'next',
     displayTime: 5000,
-    wordList: [controllerState.currentWord],
   }),
 }));
 


### PR DESCRIPTION
## Summary
- simplify state management in useVocabularyContainerState
- refactor useAutoPlayOnDataLoad to use current word
- update app containers to new autoplay API
- enhance logging in unified vocabulary controller
- adjust tests for new hook shape

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing eslint deps)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684920d3bf2c832f9f99147c99d332b4