### PR TITLE
Fix reference error in vocab controller

### DIFF
--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -12,6 +12,7 @@ export const useUnifiedVocabularyController = () => {
   // Core vocabulary state
   const [wordList, setWordList] = useState<VocabularyWord[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const currentWord = wordList[currentIndex] || null;
   const [hasData, setHasData] = useState(false);
   
   // Control state
@@ -121,9 +122,6 @@ export const useUnifiedVocabularyController = () => {
       unifiedSpeechController.setWordCompleteCallback(null);
     };
   }, [scheduleAutoAdvance]);
-
-  // Get current word
-  const currentWord = wordList[currentIndex] || null;
 
   // Go to next word with proper timer management
   const goToNext = useCallback(() => {


### PR DESCRIPTION
## Summary
- initialize `currentWord` before using it in `useUnifiedVocabularyController`

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "button" and name "US")*

------
https://chatgpt.com/codex/tasks/task_e_6849246f4ee8832fa36ab35c458f0711