### PR TITLE
Fix duplicate autoplay

### DIFF
--- a/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
+++ b/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
@@ -1,5 +1,5 @@
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface AutoPlayProps {
   hasData: boolean;
@@ -15,6 +15,7 @@ export const useAutoPlayOnDataLoad = ({
   playCurrentWord,
 }: AutoPlayProps) => {
   const [hasUserInteracted, setHasUserInteracted] = useState(userInteractionRef.current);
+  const hasAutoPlayedRef = useRef(false);
 
   // Track changes to the ref in a state variable so effects re-run
   useEffect(() => {
@@ -23,13 +24,19 @@ export const useAutoPlayOnDataLoad = ({
 
   // Force audio to play when data becomes available
   useEffect(() => {
-    if (hasData && currentWord && hasUserInteracted) {
+    if (hasData && currentWord && hasUserInteracted && !hasAutoPlayedRef.current) {
       console.log('Data loaded and user has interacted, triggering playback');
+      hasAutoPlayedRef.current = true;
       // Small delay to ensure rendering completes
       const timerId = setTimeout(() => {
         playCurrentWord();
       }, 500);
       return () => clearTimeout(timerId);
+    }
+
+    // Reset flag if data becomes unavailable
+    if (!hasData || !currentWord) {
+      hasAutoPlayedRef.current = false;
     }
   }, [hasData, currentWord, hasUserInteracted, playCurrentWord]);
 };

--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -44,13 +44,7 @@ export const useUserInteractionHandler = ({
           
           utterance.onend = () => {
             console.log('Speech system initialized successfully');
-            // Only try to play current word if we have one and after a delay
-            if (playbackCurrentWord) {
-              setTimeout(() => {
-                if (!userInteractionRef.current) return; // Double-check
-                playCurrentWord();
-              }, 500);
-            }
+            // Playback will be triggered by the auto-play hook when appropriate
           };
           
           utterance.onerror = (err) => {


### PR DESCRIPTION
## Summary
- prevent silent initialization from replaying words
- guard auto play on data load with a one-time flag

## Testing
- `npm test`
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684950f8c430832fb6b95922f77c2252