### PR TITLE
Fix interaction handler reinitialization

### DIFF
--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -79,12 +79,10 @@ export const useUserInteractionHandler = ({
       document.removeEventListener('keydown', enableAudioPlayback);
     };
     
-    // Check if we've had interaction before
+    // Check if we've had interaction before, but still attach listeners to
+    // ensure audio is unlocked with a fresh user gesture
     if (localStorage.getItem('hadUserInteraction') === 'true') {
       console.log('Previous interaction detected from localStorage');
-      userInteractionRef.current = true;
-      initializedRef.current = true;
-      return; // Don't add event listeners if already initialized
     }
     
     // Add event listeners for various user interaction types


### PR DESCRIPTION
## Summary
- keep user interaction listeners even when `hadUserInteraction` is saved
- run initialization on the next user gesture

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684963ab79c8832f9a38d4ccc9189570