### PR TITLE
Add mobile voice note

### DIFF
--- a/src/components/vocabulary-app/WordActionButtons.tsx
+++ b/src/components/vocabulary-app/WordActionButtons.tsx
@@ -16,13 +16,18 @@ const WordActionButtons: React.FC<WordActionButtonsProps> = ({
   onOpenEditModal
 }) => {
   return (
-    <div className="flex items-center justify-center gap-2 my-2">
-      <EditWordButton 
-        onClick={onOpenEditModal} 
-        disabled={!currentWord}
-      />
-      <AddWordButton onClick={onOpenAddModal} />
-    </div>
+    <>
+      <div className="flex items-center justify-center gap-2 my-2">
+        <EditWordButton
+          onClick={onOpenEditModal}
+          disabled={!currentWord}
+        />
+        <AddWordButton onClick={onOpenAddModal} />
+      </div>
+      <p className="text-xs italic text-gray-500 text-center">
+        On Mobile, only Australia voice available (to be enhanced)
+      </p>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add grey italic note below Edit/Add Word buttons regarding mobile voice availability

## Testing
- `npm test` *(fails: watch mode ended)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68496c95b578832fae48a2620cf6d291