### PR TITLE
Rename Advanced Words to Topic Vocab

### DIFF
--- a/public/defaultVocabulary.json
+++ b/public/defaultVocabulary.json
@@ -4894,7 +4894,7 @@
     }
 
   ],
-  "advanced words": [
+  "topic vocab": [
     {
       "word": "leverage",
       "meaning": "the mechanical advantage gained by being in a position to use a lever strategic advantage; power to act effectively investing with borrowed money as a way to amplify potential gains (at the risk of greater losses) supplement with leverage provide with leverage",

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -18,7 +18,7 @@ interface WordFormFieldsProps {
 const CATEGORY_OPTIONS = [
   { value: "phrasal verbs", label: "Phrasal Verbs" },
   { value: "idioms", label: "Idioms" },
-  { value: "advanced words", label: "Advanced Words" },
+  { value: "topic vocab", label: "Topic Vocab" },
   { value: "grammar", label: "Grammar" },
   { value: "phrases, collocations", label: "Phrases & Collocations" }
 ];

--- a/src/services/sheet/SheetManager.ts
+++ b/src/services/sheet/SheetManager.ts
@@ -8,7 +8,7 @@ export class SheetManager {
   readonly sheetOptions = [
     "phrasal verbs",
     "idioms",
-    "advanced words",
+    "topic vocab",
     "grammar",
     "phrases, collocations"
   ];

--- a/src/services/sheet/SheetNormalizer.ts
+++ b/src/services/sheet/SheetNormalizer.ts
@@ -12,7 +12,7 @@ export class SheetNormalizer {
     
     if (normalized.includes("phrasal") || normalized.includes("verb")) return "phrasal verbs";
     if (normalized.includes("idiom")) return "idioms";
-    if (normalized.includes("advanced")) return "advanced words";
+    if (normalized.includes("advanced")) return "topic vocab";
     if (normalized.includes("grammar")) return "grammar";
     if (normalized.includes("phrase") || normalized.includes("collocation")) return "phrases, collocations";
     

--- a/src/services/vocabulary/VocabularyDataManager.ts
+++ b/src/services/vocabulary/VocabularyDataManager.ts
@@ -98,7 +98,7 @@ export class VocabularyDataManager {
           const fallbackData: SheetData = {
             "phrasal verbs": [],
             "idioms": [],
-            "advanced words": [],
+            "topic vocab": [],
             "grammar": [],
             "phrases, collocations": []
           };

--- a/src/services/vocabulary/VocabularyService.ts
+++ b/src/services/vocabulary/VocabularyService.ts
@@ -19,7 +19,7 @@ export class VocabularyService {
     this.sheetOptions = [
       "phrasal verbs",
       "idioms",
-      "advanced words",
+      "topic vocab",
       "grammar",
       "phrases, collocations"
     ];


### PR DESCRIPTION
## Summary
- rename the "Advanced Words" category to "Topic Vocab" across the codebase

## Testing
- `npm test`
- `npm run lint` *(fails: 61 problems)*


------
https://chatgpt.com/codex/tasks/task_e_68496f1a96ac832fbd4715675a14d497