### PR TITLE
Add speech unlock and CORS helpers

### DIFF
--- a/src/lovable.ts
+++ b/src/lovable.ts
@@ -1,0 +1,63 @@
+// Utilities for speech playback and API integration
+
+interface SpeechState {
+  isMuted: boolean;
+  voiceRegion: 'US' | 'UK' | 'AU';
+}
+
+let speechUnlocked = false;
+
+function unlockSpeech() {
+  if (speechUnlocked) return;
+  speechUnlocked = true;
+  try {
+    const u = new SpeechSynthesisUtterance('');
+    u.volume = 0;
+    window.speechSynthesis.speak(u);
+  } catch (err) {
+    console.warn('Failed to unlock speech', err);
+  }
+}
+
+document.addEventListener('click', unlockSpeech, { once: true });
+document.addEventListener('touchstart', unlockSpeech, { once: true });
+
+export function executeSpeech(
+  text: string,
+  state: SpeechState,
+  scheduleNextWord: () => void
+) {
+  if (!text || state.isMuted || !speechUnlocked) return;
+
+  const speakNow = () => {
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = state.voiceRegion === 'UK' ? 'en-GB' : 'en-US';
+    utterance.onend = () => scheduleNextWord();
+    utterance.onerror = (e) => console.error('Speech error:', e);
+    window.speechSynthesis.speak(utterance);
+  };
+
+  if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+    window.speechSynthesis.cancel();
+    setTimeout(speakNow, 50);
+  } else {
+    speakNow();
+  }
+}
+
+export async function fetchLatestMessage(projectId: string) {
+  try {
+    const res = await fetch(
+      `https://lovable-api.com/projects/${projectId}/latest-message`,
+      {
+        headers: { Accept: 'application/json' },
+        mode: 'cors'
+      }
+    );
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to load latest message:', err);
+    return null;
+  }
+}

--- a/src/server/corsMiddleware.ts
+++ b/src/server/corsMiddleware.ts
@@ -1,0 +1,7 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export function lovableCors(req: Request, res: Response, next: NextFunction) {
+  res.setHeader('Access-Control-Allow-Origin', 'https://lovable.dev');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  next();
+}


### PR DESCRIPTION
## Summary
- handle Web Speech API user gesture requirement and queued utterances
- fetch `/latest-message` with CORS and error handling
- expose Express middleware for CORS

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4f7b7ca4832fb2ce803266c16894