### PR TITLE
Fix dataset entry and clarify audio unlocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ npm test       # execute unit tests with vitest
 npm run lint   # check code style with ESLint
 ```
 
+## Enabling speech playback
+
+Modern browsers block audio playback until the user interacts with the page.
+To hear the vocabulary pronunciations, click anywhere on the page (or press any
+key) before using the play controls. The first interaction unlocks the speech
+synthesis engine so that audio can be played normally.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/public/defaultVocabulary.json
+++ b/public/defaultVocabulary.json
@@ -4988,12 +4988,6 @@
       "count": 0
     },
     {
-      "word": "He would- he'd - He'd like to see you now. why have - Why've. Why've you come? I will - I'll - I'll think about it. where did - Where'd - Where'd you get that? they are - they're - They're already here",
-      "meaning": "Less common words/expressions",
-      "example": ".",
-      "count": 0
-    },
-    {
       "word": "some ‘less common’ vocabulary, including idioms and less common collocations.",
       "meaning": "Note on using idioms . Do not try to ‘show off’ to the examiner by using an idiom in every single sentence. Idioms should be used appropriately. Think of them like spices in a cooking recipe.",
       "example": "I think his reaction was a little exaggerated. I think his reaction was a little over the top. Although they played well, they lost the match. Even though they played well, they lost the match. In my country, if you are rich, you can do bad things and not get punished. In my country, if you are wealthy, you can get away with murder.",

--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -4988,12 +4988,6 @@ export const DEFAULT_VOCABULARY_DATA: SheetData =
       "count": 0
     },
     {
-      "word": "He would - he'd - He'd like to see you now. why have - Why've. Why've you come? I will - I'll - I'll think about it. where did - Where'd - Where'd you get that? they are - they're - They're already here",
-      "meaning": "Less common words/expressions",
-      "example": ".",
-      "count": 0
-    },
-    {
       "word": "some ‘less common’ vocabulary, including idioms and less common collocations.",
       "meaning": "Note on using idioms . Do not try to ‘show off’ to the examiner by using an idiom in every single sentence. Idioms should be used appropriately. Think of them like spices in a cooking recipe.",
       "example": "I think his reaction was a little exaggerated. I think his reaction was a little over the top. Although they played well, they lost the match. Even though they played well, they lost the match. In my country, if you are rich, you can do bad things and not get punished. In my country, if you are wealthy, you can get away with murder.",


### PR DESCRIPTION
## Summary
- remove an invalid long `word` from the default vocabulary dataset
- update generated JSON file
- document how to unlock audio in the browser

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a53865fc4832f848eb77eb4a9f8bd