### PR TITLE
Improve autoplay re-evaluation on user interaction

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -35,6 +35,8 @@ const VocabularyAppContainer: React.FC = () => {
     playCurrentWord,
     playbackCurrentWord,
     userInteractionRef,
+    hasUserInteracted,
+    onUserInteraction,
     isSpeaking,
     isAddWordModalOpen,
     isEditMode,
@@ -74,13 +76,14 @@ const VocabularyAppContainer: React.FC = () => {
   useUserInteractionHandler({
     userInteractionRef,
     playCurrentWord,
-    playbackCurrentWord
+    playbackCurrentWord,
+    onUserInteraction
   });
   
   useAutoPlayOnDataLoad({
     hasData,
     currentWord: playbackCurrentWord,
-    userInteractionRef,
+    hasUserInteracted,
     playCurrentWord
   });
 
@@ -112,7 +115,8 @@ const VocabularyAppContainer: React.FC = () => {
     toggleMute,
     handleSwitchCategory,
     currentCategory,
-    nextCategory
+    nextCategory,
+    onUserInteraction
   });
 
   return (

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -29,6 +29,13 @@ const VocabularyAppContainerNew: React.FC = () => {
 
   // Track whether the user has interacted to enable audio playback
   const userInteractionRef = useRef(false);
+  const [hasUserInteracted, setHasUserInteracted] = React.useState(false);
+
+  React.useEffect(() => {
+    if (localStorage.getItem('hadUserInteraction') === 'true') {
+      setHasUserInteracted(true);
+    }
+  }, []);
 
   console.log('[VOCAB-CONTAINER-NEW] Container state:', {
     hasData,
@@ -63,12 +70,13 @@ const VocabularyAppContainerNew: React.FC = () => {
     userInteractionRef,
     playCurrentWord,
     playbackCurrentWord: currentWord,
+    onUserInteraction: () => setHasUserInteracted(true),
   });
 
   useAutoPlayOnDataLoad({
     hasData,
     currentWord,
-    userInteractionRef,
+    hasUserInteracted,
     playCurrentWord,
   });
 

--- a/src/components/vocabulary-app/hooks/useVocabularyAppState.ts
+++ b/src/components/vocabulary-app/hooks/useVocabularyAppState.ts
@@ -35,6 +35,8 @@ export const useVocabularyAppState = () => {
     playCurrentWord,
     currentWord: playbackCurrentWord,
     userInteractionRef,
+    hasUserInteracted,
+    onUserInteraction,
     isSpeaking,
     allVoiceOptions
   } = useVocabularyPlayback(wordList || []);
@@ -73,6 +75,8 @@ export const useVocabularyAppState = () => {
     playCurrentWord,
     playbackCurrentWord,
     userInteractionRef,
+    hasUserInteracted,
+    onUserInteraction,
     isSpeaking,
     allVoiceOptions,
     

--- a/src/components/vocabulary-app/interactive/UserInteractionHandlers.tsx
+++ b/src/components/vocabulary-app/interactive/UserInteractionHandlers.tsx
@@ -10,6 +10,7 @@ interface UserInteractionHandlersProps {
   handleSwitchCategory: (current: string, next: string) => void;
   currentCategory: string;
   nextCategory: string | null;
+  onUserInteraction?: () => void;
 }
 
 export const useUserInteractionHandlers = ({
@@ -20,12 +21,14 @@ export const useUserInteractionHandlers = ({
   toggleMute,
   handleSwitchCategory,
   currentCategory,
-  nextCategory
+  nextCategory,
+  onUserInteraction
 }: UserInteractionHandlersProps) => {
   // Handle category switch with explicit user interaction tracking
   const handleCategorySwitchDirect = () => {
     // Mark that we've had user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     
     if (typeof nextCategory === 'string') {
       console.log(`Switching directly to category: ${nextCategory}`);
@@ -37,6 +40,7 @@ export const useUserInteractionHandlers = ({
   const handleManualNext = () => {
     // This is definitely user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     goToNextWord();
   };
 
@@ -44,6 +48,7 @@ export const useUserInteractionHandlers = ({
   const handleTogglePauseWithInteraction = () => {
     // This is definitely user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     togglePause();
   };
 
@@ -51,6 +56,7 @@ export const useUserInteractionHandlers = ({
   const handleCycleVoiceWithInteraction = () => {
     // This is definitely user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     cycleVoice();
   };
 
@@ -58,6 +64,7 @@ export const useUserInteractionHandlers = ({
   const handleToggleMuteWithInteraction = () => {
     // This is definitely user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     toggleMute();
   };
 

--- a/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
+++ b/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
@@ -1,26 +1,20 @@
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 interface AutoPlayProps {
   hasData: boolean;
   currentWord: any | null;
-  userInteractionRef: React.MutableRefObject<boolean>;
+  hasUserInteracted: boolean;
   playCurrentWord: () => void;
 }
 
 export const useAutoPlayOnDataLoad = ({
   hasData,
   currentWord,
-  userInteractionRef,
+  hasUserInteracted,
   playCurrentWord,
 }: AutoPlayProps) => {
-  const [hasUserInteracted, setHasUserInteracted] = useState(userInteractionRef.current);
   const hasAutoPlayedRef = useRef(false);
-
-  // Track changes to the ref in a state variable so effects re-run
-  useEffect(() => {
-    setHasUserInteracted(userInteractionRef.current);
-  }, [userInteractionRef.current]);
 
   // Force audio to play when data becomes available
   useEffect(() => {

--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -6,12 +6,14 @@ interface UserInteractionProps {
   userInteractionRef: React.MutableRefObject<boolean>;
   playCurrentWord: () => void;
   playbackCurrentWord: any;
+  onUserInteraction?: () => void;
 }
 
 export const useUserInteractionHandler = ({
   userInteractionRef,
   playCurrentWord,
-  playbackCurrentWord
+  playbackCurrentWord,
+  onUserInteraction
 }: UserInteractionProps) => {
   // Track if we've already initialized to prevent duplicate initialization
   const initializedRef = useRef(false);
@@ -30,6 +32,7 @@ export const useUserInteractionHandler = ({
       // Mark that we've had user interaction
       userInteractionRef.current = true;
       initializedRef.current = true;
+      onUserInteraction?.();
       
       try {
         // Store this fact in localStorage to persist across page reloads
@@ -83,6 +86,7 @@ export const useUserInteractionHandler = ({
     // ensure audio is unlocked with a fresh user gesture
     if (localStorage.getItem('hadUserInteraction') === 'true') {
       console.log('Previous interaction detected from localStorage');
+      onUserInteraction?.();
     }
     
     // Add event listeners for various user interaction types
@@ -96,5 +100,5 @@ export const useUserInteractionHandler = ({
       document.removeEventListener('touchstart', enableAudioPlayback);
       document.removeEventListener('keydown', enableAudioPlayback);
     };
-  }, [userInteractionRef, playCurrentWord, playbackCurrentWord]);
+  }, [userInteractionRef, playCurrentWord, playbackCurrentWord, onUserInteraction]);
 };

--- a/src/hooks/vocabulary-playback/core/playback-states/useUserInteraction.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useUserInteraction.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Hook for managing user interaction detection
  */
-export const useUserInteraction = () => {
+export const useUserInteraction = (onUserInteraction?: () => void) => {
   // Track if user has interacted with the page
   const userInteractionRef = useRef<boolean>(false);
   
@@ -14,6 +14,7 @@ export const useUserInteraction = () => {
     if (localStorage.getItem('hadUserInteraction') === 'true') {
       console.log('User interaction detected from localStorage');
       userInteractionRef.current = true;
+      onUserInteraction?.();
     }
     
     // Function to handle user interaction
@@ -21,6 +22,7 @@ export const useUserInteraction = () => {
       if (!userInteractionRef.current) {
         console.log('User interaction detected');
         userInteractionRef.current = true;
+        onUserInteraction?.();
         localStorage.setItem('hadUserInteraction', 'true');
         
         // Try to initialize speech synthesis

--- a/src/hooks/vocabulary-playback/core/useCorePlayback.ts
+++ b/src/hooks/vocabulary-playback/core/useCorePlayback.ts
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 /**
  * Core playback state and utility functions
  */
-export const useCorePlayback = () => {
+export const useCorePlayback = (onUserInteraction?: () => void) => {
   // Basic state for playback
   const [isSpeaking, setIsSpeaking] = useState(false);
   const speakingRef = useRef(false);
@@ -21,6 +21,7 @@ export const useCorePlayback = () => {
       if (!userInteractionRef.current) {
         console.log('User interaction detected in useCorePlayback');
         userInteractionRef.current = true;
+        onUserInteraction?.();
         
         // Initialize speech synthesis after user interaction
         if (!speechInitializedRef.current) {

--- a/src/hooks/vocabulary-playback/core/useWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/core/useWordPlayback.ts
@@ -24,6 +24,7 @@ export const useWordPlayback = (
   checkSpeechSupport: () => boolean,
   lastManualActionTimeRef: React.MutableRefObject<number>,
   autoAdvanceTimerRef: React.MutableRefObject<number | null>
+  , onUserInteraction?: () => void
 ) => {
   // Use our refactored core implementation
   return useWordPlaybackCore(
@@ -42,6 +43,7 @@ export const useWordPlayback = (
     incrementRetryAttempts,
     checkSpeechSupport,
     lastManualActionTimeRef,
-    autoAdvanceTimerRef
+    autoAdvanceTimerRef,
+    onUserInteraction
   );
 };

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useUserInteractionEffect.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useUserInteractionEffect.ts
@@ -11,7 +11,8 @@ export const useUserInteractionEffect = (
   userInteractionRef: React.MutableRefObject<boolean>,
   currentWord: VocabularyWord | null,
   playCurrentWord: () => void,
-  ensureVoicesLoaded: () => Promise<boolean>
+  ensureVoicesLoaded: () => Promise<boolean>,
+  onUserInteraction?: () => void
 ) => {
   const initializationDoneRef = useRef(false);
 
@@ -22,6 +23,7 @@ export const useUserInteractionEffect = (
         console.log('[USER-INTERACTION] First user interaction detected');
         userInteractionRef.current = true;
         initializationDoneRef.current = true;
+        onUserInteraction?.();
         
         // Save interaction state
         localStorage.setItem('hadUserInteraction', 'true');
@@ -88,6 +90,7 @@ export const useUserInteractionEffect = (
       console.log('[USER-INTERACTION] Previous interaction detected from localStorage');
       userInteractionRef.current = true;
       initializationDoneRef.current = true;
+      onUserInteraction?.();
       return;
     }
     
@@ -101,5 +104,5 @@ export const useUserInteractionEffect = (
       document.removeEventListener('touchstart', handleUserInteraction);
       document.removeEventListener('keydown', handleUserInteraction);
     };
-  }, [userInteractionRef, currentWord, playCurrentWord, ensureVoicesLoaded]);
+  }, [userInteractionRef, currentWord, playCurrentWord, ensureVoicesLoaded, onUserInteraction]);
 };

--- a/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useWordPlaybackCore.ts
@@ -31,7 +31,8 @@ export const useWordPlaybackCore = (
   incrementRetryAttempts: () => boolean,
   checkSpeechSupport: () => boolean,
   lastManualActionTimeRef: React.MutableRefObject<number>,
-  autoAdvanceTimerRef: React.MutableRefObject<number | null>
+  autoAdvanceTimerRef: React.MutableRefObject<number | null>,
+  onUserInteraction?: () => void
 ) => {
   // Get utterance manager functionality
   const { utteranceRef, createUtterance } = useUtteranceManager();
@@ -79,10 +80,11 @@ export const useWordPlaybackCore = (
   
   // Setup user interaction effect
   useUserInteractionEffect(
-    userInteractionRef, 
-    currentWord, 
-    playCurrentWord, 
-    ensureVoicesLoaded
+    userInteractionRef,
+    currentWord,
+    playCurrentWord,
+    ensureVoicesLoaded,
+    onUserInteraction
   );
   
   return {

--- a/src/hooks/vocabulary-playback/useVocabularyPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/useVocabularyPlaybackCore.ts
@@ -1,5 +1,5 @@
 
-import { useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { 
   useCorePlayback, 
@@ -20,16 +20,28 @@ import { useSafariSupport } from './core/ios-support';
  */
 export const useVocabularyPlaybackCore = (wordList: VocabularyWord[]) => {
   // Get core playback functionality
-  const { 
-    isSpeaking, 
-    setIsSpeaking, 
+  const {
+    isSpeaking,
+    setIsSpeaking,
     speakingRef,
-    retryAttemptsRef, 
+    retryAttemptsRef,
     userInteractionRef,
     resetRetryAttempts,
     incrementRetryAttempts,
     checkSpeechSupport
-  } = useCorePlayback();
+  } = useCorePlayback(() => setHasUserInteracted(true));
+
+  const [hasUserInteracted, setHasUserInteracted] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem('hadUserInteraction') === 'true') {
+        setHasUserInteracted(true);
+      }
+    } catch (e) {
+      console.error('Failed to read interaction state:', e);
+    }
+  }, []);
   
   // Get voice management functionality
   const { 
@@ -87,7 +99,8 @@ export const useVocabularyPlaybackCore = (wordList: VocabularyWord[]) => {
     incrementRetryAttempts,
     checkSpeechSupport,
     lastManualActionTimeRef,
-    autoAdvanceTimerRef
+    autoAdvanceTimerRef,
+    () => setHasUserInteracted(true)
   );
 
   // Obtain the cancelSpeech function now that resetPlayInProgress is available
@@ -140,6 +153,8 @@ export const useVocabularyPlaybackCore = (wordList: VocabularyWord[]) => {
     togglePause,
     cycleVoice,
     userInteractionRef,
+    hasUserInteracted,
+    onUserInteraction: () => setHasUserInteracted(true),
     isSpeaking,
     hasSpeechPermission,
     allVoiceOptions

--- a/src/hooks/vocabulary-playback/useWordNavigation.tsx
+++ b/src/hooks/vocabulary-playback/useWordNavigation.tsx
@@ -3,11 +3,12 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 
 export const useWordNavigation = (
-  wordList: VocabularyWord[], 
+  wordList: VocabularyWord[],
   cancelSpeech: () => void,
   muted: boolean,
   paused: boolean,
-  playWord: (word: VocabularyWord) => void
+  playWord: (word: VocabularyWord) => void,
+  onUserInteraction?: () => void
 ) => {
   // Navigation state
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -27,6 +28,7 @@ export const useWordNavigation = (
   const advanceToNext = useCallback(() => {
     // Mark that we've had user interaction
     userInteractionRef.current = true;
+    onUserInteraction?.();
     
     // Cancel any ongoing speech
     cancelSpeech();


### PR DESCRIPTION
## Summary
- manage user interaction state in playback core
- update effect hooks to notify interaction callback
- let `useAutoPlayOnDataLoad` depend on the interaction state
- wire interaction callback through containers and handlers

## Testing
- `npm test` *(fails: Vitest missing / SyntaxError)*
- `npm run lint` *(fails: 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a578746e4832f92cd8cd6dc3e0b12