### PR TITLE
Fix mobile speech repeating

### DIFF
--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,0 +1,5 @@
+export function isMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+


### PR DESCRIPTION
## Summary
- detect mobile devices
- use DirectSpeechService for mobile playback to prevent repeating one word

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684a6ddf9cd8832f9eb5fc6b810d65d8