### PR TITLE
Improve speech unlock and diagnostics

### DIFF
--- a/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
+++ b/src/hooks/vocabulary-app/useAutoPlayOnDataLoad.ts
@@ -1,5 +1,6 @@
 
 import { useEffect, useRef } from 'react';
+import { unlockAudio } from '@/utils/speech/core/modules/speechUnlock';
 
 interface AutoPlayProps {
   hasData: boolean;
@@ -21,8 +22,9 @@ export const useAutoPlayOnDataLoad = ({
     if (hasData && currentWord && hasUserInteracted && !hasAutoPlayedRef.current) {
       console.log('Data loaded and user has interacted, triggering playback');
       hasAutoPlayedRef.current = true;
-      // Small delay to ensure rendering completes
-      const timerId = setTimeout(() => {
+
+      const timerId = setTimeout(async () => {
+        await unlockAudio();
         playCurrentWord();
       }, 500);
       return () => clearTimeout(timerId);

--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -1,5 +1,6 @@
 
 import { useEffect, useRef } from 'react';
+import { unlockAudio } from '@/utils/speech/core/modules/speechUnlock';
 
 interface UserInteractionProps {
   userInteractionRef: React.MutableRefObject<boolean>;
@@ -16,71 +17,31 @@ export const useUserInteractionHandler = ({
 }: UserInteractionProps) => {
   // Track if we've already initialized to prevent duplicate initialization
   const initializedRef = useRef(false);
-  
+
   // Global click handler to enable audio (only needed once)
   useEffect(() => {
-    const enableAudioPlayback = () => {
+    console.log('[USER-INTERACTION] Handler mounted');
+
+    const enableAudioPlayback = async () => {
       // Prevent duplicate initialization
       if (initializedRef.current) {
         console.log('Audio already initialized, skipping');
         return;
       }
-      
+
       console.log('User interaction detected, enabling audio playback system-wide');
-      
+
       // Mark that we've had user interaction
       userInteractionRef.current = true;
       initializedRef.current = true;
+      localStorage.setItem('hadUserInteraction', 'true');
+
+      // Unlock browser audio using shared utility
+      await unlockAudio();
+
       onUserInteraction?.();
       
-      try {
-        // Store this fact in localStorage to persist across page reloads
-        localStorage.setItem('hadUserInteraction', 'true');
 
-        // Resume audio context if needed
-        try {
-          const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
-          if (AudioCtx) {
-            const ctx = new AudioCtx();
-            if (ctx.state === 'suspended') {
-              ctx.resume();
-            }
-          }
-        } catch (err) {
-          console.warn('AudioContext resume failed:', err);
-        }
-
-        // Initialize speech synthesis with a silent utterance (required on iOS)
-        try {
-          const utterance = new SpeechSynthesisUtterance(' ');
-          utterance.volume = 0;
-          utterance.rate = 1;
-
-          utterance.onend = () => {
-            console.log('Speech system initialized successfully');
-          };
-
-          utterance.onerror = () => {
-            initializedRef.current = true;
-          };
-
-          if (window.speechSynthesis.speaking) {
-            window.speechSynthesis.cancel();
-            setTimeout(() => {
-              window.speechSynthesis.speak(utterance);
-            }, 200);
-          } else {
-            window.speechSynthesis.speak(utterance);
-          }
-        } catch (err) {
-          console.error('Speech initialization error:', err);
-          initializedRef.current = true; // Mark as initialized anyway
-        }
-      } catch (e) {
-        console.error('Error during audio unlocking:', e);
-        initializedRef.current = true; // Mark as initialized anyway
-      }
-      
       // Remove event listeners after first successful initialization
       document.removeEventListener('click', enableAudioPlayback);
       document.removeEventListener('touchstart', enableAudioPlayback);
@@ -90,7 +51,9 @@ export const useUserInteractionHandler = ({
     // Check if we've had interaction before, but still attach listeners to
     // ensure audio is unlocked with a fresh user gesture
     if (localStorage.getItem('hadUserInteraction') === 'true') {
-      console.log('Previous interaction detected from localStorage');
+      console.log('[USER-INTERACTION] Previous interaction detected from localStorage');
+      userInteractionRef.current = true;
+      initializedRef.current = true;
       onUserInteraction?.();
     }
     
@@ -105,5 +68,5 @@ export const useUserInteractionHandler = ({
       document.removeEventListener('touchstart', enableAudioPlayback);
       document.removeEventListener('keydown', enableAudioPlayback);
     };
-  }, [userInteractionRef, playCurrentWord, playbackCurrentWord, onUserInteraction]);
+  }, [userInteractionRef, onUserInteraction]);
 };

--- a/src/services/speech/core/SpeechExecutor.ts
+++ b/src/services/speech/core/SpeechExecutor.ts
@@ -5,6 +5,7 @@ import { AutoAdvanceTimer } from './AutoAdvanceTimer';
 import { VoiceManager } from './VoiceManager';
 import { isMobileDevice } from '@/utils/device';
 import { directSpeechService } from '../directSpeechService';
+import { toast } from 'sonner';
 
 /**
  * Handles the actual speech synthesis execution
@@ -109,12 +110,14 @@ export class SpeechExecutor {
         this.stateManager.setCurrentUtterance(utterance);
         this.isStopping = false;
         this.cancelledUtterance = null;
+        console.log('[SPEECH-EXECUTOR] -> invoking window.speechSynthesis.speak');
         window.speechSynthesis.speak(utterance);
 
         // Fallback timeout
         setTimeout(() => {
           if (this.stateManager.getState().currentUtterance === utterance && !this.stateManager.getState().isActive) {
             console.warn('[SPEECH-EXECUTOR] Speech may have failed silently');
+            toast.error('Audio blocked—click anywhere to enable sound.');
             resolve(false);
           }
         }, 1000);

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -44,6 +44,7 @@ class UnifiedSpeechController {
 
   // Main speak method
   async speak(word: VocabularyWord, voiceRegion: 'US' | 'UK' | 'AU' = 'US'): Promise<boolean> {
+    console.log(`[UNIFIED-SPEECH] speak() called for: ${word.word}`);
     return this.speechExecutor.speak(word, voiceRegion);
   }
 

--- a/src/utils/speech/core/modules/speechUnlock.ts
+++ b/src/utils/speech/core/modules/speechUnlock.ts
@@ -1,6 +1,42 @@
 
-// Audio unlocking is no longer required. The function now immediately resolves.
+// Attempt to unlock browser audio using a silent utterance.
+// This resolves once the attempt completes so subsequent speech
+// requests aren't blocked by autoplay restrictions.
 export const unlockAudio = (): Promise<boolean> => {
-  console.log('[ENGINE] Audio unlock skipped');
-  return Promise.resolve(true);
+  return new Promise((resolve) => {
+    try {
+      console.log('[ENGINE] Attempting audio unlock');
+
+      // Resume an AudioContext if the browser supports it
+      const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+      if (AudioCtx) {
+        try {
+          const ctx = new AudioCtx();
+          if (ctx.state === 'suspended') {
+            ctx.resume().catch(() => {});
+          }
+        } catch (err) {
+          console.warn('[ENGINE] AudioContext resume failed:', err);
+        }
+      }
+
+      // Speak a silent utterance to unlock speech synthesis
+      const u = new SpeechSynthesisUtterance(' ');
+      u.volume = 0;
+      u.onend = () => resolve(true);
+      u.onerror = () => resolve(false);
+
+      try {
+        window.speechSynthesis.speak(u);
+        // Resolve if nothing happens after a short delay
+        setTimeout(() => resolve(true), 200);
+      } catch (err) {
+        console.warn('[ENGINE] Speech unlock failed:', err);
+        resolve(false);
+      }
+    } catch (e) {
+      console.warn('[ENGINE] Audio unlock failed:', e);
+      resolve(false);
+    }
+  });
 };


### PR DESCRIPTION
## Summary
- instrument user interaction handling and speech synthesis
- unlock audio via shared helper
- ensure autoplay waits for unlock
- surface blocked audio errors with toasts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a8f7247d4832f8b257e2e6be2e21e