### PR TITLE
Allow empty speechable text

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useContentValidation.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useContentValidation.ts
@@ -1,7 +1,6 @@
 
 import { VocabularyWord } from '@/types/vocabulary';
-import { extractSpeechableContent, hasValidSpeechableContent } from '@/utils/text/contentFilters';
-import { toast } from 'sonner';
+import { extractSpeechableContent } from '@/utils/text/contentFilters';
 
 /**
  * Hook for handling content validation and filtering for speech
@@ -24,16 +23,7 @@ export const useContentValidation = () => {
     console.log('[CONTENT-VALIDATION] Speechable text length:', speechableText.length);
     console.log('[CONTENT-VALIDATION] Text to speak:', speechableText.substring(0, 100) + '...');
 
-    // Check if we have any content to speak after filtering
-    const hasValidContent = hasValidSpeechableContent(rawTextToSpeak);
-    
-    if (!hasValidContent) {
-      console.log('[CONTENT-VALIDATION] No speechable content after filtering');
-      toast.info("This word contains only IPA notation or Vietnamese text - skipping speech");
-      return { speechableText: '', hasValidContent: false };
-    }
-
-    return { speechableText, hasValidContent: true };
+    return { speechableText };
   };
 
   return {

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
@@ -110,15 +110,14 @@ export const usePlaybackExecution = (
       console.log(`[PLAYBACK-EXECUTION] Processing word for speech: ${currentWord.word}`);
 
       // Validate and prepare content with enhanced logging
-      const { speechableText, hasValidContent } = validateAndPrepareContent(currentWord);
-      
+      const { speechableText } = validateAndPrepareContent(currentWord);
+
       console.log('[PLAYBACK-EXECUTION] Content validation result:', {
-        hasValidContent,
         speechableTextLength: speechableText.length,
         speechableTextPreview: speechableText.substring(0, 100) + '...'
       });
-      
-      if (!hasValidContent) {
+
+      if (speechableText.trim().length === 0) {
         console.log('[PLAYBACK-EXECUTION] No valid content to speak, advancing');
         scheduleAutoAdvance(2000);
         setPlayInProgress(false);

--- a/tests/useContentValidation.test.ts
+++ b/tests/useContentValidation.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { useContentValidation } from '../src/hooks/vocabulary-playback/core/word-playback/hooks/useContentValidation';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+describe('useContentValidation', () => {
+  const { validateAndPrepareContent } = useContentValidation();
+
+  it('returns filtered speechable text', () => {
+    const word: VocabularyWord = {
+      word: 'quick',
+      meaning: '(adj) [kwiːk]',
+      example: '',
+      count: 1,
+    };
+
+    const { speechableText } = validateAndPrepareContent(word);
+    expect(speechableText).toBe('quick.');
+  });
+
+  it('allows empty speechable text', () => {
+    const word: VocabularyWord = {
+      word: '[kwiːk]',
+      meaning: '',
+      example: '',
+      count: 1,
+    };
+
+    const { speechableText } = validateAndPrepareContent(word);
+    expect(speechableText).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- remove `hasValidSpeechableContent` check from `useContentValidation`
- guard in `usePlaybackExecution` if the filtered text is empty
- add unit tests for `useContentValidation`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684aa9d37ae8832f9e78a4805bc486dd