### PR TITLE
Adjust interaction check

### DIFF
--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -48,13 +48,12 @@ export const useUserInteractionHandler = ({
       document.removeEventListener('keydown', enableAudioPlayback);
     };
     
-    // Check if we've had interaction before, but still attach listeners to
-    // ensure audio is unlocked with a fresh user gesture
+    // Check if we've had interaction before. We still wait for a new user
+    // gesture to actually unlock audio again, so simply log this information.
     if (localStorage.getItem('hadUserInteraction') === 'true') {
-      console.log('[USER-INTERACTION] Previous interaction detected from localStorage');
-      userInteractionRef.current = true;
-      initializedRef.current = true;
-      onUserInteraction?.();
+      console.log(
+        '[USER-INTERACTION] Previous interaction found; waiting for new gesture to unlock audio'
+      );
     }
     
     // Add event listeners for various user interaction types


### PR DESCRIPTION
## Summary
- simplify localStorage interaction check
- leave event listeners active to wait for a new gesture

## Testing
- `npm test`
- `npm run lint` *(fails: 36 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684abd7db7f8832f8304ca7479963713