### PR TITLE
Remove audio blocked fallback

### DIFF
--- a/src/services/speech/core/SpeechExecutor.ts
+++ b/src/services/speech/core/SpeechExecutor.ts
@@ -113,14 +113,7 @@ export class SpeechExecutor {
         console.log('[SPEECH-EXECUTOR] -> invoking window.speechSynthesis.speak');
         window.speechSynthesis.speak(utterance);
 
-        // Fallback timeout
-        setTimeout(() => {
-          if (this.stateManager.getState().currentUtterance === utterance && !this.stateManager.getState().isActive) {
-            console.warn('[SPEECH-EXECUTOR] Speech may have failed silently');
-            toast.error('Audio blocked—click anywhere to enable sound.');
-            resolve(false);
-          }
-        }, 1000);
+        // Removed fallback timeout which previously handled blocked audio
 
       } catch (error) {
         console.error('[SPEECH-EXECUTOR] Error in speak method:', error);


### PR DESCRIPTION
## Summary
- remove the toast check for blocked audio

## Testing
- `npm run lint`
- `npm test` *(fails: hasValidSpeechableContent is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684acdb6a3c8832fbbebdaa970438410