### PR TITLE
Fix speech stop on navigation

### DIFF
--- a/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
+++ b/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
@@ -26,7 +26,7 @@ export const useSpeechIntegration = (
 
   // Play current word with conflict prevention
   const playCurrentWord = useCallback(async () => {
-    if (!currentWord || speechState.isActive || isTransitioningRef.current || isPlayingRef.current) {
+    if (!currentWord || isTransitioningRef.current || isPlayingRef.current) {
       console.log('[SPEECH-INTEGRATION] Skipping play - conditions not met:', {
         hasWord: !!currentWord,
         isActive: speechState.isActive,
@@ -34,6 +34,12 @@ export const useSpeechIntegration = (
         isPlaying: isPlayingRef.current
       });
       return;
+    }
+
+    // If speech is currently active, stop it before starting the new word
+    if (speechState.isActive) {
+      unifiedSpeechController.stop();
+      await new Promise(resolve => setTimeout(resolve, 50));
     }
 
     // Prevent duplicate plays of the same word

--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -4,6 +4,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { saveVoiceRegionToStorage } from '@/utils/speech/core/speechSettings';
 import { SpeechState } from '@/services/speech/core/SpeechState';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Vocabulary control actions
@@ -79,9 +80,10 @@ export const useVocabularyControls = (
   // Switch category with mobile-friendly handling
   const switchCategory = useCallback(() => {
     console.log('[VOCABULARY-CONTROLS] Switching category');
-    
-    // Clear timers during category switch
+
+    // Clear timers and stop current speech during category switch
     clearAutoAdvanceTimer();
+    unifiedSpeechController.stop();
     
     try {
       const newCategory = vocabularyService.nextSheet();
@@ -101,7 +103,7 @@ export const useVocabularyControls = (
     } catch (error) {
       console.error('[VOCABULARY-CONTROLS] Error switching category:', error);
     }
-  }, [clearAutoAdvanceTimer, isPaused, isMuted, playCurrentWord]);
+  }, [clearAutoAdvanceTimer, isPaused, isMuted, playCurrentWord, unifiedSpeechController]);
 
   return {
     togglePause,

--- a/src/hooks/vocabulary-controller/core/useWordNavigation.ts
+++ b/src/hooks/vocabulary-controller/core/useWordNavigation.ts
@@ -2,6 +2,7 @@
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Word navigation logic
@@ -35,8 +36,9 @@ export const useWordNavigation = (
     lastWordChangeRef.current = now;
     isTransitioningRef.current = true;
 
-    // Clear any auto-advance timers
+    // Clear any auto-advance timers and stop current speech
     clearAutoAdvanceTimer();
+    unifiedSpeechController.stop();
 
     console.log('[WORD-NAVIGATION] Going to next word', {
       from: currentWord?.word || 'none',

--- a/src/services/speech/core/SpeechExecutor.ts
+++ b/src/services/speech/core/SpeechExecutor.ts
@@ -5,6 +5,7 @@ import { AutoAdvanceTimer } from './AutoAdvanceTimer';
 import { VoiceManager } from './VoiceManager';
 import { isMobileDevice } from '@/utils/device';
 import { directSpeechService } from '../directSpeechService';
+import { mobileAudioManager } from '@/utils/audio/mobileAudioManager';
 
 /**
  * Enhanced Speech Executor with improved cancellation handling and mobile support
@@ -94,19 +95,13 @@ export class SpeechExecutor {
       return false;
     }
 
-    // Initialize mobile audio context if needed
+    // Initialize/resume mobile audio context if needed
     if (isMobileDevice()) {
       try {
-        const AudioContext = window.AudioContext || (window as any).webkitAudioContext;
-        if (AudioContext) {
-          const audioContext = new AudioContext();
-          if (audioContext.state === 'suspended') {
-            console.log('[SPEECH-EXECUTOR] Resuming mobile audio context');
-            await audioContext.resume();
-          }
-        }
+        await mobileAudioManager.initialize();
+        await mobileAudioManager.resume();
       } catch (error) {
-        console.warn('[SPEECH-EXECUTOR] Mobile audio context initialization failed:', error);
+        console.warn('[SPEECH-EXECUTOR] Mobile audio manager init failed:', error);
       }
     }
 

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -1,5 +1,6 @@
 
 import { getVoiceByRegion } from '@/utils/speech/voiceUtils';
+import { mobileAudioManager } from '@/utils/audio/mobileAudioManager';
 
 /**
  * Enhanced direct speech service with improved completion detection and error handling
@@ -74,7 +75,7 @@ class DirectSpeechService {
   }
 
   async speak(
-    text: string, 
+    text: string,
     options: {
       voiceRegion?: 'US' | 'UK' | 'AU';
       word?: string;
@@ -91,6 +92,14 @@ class DirectSpeechService {
     // Stop any existing speech
     this.stop();
     this.wasManuallyStopped = false;
+
+    // Ensure mobile audio context is ready
+    try {
+      await mobileAudioManager.initialize();
+      await mobileAudioManager.resume();
+    } catch (e) {
+      console.warn('[DIRECT-SPEECH] Failed to init mobile audio manager:', e);
+    }
     
     return new Promise((resolve) => {
       try {

--- a/tests/wordNavigationStop.test.tsx
+++ b/tests/wordNavigationStop.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { useWordNavigation } from '../src/hooks/vocabulary-controller/core/useWordNavigation';
+
+vi.mock('../src/services/speech/unifiedSpeechController', () => ({
+  unifiedSpeechController: { stop: vi.fn() }
+}));
+
+import { unifiedSpeechController } from '../src/services/speech/unifiedSpeechController';
+
+describe('useWordNavigation', () => {
+  it('stops current speech when navigating to next word', () => {
+    const words = [
+      { word: 'one', meaning: '', example: '', category: 'c' },
+      { word: 'two', meaning: '', example: '', category: 'c' }
+    ];
+    let index = 0;
+    const setIndex = (i: number) => {
+      index = i;
+    };
+    const isTransRef = { current: false };
+    const lastChangeRef = { current: 0 };
+    const clear = vi.fn();
+
+    const { result } = renderHook(() =>
+      useWordNavigation(words, index, setIndex, words[index], isTransRef, lastChangeRef, clear)
+    );
+
+    act(() => {
+      result.current.goToNext();
+    });
+
+    expect((unifiedSpeechController.stop as any).mock.calls.length).toBeGreaterThan(0);
+    expect(index).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- handle mobile audio initialization via mobileAudioManager
- stop current speech when navigating or switching categories
- stop before playing next word on word change
- add test verifying navigation stops speech

## Testing
- `npm test --silent`
- `npm run lint` *(fails: unexpected any, react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684bdc6238ec832fa16452702fe29a3e