### PR TITLE
Improve speech event handling

### DIFF
--- a/src/services/speech/core/SpeechExecutor.ts
+++ b/src/services/speech/core/SpeechExecutor.ts
@@ -230,6 +230,16 @@ export class SpeechExecutor {
       console.error(`[SPEECH-EXECUTOR] ✗ Speech error: ${event.error} for word: ${word.word}`);
       this.handleUtteranceError(event, utterance, resolve);
     };
+
+    utterance.onpause = () => {
+      console.log('[SPEECH-EXECUTOR] Speech paused');
+      this.stateManager.setPaused(true);
+    };
+
+    utterance.onresume = () => {
+      console.log('[SPEECH-EXECUTOR] Speech resumed');
+      this.stateManager.setPaused(false);
+    };
   }
 
   private handleUtteranceError(


### PR DESCRIPTION
## Summary
- handle `onpause` and `onresume` events in `SpeechExecutor`

## Testing
- `npm test -- -t '' --run`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_684be6205250832f9b21aa3f017e25f4