### PR TITLE
Fix autoplay resuming after unmute/unpause

### DIFF
--- a/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
@@ -14,7 +14,25 @@ export const useAutoPlay = (
   playCurrentWord: () => void
 ) => {
   const lastWordRef = useRef<string | null>(null);
+  const prevMutedRef = useRef(muted);
+  const prevPausedRef = useRef(paused);
   const autoPlayTimeoutRef = useRef<number | null>(null);
+
+  // Reset lastWordRef when unmuting
+  useEffect(() => {
+    if (prevMutedRef.current && !muted) {
+      lastWordRef.current = null;
+    }
+    prevMutedRef.current = muted;
+  }, [muted]);
+
+  // Reset lastWordRef when unpausing
+  useEffect(() => {
+    if (prevPausedRef.current && !paused) {
+      lastWordRef.current = null;
+    }
+    prevPausedRef.current = paused;
+  }, [paused]);
 
   // Auto-play effect with proper coordination
   useEffect(() => {

--- a/tests/useAutoPlayResume.test.ts
+++ b/tests/useAutoPlayResume.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useAutoPlay } from '../src/hooks/vocabulary-playback/core/playback-states/useAutoPlay';
+import { VocabularyWord } from '../src/types/vocabulary';
+import { speechController } from '../src/utils/speech/core/speechController';
+
+vi.mock('../src/utils/speech/core/speechController', () => ({
+  speechController: { isActive: vi.fn(() => false) }
+}));
+
+const word: VocabularyWord = { word: 'hello', meaning: '', example: '', category: 'c' };
+
+describe('useAutoPlay resume', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('replays current word when unpaused', () => {
+    const play = vi.fn();
+    const { rerender } = renderHook(({currentWord, muted, paused}) =>
+      useAutoPlay(currentWord, muted, paused, play),
+      { initialProps: { currentWord: word, muted: false, paused: true } }
+    );
+
+    vi.advanceTimersByTime(500);
+    expect(play).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ currentWord: word, muted: false, paused: false });
+    });
+
+    vi.advanceTimersByTime(500);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays current word when unmuted', () => {
+    const play = vi.fn();
+    const { rerender } = renderHook(({currentWord, muted, paused}) =>
+      useAutoPlay(currentWord, muted, paused, play),
+      { initialProps: { currentWord: word, muted: true, paused: false } }
+    );
+
+    vi.advanceTimersByTime(500);
+    expect(play).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ currentWord: word, muted: false, paused: false });
+    });
+
+    vi.advanceTimersByTime(500);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- reset auto-play tracking when mute/pause toggles off
- add tests to ensure auto-play resumes on unmute/unpause

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684bf1c2d658832fb7c3449c941891b2