### PR TITLE
Handle async audio unlocking before speech

### DIFF
--- a/src/services/speech/core/SpeechExecutor.ts
+++ b/src/services/speech/core/SpeechExecutor.ts
@@ -90,6 +90,10 @@ export class SpeechExecutor {
     this.stateManager.setPhase('preparing');
     this.isExecuting = true;
 
+    // Ensure the unlock process has fully completed before speaking
+    console.log(`[SPEECH-EXECUTOR-${speechId}] Waiting for audio unlock completion`);
+    await audioUnlockService.unlock();
+
     try {
       this.currentSpeechPromise = this.executeSpeech(word, voiceRegion, speechId);
       const result = await this.currentSpeechPromise;


### PR DESCRIPTION
## Summary
- track unlock progress in `AudioUnlockService`
- wait for unlock completion before playing speech

## Testing
- `npm test` *(fails: vitest runs in watch mode)*
- `npm run lint` *(fails: numerous lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6850199c6f00832fb1b541c94d0a69d5