### PR TITLE
Update category labels and UI widths

### DIFF
--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward } from 'lucide-react';
+import { getCategoryLabel } from '@/utils/categoryLabels';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 
 interface VocabularyCardProps {
@@ -65,6 +66,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
 
   // Safety check for nextCategory - ensure it's a string
   const safeNextCategory = nextCategory || 'Next';
+  const nextCategoryLabel = getCategoryLabel(safeNextCategory);
 
   return (
     <Card 
@@ -146,9 +148,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               className="h-6 text-xs px-2 text-green-700"
             >
               <RefreshCw size={10} className="mr-1" />
-              {typeof safeNextCategory === 'string' ? 
-                safeNextCategory.charAt(0).toUpperCase() + safeNextCategory.slice(1) : 
-                'Next'}
+              {nextCategoryLabel}
             </Button>
             
             {/* Single voice toggle button */}

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -5,6 +5,7 @@ import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
+import { getCategoryLabel } from '@/utils/categoryLabels';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -36,6 +37,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenEditModal,
 }) => {
   const safeNextCategory = nextCategory || 'Next';
+  const nextCategoryLabel = getCategoryLabel(safeNextCategory);
 
   return (
     <div className="flex flex-col gap-2 items-stretch">
@@ -82,9 +84,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         className="h-6 text-xs px-2 text-green-700"
       >
         <RefreshCw size={10} className="mr-1" />
-        {typeof safeNextCategory === 'string'
-          ? safeNextCategory.charAt(0).toUpperCase() + safeNextCategory.slice(1)
-          : 'Next'}
+        {nextCategoryLabel}
       </Button>
 
       <Button

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -16,11 +16,11 @@ interface WordFormFieldsProps {
 
 // Updated category options without "All words"
 const CATEGORY_OPTIONS = [
-  { value: "phrasal verbs", label: "Phrasal Verbs" },
+  { value: "phrasal verbs", label: "Phrasal V" },
   { value: "idioms", label: "Idioms" },
-  { value: "topic vocab", label: "Topic Vocab" },
+  { value: "topic vocab", label: "Topic" },
   { value: "grammar", label: "Grammar" },
-  { value: "phrases, collocations", label: "Phrases & Collocations" }
+  { value: "phrases, collocations", label: "Phrasals" }
 ];
 
 const WordFormFields: React.FC<WordFormFieldsProps> = ({
@@ -70,7 +70,7 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
         </Label>
         <div className="col-span-3">
           <Select value={category} onValueChange={onCategoryChange} disabled={isDisabled}>
-            <SelectTrigger>
+            <SelectTrigger className="w-28">
               <SelectValue placeholder="Select a category" />
             </SelectTrigger>
             <SelectContent>

--- a/src/utils/categoryLabels.ts
+++ b/src/utils/categoryLabels.ts
@@ -1,0 +1,10 @@
+export const CATEGORY_LABELS: Record<string, string> = {
+  'phrases, collocations': 'Phrasals',
+  'topic vocab': 'Topic',
+  'phrasal verbs': 'Phrasal V',
+};
+
+export function getCategoryLabel(category: string): string {
+  return CATEGORY_LABELS[category] ||
+    category.charAt(0).toUpperCase() + category.slice(1);
+}


### PR DESCRIPTION
## Summary
- map category keys to shorter labels
- shorten category labels in add word form and fix button width
- display shorter next category label on vocabulary card and sidebar

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68501f8fbd94832f95ca69daa7d8aa03