### PR TITLE
Fix bypass validation regex

### DIFF
--- a/src/utils/text/contentFilters.ts
+++ b/src/utils/text/contentFilters.ts
@@ -44,8 +44,12 @@ export const getPreserveSpecialFromStorage = (): boolean => {
  */
 export const shouldBypassValidation = (text: string): boolean => {
   if (!text || typeof text !== 'string') return false;
-  
-  return BYPASS_PATTERNS.some(pattern => pattern.test(text));
+
+  return BYPASS_PATTERNS.some(pattern => {
+    // Reset lastIndex in case the regex has the global flag
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary
- reset `lastIndex` for bypass regex patterns to avoid stateful failures

## Testing
- `npx -y vitest run` *(fails: cannot find package 'vitest')*


------
https://chatgpt.com/codex/tasks/task_e_685020dd1970832f8704e35858071aca