### PR TITLE
Shrink buttons and shorten labels

### DIFF
--- a/src/components/vocabulary-app/AddWordButton.tsx
+++ b/src/components/vocabulary-app/AddWordButton.tsx
@@ -11,12 +11,12 @@ const AddWordButton: React.FC<AddWordButtonProps> = ({ onClick }) => {
   return (
     <Button
       onClick={onClick}
-      className="flex items-center justify-center gap-2 py-0.5 px-1.5 text-xs"
+      className="flex items-center justify-center gap-1 py-0.5 px-1 text-xs"
       variant="outline"
       size="sm"
     >
       <Plus className="h-4 w-4" />
-      <span>Add Word</span>
+      <span>Add</span>
     </Button>
   );
 };

--- a/src/components/vocabulary-app/EditWordButton.tsx
+++ b/src/components/vocabulary-app/EditWordButton.tsx
@@ -12,7 +12,7 @@ const EditWordButton: React.FC<EditWordButtonProps> = ({ onClick, disabled }) =>
   return (
     <Button
       onClick={onClick}
-      className="flex items-center justify-center gap-2 py-0.5 px-1.5 text-xs"
+      className="flex items-center justify-center gap-1 py-0.5 px-1 text-xs"
       variant="outline"
       size="sm"
       disabled={disabled}

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -110,12 +110,12 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               size="sm"
               onClick={onToggleMute}
               className={cn(
-                "h-6 text-xs px-2",
+                "h-6 text-xs px-1.5",
                 isMuted ? "text-purple-700 border-purple-300 bg-purple-50" : "text-gray-700"
               )}
             >
               {isMuted ? <VolumeX size={12} className="mr-1" /> : <Volume2 size={12} className="mr-1" />}
-              {isMuted ? "UNMUTE" : "MUTE"}
+              {isMuted ? "Unmute" : "Mute"}
             </Button>
             
             <Button
@@ -123,7 +123,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               size="sm"
               onClick={onTogglePause}
               className={cn(
-                "h-6 text-xs px-2",
+                "h-6 text-xs px-1.5",
                 isPaused ? "text-orange-500 border-orange-300 bg-orange-50" : "text-gray-700"
               )}
             >
@@ -135,7 +135,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               variant="outline"
               size="sm"
               onClick={onNextWord}
-              className="h-6 text-xs px-2 text-indigo-700 bg-indigo-50"
+              className="h-6 text-xs px-1.5 text-indigo-700 bg-indigo-50"
             >
               <SkipForward size={12} className="mr-1" />
               Next
@@ -145,7 +145,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               variant="outline"
               size="sm"
               onClick={onSwitchCategory}
-              className="h-6 text-xs px-2 text-green-700"
+              className="h-6 text-xs px-1.5 text-green-700"
             >
               <RefreshCw size={10} className="mr-1" />
               {nextCategoryLabel}
@@ -156,7 +156,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               variant="outline"
               size="sm"
               onClick={onCycleVoice}
-              className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
+              className="h-6 text-xs px-1.5 text-blue-700 border-blue-300 bg-blue-50"
             >
               {nextVoiceLabel}
             </Button>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -46,12 +46,12 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         size="sm"
         onClick={onToggleMute}
         className={cn(
-          'h-6 text-xs px-2',
+          'h-6 text-xs px-1.5',
           isMuted ? 'text-purple-700 border-purple-300 bg-purple-50' : 'text-gray-700'
         )}
       >
         {isMuted ? <VolumeX size={12} className="mr-1" /> : <Volume2 size={12} className="mr-1" />}
-        {isMuted ? 'UNMUTE' : 'MUTE'}
+        {isMuted ? 'Unmute' : 'Mute'}
       </Button>
 
       <Button
@@ -59,7 +59,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         size="sm"
         onClick={onTogglePause}
         className={cn(
-          'h-6 text-xs px-2',
+          'h-6 text-xs px-1.5',
           isPaused ? 'text-orange-500 border-orange-300 bg-orange-50' : 'text-gray-700'
         )}
       >
@@ -71,7 +71,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         variant="outline"
         size="sm"
         onClick={onNextWord}
-        className="h-6 text-xs px-2 text-indigo-700 bg-indigo-50"
+        className="h-6 text-xs px-1.5 text-indigo-700 bg-indigo-50"
       >
         <SkipForward size={12} className="mr-1" />
         Next
@@ -81,7 +81,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         variant="outline"
         size="sm"
         onClick={onSwitchCategory}
-        className="h-6 text-xs px-2 text-green-700"
+        className="h-6 text-xs px-1.5 text-green-700"
       >
         <RefreshCw size={10} className="mr-1" />
         {nextCategoryLabel}
@@ -91,7 +91,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         variant="outline"
         size="sm"
         onClick={onCycleVoice}
-        className="h-6 text-xs px-2 text-blue-700 border-blue-300 bg-blue-50"
+        className="h-6 text-xs px-1.5 text-blue-700 border-blue-300 bg-blue-50"
       >
         {nextVoiceLabel}
       </Button>

--- a/src/components/vocabulary-app/WordSearchSection.tsx
+++ b/src/components/vocabulary-app/WordSearchSection.tsx
@@ -40,14 +40,14 @@ const WordSearchSection: React.FC<WordSearchSectionProps> = ({
             maxLength={100}
           />
           {!editMode && (
-            <Button 
-              type="button" 
+            <Button
+              type="button"
               onClick={onSearch}
               disabled={isSearching || !word.trim()}
               aria-busy={isSearching}
-              className="shrink-0"
+              className="shrink-0 px-1.5"
             >
-              {isSearching ? <Loader className="h-4 w-4 animate-spin mr-1" /> : 'Search'}
+              {isSearching ? <Loader className="h-4 w-4 animate-spin mr-1" /> : 'Go'}
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- condense AddWord and EditWord buttons
- shorten search button label to "Go"
- reduce control button padding and labels for mute/unmute

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_685025c81cec832f99c248586d82bb0c