### PR TITLE
Align controls right and reduce spacing

### DIFF
--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -67,7 +67,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2 items-center">
+    <div className="flex flex-col gap-2 items-end">
       <Button
         variant="outline"
         size="sm"

--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -46,7 +46,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
   const { backgroundColor } = useBackgroundColor();
 
   return (
-    <div className="flex flex-col sm:flex-row items-start gap-4">
+    <div className="flex flex-col sm:flex-row items-start gap-1">
       <VocabularyCard
         word={currentWord.word}
         meaning={currentWord.meaning}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -45,7 +45,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   const { backgroundColor } = useBackgroundColor();
 
   return (
-    <div className="flex flex-row items-start gap-4 w-full max-w-5xl mx-auto">
+    <div className="flex flex-row items-start gap-1 w-full max-w-5xl mx-auto">
       {/* Main card - takes most of the space */}
       <div className="flex-1 min-w-0">
         <VocabularyCardNew
@@ -70,7 +70,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
       </div>
       
       {/* Controls column - positioned on the right side */}
-      <div className="flex-none w-20 flex flex-col justify-start">
+      <div className="flex-none w-20 flex flex-col justify-start items-end">
         <VocabularyControlsColumn
         isMuted={mute}
         isPaused={isPaused}


### PR DESCRIPTION
## Summary
- align `VocabularyControlsColumn` content to the right
- tighten the gap between the card and control buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511655b0c4832fb3bcc95d1f539f3b