### PR TITLE
Adjust spacing between card and controls

### DIFF
--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -46,7 +46,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
   const { backgroundColor } = useBackgroundColor();
 
   return (
-    <div className="flex flex-col sm:flex-row items-start gap-1">
+    <div className="flex flex-col sm:flex-row items-start gap-2 sm:gap-4">
       <VocabularyCard
         word={currentWord.word}
         meaning={currentWord.meaning}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -45,7 +45,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   const { backgroundColor } = useBackgroundColor();
 
   return (
-    <div className="flex flex-row items-start gap-1 w-full max-w-5xl mx-auto">
+    <div className="flex flex-row items-start gap-2 sm:gap-4 w-full max-w-5xl mx-auto">
       {/* Main card - takes most of the space */}
       <div className="flex-1 min-w-0">
         <VocabularyCardNew


### PR DESCRIPTION
## Summary
- increase gap between the Vocabulary card and control column to match page padding

## Testing
- `npx vitest run` *(fails: Unable to find accessible element "US" in tests/vocabularyContainerVoiceToggle.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685118445de0832f8f6ed5881738513a