### PR TITLE
Fix controls column width

### DIFF
--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -70,7 +70,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
       </div>
       
       {/* Controls column - positioned on the right side */}
-      <div className="flex-none w-20 flex flex-col justify-start items-end">
+      <div className="flex-none flex flex-col justify-start items-end">
         <VocabularyControlsColumn
         isMuted={mute}
         isPaused={isPaused}


### PR DESCRIPTION
## Summary
- remove w-20 width class from controls column

## Testing
- `npx vitest` *(fails: Unable to find element with role "button" and name "US")*

------
https://chatgpt.com/codex/tasks/task_e_685122c93d34832f8fa9dae453b86f07