### PR TITLE
Fix long meaning entries and document limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ npm test       # execute unit tests with vitest
 npm run lint   # check code style with ESLint
 ```
 
+## Vocabulary limits
+
+Meanings longer than 500 characters will be rejected during validation. The limit
+is defined as `MAX_MEANING_LENGTH` in
+`src/services/vocabulary/storage/constants.ts`. If you import custom lists,
+shorten or split very long definitions so they stay under this threshold.
+
 ## Enabling speech playback
 
 Modern browsers block audio playback until the user interacts with the page.

--- a/public/defaultVocabulary.json
+++ b/public/defaultVocabulary.json
@@ -3299,117 +3299,117 @@
       "meaning": "continue doing something in a determined way: quyết tâm tiến hành.",
       "example": "Don't worry, your dad's going to pull through.",
       "count": 0
-    }   
+    }
   ],
   "idioms": [
     {
-    "word": "keep a straight face",
-    "meaning": "remain serious and not laugh (giữ vẻ mặt nghiêm túc)",
-    "example": "I couldn't keep a straight face when I saw Mike’s new haircut.",
-    "count": 0
+      "word": "keep a straight face",
+      "meaning": "remain serious and not laugh (giữ vẻ mặt nghiêm túc)",
+      "example": "I couldn't keep a straight face when I saw Mike’s new haircut.",
+      "count": 0
     },
     {
-    "word": "keep sb posted",
-    "meaning": "regularly give someone information about something they are interested in (thường xuyên cập nhật thông tin)",
-    "example": "Do please keep me posted about any developments.",
-    "count": 0
+      "word": "keep sb posted",
+      "meaning": "regularly give someone information about something they are interested in (thường xuyên cập nhật thông tin)",
+      "example": "Do please keep me posted about any developments.",
+      "count": 0
     },
     {
-    "word": "keep sth under your hat",
-    "meaning": "keep something secret (giữ bí mật)",
-    "example": "Keep it under your hat, but we’re thinking of buying a new house.",
-    "count": 0
+      "word": "keep sth under your hat",
+      "meaning": "keep something secret (giữ bí mật)",
+      "example": "Keep it under your hat, but we’re thinking of buying a new house.",
+      "count": 0
     },
     {
-    "word": "keep up with the Joneses",
-    "meaning": "try to be as rich, successful, etc. as your neighbours (đu đòi)",
-    "example": "I don’t need a new car, and I’m really not interested in keeping up with the Joneses.",
-    "count": 0
+      "word": "keep up with the Joneses",
+      "meaning": "try to be as rich, successful, etc. as your neighbours (đu đòi)",
+      "example": "I don’t need a new car, and I’m really not interested in keeping up with the Joneses.",
+      "count": 0
     },
     {
-    "word": "keep your hair on",
-    "meaning": "used for telling someone not to get angry or upset (bình tĩnh nào)",
-    "example": "Keep your hair on! There’s no need to get annoyed.",
-    "count": 0
+      "word": "keep your hair on",
+      "meaning": "used for telling someone not to get angry or upset (bình tĩnh nào)",
+      "example": "Keep your hair on! There’s no need to get annoyed.",
+      "count": 0
     },
     {
-    "word": "kick yourself",
-    "meaning": "be very annoyed because you made a mistake or missed an opportunity (dằn vặt bản thân)",
-    "example": "I could have kicked myself when I realised I’d left my wallet in the restaurant.",
-    "count": 0
+      "word": "kick yourself",
+      "meaning": "be very annoyed because you made a mistake or missed an opportunity (dằn vặt bản thân)",
+      "example": "I could have kicked myself when I realised I’d left my wallet in the restaurant.",
+      "count": 0
     },
     {
-    "word": "knee-high to a grasshopper",
-    "meaning": "very small, because you were very young (lúc còn nhỏ xíu)",
-    "example": "When I was knee-high to a grasshopper, I used to believe that a monster lived under my bed.",
-    "count": 0
+      "word": "knee-high to a grasshopper",
+      "meaning": "very small, because you were very young (lúc còn nhỏ xíu)",
+      "example": "When I was knee-high to a grasshopper, I used to believe that a monster lived under my bed.",
+      "count": 0
     },
     {
-    "word": "know sth inside out",
-    "meaning": "be very familiar with; know everything about (biết tường tận)",
-    "example": "Maria’s been in the business for years and she knows advertising inside out.",
-    "count": 0
+      "word": "know sth inside out",
+      "meaning": "be very familiar with; know everything about (biết tường tận)",
+      "example": "Maria’s been in the business for years and she knows advertising inside out.",
+      "count": 0
     },
     {
-    "word": "know what’s what",
-    "meaning": "know the important facts about a situation (hiểu rõ cái gì ra cái gì)",
-    "example": "Ask Tony about the proposed changes. He knows what’s what.",
-    "count": 0
+      "word": "know what’s what",
+      "meaning": "know the important facts about a situation (hiểu rõ cái gì ra cái gì)",
+      "example": "Ask Tony about the proposed changes. He knows what’s what.",
+      "count": 0
     },
     {
-    "word": "last word in sth",
-    "meaning": "the newest and best type of something (kiểu mới nhất, thành tựu mới nhất)",
-    "example": "The ZD-2000 is the last word in mobile phones.",
-    "count": 0
+      "word": "last word in sth",
+      "meaning": "the newest and best type of something (kiểu mới nhất, thành tựu mới nhất)",
+      "example": "The ZD-2000 is the last word in mobile phones.",
+      "count": 0
     },
     {
-    "word": "lay/put your cards on the table",
-    "meaning": "tell people exactly what you are thinking or what you intend to do (thẳng thắn nói hết ra)",
-    "example": "I’m going to lay my cards on the table and offer you an extra £1,000. But that’s my final offer!",
-    "count": 0
+      "word": "lay/put your cards on the table",
+      "meaning": "tell people exactly what you are thinking or what you intend to do (thẳng thắn nói hết ra)",
+      "example": "I’m going to lay my cards on the table and offer you an extra £1,000. But that’s my final offer!",
+      "count": 0
     },
     {
-    "word": "let nature take its course",
-    "meaning": "allow something to develop without trying to influence it (hãy cứ để tự nhiên đi)",
-    "example": "I’m sure sales will improve if we just let nature take its course.",
-    "count": 0
+      "word": "let nature take its course",
+      "meaning": "allow something to develop without trying to influence it (hãy cứ để tự nhiên đi)",
+      "example": "I’m sure sales will improve if we just let nature take its course.",
+      "count": 0
     },
     {
-    "word": "let off steam",
-    "meaning": "shout or do something that allows you to get rid of anger (xả hơi, xả giận)",
-    "example": "I was so annoyed I had to go for a long walk to let off steam.",
-    "count": 0
+      "word": "let off steam",
+      "meaning": "shout or do something that allows you to get rid of anger (xả hơi, xả giận)",
+      "example": "I was so annoyed I had to go for a long walk to let off steam.",
+      "count": 0
     },
     {
-    "word": "let sleeping dogs lie",
-    "meaning": "leave a person or situation alone if it might cause you trouble (chuyện đã qua hãy để cho qua đi)",
-    "example": "I know you think your parents are being unfair, but it’s probably best to let sleeping dogs lie and not make it worse by arguing.",
-    "count": 0
+      "word": "let sleeping dogs lie",
+      "meaning": "leave a person or situation alone if it might cause you trouble (chuyện đã qua hãy để cho qua đi)",
+      "example": "I know you think your parents are being unfair, but it’s probably best to let sleeping dogs lie and not make it worse by arguing.",
+      "count": 0
     },
     {
-    "word": "let your hair down",
-    "meaning": "relax and enjoy yourself in a comfortable environment (xõa đi)",
-    "example": "It’s good to let your hair down after a hard week at work.",
-    "count": 0
+      "word": "let your hair down",
+      "meaning": "relax and enjoy yourself in a comfortable environment (xõa đi)",
+      "example": "It’s good to let your hair down after a hard week at work.",
+      "count": 0
     },
     {
-    "word": "life and soul of the party",
-    "meaning": "someone who is very lively at social events (linh hồn của bữa tiệc)",
-    "example": "Harry’s so much fun and everyone says he’s the life and soul of the party.",
-    "count": 0
+      "word": "life and soul of the party",
+      "meaning": "someone who is very lively at social events (linh hồn của bữa tiệc)",
+      "example": "Harry’s so much fun and everyone says he’s the life and soul of the party.",
+      "count": 0
     },
     {
-    "word": "like two peas in a pod",
-    "meaning": "used for saying that two people look or think exactly the same (giống như hai giọt nước)",
-    "example": "Irene and her sister are like two peas in a pod.",
-    "count": 0
+      "word": "like two peas in a pod",
+      "meaning": "used for saying that two people look or think exactly the same (giống như hai giọt nước)",
+      "example": "Irene and her sister are like two peas in a pod.",
+      "count": 0
     },
     {
-    "word": "line your pocket(s)",
-    "meaning": "obtain money, especially dishonestly (vì tiền mà bất chấp, mờ mắt vì tiền)",
-    "example": "He’d been lining his pockets for years before he was finally caught.",
-    "count": 0
-    },      
+      "word": "line your pocket(s)",
+      "meaning": "obtain money, especially dishonestly (vì tiền mà bất chấp, mờ mắt vì tiền)",
+      "example": "He’d been lining his pockets for years before he was finally caught.",
+      "count": 0
+    },
     {
       "word": "Your Guess is as Good as Mine",
       "meaning": "To have no idea about anything",
@@ -5000,1988 +5000,1987 @@
       "example": "Have Don and Jenny split up for good, do you think, or is it only temporary?",
       "count": 0
     }
-
   ],
   "topic vocab": [
     {
-    "word": "yearn (v) /jɜːn/",
-    "meaning": "to want something a lot, especially something difficult to get (ao ước)",
-    "example": "Many people yearn to retire to the country, but not everyone manages it.",
-    "count": 0
+      "word": "yearn (v) /jɜːn/",
+      "meaning": "to want something a lot, especially something difficult to get (ao ước)",
+      "example": "Many people yearn to retire to the country, but not everyone manages it.",
+      "count": 0
     },
     {
-    "word": "absorbing (adj) /əbˈzɔːbɪŋ/",
-    "meaning": "so entertaining that you give it all your attention (hấp dẫn)",
-    "example": "The film was so absorbing that time simply flew by.",
-    "count": 0
+      "word": "absorbing (adj) /əbˈzɔːbɪŋ/",
+      "meaning": "so entertaining that you give it all your attention (hấp dẫn)",
+      "example": "The film was so absorbing that time simply flew by.",
+      "count": 0
     },
     {
-    "word": "casual (adj) /ˈkæʒuəl/",
-    "meaning": "relaxed and informal (tự nhiên, không trịnh trọng)",
-    "example": "The party is quite casual, so don’t dress too formally.",
-    "count": 0
+      "word": "casual (adj) /ˈkæʒuəl/",
+      "meaning": "relaxed and informal (tự nhiên, không trịnh trọng)",
+      "example": "The party is quite casual, so don’t dress too formally.",
+      "count": 0
     },
     {
-    "word": "exhilarating (adj) /ɪɡˈzɪləreɪtɪŋ/",
-    "meaning": "making you feel happy, excited and full of energy (gây hứng khởi, hồi hộp)",
-    "example": "The funfair was really exhilarating.",
-    "count": 0
+      "word": "exhilarating (adj) /ɪɡˈzɪləreɪtɪŋ/",
+      "meaning": "making you feel happy, excited and full of energy (gây hứng khởi, hồi hộp)",
+      "example": "The funfair was really exhilarating.",
+      "count": 0
     },
     {
-    "word": "fatigue (n) /fəˈtiːɡ/",
-    "meaning": "a feeling of being very tired (mệt nhọc)",
-    "example": "Fatigue can lead to mistakes.",
-    "count": 0
+      "word": "fatigue (n) /fəˈtiːɡ/",
+      "meaning": "a feeling of being very tired (mệt nhọc)",
+      "example": "Fatigue can lead to mistakes.",
+      "count": 0
     },
     {
-    "word": "idle (adj) /ˈaɪdl/",
-    "meaning": "not doing anything when you should be (lười biếng, vô công rồi nghề)",
-    "example": "Don’t just sit there being idle — there’s housework to be done.",
-    "count": 0
+      "word": "idle (adj) /ˈaɪdl/",
+      "meaning": "not doing anything when you should be (lười biếng, vô công rồi nghề)",
+      "example": "Don’t just sit there being idle — there’s housework to be done.",
+      "count": 0
     },
     {
-    "word": "idle (adj) /ˈaɪdl/",
-    "meaning": "not working or not being used (ăn không ngồi rồi)",
-    "example": "The company is losing money all the time the workers are idle.",
-    "count": 0
+      "word": "idle (adj) /ˈaɪdl/",
+      "meaning": "not working or not being used (ăn không ngồi rồi)",
+      "example": "The company is losing money all the time the workers are idle.",
+      "count": 0
     },
     {
-    "word": "indulge (v) /ɪnˈdʌldʒ/",
-    "meaning": "to allow yourself to have or do something enjoyable (nuông chiều, thỏa mãn)",
-    "example": "I decided to indulge myself and had a holiday in the Bahamas.",
-    "count": 0
+      "word": "indulge (v) /ɪnˈdʌldʒ/",
+      "meaning": "to allow yourself to have or do something enjoyable (nuông chiều, thỏa mãn)",
+      "example": "I decided to indulge myself and had a holiday in the Bahamas.",
+      "count": 0
     },
     {
-    "word": "lifestyle (n) /ˈlaɪfstaɪl/",
-    "meaning": "the way in which a person lives (lối sống)",
-    "example": "This product is ideal for today’s busy lifestyles.",
-    "count": 0
+      "word": "lifestyle (n) /ˈlaɪfstaɪl/",
+      "meaning": "the way in which a person lives (lối sống)",
+      "example": "This product is ideal for today’s busy lifestyles.",
+      "count": 0
     },
     {
-    "word": "leave (n) /liːv/",
-    "meaning": "a period of time away from your job or the armed forces (thời gian nghỉ phép)",
-    "example": "My brother comes out of the army on leave next week.",
-    "count": 0
+      "word": "leave (n) /liːv/",
+      "meaning": "a period of time away from your job or the armed forces (thời gian nghỉ phép)",
+      "example": "My brother comes out of the army on leave next week.",
+      "count": 0
     },
     {
-    "word": "outing (n) /ˈaʊtɪŋ/",
-    "meaning": "a short journey taken for enjoyment (cuộc đi chơi ngắn)",
-    "example": "Let’s have an outing to the beach this weekend.",
-    "count": 0
+      "word": "outing (n) /ˈaʊtɪŋ/",
+      "meaning": "a short journey taken for enjoyment (cuộc đi chơi ngắn)",
+      "example": "Let’s have an outing to the beach this weekend.",
+      "count": 0
     },
     {
-    "word": "pastime (n) /ˈpɑːstaɪm/",
-    "meaning": "an activity that you do for fun in your free time (trò tiêu khiển)",
-    "example": "I need to find a pastime that doesn’t demand a lot of money.",
-    "count": 0
+      "word": "pastime (n) /ˈpɑːstaɪm/",
+      "meaning": "an activity that you do for fun in your free time (trò tiêu khiển)",
+      "example": "I need to find a pastime that doesn’t demand a lot of money.",
+      "count": 0
     },
     {
-    "word": "pursue (v) /pəˈsjuː/",
-    "meaning": "to follow or try to achieve something (theo đuổi)",
-    "example": "I’m thinking of pursuing a career in medicine.",
-    "count": 0
+      "word": "pursue (v) /pəˈsjuː/",
+      "meaning": "to follow or try to achieve something (theo đuổi)",
+      "example": "I’m thinking of pursuing a career in medicine.",
+      "count": 0
     },
     {
-    "word": "recreation (n) /ˌrekriˈeɪʃn/",
-    "meaning": "activities done for enjoyment (sự giải trí, tiêu khiển)",
-    "example": "Sport can be a very social form of recreation.",
-    "count": 0
+      "word": "recreation (n) /ˌrekriˈeɪʃn/",
+      "meaning": "activities done for enjoyment (sự giải trí, tiêu khiển)",
+      "example": "Sport can be a very social form of recreation.",
+      "count": 0
     },
     {
-    "word": "respite (n) /ˈrespaɪt/",
-    "meaning": "a short break from something difficult or unpleasant (thời gian nghỉ ngơi)",
-    "example": "We had a few days of respite from the hot weather, but it soon got warmer again.",
-    "count": 0
+      "word": "respite (n) /ˈrespaɪt/",
+      "meaning": "a short break from something difficult or unpleasant (thời gian nghỉ ngơi)",
+      "example": "We had a few days of respite from the hot weather, but it soon got warmer again.",
+      "count": 0
     },
     {
-    "word": "sedentary (adj) /ˈsedntri/",
-    "meaning": "involving little physical activity (tĩnh tại, ít vận động)",
-    "example": "I’ve got quite a sedentary job, so I like to go to the gym once a week.",
-    "count": 0
+      "word": "sedentary (adj) /ˈsedntri/",
+      "meaning": "involving little physical activity (tĩnh tại, ít vận động)",
+      "example": "I’ve got quite a sedentary job, so I like to go to the gym once a week.",
+      "count": 0
     },
     {
-    "word": "socialise (v) /ˈsəʊʃəlaɪz/",
-    "meaning": "to spend time with others in a friendly way (giao tiếp xã hội)",
-    "example": "We seem to have done a lot of socialising this month.",
-    "count": 0
+      "word": "socialise (v) /ˈsəʊʃəlaɪz/",
+      "meaning": "to spend time with others in a friendly way (giao tiếp xã hội)",
+      "example": "We seem to have done a lot of socialising this month.",
+      "count": 0
     },
     {
-    "word": "solitude (n) /ˈsɒlɪtjuːd/",
-    "meaning": "the state of being alone in a pleasant way (trạng thái cô độc dễ chịu)",
-    "example": "There’s nothing like the peace and solitude you get when you’re fishing.",
-    "count": 0
+      "word": "solitude (n) /ˈsɒlɪtjuːd/",
+      "meaning": "the state of being alone in a pleasant way (trạng thái cô độc dễ chịu)",
+      "example": "There’s nothing like the peace and solitude you get when you’re fishing.",
+      "count": 0
     },
     {
-    "word": "tedious (adj) /ˈtiːdiəs/",
-    "meaning": "boring and lasting a long time (chán ngắt)",
-    "example": "I couldn’t believe how tedious that meeting was!",
-    "count": 0
+      "word": "tedious (adj) /ˈtiːdiəs/",
+      "meaning": "boring and lasting a long time (chán ngắt)",
+      "example": "I couldn’t believe how tedious that meeting was!",
+      "count": 0
     },
     {
-    "word": "trivial (adj) /ˈtrɪviəl/",
-    "meaning": "not important or serious (tầm thường, vụn vặt)",
-    "example": "Fran always seems to think that her problems are important, while yours are quite trivial.",
-    "count": 0
+      "word": "trivial (adj) /ˈtrɪviəl/",
+      "meaning": "not important or serious (tầm thường, vụn vặt)",
+      "example": "Fran always seems to think that her problems are important, while yours are quite trivial.",
+      "count": 0
     },
     {
-    "word": "unwind (v) /ʌnˈwaɪnd/",
-    "meaning": "to relax after working or being nervous (thư giãn)",
-    "example": "I like to unwind with a good book in the evenings.",
-    "count": 0
+      "word": "unwind (v) /ʌnˈwaɪnd/",
+      "meaning": "to relax after working or being nervous (thư giãn)",
+      "example": "I like to unwind with a good book in the evenings.",
+      "count": 0
     },
     {
-    "word": "venue (n) /ˈvenjuː/",
-    "meaning": "a place where an event happens (địa điểm)",
-    "example": "Have they chosen a venue for the wedding yet?",
-    "count": 0
-    },      
+      "word": "venue (n) /ˈvenjuː/",
+      "meaning": "a place where an event happens (địa điểm)",
+      "example": "Have they chosen a venue for the wedding yet?",
+      "count": 0
+    },
     {
-    "word": "decline (v) /dɪˈklaɪn/",
-    "meaning": "to become less or worse (giảm, suy tàn)",
-    "example": "The service in this hotel has really declined over the last couple of years.",
-    "count": 0
+      "word": "decline (v) /dɪˈklaɪn/",
+      "meaning": "to become less or worse (giảm, suy tàn)",
+      "example": "The service in this hotel has really declined over the last couple of years.",
+      "count": 0
     },
     {
-    "word": "dedicated (adj) /ˈdedɪkeɪtɪd/",
-    "meaning": "spending all your time and effort on something (tận tâm)",
-    "example": "Kelly’s very dedicated to her job and should go far.",
-    "count": 0
+      "word": "dedicated (adj) /ˈdedɪkeɪtɪd/",
+      "meaning": "spending all your time and effort on something (tận tâm)",
+      "example": "Kelly’s very dedicated to her job and should go far.",
+      "count": 0
     },
     {
-    "word": "delight (v) /dɪˈlaɪt/",
-    "meaning": "to give someone a lot of enjoyment or pleasure (làm vui sướng)",
-    "example": "I was delighted by the decision.",
-    "count": 0
+      "word": "delight (v) /dɪˈlaɪt/",
+      "meaning": "to give someone a lot of enjoyment or pleasure (làm vui sướng)",
+      "example": "I was delighted by the decision.",
+      "count": 0
     },
     {
-    "word": "desire (v) /dɪˈzaɪə(r)/",
-    "meaning": "to want something (ao ước, khát khao)",
-    "example": "It’s quite common for people to desire what they can’t have.",
-    "count": 0
+      "word": "desire (v) /dɪˈzaɪə(r)/",
+      "meaning": "to want something (ao ước, khát khao)",
+      "example": "It’s quite common for people to desire what they can’t have.",
+      "count": 0
     },
     {
-    "word": "desire (n) /dɪˈzaɪə(r)/",
-    "meaning": "a strong feeling of wanting to have or do something (niềm mơ ước, khao khát)",
-    "example": "She had a strong desire to work in the media.",
-    "count": 0
+      "word": "desire (n) /dɪˈzaɪə(r)/",
+      "meaning": "a strong feeling of wanting to have or do something (niềm mơ ước, khao khát)",
+      "example": "She had a strong desire to work in the media.",
+      "count": 0
     },
     {
-    "word": "devote (v) /dɪˈvəʊt/",
-    "meaning": "to spend a lot of time or effort doing something (cống hiến)",
-    "example": "Gordon’s absolutely devoted to his kids.",
-    "count": 0
+      "word": "devote (v) /dɪˈvəʊt/",
+      "meaning": "to spend a lot of time or effort doing something (cống hiến)",
+      "example": "Gordon’s absolutely devoted to his kids.",
+      "count": 0
     },
     {
-    "word": "devote (v) /dɪˈvəʊt/",
-    "meaning": "to use something such as money for a particular purpose (dành cho việc gì)",
-    "example": "The government has devoted £10 million to the museum.",
-    "count": 0
+      "word": "devote (v) /dɪˈvəʊt/",
+      "meaning": "to use something such as money for a particular purpose (dành cho việc gì)",
+      "example": "The government has devoted £10 million to the museum.",
+      "count": 0
     },
     {
-    "word": "differentiate (v) /ˌdɪfəˈrenʃieɪt/",
-    "meaning": "to see or show the difference between things (phân biệt)",
-    "example": "I’m colour blind, so I have problems differentiating between red and green.",
-    "count": 0
+      "word": "differentiate (v) /ˌdɪfəˈrenʃieɪt/",
+      "meaning": "to see or show the difference between things (phân biệt)",
+      "example": "I’m colour blind, so I have problems differentiating between red and green.",
+      "count": 0
     },
     {
-    "word": "envy (v) /ˈenvi/",
-    "meaning": "to have the unhappy feeling of wanting to be like someone else (ghen tị)",
-    "example": "Carla’s brother never showed envy at her success.",
-    "count": 0
+      "word": "envy (v) /ˈenvi/",
+      "meaning": "to have the unhappy feeling of wanting to be like someone else (ghen tị)",
+      "example": "Carla’s brother never showed envy at her success.",
+      "count": 0
     },
     {
-    "word": "envy (n) /ˈenvi/",
-    "meaning": "the unhappy feeling of wanting what someone else has (sự ghen tị)",
-    "example": "Envy can destroy a relationship.",
-    "count": 0
+      "word": "envy (n) /ˈenvi/",
+      "meaning": "the unhappy feeling of wanting what someone else has (sự ghen tị)",
+      "example": "Envy can destroy a relationship.",
+      "count": 0
     },
     {
-    "word": "fancy (v) /ˈfænsi/",
-    "meaning": "to want to have or do something (thích, muốn)",
-    "example": "Do you fancy going out tonight?",
-    "count": 0
+      "word": "fancy (v) /ˈfænsi/",
+      "meaning": "to want to have or do something (thích, muốn)",
+      "example": "Do you fancy going out tonight?",
+      "count": 0
     },
     {
-    "word": "fascination (n) /ˌfæsɪˈneɪʃn/",
-    "meaning": "state of being extremely interested in something (sự quyến rũ, hấp dẫn)",
-    "example": "Carol’s always had a fascination with insects.",
-    "count": 0
+      "word": "fascination (n) /ˌfæsɪˈneɪʃn/",
+      "meaning": "state of being extremely interested in something (sự quyến rũ, hấp dẫn)",
+      "example": "Carol’s always had a fascination with insects.",
+      "count": 0
     },
     {
-    "word": "favour (n) /ˈfeɪvə(r)/",
-    "meaning": "to support or agree with one thing more than another (sự ủng hộ)",
-    "example": "I favour the first suggestion.",
-    "count": 0
+      "word": "favour (n) /ˈfeɪvə(r)/",
+      "meaning": "to support or agree with one thing more than another (sự ủng hộ)",
+      "example": "I favour the first suggestion.",
+      "count": 0
     },
     {
-    "word": "favour (v) /ˈfeɪvə(r)/",
-    "meaning": "to help or give advantage to someone (thiên vị)",
-    "example": "It’s not fair to favour one student over another.",
-    "count": 0
+      "word": "favour (v) /ˈfeɪvə(r)/",
+      "meaning": "to help or give advantage to someone (thiên vị)",
+      "example": "It’s not fair to favour one student over another.",
+      "count": 0
     },
     {
-    "word": "favour (v) /ˈfeɪvə(r)/",
-    "meaning": "to do something for someone as an act of kindness (sự giúp đỡ)",
-    "example": "I don’t suppose you could do me a favour, could you?",
-    "count": 0
+      "word": "favour (v) /ˈfeɪvə(r)/",
+      "meaning": "to do something for someone as an act of kindness (sự giúp đỡ)",
+      "example": "I don’t suppose you could do me a favour, could you?",
+      "count": 0
     },
     {
-    "word": "greedy (adj) /ˈɡriːdi/",
-    "meaning": "wanting more money, things or power than needed (tham lam)",
-    "example": "Maybe being sick will teach you not to be so greedy next time.",
-    "count": 0
+      "word": "greedy (adj) /ˈɡriːdi/",
+      "meaning": "wanting more money, things or power than needed (tham lam)",
+      "example": "Maybe being sick will teach you not to be so greedy next time.",
+      "count": 0
     },
     {
-    "word": "impulse (n) /ˈɪmpʌls/",
-    "meaning": "a sudden strong desire to do something (sự thôi thúc)",
-    "example": "I couldn’t resist the impulse to kiss her.",
-    "count": 0
+      "word": "impulse (n) /ˈɪmpʌls/",
+      "meaning": "a sudden strong desire to do something (sự thôi thúc)",
+      "example": "I couldn’t resist the impulse to kiss her.",
+      "count": 0
     },
     {
-    "word": "inclined (adj) /ɪnˈklaɪnd/",
-    "meaning": "feeling that you want to do something (có khuynh hướng)",
-    "example": "I’m inclined to agree with you.",
-    "count": 0
+      "word": "inclined (adj) /ɪnˈklaɪnd/",
+      "meaning": "feeling that you want to do something (có khuynh hướng)",
+      "example": "I’m inclined to agree with you.",
+      "count": 0
     },
     {
-    "word": "liking (n) /ˈlaɪkɪŋ/",
-    "meaning": "an enjoyment or fondness for something (sự ưa thích)",
-    "example": "I developed a liking for Chinese food when I lived there.",
-    "count": 0
+      "word": "liking (n) /ˈlaɪkɪŋ/",
+      "meaning": "an enjoyment or fondness for something (sự ưa thích)",
+      "example": "I developed a liking for Chinese food when I lived there.",
+      "count": 0
     },
     {
-    "word": "mediocre (adj) /ˌmiːdiˈəʊkə(r)/",
-    "meaning": "average or below average in quality (tầm thường)",
-    "example": "The food was only mediocre.",
-    "count": 0
+      "word": "mediocre (adj) /ˌmiːdiˈəʊkə(r)/",
+      "meaning": "average or below average in quality (tầm thường)",
+      "example": "The food was only mediocre.",
+      "count": 0
     },
     {
-    "word": "motive (n) /ˈməʊtɪv/",
-    "meaning": "the reason why someone does something (động cơ)",
-    "example": "What was the murderer’s motive?",
-    "count": 0
+      "word": "motive (n) /ˈməʊtɪv/",
+      "meaning": "the reason why someone does something (động cơ)",
+      "example": "What was the murderer’s motive?",
+      "count": 0
     },
     {
-    "word": "mundane (adj) /mʌnˈdeɪn/",
-    "meaning": "ordinary and not interesting or exciting (tẻ nhạt)",
-    "example": "I’m thinking of changing jobs. This one’s become quite mundane.",
-    "count": 0
+      "word": "mundane (adj) /mʌnˈdeɪn/",
+      "meaning": "ordinary and not interesting or exciting (tẻ nhạt)",
+      "example": "I’m thinking of changing jobs. This one’s become quite mundane.",
+      "count": 0
     },
     {
-    "word": "obsessed (adj) /əbˈsest/",
-    "meaning": "thinking or worrying about something all the time (bị ám ảnh)",
-    "example": "Oliver’s totally obsessed with football.",
-    "count": 0
+      "word": "obsessed (adj) /əbˈsest/",
+      "meaning": "thinking or worrying about something all the time (bị ám ảnh)",
+      "example": "Oliver’s totally obsessed with football.",
+      "count": 0
     },
     {
-    "word": "optional (adj) /ˈɒpʃənl/",
-    "meaning": "not required, you can choose to do it (tùy chọn)",
-    "example": "The course includes some optional language classes.",
-    "count": 0
+      "word": "optional (adj) /ˈɒpʃənl/",
+      "meaning": "not required, you can choose to do it (tùy chọn)",
+      "example": "The course includes some optional language classes.",
+      "count": 0
     },
     {
-    "word": "passion (n) /ˈpæʃn/",
-    "meaning": "a strong enthusiasm for something (niềm đam mê)",
-    "example": "Alice had a passion for cooking.",
-    "count": 0
+      "word": "passion (n) /ˈpæʃn/",
+      "meaning": "a strong enthusiasm for something (niềm đam mê)",
+      "example": "Alice had a passion for cooking.",
+      "count": 0
     },
     {
-    "word": "praise (v) /preɪz/",
-    "meaning": "to express admiration or approval (khen ngợi)",
-    "example": "The teacher praised the students for their efforts.",
-    "count": 0
+      "word": "praise (v) /preɪz/",
+      "meaning": "to express admiration or approval (khen ngợi)",
+      "example": "The teacher praised the students for their efforts.",
+      "count": 0
     },
     {
-    "word": "praise (n) /preɪz/",
-    "meaning": "expression of approval or admiration (lời khen)",
-    "example": "Praise usually works far better than criticism.",
-    "count": 0
+      "word": "praise (n) /preɪz/",
+      "meaning": "expression of approval or admiration (lời khen)",
+      "example": "Praise usually works far better than criticism.",
+      "count": 0
     },
     {
-    "word": "resolve (v) /rɪˈzɒlv/",
-    "meaning": "to make a firm decision to do something (quyết tâm)",
-    "example": "We resolved to leave early and avoid traffic.",
-    "count": 0
+      "word": "resolve (v) /rɪˈzɒlv/",
+      "meaning": "to make a firm decision to do something (quyết tâm)",
+      "example": "We resolved to leave early and avoid traffic.",
+      "count": 0
     },
     {
-    "word": "sacrifice (v) /ˈsækrɪfaɪs/",
-    "meaning": "to give up something for the sake of others (hy sinh)",
-    "example": "We had to sacrifice a lot to get here.",
-    "count": 0
+      "word": "sacrifice (v) /ˈsækrɪfaɪs/",
+      "meaning": "to give up something for the sake of others (hy sinh)",
+      "example": "We had to sacrifice a lot to get here.",
+      "count": 0
     },
     {
-    "word": "sacrifice (n) /ˈsækrɪfaɪs/",
-    "meaning": "the act of giving up something valuable (sự hy sinh)",
-    "example": "She made many sacrifices for her family.",
-    "count": 0
+      "word": "sacrifice (n) /ˈsækrɪfaɪs/",
+      "meaning": "the act of giving up something valuable (sự hy sinh)",
+      "example": "She made many sacrifices for her family.",
+      "count": 0
     },
     {
-    "word": "strive (v) /straɪv/",
-    "meaning": "to make a great effort to achieve something (phấn đấu)",
-    "example": "You won’t achieve your goals unless you strive towards them.",
-    "count": 0
+      "word": "strive (v) /straɪv/",
+      "meaning": "to make a great effort to achieve something (phấn đấu)",
+      "example": "You won’t achieve your goals unless you strive towards them.",
+      "count": 0
     },
     {
-    "word": "taste (n) /teɪst/",
-    "meaning": "ability to judge if something is good or bad (gu, khiếu thẩm mỹ)",
-    "example": "He really has no taste in clothes.",
-    "count": 0
+      "word": "taste (n) /teɪst/",
+      "meaning": "ability to judge if something is good or bad (gu, khiếu thẩm mỹ)",
+      "example": "He really has no taste in clothes.",
+      "count": 0
     },
     {
-    "word": "tempting (adj) /ˈtemptɪŋ/",
-    "meaning": "appealing, making you want it (đầy cám dỗ)",
-    "example": "It was a tempting offer, but I had to refuse.",
-    "count": 0
+      "word": "tempting (adj) /ˈtemptɪŋ/",
+      "meaning": "appealing, making you want it (đầy cám dỗ)",
+      "example": "It was a tempting offer, but I had to refuse.",
+      "count": 0
     },
     {
-    "word": "urge (v) /ɜːdʒ/",
-    "meaning": "to advise strongly about what action to take (thúc giục)",
-    "example": "I would urge you to speak to a lawyer.",
-    "count": 0
+      "word": "urge (v) /ɜːdʒ/",
+      "meaning": "to advise strongly about what action to take (thúc giục)",
+      "example": "I would urge you to speak to a lawyer.",
+      "count": 0
     },
     {
-    "word": "urge (n) /ɜːdʒ/",
-    "meaning": "a strong feeling of wanting to do something (sự thôi thúc)",
-    "example": "I suddenly felt an urge to run from the room.",
-    "count": 0
+      "word": "urge (n) /ɜːdʒ/",
+      "meaning": "a strong feeling of wanting to do something (sự thôi thúc)",
+      "example": "I suddenly felt an urge to run from the room.",
+      "count": 0
     },
     {
-    "word": "welcome (v) /ˈwelkəm/",
-    "meaning": "to say that you accept or support something (hoan nghênh)",
-    "example": "We welcome your feedback and suggestions.",
-    "count": 0
+      "word": "welcome (v) /ˈwelkəm/",
+      "meaning": "to say that you accept or support something (hoan nghênh)",
+      "example": "We welcome your feedback and suggestions.",
+      "count": 0
     },
     {
-    "word": "welcome (adj) /ˈwelkəm/",
-    "meaning": "pleased to be accepted or included (được chào đón)",
-    "example": "We were made to feel very welcome.",
-    "count": 0
+      "word": "welcome (adj) /ˈwelkəm/",
+      "meaning": "pleased to be accepted or included (được chào đón)",
+      "example": "We were made to feel very welcome.",
+      "count": 0
     },
     {
-    "word": "worthwhile (adj) /ˌwɜːθˈwaɪl/",
-    "meaning": "worth the time, effort, or money (đáng giá)",
-    "example": "Why don’t you watch less TV and do something more worthwhile?",
-    "count": 0
-    },      
+      "word": "worthwhile (adj) /ˌwɜːθˈwaɪl/",
+      "meaning": "worth the time, effort, or money (đáng giá)",
+      "example": "Why don’t you watch less TV and do something more worthwhile?",
+      "count": 0
+    },
     {
-    "word": "adopt (v) /əˈdɒpt/",
-    "meaning": "to decide to start using a particular idea, plan, or method (thực hiện)",
-    "example": "I adopted the method the coach showed me and played far better.",
-    "count": 0
+      "word": "adopt (v) /əˈdɒpt/",
+      "meaning": "to decide to start using a particular idea, plan, or method (thực hiện)",
+      "example": "I adopted the method the coach showed me and played far better.",
+      "count": 0
     },
     {
-    "word": "adopt (v) /əˈdɒpt/",
-    "meaning": "to take someone else’s child into your family and legally make them your own (nhận nuôi)",
-    "example": "We’re hoping to adopt a young boy.",
-    "count": 0
+      "word": "adopt (v) /əˈdɒpt/",
+      "meaning": "to take someone else’s child into your family and legally make them your own (nhận nuôi)",
+      "example": "We’re hoping to adopt a young boy.",
+      "count": 0
     },
     {
-    "word": "ancestor (n) /ˈænsestə(r)/",
-    "meaning": "someone in your family who lived a long time ago (tổ tiên)",
-    "example": "My ancestors all came from the same part of China.",
-    "count": 0
+      "word": "ancestor (n) /ˈænsestə(r)/",
+      "meaning": "someone in your family who lived a long time ago (tổ tiên)",
+      "example": "My ancestors all came from the same part of China.",
+      "count": 0
     },
     {
-    "word": "citizen (n) /ˈsɪtɪzn/",
-    "meaning": "someone who has the right to live in a particular country (công dân)",
-    "example": "He was an American citizen.",
-    "count": 0
+      "word": "citizen (n) /ˈsɪtɪzn/",
+      "meaning": "someone who has the right to live in a particular country (công dân)",
+      "example": "He was an American citizen.",
+      "count": 0
     },
     {
-    "word": "companion (n) /kəmˈpænjən/",
-    "meaning": "someone you spend a lot of time with (người đồng hành)",
-    "example": "This prize is a holiday for you and your companion.",
-    "count": 0
+      "word": "companion (n) /kəmˈpænjən/",
+      "meaning": "someone you spend a lot of time with (người đồng hành)",
+      "example": "This prize is a holiday for you and your companion.",
+      "count": 0
     },
     {
-    "word": "dependant (n) /dɪˈpendənt/",
-    "meaning": "a child or other relative you care for financially (người sống phụ thuộc)",
-    "example": "I couldn’t believe how many dependants he’s got!",
-    "count": 0
+      "word": "dependant (n) /dɪˈpendənt/",
+      "meaning": "a child or other relative you care for financially (người sống phụ thuộc)",
+      "example": "I couldn’t believe how many dependants he’s got!",
+      "count": 0
     },
     {
-    "word": "descendant (n) /dɪˈsendənt/",
-    "meaning": "a relative of someone from the past (hậu duệ)",
-    "example": "I’m a descendant of Lord Byron.",
-    "count": 0
+      "word": "descendant (n) /dɪˈsendənt/",
+      "meaning": "a relative of someone from the past (hậu duệ)",
+      "example": "I’m a descendant of Lord Byron.",
+      "count": 0
     },
     {
-    "word": "empathetic (adj) /ˌempəˈθetɪk/",
-    "meaning": "able to understand how someone feels (thấu cảm)",
-    "example": "I’ve had a similar experience, so I can empathise.",
-    "count": 0
+      "word": "empathetic (adj) /ˌempəˈθetɪk/",
+      "meaning": "able to understand how someone feels (thấu cảm)",
+      "example": "I’ve had a similar experience, so I can empathise.",
+      "count": 0
     },
     {
-    "word": "extrovert (n) /ˈekstrəvɜːt/",
-    "meaning": "someone confident and outgoing (người hướng ngoại)",
-    "example": "She’s such an extrovert and loves meeting new people.",
-    "count": 0
+      "word": "extrovert (n) /ˈekstrəvɜːt/",
+      "meaning": "someone confident and outgoing (người hướng ngoại)",
+      "example": "She’s such an extrovert and loves meeting new people.",
+      "count": 0
     },
     {
-    "word": "foster (v) /ˈfɒstə(r)/",
-    "meaning": "to take care of a child temporarily (nuôi dưỡng tạm thời)",
-    "example": "Parents have fostered lots of children over the years.",
-    "count": 0
+      "word": "foster (v) /ˈfɒstə(r)/",
+      "meaning": "to take care of a child temporarily (nuôi dưỡng tạm thời)",
+      "example": "Parents have fostered lots of children over the years.",
+      "count": 0
     },
     {
-    "word": "guardian (n) /ˈɡɑːdiən/",
-    "meaning": "someone legally responsible for a child (người giám hộ)",
-    "example": "You need to get the form signed by a parent or guardian.",
-    "count": 0
+      "word": "guardian (n) /ˈɡɑːdiən/",
+      "meaning": "someone legally responsible for a child (người giám hộ)",
+      "example": "You need to get the form signed by a parent or guardian.",
+      "count": 0
     },
     {
-    "word": "introvert (n) /ˈɪntrəvɜːt/",
-    "meaning": "someone who prefers being alone or quiet (người hướng nội)",
-    "example": "I’m more of an introvert and prefer to spend time on my own.",
-    "count": 0
+      "word": "introvert (n) /ˈɪntrəvɜːt/",
+      "meaning": "someone who prefers being alone or quiet (người hướng nội)",
+      "example": "I’m more of an introvert and prefer to spend time on my own.",
+      "count": 0
     },
     {
-    "word": "partner (n) /ˈpɑːtnə(r)/",
-    "meaning": "someone you do a particular activity with (đối tác)",
-    "example": "Nadine and I are partners at tennis.",
-    "count": 0
+      "word": "partner (n) /ˈpɑːtnə(r)/",
+      "meaning": "someone you do a particular activity with (đối tác)",
+      "example": "Nadine and I are partners at tennis.",
+      "count": 0
     },
     {
-    "word": "partner (n) /ˈpɑːtnə(r)/",
-    "meaning": "someone you live with and have a relationship with (bạn đời)",
-    "example": "The invitation is for me and my partner.",
-    "count": 0
+      "word": "partner (n) /ˈpɑːtnə(r)/",
+      "meaning": "someone you live with and have a relationship with (bạn đời)",
+      "example": "The invitation is for me and my partner.",
+      "count": 0
     },
     {
-    "word": "peer (n) /pɪə(r)/",
-    "meaning": "someone who is the same age or level as you (người đồng lứa)",
-    "example": "What your peers think of you can be very important.",
-    "count": 0
+      "word": "peer (n) /pɪə(r)/",
+      "meaning": "someone who is the same age or level as you (người đồng lứa)",
+      "example": "What your peers think of you can be very important.",
+      "count": 0
     },
     {
-    "word": "predecessor (n) /ˈpriːdəsesə(r)/",
-    "meaning": "someone who had the job before you (người tiền nhiệm)",
-    "example": "I hope to avoid making my predecessor’s mistakes.",
-    "count": 0
+      "word": "predecessor (n) /ˈpriːdəsesə(r)/",
+      "meaning": "someone who had the job before you (người tiền nhiệm)",
+      "example": "I hope to avoid making my predecessor’s mistakes.",
+      "count": 0
     },
     {
-    "word": "sibling (n) /ˈsɪblɪŋ/",
-    "meaning": "your brothers and sisters (anh/chị/em ruột)",
-    "example": "The elder sibling is often more successful in his or her career.",
-    "count": 0
+      "word": "sibling (n) /ˈsɪblɪŋ/",
+      "meaning": "your brothers and sisters (anh/chị/em ruột)",
+      "example": "The elder sibling is often more successful in his or her career.",
+      "count": 0
     },
     {
-    "word": "spouse (n) /spaʊs/",
-    "meaning": "a husband or wife (vợ hoặc chồng)",
-    "example": "Each spouse is responsible for paying their own income tax.",
-    "count": 0
+      "word": "spouse (n) /spaʊs/",
+      "meaning": "a husband or wife (vợ hoặc chồng)",
+      "example": "Each spouse is responsible for paying their own income tax.",
+      "count": 0
     },
     {
-    "word": "stepmother/son/etc (n) /ˈstepˌmʌðə(r)/",
-    "meaning": "someone’s step-relative from a second marriage (mẹ kế, con riêng...)",
-    "example": "I didn’t really get on with my stepmother.",
-    "count": 0
+      "word": "stepmother/son/etc (n) /ˈstepˌmʌðə(r)/",
+      "meaning": "someone’s step-relative from a second marriage (mẹ kế, con riêng...)",
+      "example": "I didn’t really get on with my stepmother.",
+      "count": 0
     },
     {
-    "word": "successor (n) /səkˈsesə(r)/",
-    "meaning": "someone who takes a job after someone else (người kế nhiệm)",
-    "example": "I hope my successor enjoys the job as much as I have.",
-    "count": 0
+      "word": "successor (n) /səkˈsesə(r)/",
+      "meaning": "someone who takes a job after someone else (người kế nhiệm)",
+      "example": "I hope my successor enjoys the job as much as I have.",
+      "count": 0
     },
     {
-    "word": "sympathise (v) /ˈsɪmpəθaɪz/",
-    "meaning": "to show that you understand and care about someone’s problems (đồng cảm)",
-    "example": "Why do you always sympathise with people instead of blaming them?",
-    "count": 0
+      "word": "sympathise (v) /ˈsɪmpəθaɪz/",
+      "meaning": "to show that you understand and care about someone’s problems (đồng cảm)",
+      "example": "Why do you always sympathise with people instead of blaming them?",
+      "count": 0
     },
     {
-    "word": "addiction (n) /əˈdɪkʃn/",
-    "meaning": "a strong need to regularly have or do something (nghiện)",
-    "example": "I developed an addiction to video games.",
-    "count": 0
+      "word": "addiction (n) /əˈdɪkʃn/",
+      "meaning": "a strong need to regularly have or do something (nghiện)",
+      "example": "I developed an addiction to video games.",
+      "count": 0
     },
     {
-    "word": "adore (v) /əˈdɔː(r)/",
-    "meaning": "to love someone or something very much (rất yêu thích)",
-    "example": "I absolutely adore Indian food!",
-    "count": 0
+      "word": "adore (v) /əˈdɔː(r)/",
+      "meaning": "to love someone or something very much (rất yêu thích)",
+      "example": "I absolutely adore Indian food!",
+      "count": 0
     },
     {
-    "word": "appeal (n) /əˈpiːl/",
-    "meaning": "a feeling of excitement about something new (sự hấp dẫn)",
-    "example": "I waited for the appeal of something new.",
-    "count": 0
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "a feeling of excitement about something new (sự hấp dẫn)",
+      "example": "I waited for the appeal of something new.",
+      "count": 0
     },
     {
-    "word": "appeal (n) /əˈpiːl/",
-    "meaning": "a quality that makes something attractive (tính hấp dẫn)",
-    "example": "It’s difficult to explain the appeal of this place.",
-    "count": 0
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "a quality that makes something attractive (tính hấp dẫn)",
+      "example": "It’s difficult to explain the appeal of this place.",
+      "count": 0
     },
     {
-    "word": "appeal (n) /əˈpiːl/",
-    "meaning": "a request to change a decision (lời kháng cáo)",
-    "example": "He made an appeal for witnesses to come forward.",
-    "count": 0
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "a request to change a decision (lời kháng cáo)",
+      "example": "He made an appeal for witnesses to come forward.",
+      "count": 0
     },
     {
-    "word": "arbitrary (adj) /ˈɑːbɪtrəri/",
-    "meaning": "not based on any particular plan or reason (tùy tiện)",
-    "example": "The wedding was just arbitrary.",
-    "count": 0
+      "word": "arbitrary (adj) /ˈɑːbɪtrəri/",
+      "meaning": "not based on any particular plan or reason (tùy tiện)",
+      "example": "The wedding was just arbitrary.",
+      "count": 0
     },
     {
-    "word": "aspiration (n) /ˌæspəˈreɪʃn/",
-    "meaning": "a strong desire to achieve something (khát vọng)",
-    "example": "One of my aspirations is to become fluent in French.",
-    "count": 0
+      "word": "aspiration (n) /ˌæspəˈreɪʃn/",
+      "meaning": "a strong desire to achieve something (khát vọng)",
+      "example": "One of my aspirations is to become fluent in French.",
+      "count": 0
     },
     {
-    "word": "bear (v) /beə(r)/",
-    "meaning": "to accept or tolerate something difficult (chịu đựng)",
-    "example": "I can’t bear waiting in queues.",
-    "count": 0
+      "word": "bear (v) /beə(r)/",
+      "meaning": "to accept or tolerate something difficult (chịu đựng)",
+      "example": "I can’t bear waiting in queues.",
+      "count": 0
     },
     {
-    "word": "compulsory (adj) /kəmˈpʌlsəri/",
-    "meaning": "required by rule or law (bắt buộc)",
-    "example": "This course is compulsory for all students.",
-    "count": 0
+      "word": "compulsory (adj) /kəmˈpʌlsəri/",
+      "meaning": "required by rule or law (bắt buộc)",
+      "example": "This course is compulsory for all students.",
+      "count": 0
     },
     {
-    "word": "content (adj) /kənˈtent/",
-    "meaning": "happy and satisfied (hài lòng)",
-    "example": "I’m quite content working here.",
-    "count": 0
+      "word": "content (adj) /kənˈtent/",
+      "meaning": "happy and satisfied (hài lòng)",
+      "example": "I’m quite content working here.",
+      "count": 0
     },
     {
-    "word": "craving (n) /ˈkreɪvɪŋ/",
-    "meaning": "a very strong desire for something (sự thèm muốn)",
-    "example": "I had a sudden craving for chocolate ice cream.",
-    "count": 0
+      "word": "craving (n) /ˈkreɪvɪŋ/",
+      "meaning": "a very strong desire for something (sự thèm muốn)",
+      "example": "I had a sudden craving for chocolate ice cream.",
+      "count": 0
     },
     {
-    "word": "decline (v) /dɪˈklaɪn/",
-    "meaning": "to say politely that you will not accept something (từ chối)",
-    "example": "The Prime Minister declined to answer questions.",
-    "count": 0
-    },      
+      "word": "decline (v) /dɪˈklaɪn/",
+      "meaning": "to say politely that you will not accept something (từ chối)",
+      "example": "The Prime Minister declined to answer questions.",
+      "count": 0
+    },
     {
-    "word": "dispute (n) /dɪˈspjuːt/",
-    "meaning": "a serious disagreement, especially one between groups that lasts a long time (tranh chấp)",
-    "example": "The dispute seems likely to continue.",
-    "count": 0
+      "word": "dispute (n) /dɪˈspjuːt/",
+      "meaning": "a serious disagreement, especially one between groups that lasts a long time (tranh chấp)",
+      "example": "The dispute seems likely to continue.",
+      "count": 0
     },
     {
-    "word": "distinguish (v) /dɪˈstɪŋɡwɪʃ/",
-    "meaning": "to recognize the difference between two things (phân biệt)",
-    "example": "It’s not always easy to distinguish between expensive coffee and the cheap brand.",
-    "count": 0
+      "word": "distinguish (v) /dɪˈstɪŋɡwɪʃ/",
+      "meaning": "to recognize the difference between two things (phân biệt)",
+      "example": "It’s not always easy to distinguish between expensive coffee and the cheap brand.",
+      "count": 0
     },
     {
-    "word": "diverse (adj) /daɪˈvɜːs/",
-    "meaning": "very different from each other (đa dạng)",
-    "example": "The school has students from quite a diverse range of backgrounds.",
-    "count": 0
+      "word": "diverse (adj) /daɪˈvɜːs/",
+      "meaning": "very different from each other (đa dạng)",
+      "example": "The school has students from quite a diverse range of backgrounds.",
+      "count": 0
     },
     {
-    "word": "divorce (v) /dɪˈvɔːs/",
-    "meaning": "to take legal action to end your marriage (ly hôn)",
-    "example": "She and her husband divorced ten years ago.",
-    "count": 0
+      "word": "divorce (v) /dɪˈvɔːs/",
+      "meaning": "to take legal action to end your marriage (ly hôn)",
+      "example": "She and her husband divorced ten years ago.",
+      "count": 0
     },
     {
-    "word": "divorce (n) /dɪˈvɔːs/",
-    "meaning": "the legal ending of a marriage (ly hôn)",
-    "example": "I’ve been meaning to tell you for some time now… I’d like a divorce.",
-    "count": 0
+      "word": "divorce (n) /dɪˈvɔːs/",
+      "meaning": "the legal ending of a marriage (ly hôn)",
+      "example": "I’ve been meaning to tell you for some time now… I’d like a divorce.",
+      "count": 0
     },
     {
-    "word": "equivalent (n) /ɪˈkwɪvələnt/",
-    "meaning": "something that has the same size, value, importance or meaning (vật tương đương)",
-    "example": "There’s no equivalent word in English.",
-    "count": 0
+      "word": "equivalent (n) /ɪˈkwɪvələnt/",
+      "meaning": "something that has the same size, value, importance or meaning (vật tương đương)",
+      "example": "There’s no equivalent word in English.",
+      "count": 0
     },
     {
-    "word": "equivalent (adj) /ɪˈkwɪvələnt/",
-    "meaning": "of the same size, value, or meaning as something else (tương đương)",
-    "example": "We can exchange it for one of equivalent value.",
-    "count": 0
+      "word": "equivalent (adj) /ɪˈkwɪvələnt/",
+      "meaning": "of the same size, value, or meaning as something else (tương đương)",
+      "example": "We can exchange it for one of equivalent value.",
+      "count": 0
     },
     {
-    "word": "exclude (v) /ɪkˈskluːd/",
-    "meaning": "to deliberately not include something (loại trừ)",
-    "example": "Excluding ourselves, we’re 18 people on the trip.",
-    "count": 0
+      "word": "exclude (v) /ɪkˈskluːd/",
+      "meaning": "to deliberately not include something (loại trừ)",
+      "example": "Excluding ourselves, we’re 18 people on the trip.",
+      "count": 0
     },
     {
-    "word": "external (adj) /ɪkˈstɜːnl/",
-    "meaning": "coming from outside a place or organisation (bên ngoài)",
-    "example": "You’ll be interviewed by an external examiner.",
-    "count": 0
+      "word": "external (adj) /ɪkˈstɜːnl/",
+      "meaning": "coming from outside a place or organisation (bên ngoài)",
+      "example": "You’ll be interviewed by an external examiner.",
+      "count": 0
     },
     {
-    "word": "external (adj) /ɪkˈstɜːnl/",
-    "meaning": "on or from the outside of something like a building or body (ở bên ngoài)",
-    "example": "This cream is for external use only.",
-    "count": 0
+      "word": "external (adj) /ɪkˈstɜːnl/",
+      "meaning": "on or from the outside of something like a building or body (ở bên ngoài)",
+      "example": "This cream is for external use only.",
+      "count": 0
     },
     {
-    "word": "identify (v) /aɪˈdentɪfaɪ/",
-    "meaning": "to recognize someone and be able to say who they are (xác nhận, nhận diện)",
-    "example": "The witness wasn’t able to identify the man.",
-    "count": 0
+      "word": "identify (v) /aɪˈdentɪfaɪ/",
+      "meaning": "to recognize someone and be able to say who they are (xác nhận, nhận diện)",
+      "example": "The witness wasn’t able to identify the man.",
+      "count": 0
     },
     {
-    "word": "identify with (v) /aɪˈdentɪfaɪ wɪð/",
-    "meaning": "to feel that you understand and share someone’s feelings (thấu hiểu)",
-    "example": "I could really identify with the character of Melissa in the film.",
-    "count": 0
+      "word": "identify with (v) /aɪˈdentɪfaɪ wɪð/",
+      "meaning": "to feel that you understand and share someone’s feelings (thấu hiểu)",
+      "example": "I could really identify with the character of Melissa in the film.",
+      "count": 0
     },
     {
-    "word": "integral (adj) /ˈɪntɪɡrəl/",
-    "meaning": "essential or necessary to make something complete (cần thiết, không thể thiếu)",
-    "example": "Learning to forgive is an integral part of growing up.",
-    "count": 0
+      "word": "integral (adj) /ˈɪntɪɡrəl/",
+      "meaning": "essential or necessary to make something complete (cần thiết, không thể thiếu)",
+      "example": "Learning to forgive is an integral part of growing up.",
+      "count": 0
     },
     {
-    "word": "integrate (v) /ˈɪntɪɡreɪt/",
-    "meaning": "to make someone become a full member of society or group (hòa nhập)",
-    "example": "I think people who come to this country should make an effort to integrate.",
-    "count": 0
+      "word": "integrate (v) /ˈɪntɪɡreɪt/",
+      "meaning": "to make someone become a full member of society or group (hòa nhập)",
+      "example": "I think people who come to this country should make an effort to integrate.",
+      "count": 0
     },
     {
-    "word": "interfere (v) /ˌɪntəˈfɪə(r)/",
-    "meaning": "to become involved in a situation and try to influence it without being wanted (xen vào, quấy rầy)",
-    "example": "Stop interfering in my relationship with Jane!",
-    "count": 0
+      "word": "interfere (v) /ˌɪntəˈfɪə(r)/",
+      "meaning": "to become involved in a situation and try to influence it without being wanted (xen vào, quấy rầy)",
+      "example": "Stop interfering in my relationship with Jane!",
+      "count": 0
     },
     {
-    "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
-    "meaning": "in between two stages or levels (trung gian)",
-    "example": "You can’t become a pilot without going through a lot of intermediate steps.",
-    "count": 0
+      "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
+      "meaning": "in between two stages or levels (trung gian)",
+      "example": "You can’t become a pilot without going through a lot of intermediate steps.",
+      "count": 0
     },
     {
-    "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
-    "meaning": "at a level of education higher than beginner but lower than advanced (trung cấp)",
-    "example": "This course is aimed at intermediate learners.",
-    "count": 0
+      "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
+      "meaning": "at a level of education higher than beginner but lower than advanced (trung cấp)",
+      "example": "This course is aimed at intermediate learners.",
+      "count": 0
     },
     {
-    "word": "internal (adj) /ɪnˈtɜːnl/",
-    "meaning": "existing or happening inside a building, body, or organisation (bên trong)",
-    "example": "We decided to knock down one of the internal walls.",
-    "count": 0
+      "word": "internal (adj) /ɪnˈtɜːnl/",
+      "meaning": "existing or happening inside a building, body, or organisation (bên trong)",
+      "example": "We decided to knock down one of the internal walls.",
+      "count": 0
     },
     {
-    "word": "intervene (v) /ˌɪntəˈviːn/",
-    "meaning": "to become involved in a situation in order to improve or change it (can thiệp)",
-    "example": "The fight could have got ugly if the teacher hadn’t intervened.",
-    "count": 0
+      "word": "intervene (v) /ˌɪntəˈviːn/",
+      "meaning": "to become involved in a situation in order to improve or change it (can thiệp)",
+      "example": "The fight could have got ugly if the teacher hadn’t intervened.",
+      "count": 0
     },
     {
-    "word": "intimate (adj) /ˈɪntɪmət/",
-    "meaning": "describes a very close and personal relationship (thân mật)",
-    "example": "Martin seems to have problems forming intimate relationships.",
-    "count": 0
+      "word": "intimate (adj) /ˈɪntɪmət/",
+      "meaning": "describes a very close and personal relationship (thân mật)",
+      "example": "Martin seems to have problems forming intimate relationships.",
+      "count": 0
     },
     {
-    "word": "intimate (adj) /ˈɪntɪmət/",
-    "meaning": "relating to very private or personal things (riêng tư)",
-    "example": "Try not to ask too many intimate questions.",
-    "count": 0
+      "word": "intimate (adj) /ˈɪntɪmət/",
+      "meaning": "relating to very private or personal things (riêng tư)",
+      "example": "Try not to ask too many intimate questions.",
+      "count": 0
     },
     {
-    "word": "involve (v) /ɪnˈvɒlv/",
-    "meaning": "to include as a necessary part or result (bao gồm)",
-    "example": "Getting your degree is going to involve a lot of hard work.",
-    "count": 0
+      "word": "involve (v) /ɪnˈvɒlv/",
+      "meaning": "to include as a necessary part or result (bao gồm)",
+      "example": "Getting your degree is going to involve a lot of hard work.",
+      "count": 0
     },
     {
-    "word": "involve (v) /ɪnˈvɒlv/",
-    "meaning": "to include someone in an activity (bao gồm ai đó tham gia)",
-    "example": "You need to involve your team in decision-making.",
-    "count": 0
+      "word": "involve (v) /ɪnˈvɒlv/",
+      "meaning": "to include someone in an activity (bao gồm ai đó tham gia)",
+      "example": "You need to involve your team in decision-making.",
+      "count": 0
     },
     {
-    "word": "joint (adj) /dʒɔɪnt/",
-    "meaning": "involving two or more people (chung, cùng nhau)",
-    "example": "We decided to open a joint bank account.",
-    "count": 0
+      "word": "joint (adj) /dʒɔɪnt/",
+      "meaning": "involving two or more people (chung, cùng nhau)",
+      "example": "We decided to open a joint bank account.",
+      "count": 0
     },
     {
-    "word": "liken (v) /ˈlaɪkən/",
-    "meaning": "to say that someone or something is similar to someone or something else (so sánh với)",
-    "example": "She likened her experience to being on a roller coaster.",
-    "count": 0
+      "word": "liken (v) /ˈlaɪkən/",
+      "meaning": "to say that someone or something is similar to someone or something else (so sánh với)",
+      "example": "She likened her experience to being on a roller coaster.",
+      "count": 0
     },
     {
-    "word": "link (v) /lɪŋk/",
-    "meaning": "to connect or relate two or more things (liên kết)",
-    "example": "The robbery is linked to the one that took place last week.",
-    "count": 0
+      "word": "link (v) /lɪŋk/",
+      "meaning": "to connect or relate two or more things (liên kết)",
+      "example": "The robbery is linked to the one that took place last week.",
+      "count": 0
     },
     {
-    "word": "link (n) /lɪŋk/",
-    "meaning": "a connection or relationship between two or more things (mối liên hệ)",
-    "example": "There’s a strong link between diet and health.",
-    "count": 0
+      "word": "link (n) /lɪŋk/",
+      "meaning": "a connection or relationship between two or more things (mối liên hệ)",
+      "example": "There’s a strong link between diet and health.",
+      "count": 0
     },
     {
-    "word": "merge (v) /mɜːdʒ/",
-    "meaning": "to combine two or more things into one (sáp nhập)",
-    "example": "I might lose my job when the two businesses merge.",
-    "count": 0
+      "word": "merge (v) /mɜːdʒ/",
+      "meaning": "to combine two or more things into one (sáp nhập)",
+      "example": "I might lose my job when the two businesses merge.",
+      "count": 0
     },
     {
-    "word": "mutual (adj) /ˈmjuːtʃuəl/",
-    "meaning": "shared equally by two or more people (lẫn nhau, chung)",
-    "example": "John doesn’t respect mutual feelings of trust.",
-    "count": 0
+      "word": "mutual (adj) /ˈmjuːtʃuəl/",
+      "meaning": "shared equally by two or more people (lẫn nhau, chung)",
+      "example": "John doesn’t respect mutual feelings of trust.",
+      "count": 0
     },
     {
-    "word": "negotiate (v) /nɪˈɡəʊʃieɪt/",
-    "meaning": "to try to reach an agreement by discussion (đàm phán)",
-    "example": "We managed to negotiate through traffic and arrive on time.",
-    "count": 0
+      "word": "negotiate (v) /nɪˈɡəʊʃieɪt/",
+      "meaning": "to try to reach an agreement by discussion (đàm phán)",
+      "example": "We managed to negotiate through traffic and arrive on time.",
+      "count": 0
     },
     {
-    "word": "related (adj) /rɪˈleɪtɪd/",
-    "meaning": "connected in some way (liên quan)",
-    "example": "The stress you are under is related to your workload.",
-    "count": 0
+      "word": "related (adj) /rɪˈleɪtɪd/",
+      "meaning": "connected in some way (liên quan)",
+      "example": "The stress you are under is related to your workload.",
+      "count": 0
     },
     {
-    "word": "relative (adj) /ˈrelətɪv/",
-    "meaning": "considered in comparison with something else (tương đối)",
-    "example": "After the failure of other schemes, the last one was a relative success.",
-    "count": 0
+      "word": "relative (adj) /ˈrelətɪv/",
+      "meaning": "considered in comparison with something else (tương đối)",
+      "example": "After the failure of other schemes, the last one was a relative success.",
+      "count": 0
     },
     {
-    "word": "resemblance (n) /rɪˈzembləns/",
-    "meaning": "similarity in appearance or nature (sự tương đồng)",
-    "example": "Can you see the resemblance between me and my father?",
-    "count": 0
+      "word": "resemblance (n) /rɪˈzembləns/",
+      "meaning": "similarity in appearance or nature (sự tương đồng)",
+      "example": "Can you see the resemblance between me and my father?",
+      "count": 0
     },
     {
-    "word": "acquaintance (n) /əˈkweɪntəns/",
-    "meaning": "someone you know a little, but who is not a close friend (người quen)",
-    "example": "He’s not really a friend, more of an acquaintance.",
-    "count": 0
-    },      
+      "word": "acquaintance (n) /əˈkweɪntəns/",
+      "meaning": "someone you know a little, but who is not a close friend (người quen)",
+      "example": "He’s not really a friend, more of an acquaintance.",
+      "count": 0
+    },
     {
-    "word": "installation (n) /ˌɪnstəˈleɪʃn/",
-    "meaning": "a piece of art that consists of several different objects or images arranged to produce a particular effect (tác phẩm trưng bày)",
-    "example": "There’s an interesting installation at the Tate Gallery next month. The artist created a powerful light installation. Visitors admired the outdoor sound installation. The museum hosts interactive installations annually.",
-    "count": 0
+      "word": "installation (n) /ˌɪnstəˈleɪʃn/",
+      "meaning": "a piece of art that consists of several different objects or images arranged to produce a particular effect (tác phẩm trưng bày)",
+      "example": "There’s an interesting installation at the Tate Gallery next month. The artist created a powerful light installation. Visitors admired the outdoor sound installation. The museum hosts interactive installations annually.",
+      "count": 0
     },
     {
-    "word": "lines (n pl) /laɪnz/",
-    "meaning": "the words that an actor says in a performance (lời thoại)",
-    "example": "He forgot his lines. She memorized her lines overnight. The actor practiced his lines before rehearsal. His delivery of the final lines was perfect.",
-    "count": 0
+      "word": "lines (n pl) /laɪnz/",
+      "meaning": "the words that an actor says in a performance (lời thoại)",
+      "example": "He forgot his lines. She memorized her lines overnight. The actor practiced his lines before rehearsal. His delivery of the final lines was perfect.",
+      "count": 0
     },
     {
-    "word": "lyrics (n pl) /ˈlɪrɪks/",
-    "meaning": "the words of a song (lời bài hát)",
-    "example": "I’ve written the music but not the lyrics. She always mishears the lyrics. He studies song lyrics for inspiration. These lyrics are beautifully poetic.",
-    "count": 0
+      "word": "lyrics (n pl) /ˈlɪrɪks/",
+      "meaning": "the words of a song (lời bài hát)",
+      "example": "I’ve written the music but not the lyrics. She always mishears the lyrics. He studies song lyrics for inspiration. These lyrics are beautifully poetic.",
+      "count": 0
     },
     {
-    "word": "masterpiece (n) /ˈmɑːstəpiːs/",
-    "meaning": "an excellent work of art, book, piece of music, etc. (kiệt tác)",
-    "example": "The film widely regarded as Hitchcock’s masterpiece. This novel is her literary masterpiece. The painting was declared a masterpiece. That sculpture is considered a modern masterpiece.",
-    "count": 0
+      "word": "masterpiece (n) /ˈmɑːstəpiːs/",
+      "meaning": "an excellent work of art, book, piece of music, etc. (kiệt tác)",
+      "example": "The film widely regarded as Hitchcock’s masterpiece. This novel is her literary masterpiece. The painting was declared a masterpiece. That sculpture is considered a modern masterpiece.",
+      "count": 0
     },
     {
-    "word": "paperback (n) /ˈpeɪəbæk/",
-    "meaning": "a book with a soft cover (sách bìa mềm)",
-    "example": "His collection of rare books is now out in paperback. She prefers to travel with paperbacks. I found an old paperback edition. The book was released in paperback this spring.",
-    "count": 0
+      "word": "paperback (n) /ˈpeɪəbæk/",
+      "meaning": "a book with a soft cover (sách bìa mềm)",
+      "example": "His collection of rare books is now out in paperback. She prefers to travel with paperbacks. I found an old paperback edition. The book was released in paperback this spring.",
+      "count": 0
     },
     {
-    "word": "period (adj) /ˈpɪəriəd/",
-    "meaning": "typical of a particular historical time (thuộc về thời kỳ nào đó)",
-    "example": "Will you be wearing period costumes in the play? The film used period furniture. She collects period jewelry. A period drama aired last night.",
-    "count": 0
+      "word": "period (adj) /ˈpɪəriəd/",
+      "meaning": "typical of a particular historical time (thuộc về thời kỳ nào đó)",
+      "example": "Will you be wearing period costumes in the play? The film used period furniture. She collects period jewelry. A period drama aired last night.",
+      "count": 0
     },
     {
-    "word": "period (n) /ˈpɪəriəd/",
-    "meaning": "a particular time in history (thời kỳ)",
-    "example": "Her collection is solely related to the Roman period. It was a difficult period in his life. We studied the Baroque period in class. The medieval period was very harsh.",
-    "count": 0
+      "word": "period (n) /ˈpɪəriəd/",
+      "meaning": "a particular time in history (thời kỳ)",
+      "example": "Her collection is solely related to the Roman period. It was a difficult period in his life. We studied the Baroque period in class. The medieval period was very harsh.",
+      "count": 0
     },
     {
-    "word": "priceless (adj) /ˈpraɪsləs/",
-    "meaning": "very valuable and impossible to replace (vô giá)",
-    "example": "These are priceless jewels. That vase is absolutely priceless. The moment we shared was priceless. Her advice turned out to be priceless.",
-    "count": 0
+      "word": "priceless (adj) /ˈpraɪsləs/",
+      "meaning": "very valuable and impossible to replace (vô giá)",
+      "example": "These are priceless jewels. That vase is absolutely priceless. The moment we shared was priceless. Her advice turned out to be priceless.",
+      "count": 0
     },
     {
-    "word": "ritual (n) /ˈrɪtʃuəl/",
-    "meaning": "a set of fixed actions performed regularly (nghi lễ, nghi thức)",
-    "example": "Are you coming to the piano recital ritual tonight? He follows a strict morning ritual. The ritual lasted for two hours. Candle lighting was part of the ritual.",
-    "count": 0
+      "word": "ritual (n) /ˈrɪtʃuəl/",
+      "meaning": "a set of fixed actions performed regularly (nghi lễ, nghi thức)",
+      "example": "Are you coming to the piano recital ritual tonight? He follows a strict morning ritual. The ritual lasted for two hours. Candle lighting was part of the ritual.",
+      "count": 0
     },
     {
-    "word": "retrospective (adj) /ˌretrəˈspektɪv/",
-    "meaning": "relating to things that happened in the past (hồi tưởng)",
-    "example": "The show includes a retrospective look at the 1970s. It was a retrospective exhibition of her work. His writing had a retrospective tone. The museum held a retrospective series.",
-    "count": 0
+      "word": "retrospective (adj) /ˌretrəˈspektɪv/",
+      "meaning": "relating to things that happened in the past (hồi tưởng)",
+      "example": "The show includes a retrospective look at the 1970s. It was a retrospective exhibition of her work. His writing had a retrospective tone. The museum held a retrospective series.",
+      "count": 0
     },
     {
-    "word": "retrospective (n) /ˌretrəˈspektɪv/",
-    "meaning": "an exhibition showing the work of an artist over a long period (triển lãm hồi cố)",
-    "example": "I really want to get to the Tim Burton retrospective. They opened a retrospective of Picasso. The gallery hosted a Van Gogh retrospective. The retrospective drew large crowds.",
-    "count": 0
+      "word": "retrospective (n) /ˌretrəˈspektɪv/",
+      "meaning": "an exhibition showing the work of an artist over a long period (triển lãm hồi cố)",
+      "example": "I really want to get to the Tim Burton retrospective. They opened a retrospective of Picasso. The gallery hosted a Van Gogh retrospective. The retrospective drew large crowds.",
+      "count": 0
     },
     {
-    "word": "score (n) /skɔːr/",
-    "meaning": "the music written for a film, play, etc. (nhạc phim)",
-    "example": "Who wrote the musical score for Star Wars? The score enhanced the scene’s emotion. That composer won awards for his score. The film’s score is unforgettable.",
-    "count": 0
+      "word": "score (n) /skɔːr/",
+      "meaning": "the music written for a film, play, etc. (nhạc phim)",
+      "example": "Who wrote the musical score for Star Wars? The score enhanced the scene’s emotion. That composer won awards for his score. The film’s score is unforgettable.",
+      "count": 0
     },
     {
-    "word": "sketch (n) /sketʃ/",
-    "meaning": "a drawing made quickly that does not have many details (bức phác thảo)",
-    "example": "Draw a rough sketch of the dog. She shared her travel sketches. His sketch captured the skyline beautifully. The museum displayed several artist sketches.",
-    "count": 0
+      "word": "sketch (n) /sketʃ/",
+      "meaning": "a drawing made quickly that does not have many details (bức phác thảo)",
+      "example": "Draw a rough sketch of the dog. She shared her travel sketches. His sketch captured the skyline beautifully. The museum displayed several artist sketches.",
+      "count": 0
     },
     {
-    "word": "sketch (v) /sketʃ/",
-    "meaning": "to make a quick drawing (phác thảo)",
-    "example": "She sketched the outline of the landscape. He sketched a portrait from memory. I just sketch and go with the flow. We sat by the lake and sketched birds.",
-    "count": 0
+      "word": "sketch (v) /sketʃ/",
+      "meaning": "to make a quick drawing (phác thảo)",
+      "example": "She sketched the outline of the landscape. He sketched a portrait from memory. I just sketch and go with the flow. We sat by the lake and sketched birds.",
+      "count": 0
     },
     {
-    "word": "sketch (v) /sketʃ/",
-    "meaning": "to describe something briefly (mô tả sơ lược)",
-    "example": "I’ll just sketch out a few ideas. She sketched the plan to the team. He sketched the situation before we entered. They asked him to sketch the event quickly.",
-    "count": 0
+      "word": "sketch (v) /sketʃ/",
+      "meaning": "to describe something briefly (mô tả sơ lược)",
+      "example": "I’ll just sketch out a few ideas. She sketched the plan to the team. He sketched the situation before we entered. They asked him to sketch the event quickly.",
+      "count": 0
     },
     {
-    "word": "work of art (n phr) /ˌwɜːk əv ˈɑːt/",
-    "meaning": "something that is made or done in a skilful or attractive way (công trình nghệ thuật)",
-    "example": "Her house is a real work of art. The dress was a work of art. The garden is a living work of art. That mural is a true work of art.",
-    "count": 0
+      "word": "work of art (n phr) /ˌwɜːk əv ˈɑːt/",
+      "meaning": "something that is made or done in a skilful or attractive way (công trình nghệ thuật)",
+      "example": "Her house is a real work of art. The dress was a work of art. The garden is a living work of art. That mural is a true work of art.",
+      "count": 0
     },
     {
-    "word": "worthless (adj) /ˈwɜːθləs/",
-    "meaning": "not having any value or good qualities (vô giá trị)",
-    "example": "The country’s currency is nearly worthless. That promise turned out worthless. This broken device is worthless now. The coins looked old but were worthless.",
-    "count": 0
+      "word": "worthless (adj) /ˈwɜːθləs/",
+      "meaning": "not having any value or good qualities (vô giá trị)",
+      "example": "The country’s currency is nearly worthless. That promise turned out worthless. This broken device is worthless now. The coins looked old but were worthless.",
+      "count": 0
     },
     {
-    "word": "adjacent (adj) /əˈdʒeɪsnt/",
-    "meaning": "next to or near something else (ở sát cạnh)",
-    "example": "The theatre is adjacent to the library. Our room was adjacent to the pool. The adjacent street was blocked. We sat in adjacent seats.",
-    "count": 0
+      "word": "adjacent (adj) /əˈdʒeɪsnt/",
+      "meaning": "next to or near something else (ở sát cạnh)",
+      "example": "The theatre is adjacent to the library. Our room was adjacent to the pool. The adjacent street was blocked. We sat in adjacent seats.",
+      "count": 0
     },
     {
-    "word": "attach (v) /əˈtætʃ/",
-    "meaning": "to join or fasten something (gắn liền, đính)",
-    "example": "You need to attach these two parts. The form is attached to the letter. She attached her name to the application. Please attach a recent photo.",
-    "count": 0
+      "word": "attach (v) /əˈtætʃ/",
+      "meaning": "to join or fasten something (gắn liền, đính)",
+      "example": "You need to attach these two parts. The form is attached to the letter. She attached her name to the application. Please attach a recent photo.",
+      "count": 0
     },
     {
-    "word": "bond (v) /bɒnd/",
-    "meaning": "to fix things firmly together with glue, or to form a close connection (gắn kết)",
-    "example": "It’s not easy to bond plastic and metal. They bonded quickly during the trip. Heat helps bond the materials. They bonded over shared experiences.",
-    "count": 0
+      "word": "bond (v) /bɒnd/",
+      "meaning": "to fix things firmly together with glue, or to form a close connection (gắn kết)",
+      "example": "It’s not easy to bond plastic and metal. They bonded quickly during the trip. Heat helps bond the materials. They bonded over shared experiences.",
+      "count": 0
     },
     {
-    "word": "bond (n) /bɒnd/",
-    "meaning": "a close connection joining two or more people (mối liên kết)",
-    "example": "We shared a strong bond from the start. Their bond grew stronger over time. Family bonds can last a lifetime. There’s a bond of trust between us.",
-    "count": 0
+      "word": "bond (n) /bɒnd/",
+      "meaning": "a close connection joining two or more people (mối liên kết)",
+      "example": "We shared a strong bond from the start. Their bond grew stronger over time. Family bonds can last a lifetime. There’s a bond of trust between us.",
+      "count": 0
     },
     {
-    "word": "coexist (v) /ˌkəʊɪɡˈzɪst/",
-    "meaning": "to live or exist together (cùng tồn tại)",
-    "example": "Can art and commerce coexist? These traditions coexist peacefully. Humans and animals coexist in harmony. Two different views can coexist.",
-    "count": 0
+      "word": "coexist (v) /ˌkəʊɪɡˈzɪst/",
+      "meaning": "to live or exist together (cùng tồn tại)",
+      "example": "Can art and commerce coexist? These traditions coexist peacefully. Humans and animals coexist in harmony. Two different views can coexist.",
+      "count": 0
     },
     {
-    "word": "coherent (adj) /kəʊˈhɪərənt/",
-    "meaning": "logical and well-organized (mạch lạc)",
-    "example": "Your argument is not coherent. He gave a coherent explanation. Her writing is clear and coherent. The plan must be coherent and realistic.",
-    "count": 0
+      "word": "coherent (adj) /kəʊˈhɪərənt/",
+      "meaning": "logical and well-organized (mạch lạc)",
+      "example": "Your argument is not coherent. He gave a coherent explanation. Her writing is clear and coherent. The plan must be coherent and realistic.",
+      "count": 0
     },
     {
-    "word": "compatible (adj) /kəmˈpætəbl/",
-    "meaning": "able to exist or work together (tương thích, hòa hợp)",
-    "example": "Lisa and Jim are very compatible. The software isn’t compatible with my phone. Their goals aren’t compatible. The charger is compatible with all models.",
-    "count": 0
+      "word": "compatible (adj) /kəmˈpætəbl/",
+      "meaning": "able to exist or work together (tương thích, hòa hợp)",
+      "example": "Lisa and Jim are very compatible. The software isn’t compatible with my phone. Their goals aren’t compatible. The charger is compatible with all models.",
+      "count": 0
     },
     {
-    "word": "compromise (n) /ˈkɒmprəmaɪz/",
-    "meaning": "a way of solving a problem in which people agree to accept less (sự thỏa hiệp)",
-    "example": "They reached a compromise after long talks. Compromise is vital in any relationship. We made a compromise on budget. The solution was a fair compromise.",
-    "count": 0
+      "word": "compromise (n) /ˈkɒmprəmaɪz/",
+      "meaning": "a way of solving a problem in which people agree to accept less (sự thỏa hiệp)",
+      "example": "They reached a compromise after long talks. Compromise is vital in any relationship. We made a compromise on budget. The solution was a fair compromise.",
+      "count": 0
     },
     {
-    "word": "compromise (v) /ˈkɒmprəmaɪz/",
-    "meaning": "to settle a disagreement by each side accepting less (thỏa hiệp)",
-    "example": "They agreed to compromise on the schedule. You must compromise to move forward. We compromised after hours of debate. Don’t compromise your values easily.",
-    "count": 0
+      "word": "compromise (v) /ˈkɒmprəmaɪz/",
+      "meaning": "to settle a disagreement by each side accepting less (thỏa hiệp)",
+      "example": "They agreed to compromise on the schedule. You must compromise to move forward. We compromised after hours of debate. Don’t compromise your values easily.",
+      "count": 0
     },
     {
-    "word": "conflict (n) /ˈkɒnflɪkt/",
-    "meaning": "a serious disagreement (xung đột)",
-    "example": "Many people have died in the conflict. There’s a conflict between two departments. Family conflict affects children deeply. Conflict over pay led to the strike.",
-    "count": 0
+      "word": "conflict (n) /ˈkɒnflɪkt/",
+      "meaning": "a serious disagreement (xung đột)",
+      "example": "Many people have died in the conflict. There’s a conflict between two departments. Family conflict affects children deeply. Conflict over pay led to the strike.",
+      "count": 0
     },
     {
-    "word": "confront (v) /kənˈfrʌnt/",
-    "meaning": "to go close to someone in a threatening way (đối mặt)",
-    "example": "A man in a suit confronted me. She was afraid to confront her boss. He confronted the thief in the act. They confronted protesters at the gate.",
-    "count": 0
+      "word": "confront (v) /kənˈfrʌnt/",
+      "meaning": "to go close to someone in a threatening way (đối mặt)",
+      "example": "A man in a suit confronted me. She was afraid to confront her boss. He confronted the thief in the act. They confronted protesters at the gate.",
+      "count": 0
     },
     {
-    "word": "confront (v) /kənˈfrʌnt/",
-    "meaning": "to deal with a difficult situation (đương đầu)",
-    "example": "Just confront the problem head on. He confronted his past mistakes. She decided to confront the issue. They must confront their fears together.",
-    "count": 0
+      "word": "confront (v) /kənˈfrʌnt/",
+      "meaning": "to deal with a difficult situation (đương đầu)",
+      "example": "Just confront the problem head on. He confronted his past mistakes. She decided to confront the issue. They must confront their fears together.",
+      "count": 0
     },
     {
-    "word": "consistent (adj) /kənˈsɪstənt/",
-    "meaning": "not changing in behaviour, attitudes or qualities (nhất quán)",
-    "example": "He is consistent but not quick. Her results are always consistent. The policy must be consistent. They demand consistent performance.",
-    "count": 0
+      "word": "consistent (adj) /kənˈsɪstənt/",
+      "meaning": "not changing in behaviour, attitudes or qualities (nhất quán)",
+      "example": "He is consistent but not quick. Her results are always consistent. The policy must be consistent. They demand consistent performance.",
+      "count": 0
     },
     {
-    "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
-    "meaning": "to say the opposite of what someone else has said (mâu thuẫn, phủ nhận)",
-    "example": "The witness contradicted the evidence. Don’t contradict your teacher. His story contradicts the facts. You shouldn’t contradict me all the time.",
-    "count": 0
+      "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
+      "meaning": "to say the opposite of what someone else has said (mâu thuẫn, phủ nhận)",
+      "example": "The witness contradicted the evidence. Don’t contradict your teacher. His story contradicts the facts. You shouldn’t contradict me all the time.",
+      "count": 0
     },
     {
-    "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
-    "meaning": "to show that something is wrong or false (bác bỏ)",
-    "example": "The second witness contradicted the alibi. Your statement contradicts the timeline. Facts contradict what you claim. His later words contradicted the original promise.",
-    "count": 0
+      "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
+      "meaning": "to show that something is wrong or false (bác bỏ)",
+      "example": "The second witness contradicted the alibi. Your statement contradicts the timeline. Facts contradict what you claim. His later words contradicted the original promise.",
+      "count": 0
     },
     {
-    "word": "contrasting (adj) /kənˈtrɑːstɪŋ/",
-    "meaning": "very different from each other (đối lập)",
-    "example": "They wore contrasting styles. The essay compared two contrasting views. Their personalities are contrasting. We studied contrasting colors in design.",
-    "count": 0
+      "word": "contrasting (adj) /kənˈtrɑːstɪŋ/",
+      "meaning": "very different from each other (đối lập)",
+      "example": "They wore contrasting styles. The essay compared two contrasting views. Their personalities are contrasting. We studied contrasting colors in design.",
+      "count": 0
     },
     {
-    "word": "cooperate (v) /kəʊˈɒpəreɪt/",
-    "meaning": "to work with other people to achieve something (hợp tác)",
-    "example": "We can achieve more if we cooperate. Countries must cooperate to fight climate change. He refused to cooperate with the police. Let’s cooperate on the project.",
-    "count": 0
+      "word": "cooperate (v) /kəʊˈɒpəreɪt/",
+      "meaning": "to work with other people to achieve something (hợp tác)",
+      "example": "We can achieve more if we cooperate. Countries must cooperate to fight climate change. He refused to cooperate with the police. Let’s cooperate on the project.",
+      "count": 0
     },
     {
-    "word": "correspond (v) /ˌkɒrəˈspɒnd/",
-    "meaning": "to be the same as or very much like something (tương ứng, khớp)",
-    "example": "The two accounts did not correspond. Your idea corresponds with mine. The evidence corresponds to the theory. Results must correspond to the expectations.",
-    "count": 0
+      "word": "correspond (v) /ˌkɒrəˈspɒnd/",
+      "meaning": "to be the same as or very much like something (tương ứng, khớp)",
+      "example": "The two accounts did not correspond. Your idea corresponds with mine. The evidence corresponds to the theory. Results must correspond to the expectations.",
+      "count": 0
     },
     {
-    "word": "dispute (v) /dɪˈspjuːt/",
-    "meaning": "to say something is incorrect or false (tranh cãi, phản bác)",
-    "example": "I’m not disputing the facts. She disputed the charges. We disputed the decision. He always disputes authority.",
-    "count": 0
+      "word": "dispute (v) /dɪˈspjuːt/",
+      "meaning": "to say something is incorrect or false (tranh cãi, phản bác)",
+      "example": "I’m not disputing the facts. She disputed the charges. We disputed the decision. He always disputes authority.",
+      "count": 0
     },
     {
-    "word": "dispute (n) /ˈdɪspjuːt/",
-    "meaning": "a serious argument (cuộc tranh cãi)",
-    "example": "The dispute was finally resolved. There’s a long-standing dispute over the land. That caused a bitter dispute. The contract ended in legal dispute.",
-    "count": 0
-    },      
+      "word": "dispute (n) /ˈdɪspjuːt/",
+      "meaning": "a serious argument (cuộc tranh cãi)",
+      "example": "The dispute was finally resolved. There’s a long-standing dispute over the land. That caused a bitter dispute. The contract ended in legal dispute.",
+      "count": 0
+    },
     {
-    "word": "ideal (adj) /aɪˈdɪəl/",
-    "meaning": "the best or most suitable type (lý tưởng, tốt nhất)",
-    "example": "The fair provides an ideal opportunity for job seekers and employers to meet.",
-    "count": 0
+      "word": "ideal (adj) /aɪˈdɪəl/",
+      "meaning": "the best or most suitable type (lý tưởng, tốt nhất)",
+      "example": "The fair provides an ideal opportunity for job seekers and employers to meet.",
+      "count": 0
     },
     {
-    "word": "ideal (n) /aɪˈdɪəl/",
-    "meaning": "an idea or standard that seems perfect and worth aiming for (lý tưởng)",
-    "example": "In an ideal world there would be no poverty or war.",
-    "count": 0
+      "word": "ideal (n) /aɪˈdɪəl/",
+      "meaning": "an idea or standard that seems perfect and worth aiming for (lý tưởng)",
+      "example": "In an ideal world there would be no poverty or war.",
+      "count": 0
     },
     {
-    "word": "inadequate (adj) /ɪnˈædɪkwət/",
-    "meaning": "not good enough or not sufficient for a particular purpose (không đủ, không tương xứng)",
-    "example": "We are suffering because of inadequate resources.",
-    "count": 0
+      "word": "inadequate (adj) /ɪnˈædɪkwət/",
+      "meaning": "not good enough or not sufficient for a particular purpose (không đủ, không tương xứng)",
+      "example": "We are suffering because of inadequate resources.",
+      "count": 0
     },
     {
-    "word": "invaluable (adj) /ɪnˈvæljuəbl/",
-    "meaning": "extremely useful (vô giá)",
-    "example": "The Internet is an invaluable resource for students.",
-    "count": 0
+      "word": "invaluable (adj) /ɪnˈvæljuəbl/",
+      "meaning": "extremely useful (vô giá)",
+      "example": "The Internet is an invaluable resource for students.",
+      "count": 0
     },
     {
-    "word": "optimum (adj) /ˈɒptɪməm/",
-    "meaning": "most suitable within a range of possibilities (tối ưu)",
-    "example": "The warm water provides the optimum conditions for breeding.",
-    "count": 0
+      "word": "optimum (adj) /ˈɒptɪməm/",
+      "meaning": "most suitable within a range of possibilities (tối ưu)",
+      "example": "The warm water provides the optimum conditions for breeding.",
+      "count": 0
     },
     {
-    "word": "optimum (n) /ˈɒptɪməm/",
-    "meaning": "the best or most suitable situation, level or amount (mức tối ưu)",
-    "example": "The optimum we should be producing is 100 units per hour.",
-    "count": 0
+      "word": "optimum (n) /ˈɒptɪməm/",
+      "meaning": "the best or most suitable situation, level or amount (mức tối ưu)",
+      "example": "The optimum we should be producing is 100 units per hour.",
+      "count": 0
     },
     {
-    "word": "outclass (v) /ˌaʊtˈklɑːs/",
-    "meaning": "to be much better than someone or something else (vượt trội)",
-    "example": "The team was completely outclassed by the opposition.",
-    "count": 0
+      "word": "outclass (v) /ˌaʊtˈklɑːs/",
+      "meaning": "to be much better than someone or something else (vượt trội)",
+      "example": "The team was completely outclassed by the opposition.",
+      "count": 0
     },
     {
-    "word": "prime (adj) /praɪm/",
-    "meaning": "most important, most suitable or of the highest quality (chính, chủ yếu, ưu tú)",
-    "example": "Our prime concern was the safety of the children.",
-    "count": 0
+      "word": "prime (adj) /praɪm/",
+      "meaning": "most important, most suitable or of the highest quality (chính, chủ yếu, ưu tú)",
+      "example": "Our prime concern was the safety of the children.",
+      "count": 0
     },
     {
-    "word": "redeeming feature (n phr) /rɪˈdiːmɪŋ ˈfiːtʃə/",
-    "meaning": "a quality that improves something that is not very good (điểm bù trừ)",
-    "example": "Smith’s only redeeming feature is his sense of humor.",
-    "count": 0
+      "word": "redeeming feature (n phr) /rɪˈdiːmɪŋ ˈfiːtʃə/",
+      "meaning": "a quality that improves something that is not very good (điểm bù trừ)",
+      "example": "Smith’s only redeeming feature is his sense of humor.",
+      "count": 0
     },
     {
-    "word": "refurbish (v) /ˌriːˈfɜːbɪʃ/",
-    "meaning": "to improve a room or building by cleaning and decorating it (tân trang, cải tạo)",
-    "example": "They’re planning to refurbish the teachers’ room.",
-    "count": 0
+      "word": "refurbish (v) /ˌriːˈfɜːbɪʃ/",
+      "meaning": "to improve a room or building by cleaning and decorating it (tân trang, cải tạo)",
+      "example": "They’re planning to refurbish the teachers’ room.",
+      "count": 0
     },
     {
-    "word": "reinforce (v) /ˌriːɪnˈfɔːs/",
-    "meaning": "to make a building, structure or object stronger (gia cố)",
-    "example": "Crews started work today to reinforce the seriously damaged bridge.",
-    "count": 0
+      "word": "reinforce (v) /ˌriːɪnˈfɔːs/",
+      "meaning": "to make a building, structure or object stronger (gia cố)",
+      "example": "Crews started work today to reinforce the seriously damaged bridge.",
+      "count": 0
     },
     {
-    "word": "renovate (v) /ˈrenəveɪt/",
-    "meaning": "to make something old look new again by repairing and improving it (nâng cấp, cải tạo)",
-    "example": "They plan to renovate the fire station.",
-    "count": 0
+      "word": "renovate (v) /ˈrenəveɪt/",
+      "meaning": "to make something old look new again by repairing and improving it (nâng cấp, cải tạo)",
+      "example": "They plan to renovate the fire station.",
+      "count": 0
     },
     {
-    "word": "rotten (adj) /ˈrɒtn/",
-    "meaning": "something that is decayed or bad (thối, hỏng)",
-    "example": "There was a horrible smell of rotten eggs.",
-    "count": 0
+      "word": "rotten (adj) /ˈrɒtn/",
+      "meaning": "something that is decayed or bad (thối, hỏng)",
+      "example": "There was a horrible smell of rotten eggs.",
+      "count": 0
     },
     {
-    "word": "rotten (adj) /ˈrɒtn/",
-    "meaning": "of low quality, standard or behavior (tệ hại)",
-    "example": "She’s a rotten singer.",
-    "count": 0
+      "word": "rotten (adj) /ˈrɒtn/",
+      "meaning": "of low quality, standard or behavior (tệ hại)",
+      "example": "She’s a rotten singer.",
+      "count": 0
     },
     {
-    "word": "rusty (adj) /ˈrʌsti/",
-    "meaning": "a rusty metal object is covered in rust (bị gỉ sét)",
-    "example": "I don’t know why you bought that rusty old car.",
-    "count": 0
+      "word": "rusty (adj) /ˈrʌsti/",
+      "meaning": "a rusty metal object is covered in rust (bị gỉ sét)",
+      "example": "I don’t know why you bought that rusty old car.",
+      "count": 0
     },
     {
-    "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
-    "meaning": "good enough to be accepted in a particular situation (đủ dùng)",
-    "example": "I have still not received a satisfactory answer to my question.",
-    "count": 0
+      "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
+      "meaning": "good enough to be accepted in a particular situation (đủ dùng)",
+      "example": "I have still not received a satisfactory answer to my question.",
+      "count": 0
     },
     {
-    "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
-    "meaning": "enjoyable and pleasing (hài lòng)",
-    "example": "This new arrangement proved highly satisfactory to us all.",
-    "count": 0
+      "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
+      "meaning": "enjoyable and pleasing (hài lòng)",
+      "example": "This new arrangement proved highly satisfactory to us all.",
+      "count": 0
     },
     {
-    "word": "shambles (n) /ˈʃæmbəlz/",
-    "meaning": "a situation that is very badly organised and does not operate effectively (rối ren, hỗn loạn)",
-    "example": "Government corruption has left the economy in a shambles.",
-    "count": 0
+      "word": "shambles (n) /ˈʃæmbəlz/",
+      "meaning": "a situation that is very badly organised and does not operate effectively (rối ren, hỗn loạn)",
+      "example": "Government corruption has left the economy in a shambles.",
+      "count": 0
     },
     {
-    "word": "shoddy (adj) /ˈʃɒdi/",
-    "meaning": "shoddy work, services or products are of very low standard (chất lượng kém)",
-    "example": "The work they did on the new road was very shoddy in places.",
-    "count": 0
+      "word": "shoddy (adj) /ˈʃɒdi/",
+      "meaning": "shoddy work, services or products are of very low standard (chất lượng kém)",
+      "example": "The work they did on the new road was very shoddy in places.",
+      "count": 0
     },
     {
-    "word": "sound (adj) /saʊnd/",
-    "meaning": "involving good judgment or reliable methods (hợp lý, đúng đắn)",
-    "example": "You’ll need a sound understanding of basic teaching skills before you start.",
-    "count": 0
+      "word": "sound (adj) /saʊnd/",
+      "meaning": "involving good judgment or reliable methods (hợp lý, đúng đắn)",
+      "example": "You’ll need a sound understanding of basic teaching skills before you start.",
+      "count": 0
     },
     {
-    "word": "sound (adj) /saʊnd/",
-    "meaning": "thorough or solid (toàn diện, vững chắc)",
-    "example": "Wrap the bread in foil to keep it sound.",
-    "count": 0
+      "word": "sound (adj) /saʊnd/",
+      "meaning": "thorough or solid (toàn diện, vững chắc)",
+      "example": "Wrap the bread in foil to keep it sound.",
+      "count": 0
     },
     {
-    "word": "stale (adj) /steɪl/",
-    "meaning": "food that is stale is old and no longer fresh (ôi, thiu)",
-    "example": "This bread is stale. Throw it away.",
-    "count": 0
+      "word": "stale (adj) /steɪl/",
+      "meaning": "food that is stale is old and no longer fresh (ôi, thiu)",
+      "example": "This bread is stale. Throw it away.",
+      "count": 0
     },
     {
-    "word": "streamline (v) /ˈstriːmlaɪn/",
-    "meaning": "to improve a business, organisation, process etc by making it more modern and efficient (tinh gọn)",
-    "example": "We need to streamline the whole process.",
-    "count": 0
+      "word": "streamline (v) /ˈstriːmlaɪn/",
+      "meaning": "to improve a business, organisation, process etc by making it more modern and efficient (tinh gọn)",
+      "example": "We need to streamline the whole process.",
+      "count": 0
     },
     {
-    "word": "strengthen (v) /ˈstreŋθn/",
-    "meaning": "to make something stronger (gia cố, củng cố)",
-    "example": "The bridge strengthens the connection between the two cities.",
-    "count": 0
+      "word": "strengthen (v) /ˈstreŋθn/",
+      "meaning": "to make something stronger (gia cố, củng cố)",
+      "example": "The bridge strengthens the connection between the two cities.",
+      "count": 0
     },
     {
-    "word": "surpass (v) /səˈpɑːs/",
-    "meaning": "to be better or greater than something else (vượt qua)",
-    "example": "Winning the gold medal surpassed our expectations.",
-    "count": 0
+      "word": "surpass (v) /səˈpɑːs/",
+      "meaning": "to be better or greater than something else (vượt qua)",
+      "example": "Winning the gold medal surpassed our expectations.",
+      "count": 0
     },
     {
-    "word": "ultimate (adj) /ˈʌltɪmət/",
-    "meaning": "happening at the end of a process or activity (cuối cùng)",
-    "example": "The incident affected the outcome of the ultimate decision.",
-    "count": 0
+      "word": "ultimate (adj) /ˈʌltɪmət/",
+      "meaning": "happening at the end of a process or activity (cuối cùng)",
+      "example": "The incident affected the outcome of the ultimate decision.",
+      "count": 0
     },
     {
-    "word": "ultimate (adj) /ˈʌltɪmət/",
-    "meaning": "as good or as bad as possible (tối thượng, tốt nhất)",
-    "example": "The course offers the ultimate test of skill.",
-    "count": 0
+      "word": "ultimate (adj) /ˈʌltɪmət/",
+      "meaning": "as good or as bad as possible (tối thượng, tốt nhất)",
+      "example": "The course offers the ultimate test of skill.",
+      "count": 0
     },
     {
-    "word": "worsen (v) /ˈwɜːsn/",
-    "meaning": "to become worse, or to make something worse (làm trầm trọng hơn)",
-    "example": "Temperatures fell and the weather worsened.",
-    "count": 0
+      "word": "worsen (v) /ˈwɜːsn/",
+      "meaning": "to become worse, or to make something worse (làm trầm trọng hơn)",
+      "example": "Temperatures fell and the weather worsened.",
+      "count": 0
     },
     {
-    "word": "wreck (n) /rek/",
-    "meaning": "something that has been badly damaged (đống đổ nát)",
-    "example": "The car was a wreck after the accident.",
-    "count": 0
+      "word": "wreck (n) /rek/",
+      "meaning": "something that has been badly damaged (đống đổ nát)",
+      "example": "The car was a wreck after the accident.",
+      "count": 0
     },
     {
-    "word": "wreck (v) /rek/",
-    "meaning": "to severely damage (phá hủy)",
-    "example": "The town was wrecked by the bombing.",
-    "count": 0
+      "word": "wreck (v) /rek/",
+      "meaning": "to severely damage (phá hủy)",
+      "example": "The town was wrecked by the bombing.",
+      "count": 0
     },
     {
-    "word": "abstract (adj) /ˈæbstrækt/",
-    "meaning": "abstract art shows ideas rather than actual objects (trừu tượng)",
-    "example": "I’m not very keen on abstract paintings.",
-    "count": 0
+      "word": "abstract (adj) /ˈæbstrækt/",
+      "meaning": "abstract art shows ideas rather than actual objects (trừu tượng)",
+      "example": "I’m not very keen on abstract paintings.",
+      "count": 0
     },
     {
-    "word": "abstract (n) /ˈæbstrækt/",
-    "meaning": "an abstract painting or design (tác phẩm trừu tượng)",
-    "example": "You’re not supposed to understand what an abstract is.",
-    "count": 0
+      "word": "abstract (n) /ˈæbstrækt/",
+      "meaning": "an abstract painting or design (tác phẩm trừu tượng)",
+      "example": "You’re not supposed to understand what an abstract is.",
+      "count": 0
     },
     {
-    "word": "auction (n) /ˈɔːkʃn/",
-    "meaning": "a public occasion when things are sold to the person who offers the most money (buổi đấu giá)",
-    "example": "They bought the paintings at auction in 1989.",
-    "count": 0
+      "word": "auction (n) /ˈɔːkʃn/",
+      "meaning": "a public occasion when things are sold to the person who offers the most money (buổi đấu giá)",
+      "example": "They bought the paintings at auction in 1989.",
+      "count": 0
     },
     {
-    "word": "audition (n) /ɔːˈdɪʃn/",
-    "meaning": "a short performance to decide if someone is good enough (buổi thử vai)",
-    "example": "I’ve got an audition for the school play tomorrow.",
-    "count": 0
+      "word": "audition (n) /ɔːˈdɪʃn/",
+      "meaning": "a short performance to decide if someone is good enough (buổi thử vai)",
+      "example": "I’ve got an audition for the school play tomorrow.",
+      "count": 0
     },
     {
-    "word": "bestseller (n) /ˌbestˈselə/",
-    "meaning": "a book that many people buy (sách bán chạy)",
-    "example": "His first novel was a bestseller.",
-    "count": 0
+      "word": "bestseller (n) /ˌbestˈselə/",
+      "meaning": "a book that many people buy (sách bán chạy)",
+      "example": "His first novel was a bestseller.",
+      "count": 0
     },
     {
-    "word": "collector’s item (n phr) /kəˈlektəz ˈaɪtəm/",
-    "meaning": "a rare or valuable object that collectors want (đồ hiếm)",
-    "example": "Do you think this watch is a collector’s item?",
-    "count": 0
+      "word": "collector’s item (n phr) /kəˈlektəz ˈaɪtəm/",
+      "meaning": "a rare or valuable object that collectors want (đồ hiếm)",
+      "example": "Do you think this watch is a collector’s item?",
+      "count": 0
     },
     {
-    "word": "curator (n) /kjʊˈreɪtə/",
-    "meaning": "someone whose job is to look after the objects in a museum or art gallery (bảo tàng viên)",
-    "example": "He’ll be able to tell you more about it – he’s the curator.",
-    "count": 0
+      "word": "curator (n) /kjʊˈreɪtə/",
+      "meaning": "someone whose job is to look after the objects in a museum or art gallery (bảo tàng viên)",
+      "example": "He’ll be able to tell you more about it – he’s the curator.",
+      "count": 0
     },
     {
-    "word": "fine art (n phr) /ˌfaɪn ˈɑːt/",
-    "meaning": "art forms like painting, drawing, or sculpture (mỹ thuật)",
-    "example": "I’m thinking of studying fine art at university.",
-    "count": 0
-    },      
+      "word": "fine art (n phr) /ˌfaɪn ˈɑːt/",
+      "meaning": "art forms like painting, drawing, or sculpture (mỹ thuật)",
+      "example": "I’m thinking of studying fine art at university.",
+      "count": 0
+    },
     {
-    "word": "diagnosis (n)",
-    "meaning": "a statement about what disease someone has, based on examining them (chẩn đoán); a diagnosis of appendicitis (chẩn đoán viêm ruột thừa)",
-    "example": "The doctor’s diagnosis was pneumonia. Early diagnosis of diabetes can save lives. She awaited the final diagnosis with anxiety. His diagnosis of appendicitis was confirmed by blood tests.",
-    "count": 0
+      "word": "diagnosis (n)",
+      "meaning": "a statement about what disease someone has, based on examining them (chẩn đoán); a diagnosis of appendicitis (chẩn đoán viêm ruột thừa)",
+      "example": "The doctor’s diagnosis was pneumonia. Early diagnosis of diabetes can save lives. She awaited the final diagnosis with anxiety. His diagnosis of appendicitis was confirmed by blood tests.",
+      "count": 0
     },
     {
-    "word": "inoculate (v)",
-    "meaning": "to protect someone against a particular disease by injecting a small amount of it so that their body becomes immune (tiêm phòng); to inoculate someone against diphtheria",
-    "example": "The hospital inoculated all staff against influenza. They plan to inoculate children before flu season. She was inoculated against measles at birth. The clinic offers to inoculate travelers for free.",
-    "count": 0
+      "word": "inoculate (v)",
+      "meaning": "to protect someone against a particular disease by injecting a small amount of it so that their body becomes immune (tiêm phòng); to inoculate someone against diphtheria",
+      "example": "The hospital inoculated all staff against influenza. They plan to inoculate children before flu season. She was inoculated against measles at birth. The clinic offers to inoculate travelers for free.",
+      "count": 0
     },
     {
-    "word": "irritation (n)",
-    "meaning": "a painful feeling in a part of the body, often with red skin or swelling (kích ứng); stomach irritation (đau dạ dày)",
-    "example": "The cream reduced skin irritation quickly. Spicy food can cause throat irritation. He experienced eye irritation from the smoke. The patch may cause mild irritation initially.",
-    "count": 0
+      "word": "irritation (n)",
+      "meaning": "a painful feeling in a part of the body, often with red skin or swelling (kích ứng); stomach irritation (đau dạ dày)",
+      "example": "The cream reduced skin irritation quickly. Spicy food can cause throat irritation. He experienced eye irritation from the smoke. The patch may cause mild irritation initially.",
+      "count": 0
     },
     {
-    "word": "numb (adj)",
-    "meaning": "a part of your body that is numb has no feeling (tê liệt); After hours of sitting on the floor, her legs had gone numb",
-    "example": "Her fingers went numb in the cold. He felt numb after hearing the shocking news. The dentist gave her an injection to make her gums numb. He sat so long that his foot went completely numb.",
-    "count": 0
+      "word": "numb (adj)",
+      "meaning": "a part of your body that is numb has no feeling (tê liệt); After hours of sitting on the floor, her legs had gone numb",
+      "example": "Her fingers went numb in the cold. He felt numb after hearing the shocking news. The dentist gave her an injection to make her gums numb. He sat so long that his foot went completely numb.",
+      "count": 0
     },
     {
-    "word": "numb (v)",
-    "meaning": "not able to react or to show your emotions, often because of an extreme shock (làm tê liệt); I was numb with fear",
-    "example": "He was numb with disbelief after the accident. She sat there, numb from the news. The pain numned her senses. He felt numb and could not cry.",
-    "count": 0
+      "word": "numb (v)",
+      "meaning": "not able to react or to show your emotions, often because of an extreme shock (làm tê liệt); I was numb with fear",
+      "example": "He was numb with disbelief after the accident. She sat there, numb from the news. The pain numned her senses. He felt numb and could not cry.",
+      "count": 0
     },
     {
-    "word": "nursing home (n phr)",
-    "meaning": "an institution where old or ill people live when they are too old or ill to look after themselves without help (viện dưỡng lão)",
-    "example": "My grandmother is moving into a nursing home next week. The nursing home provides 24-hour care. Their grandfather lives in a private nursing home. She visits the nursing home every Sunday.",
-    "count": 0
+      "word": "nursing home (n phr)",
+      "meaning": "an institution where old or ill people live when they are too old or ill to look after themselves without help (viện dưỡng lão)",
+      "example": "My grandmother is moving into a nursing home next week. The nursing home provides 24-hour care. Their grandfather lives in a private nursing home. She visits the nursing home every Sunday.",
+      "count": 0
     },
     {
-    "word": "paralysis (n)",
-    "meaning": "the loss of the ability to move your body or a part of it, usually because of an injury or illness (liệt); uỷ liệt; The syndrome can lead to sudden paralysis",
-    "example": "He recovered slowly from the paralysis. The accident caused partial paralysis in his arm. Early treatment can prevent permanent paralysis. She fears paralysis if the injury worsens.",
-    "count": 0
+      "word": "paralysis (n)",
+      "meaning": "the loss of the ability to move your body or a part of it, usually because of an injury or illness (liệt); uỷ liệt; The syndrome can lead to sudden paralysis",
+      "example": "He recovered slowly from the paralysis. The accident caused partial paralysis in his arm. Early treatment can prevent permanent paralysis. She fears paralysis if the injury worsens.",
+      "count": 0
     },
     {
-    "word": "plaster (v)",
-    "meaning": "to cover a cut or broken bone with a band of plaster (băng dán vết thương); I’ve cut my finger. Have you got a plaster?",
-    "example": "The nurse plastered his arm after the fall. She plastered the wound to prevent infection. He asked for a plaster for his cut. They plastered her leg until it healed.",
-    "count": 0
+      "word": "plaster (v)",
+      "meaning": "to cover a cut or broken bone with a band of plaster (băng dán vết thương); I’ve cut my finger. Have you got a plaster?",
+      "example": "The nurse plastered his arm after the fall. She plastered the wound to prevent infection. He asked for a plaster for his cut. They plastered her leg until it healed.",
+      "count": 0
     },
     {
-    "word": "plaster (n)",
-    "meaning": "if a part of someone’s body is in plaster, it has a hard cover around it to protect a broken bone (thạch cao); One man had his leg in plaster, having broken it in an accident",
-    "example": "She had her arm in plaster for six weeks. His plaster was removed yesterday. The child played despite having a plaster on his knee. He accidentally cracked his plaster doing sports.",
-    "count": 0
+      "word": "plaster (n)",
+      "meaning": "if a part of someone’s body is in plaster, it has a hard cover around it to protect a broken bone (thạch cao); One man had his leg in plaster, having broken it in an accident",
+      "example": "She had her arm in plaster for six weeks. His plaster was removed yesterday. The child played despite having a plaster on his knee. He accidentally cracked his plaster doing sports.",
+      "count": 0
     },
     {
-    "word": "prescribe (v)",
-    "meaning": "if a doctor prescribes a drug or treatment, they say you should have it (kê đơn); The drug should not be taken unless prescribed by a doctor",
-    "example": "The physician prescribed antibiotics for the infection. He was prescribed rest and fluids. The doctor prescribed a new treatment plan. She prescribes only what’s necessary.",
-    "count": 0
+      "word": "prescribe (v)",
+      "meaning": "if a doctor prescribes a drug or treatment, they say you should have it (kê đơn); The drug should not be taken unless prescribed by a doctor",
+      "example": "The physician prescribed antibiotics for the infection. He was prescribed rest and fluids. The doctor prescribed a new treatment plan. She prescribes only what’s necessary.",
+      "count": 0
     },
     {
-    "word": "preventative medicine (n phr)",
-    "meaning": "medical examinations, treatments, advice, etc. intended to prevent illness or discover it before it becomes serious (y tế dự phòng)",
-    "example": "The government should invest more in preventative medicine. Preventative medicine reduces healthcare costs. She studies preventative medicine at university. Vaccination is a key part of preventative medicine.",
-    "count": 0
+      "word": "preventative medicine (n phr)",
+      "meaning": "medical examinations, treatments, advice, etc. intended to prevent illness or discover it before it becomes serious (y tế dự phòng)",
+      "example": "The government should invest more in preventative medicine. Preventative medicine reduces healthcare costs. She studies preventative medicine at university. Vaccination is a key part of preventative medicine.",
+      "count": 0
     },
     {
-    "word": "prognosis (n)",
-    "meaning": "a doctor’s opinion about the way in which a disease or illness is likely to develop (tiên lượng); What’s the prognosis, doctor?",
-    "example": "The prognosis for full recovery is good. He asked the doctor about his prognosis. Early diagnosis improved her prognosis. The specialist gave a grim prognosis.",
-    "count": 0
+      "word": "prognosis (n)",
+      "meaning": "a doctor’s opinion about the way in which a disease or illness is likely to develop (tiên lượng); What’s the prognosis, doctor?",
+      "example": "The prognosis for full recovery is good. He asked the doctor about his prognosis. Early diagnosis improved her prognosis. The specialist gave a grim prognosis.",
+      "count": 0
     },
     {
-    "word": "sick leave (n phr)",
-    "meaning": "a period of time during which you do not work because you are ill (nghỉ ốm); Mr Jenkins is away on sick leave today",
-    "example": "She took two weeks of sick leave after surgery. He filed for sick leave last Monday. The company offers paid sick leave. He returned from sick leave refreshed.",
-    "count": 0
+      "word": "sick leave (n phr)",
+      "meaning": "a period of time during which you do not work because you are ill (nghỉ ốm); Mr Jenkins is away on sick leave today",
+      "example": "She took two weeks of sick leave after surgery. He filed for sick leave last Monday. The company offers paid sick leave. He returned from sick leave refreshed.",
+      "count": 0
     },
     {
-    "word": "side effect (n phr)",
-    "meaning": "an effect of a medicine that is not intended and could be unpleasant (tác dụng phụ); The treatment has no significant side effects",
-    "example": "Nausea is a common side effect of this drug. She experienced severe side effects. The doctor warned him about side effects. He stopped the medication due to side effects.",
-    "count": 0
+      "word": "side effect (n phr)",
+      "meaning": "an effect of a medicine that is not intended and could be unpleasant (tác dụng phụ); The treatment has no significant side effects",
+      "example": "Nausea is a common side effect of this drug. She experienced severe side effects. The doctor warned him about side effects. He stopped the medication due to side effects.",
+      "count": 0
     },
     {
-    "word": "syringe (n)",
-    "meaning": "a needle fitted to a plastic tube, used for taking blood from your body or for putting medicine or drugs into it (ống tiêm)",
-    "example": "The nurse filled the syringe with vaccine. He handled the syringe carefully. She taught me how to use a syringe. The syringe needs to be sterilized.",
-    "count": 0
+      "word": "syringe (n)",
+      "meaning": "a needle fitted to a plastic tube, used for taking blood from your body or for putting medicine or drugs into it (ống tiêm)",
+      "example": "The nurse filled the syringe with vaccine. He handled the syringe carefully. She taught me how to use a syringe. The syringe needs to be sterilized.",
+      "count": 0
     },
     {
-    "word": "vaccine (n)",
-    "meaning": "a substance put into the body, usually by injection, in order to provide protection against a disease (vắc xin); Is there an effective vaccine for meningitis?",
-    "example": "Scientists developed a new vaccine for malaria. The clinic offers free vaccines. He opted to receive the flu vaccine. A vaccine can prevent many illnesses.",
-    "count": 0
+      "word": "vaccine (n)",
+      "meaning": "a substance put into the body, usually by injection, in order to provide protection against a disease (vắc xin); Is there an effective vaccine for meningitis?",
+      "example": "Scientists developed a new vaccine for malaria. The clinic offers free vaccines. He opted to receive the flu vaccine. A vaccine can prevent many illnesses.",
+      "count": 0
     },
     {
-    "word": "ward (n)",
-    "meaning": "a large room in a hospital with beds for people to stay in; phòng bệnh, khu bệnh; Jo is a staff nurse working on the maternity ward",
-    "example": "She visited her grandmother in the ward. The ward was full of healthy babies. He volunteered to work in the children’s ward. The ward staff were very attentive.",
-    "count": 0
+      "word": "ward (n)",
+      "meaning": "a large room in a hospital with beds for people to stay in; phòng bệnh, khu bệnh; Jo is a staff nurse working on the maternity ward",
+      "example": "She visited her grandmother in the ward. The ward was full of healthy babies. He volunteered to work in the children’s ward. The ward staff were very attentive.",
+      "count": 0
     },
     {
-    "word": "aggression (n)",
-    "meaning": "an angry feeling that makes you want to attack or defeat someone else (sự hung hăng)",
-    "example": "He struggled to control his aggression during the heated debate. Road rage is a common form of aggression on busy highways. The coach warned that unchecked aggression could lead to penalties. She learned techniques to manage her aggression in stressful situations.",
-    "count": 0
+      "word": "aggression (n)",
+      "meaning": "an angry feeling that makes you want to attack or defeat someone else (sự hung hăng)",
+      "example": "He struggled to control his aggression during the heated debate. Road rage is a common form of aggression on busy highways. The coach warned that unchecked aggression could lead to penalties. She learned techniques to manage her aggression in stressful situations.",
+      "count": 0
     },
     {
-    "word": "authority (n)",
-    "meaning": "the power to make decisions for or tell people what to do (quyền hạn)",
-    "example": "Only the principal has the authority to approve changes to the curriculum. The manager’s authority was challenged by some team members. We need to escalate this issue to someone with proper authority. He questioned the authority of the new policy.",
-    "count": 0
+      "word": "authority (n)",
+      "meaning": "the power to make decisions for or tell people what to do (quyền hạn)",
+      "example": "Only the principal has the authority to approve changes to the curriculum. The manager’s authority was challenged by some team members. We need to escalate this issue to someone with proper authority. He questioned the authority of the new policy.",
+      "count": 0
     },
     {
-    "word": "benign (adj)",
-    "meaning": "kind and easygoing; not harmful (nhân từ, lành tính)",
-    "example": "Her benign smile put everyone at ease. The lump turned out to be benign, not cancerous. He has a benign demeanor that makes him well liked. The doctor said the growth was benign and required no treatment.",
-    "count": 0
+      "word": "benign (adj)",
+      "meaning": "kind and easygoing; not harmful (nhân từ, lành tính)",
+      "example": "Her benign smile put everyone at ease. The lump turned out to be benign, not cancerous. He has a benign demeanor that makes him well liked. The doctor said the growth was benign and required no treatment.",
+      "count": 0
     },
     {
-    "word": "bully (v)",
-    "meaning": "to frighten or hurt someone who is smaller or weaker (bắt nạt)",
-    "example": "He refused to bully his classmates into doing his homework. Online platforms must do more to stop users from bullying others. Don’t let anyone bully you into backing down. She stood up when she saw him bully a younger student.",
-    "count": 0
+      "word": "bully (v)",
+      "meaning": "to frighten or hurt someone who is smaller or weaker (bắt nạt)",
+      "example": "He refused to bully his classmates into doing his homework. Online platforms must do more to stop users from bullying others. Don’t let anyone bully you into backing down. She stood up when she saw him bully a younger student.",
+      "count": 0
     },
     {
-    "word": "bully (n)",
-    "meaning": "someone who frightens or hurts someone smaller or weaker (kẻ bắt nạt)",
-    "example": "The playground bully was finally reprimanded by the teacher. No one should have to tolerate a bully at work. He used to be a bully in high school but has changed. Parents worried the new student would become a target for the bully.",
-    "count": 0
+      "word": "bully (n)",
+      "meaning": "someone who frightens or hurts someone smaller or weaker (kẻ bắt nạt)",
+      "example": "The playground bully was finally reprimanded by the teacher. No one should have to tolerate a bully at work. He used to be a bully in high school but has changed. Parents worried the new student would become a target for the bully.",
+      "count": 0
     },
     {
-    "word": "command (v)",
-    "meaning": "to officially order someone to do something (mệnh lệnh)",
-    "example": "The general commanded his troops to hold their position. She commanded the team to stop all work immediately. The director can command resources for any urgent project. He commanded respect from his subordinates.",
-    "count": 0
+      "word": "command (v)",
+      "meaning": "to officially order someone to do something (mệnh lệnh)",
+      "example": "The general commanded his troops to hold their position. She commanded the team to stop all work immediately. The director can command resources for any urgent project. He commanded respect from his subordinates.",
+      "count": 0
     },
     {
-    "word": "command (n)",
-    "meaning": "an official order (mệnh lệnh)",
-    "example": "He carried out every command from his superior. The rescue team acted on the commander’s commands. You must follow the safety commands in the manual. Failure to obey that command could be dangerous.",
-    "count": 0
+      "word": "command (n)",
+      "meaning": "an official order (mệnh lệnh)",
+      "example": "He carried out every command from his superior. The rescue team acted on the commander’s commands. You must follow the safety commands in the manual. Failure to obey that command could be dangerous.",
+      "count": 0
     },
     {
-    "word": "conquer (v)",
-    "meaning": "to take control of land or people using soldiers (chinh phục)",
-    "example": "The empire set out to conquer neighboring territories. Alexander the Great conquered vast regions before age 30. They attempted to conquer the rugged mountain passes. Napoleon famously tried to conquer all of Europe.",
-    "count": 0
+      "word": "conquer (v)",
+      "meaning": "to take control of land or people using soldiers (chinh phục)",
+      "example": "The empire set out to conquer neighboring territories. Alexander the Great conquered vast regions before age 30. They attempted to conquer the rugged mountain passes. Napoleon famously tried to conquer all of Europe.",
+      "count": 0
     },
     {
-    "word": "conquer (v)",
-    "meaning": "to gain control of a situation or emotion by making a great effort (chinh phục)",
-    "example": "She trained hard to conquer her fear of public speaking. He finally conquered the challenges of learning a new language. They worked together to conquer every obstacle. It took years to conquer his self-doubt.",
-    "count": 0
+      "word": "conquer (v)",
+      "meaning": "to gain control of a situation or emotion by making a great effort (chinh phục)",
+      "example": "She trained hard to conquer her fear of public speaking. He finally conquered the challenges of learning a new language. They worked together to conquer every obstacle. It took years to conquer his self-doubt.",
+      "count": 0
     },
     {
-    "word": "consent (v)",
-    "meaning": "to give approval for something (đồng ý)",
-    "example": "You cannot proceed without the patient’s consent. She consented to share her data for the study. He consented to the new terms and conditions. They asked for parental consent before the trip.",
-    "count": 0
+      "word": "consent (v)",
+      "meaning": "to give approval for something (đồng ý)",
+      "example": "You cannot proceed without the patient’s consent. She consented to share her data for the study. He consented to the new terms and conditions. They asked for parental consent before the trip.",
+      "count": 0
     },
     {
-    "word": "consent (n)",
-    "meaning": "permission to do something (sự đồng ý)",
-    "example": "The project needed consent from all stakeholders. They obtained consent before accessing private records. He signed the form to indicate his consent. Consent is required by law for any data collection.",
-    "count": 0
+      "word": "consent (n)",
+      "meaning": "permission to do something (sự đồng ý)",
+      "example": "The project needed consent from all stakeholders. They obtained consent before accessing private records. He signed the form to indicate his consent. Consent is required by law for any data collection.",
+      "count": 0
     },
     {
-    "word": "controversy (n)",
-    "meaning": "a public disagreement about a policy or moral issue (tranh cãi)",
-    "example": "The new law sparked controversy across the country. There was controversy over the CEO’s high salary. The film’s ending caused heated controversy among fans. Scientists faced controversy when they published their findings.",
-    "count": 0
+      "word": "controversy (n)",
+      "meaning": "a public disagreement about a policy or moral issue (tranh cãi)",
+      "example": "The new law sparked controversy across the country. There was controversy over the CEO’s high salary. The film’s ending caused heated controversy among fans. Scientists faced controversy when they published their findings.",
+      "count": 0
     },
     {
-    "word": "dictator (n)",
-    "meaning": "someone who uses force to take and keep power in a country (nhà độc tài)",
-    "example": "The dictator ruled the nation with an iron fist. Citizens lived in fear under the oppressive dictator. He escaped the country to flee the dictator’s regime. Historians study how dictators maintain control.",
-    "count": 0
+      "word": "dictator (n)",
+      "meaning": "someone who uses force to take and keep power in a country (nhà độc tài)",
+      "example": "The dictator ruled the nation with an iron fist. Citizens lived in fear under the oppressive dictator. He escaped the country to flee the dictator’s regime. Historians study how dictators maintain control.",
+      "count": 0
     },
     {
-    "word": "dominate (v)",
-    "meaning": "to control something or someone, often negatively, because you have more power (áp đảo)",
-    "example": "Large corporations often dominate smaller competitors. His presence can dominate any room he enters. Social media platforms dominate our daily interactions. The team’s star player dominated the game.",
-    "count": 0
+      "word": "dominate (v)",
+      "meaning": "to control something or someone, often negatively, because you have more power (áp đảo)",
+      "example": "Large corporations often dominate smaller competitors. His presence can dominate any room he enters. Social media platforms dominate our daily interactions. The team’s star player dominated the game.",
+      "count": 0
     },
     {
-    "word": "eliminate (v)",
-    "meaning": "to get rid of something unwanted or unnecessary (loại bỏ)",
-    "example": "We need to eliminate all bugs before release. The new process eliminates redundant steps. He aimed to eliminate waste from the workflow. That diet plan promises to eliminate unhealthy fats.",
-    "count": 0
+      "word": "eliminate (v)",
+      "meaning": "to get rid of something unwanted or unnecessary (loại bỏ)",
+      "example": "We need to eliminate all bugs before release. The new process eliminates redundant steps. He aimed to eliminate waste from the workflow. That diet plan promises to eliminate unhealthy fats.",
+      "count": 0
     },
     {
-    "word": "enforce (v)",
-    "meaning": "to make sure that a law or rule is obeyed (thực thi)",
-    "example": "Police work to enforce traffic regulations. The company enforces a strict code of conduct. Judges enforce court orders without exception. It’s challenging to enforce remote-work policies.",
-    "count": 0
+      "word": "enforce (v)",
+      "meaning": "to make sure that a law or rule is obeyed (thực thi)",
+      "example": "Police work to enforce traffic regulations. The company enforces a strict code of conduct. Judges enforce court orders without exception. It’s challenging to enforce remote-work policies.",
+      "count": 0
     },
     {
-    "word": "entitled (adj)",
-    "meaning": "having the right to something (được quyền)",
-    "example": "Students are entitled to free access to the library. He was entitled to compensation after the delay. Full-time employees are entitled to health benefits. She felt entitled to a refund after poor service.",
-    "count": 0
+      "word": "entitled (adj)",
+      "meaning": "having the right to something (được quyền)",
+      "example": "Students are entitled to free access to the library. He was entitled to compensation after the delay. Full-time employees are entitled to health benefits. She felt entitled to a refund after poor service.",
+      "count": 0
     },
     {
-    "word": "exempt (adj)",
-    "meaning": "allowed to ignore a rule, obligation, or payment (được miễn)",
-    "example": "Nonprofits are exempt from certain taxes. Volunteers may be exempt from registration fees. Some countries exempt students from military service. Members with seniority are exempt from jury duty.",
-    "count": 0
-    },      
+      "word": "exempt (adj)",
+      "meaning": "allowed to ignore a rule, obligation, or payment (được miễn)",
+      "example": "Nonprofits are exempt from certain taxes. Volunteers may be exempt from registration fees. Some countries exempt students from military service. Members with seniority are exempt from jury duty.",
+      "count": 0
+    },
     {
-    "word": "aggression (n)",
-    "meaning": "an angry feeling that makes you want to attack or defeat someone else (sự hung hăng)",
-    "example": "He struggled to control his aggression during the heated debate. Road rage is a common form of aggression on busy highways. The coach warned that unchecked aggression could lead to penalties. She learned techniques to manage her aggression in stressful situations.",
-    "count": 0
+      "word": "aggression (n)",
+      "meaning": "an angry feeling that makes you want to attack or defeat someone else (sự hung hăng)",
+      "example": "He struggled to control his aggression during the heated debate. Road rage is a common form of aggression on busy highways. The coach warned that unchecked aggression could lead to penalties. She learned techniques to manage her aggression in stressful situations.",
+      "count": 0
     },
     {
-    "word": "authority (n)",
-    "meaning": "the power to make decisions for or tell people what to do (quyền hạn)",
-    "example": "Only the principal has the authority to approve changes to the curriculum. The manager’s authority was challenged by some team members. We need to escalate this issue to someone with proper authority. He questioned the authority of the new policy.",
-    "count": 0
+      "word": "authority (n)",
+      "meaning": "the power to make decisions for or tell people what to do (quyền hạn)",
+      "example": "Only the principal has the authority to approve changes to the curriculum. The manager’s authority was challenged by some team members. We need to escalate this issue to someone with proper authority. He questioned the authority of the new policy.",
+      "count": 0
     },
     {
-    "word": "benign (adj)",
-    "meaning": "kind and easygoing; not harmful (nhân từ, lành tính)",
-    "example": "Her benign smile put everyone at ease. The lump turned out to be benign, not cancerous. He has a benign demeanor that makes him well liked. The doctor said the growth was benign and required no treatment.",
-    "count": 0
+      "word": "benign (adj)",
+      "meaning": "kind and easygoing; not harmful (nhân từ, lành tính)",
+      "example": "Her benign smile put everyone at ease. The lump turned out to be benign, not cancerous. He has a benign demeanor that makes him well liked. The doctor said the growth was benign and required no treatment.",
+      "count": 0
     },
     {
-    "word": "bully (v)",
-    "meaning": "to frighten or hurt someone who is smaller or weaker (bắt nạt)",
-    "example": "He refused to bully his classmates into doing his homework. Online platforms must do more to stop users from bullying others. Don’t let anyone bully you into backing down. She stood up when she saw him bully a younger student.",
-    "count": 0
+      "word": "bully (v)",
+      "meaning": "to frighten or hurt someone who is smaller or weaker (bắt nạt)",
+      "example": "He refused to bully his classmates into doing his homework. Online platforms must do more to stop users from bullying others. Don’t let anyone bully you into backing down. She stood up when she saw him bully a younger student.",
+      "count": 0
     },
     {
-    "word": "bully (n)",
-    "meaning": "someone who frightens or hurts someone smaller or weaker (kẻ bắt nạt)",
-    "example": "The playground bully was finally reprimanded by the teacher. No one should have to tolerate a bully at work. He used to be a bully in high school but has changed. Parents worried the new student would become a target for the bully.",
-    "count": 0
+      "word": "bully (n)",
+      "meaning": "someone who frightens or hurts someone smaller or weaker (kẻ bắt nạt)",
+      "example": "The playground bully was finally reprimanded by the teacher. No one should have to tolerate a bully at work. He used to be a bully in high school but has changed. Parents worried the new student would become a target for the bully.",
+      "count": 0
     },
     {
-    "word": "command (v)",
-    "meaning": "to officially order someone to do something (mệnh lệnh)",
-    "example": "The general commanded his troops to hold their position. She commanded the team to stop all work immediately. The director can command resources for any urgent project. He commanded respect from his subordinates.",
-    "count": 0
+      "word": "command (v)",
+      "meaning": "to officially order someone to do something (mệnh lệnh)",
+      "example": "The general commanded his troops to hold their position. She commanded the team to stop all work immediately. The director can command resources for any urgent project. He commanded respect from his subordinates.",
+      "count": 0
     },
     {
-    "word": "command (n)",
-    "meaning": "an official order (mệnh lệnh)",
-    "example": "He carried out every command from his superior. The rescue team acted on the commander’s commands. You must follow the safety commands in the manual. Failure to obey that command could be dangerous.",
-    "count": 0
+      "word": "command (n)",
+      "meaning": "an official order (mệnh lệnh)",
+      "example": "He carried out every command from his superior. The rescue team acted on the commander’s commands. You must follow the safety commands in the manual. Failure to obey that command could be dangerous.",
+      "count": 0
     },
     {
-    "word": "conquer (v)",
-    "meaning": "to take control of land or people using soldiers (chinh phục)",
-    "example": "The empire set out to conquer neighboring territories. Alexander the Great conquered vast regions before age 30. They attempted to conquer the rugged mountain passes. Napoleon famously tried to conquer all of Europe.",
-    "count": 0
+      "word": "conquer (v)",
+      "meaning": "to take control of land or people using soldiers (chinh phục)",
+      "example": "The empire set out to conquer neighboring territories. Alexander the Great conquered vast regions before age 30. They attempted to conquer the rugged mountain passes. Napoleon famously tried to conquer all of Europe.",
+      "count": 0
     },
     {
-    "word": "conquer (v)",
-    "meaning": "to gain control of a situation or emotion by making a great effort (chinh phục)",
-    "example": "She trained hard to conquer her fear of public speaking. He finally conquered the challenges of learning a new language. They worked together to conquer every obstacle. It took years to conquer his self-doubt.",
-    "count": 0
+      "word": "conquer (v)",
+      "meaning": "to gain control of a situation or emotion by making a great effort (chinh phục)",
+      "example": "She trained hard to conquer her fear of public speaking. He finally conquered the challenges of learning a new language. They worked together to conquer every obstacle. It took years to conquer his self-doubt.",
+      "count": 0
     },
     {
-    "word": "consent (v)",
-    "meaning": "to give approval for something (đồng ý)",
-    "example": "You cannot proceed without the patient’s consent. She consented to share her data for the study. He consented to the new terms and conditions. They asked for parental consent before the trip.",
-    "count": 0
+      "word": "consent (v)",
+      "meaning": "to give approval for something (đồng ý)",
+      "example": "You cannot proceed without the patient’s consent. She consented to share her data for the study. He consented to the new terms and conditions. They asked for parental consent before the trip.",
+      "count": 0
     },
     {
-    "word": "consent (n)",
-    "meaning": "permission to do something (sự đồng ý)",
-    "example": "The project needed consent from all stakeholders. They obtained consent before accessing private records. He signed the form to indicate his consent. Consent is required by law for any data collection.",
-    "count": 0
+      "word": "consent (n)",
+      "meaning": "permission to do something (sự đồng ý)",
+      "example": "The project needed consent from all stakeholders. They obtained consent before accessing private records. He signed the form to indicate his consent. Consent is required by law for any data collection.",
+      "count": 0
     },
     {
-    "word": "controversy (n)",
-    "meaning": "a public disagreement about a policy or moral issue (tranh cãi)",
-    "example": "The new law sparked controversy across the country. There was controversy over the CEO’s high salary. The film’s ending caused heated controversy among fans. Scientists faced controversy when they published their findings.",
-    "count": 0
+      "word": "controversy (n)",
+      "meaning": "a public disagreement about a policy or moral issue (tranh cãi)",
+      "example": "The new law sparked controversy across the country. There was controversy over the CEO’s high salary. The film’s ending caused heated controversy among fans. Scientists faced controversy when they published their findings.",
+      "count": 0
     },
     {
-    "word": "dictator (n)",
-    "meaning": "someone who uses force to take and keep power in a country (nhà độc tài)",
-    "example": "The dictator ruled the nation with an iron fist. Citizens lived in fear under the oppressive dictator. He escaped the country to flee the dictator’s regime. Historians study how dictators maintain control.",
-    "count": 0
+      "word": "dictator (n)",
+      "meaning": "someone who uses force to take and keep power in a country (nhà độc tài)",
+      "example": "The dictator ruled the nation with an iron fist. Citizens lived in fear under the oppressive dictator. He escaped the country to flee the dictator’s regime. Historians study how dictators maintain control.",
+      "count": 0
     },
     {
-    "word": "dominate (v)",
-    "meaning": "to control something or someone, often negatively, because you have more power (áp đảo)",
-    "example": "Large corporations often dominate smaller competitors. His presence can dominate any room he enters. Social media platforms dominate our daily interactions. The team’s star player dominated the game.",
-    "count": 0
+      "word": "dominate (v)",
+      "meaning": "to control something or someone, often negatively, because you have more power (áp đảo)",
+      "example": "Large corporations often dominate smaller competitors. His presence can dominate any room he enters. Social media platforms dominate our daily interactions. The team’s star player dominated the game.",
+      "count": 0
     },
     {
-    "word": "eliminate (v)",
-    "meaning": "to get rid of something unwanted or unnecessary (loại bỏ)",
-    "example": "We need to eliminate all bugs before release. The new process eliminates redundant steps. He aimed to eliminate waste from the workflow. That diet plan promises to eliminate unhealthy fats.",
-    "count": 0
+      "word": "eliminate (v)",
+      "meaning": "to get rid of something unwanted or unnecessary (loại bỏ)",
+      "example": "We need to eliminate all bugs before release. The new process eliminates redundant steps. He aimed to eliminate waste from the workflow. That diet plan promises to eliminate unhealthy fats.",
+      "count": 0
     },
     {
-    "word": "enforce (v)",
-    "meaning": "to make sure that a law or rule is obeyed (thực thi)",
-    "example": "Police work to enforce traffic regulations. The company enforces a strict code of conduct. Judges enforce court orders without exception. It’s challenging to enforce remote-work policies.",
-    "count": 0
+      "word": "enforce (v)",
+      "meaning": "to make sure that a law or rule is obeyed (thực thi)",
+      "example": "Police work to enforce traffic regulations. The company enforces a strict code of conduct. Judges enforce court orders without exception. It’s challenging to enforce remote-work policies.",
+      "count": 0
     },
     {
-    "word": "entitled (adj)",
-    "meaning": "having the right to something (được quyền)",
-    "example": "Students are entitled to free access to the library. He was entitled to compensation after the delay. Full-time employees are entitled to health benefits. She felt entitled to a refund after poor service.",
-    "count": 0
+      "word": "entitled (adj)",
+      "meaning": "having the right to something (được quyền)",
+      "example": "Students are entitled to free access to the library. He was entitled to compensation after the delay. Full-time employees are entitled to health benefits. She felt entitled to a refund after poor service.",
+      "count": 0
     },
     {
-    "word": "exempt (adj)",
-    "meaning": "allowed to ignore a rule, obligation, or payment (được miễn)",
-    "example": "Nonprofits are exempt from certain taxes. Volunteers may be exempt from registration fees. Some countries exempt students from military service. Members with seniority are exempt from jury duty.",
-    "count": 0
+      "word": "exempt (adj)",
+      "meaning": "allowed to ignore a rule, obligation, or payment (được miễn)",
+      "example": "Nonprofits are exempt from certain taxes. Volunteers may be exempt from registration fees. Some countries exempt students from military service. Members with seniority are exempt from jury duty.",
+      "count": 0
     },
     {
-    "word": "former (adj)",
-    "meaning": "used for describing someone or something that had a particular job, title, or status in the past, but not now (trước đó)",
-    "example": "The former CEO now runs a startup. She met her former teacher at the event. Their former office was downtown. The Prime Minister of India is visiting the UK.",
-    "count": 0
+      "word": "former (adj)",
+      "meaning": "used for describing someone or something that had a particular job, title, or status in the past, but not now (trước đó)",
+      "example": "The former CEO now runs a startup. She met her former teacher at the event. Their former office was downtown. The Prime Minister of India is visiting the UK.",
+      "count": 0
     },
     {
-    "word": "impose (v)",
-    "meaning": "to introduce something such as a law or new system, and force people to accept it (áp đặt)",
-    "example": "The government imposed a new tax on imports. The school imposed stricter rules for late arrivals. Curfews were imposed after the unrest. New fees are being imposed without anyone’s opinion.",
-    "count": 0
+      "word": "impose (v)",
+      "meaning": "to introduce something such as a law or new system, and force people to accept it (áp đặt)",
+      "example": "The government imposed a new tax on imports. The school imposed stricter rules for late arrivals. Curfews were imposed after the unrest. New fees are being imposed without anyone’s opinion.",
+      "count": 0
     },
     {
-    "word": "inferior (adj)",
-    "meaning": "not as good as something else (kém hơn)",
-    "example": "Street markets often sell inferior quality goods. Their design felt inferior to the original version. The copy was clearly inferior in build. He never considered himself inferior to others.",
-    "count": 0
+      "word": "inferior (adj)",
+      "meaning": "not as good as something else (kém hơn)",
+      "example": "Street markets often sell inferior quality goods. Their design felt inferior to the original version. The copy was clearly inferior in build. He never considered himself inferior to others.",
+      "count": 0
     },
     {
-    "word": "intimidate (v)",
-    "meaning": "to deliberately make someone feel frightened, especially so that they will do what you want (hăm dọa)",
-    "example": "The bully tried to intimidate the new student. The manager’s tone intimidated everyone in the room. He uses threats to intimidate people. Richard often tries to intimidate people.",
-    "count": 0
+      "word": "intimidate (v)",
+      "meaning": "to deliberately make someone feel frightened, especially so that they will do what you want (hăm dọa)",
+      "example": "The bully tried to intimidate the new student. The manager’s tone intimidated everyone in the room. He uses threats to intimidate people. Richard often tries to intimidate people.",
+      "count": 0
     },
     {
-    "word": "label (v)",
-    "meaning": "to use a word or phrase to describe someone or something, especially one that is not completely fair (gán mác)",
-    "example": "Don’t label all young people as lazy. He was unfairly labeled a troublemaker. They labeled her without understanding her background. I wish people wouldn’t try to put a label on me.",
-    "count": 0
+      "word": "label (v)",
+      "meaning": "to use a word or phrase to describe someone or something, especially one that is not completely fair (gán mác)",
+      "example": "Don’t label all young people as lazy. He was unfairly labeled a troublemaker. They labeled her without understanding her background. I wish people wouldn’t try to put a label on me.",
+      "count": 0
     },
     {
-    "word": "label (n)",
-    "meaning": "a piece of paper or material fastened to an object that gives information about it (nhãn, nhãn hiệu)",
-    "example": "Check the label before washing the shirt. The nutrition label lists all ingredients. I don’t recognize the brand’s label. Each product has a barcode label attached.",
-    "count": 0
+      "word": "label (n)",
+      "meaning": "a piece of paper or material fastened to an object that gives information about it (nhãn, nhãn hiệu)",
+      "example": "Check the label before washing the shirt. The nutrition label lists all ingredients. I don’t recognize the brand’s label. Each product has a barcode label attached.",
+      "count": 0
     },
     {
-    "word": "liberate (v)",
-    "meaning": "to give someone the freedom to do something by taking away their restrictions (giải phóng)",
-    "example": "Leaving the job liberated her from stress. They worked to liberate the city from occupation. He felt liberated after speaking his mind. Technology can liberate us from manual tasks.",
-    "count": 0
+      "word": "liberate (v)",
+      "meaning": "to give someone the freedom to do something by taking away their restrictions (giải phóng)",
+      "example": "Leaving the job liberated her from stress. They worked to liberate the city from occupation. He felt liberated after speaking his mind. Technology can liberate us from manual tasks.",
+      "count": 0
     },
     {
-    "word": "mainstream (n)",
-    "meaning": "ideas, attitudes, or activities that are considered ordinary and accepted by most people (xu hướng chính)",
-    "example": "Most mainstream politicians dismissed the idea. He struggles to fit into the mainstream. The film never achieved mainstream popularity. Life can be difficult if you're not part of the mainstream.",
-    "count": 0
+      "word": "mainstream (n)",
+      "meaning": "ideas, attitudes, or activities that are considered ordinary and accepted by most people (xu hướng chính)",
+      "example": "Most mainstream politicians dismissed the idea. He struggles to fit into the mainstream. The film never achieved mainstream popularity. Life can be difficult if you're not part of the mainstream.",
+      "count": 0
     },
     {
-    "word": "mainstream (adj)",
-    "meaning": "considered ordinary or normal and accepted by most people (chính thống)",
-    "example": "Mainstream media didn’t cover the story. His views differ from mainstream science. She made the issue part of mainstream culture. That style isn’t considered mainstream anymore.",
-    "count": 0
+      "word": "mainstream (adj)",
+      "meaning": "considered ordinary or normal and accepted by most people (chính thống)",
+      "example": "Mainstream media didn’t cover the story. His views differ from mainstream science. She made the issue part of mainstream culture. That style isn’t considered mainstream anymore.",
+      "count": 0
     },
     {
-    "word": "master (v)",
-    "meaning": "to learn something thoroughly so that you know how to do it very well (nắm vững, tinh thông)",
-    "example": "It took her years to master graphic design. He mastered the technique through practice. I’m trying to master Spanish before my trip. She finally mastered the software tools.",
-    "count": 0
+      "word": "master (v)",
+      "meaning": "to learn something thoroughly so that you know how to do it very well (nắm vững, tinh thông)",
+      "example": "It took her years to master graphic design. He mastered the technique through practice. I’m trying to master Spanish before my trip. She finally mastered the software tools.",
+      "count": 0
     },
     {
-    "word": "master (n)",
-    "meaning": "a man who has control over servants or other people (chủ, thầy)",
-    "example": "The servant bowed to his master. He was the master of the estate. Servants should show respect to their master at all times. The master expected complete obedience.",
-    "count": 0
+      "word": "master (n)",
+      "meaning": "a man who has control over servants or other people (chủ, thầy)",
+      "example": "The servant bowed to his master. He was the master of the estate. Servants should show respect to their master at all times. The master expected complete obedience.",
+      "count": 0
     },
     {
-    "word": "minister (n)",
-    "meaning": "an official in charge of a government department (bộ trưởng)",
-    "example": "The Minister of Health announced new policies. He was appointed as the Education Minister. The Minister responsible for defense resigned. A new Minister was sworn in last week.",
-    "count": 0
+      "word": "minister (n)",
+      "meaning": "an official in charge of a government department (bộ trưởng)",
+      "example": "The Minister of Health announced new policies. He was appointed as the Education Minister. The Minister responsible for defense resigned. A new Minister was sworn in last week.",
+      "count": 0
     },
     {
-    "word": "monarch (n)",
-    "meaning": "a king or queen (vua, chúa)",
-    "example": "The monarch represents the country abroad. Britain still has a monarch as head of state. The monarch addressed the nation live. The monarch’s role today is mostly symbolic.",
-    "count": 0
+      "word": "monarch (n)",
+      "meaning": "a king or queen (vua, chúa)",
+      "example": "The monarch represents the country abroad. Britain still has a monarch as head of state. The monarch addressed the nation live. The monarch’s role today is mostly symbolic.",
+      "count": 0
     },
     {
-    "word": "prohibit (v)",
-    "meaning": "to officially stop something from being done, especially by making it illegal (cấm)",
-    "example": "Smoking is prohibited in public buildings. The school prohibits mobile phones during exams. They passed a law to prohibit animal testing. The sale of lottery tickets is prohibited.",
-    "count": 0
+      "word": "prohibit (v)",
+      "meaning": "to officially stop something from being done, especially by making it illegal (cấm)",
+      "example": "Smoking is prohibited in public buildings. The school prohibits mobile phones during exams. They passed a law to prohibit animal testing. The sale of lottery tickets is prohibited.",
+      "count": 0
     },
     {
-    "word": "reign (v)",
-    "meaning": "if a king or queen reigns, they officially rule a country (trị vì)",
-    "example": "Queen Elizabeth II reigned for decades. The king reigned during a time of great change. She reigned with fairness and grace. Monarchs traditionally reign until death.",
-    "count": 0
+      "word": "reign (v)",
+      "meaning": "if a king or queen reigns, they officially rule a country (trị vì)",
+      "example": "Queen Elizabeth II reigned for decades. The king reigned during a time of great change. She reigned with fairness and grace. Monarchs traditionally reign until death.",
+      "count": 0
     },
     {
-    "word": "reign (n)",
-    "meaning": "the period of time during which a king or queen rules a country (triều đại)",
-    "example": "The long reign of the monarch brought stability. His reign was marked by peace and reform. What was the longest reign of any king or queen? The reign ended with revolution.",
-    "count": 0
+      "word": "reign (n)",
+      "meaning": "the period of time during which a king or queen rules a country (triều đại)",
+      "example": "The long reign of the monarch brought stability. His reign was marked by peace and reform. What was the longest reign of any king or queen? The reign ended with revolution.",
+      "count": 0
     },
     {
-    "word": "reinforce (v)",
-    "meaning": "to make an idea, belief or feeling stronger (củng cố)",
-    "example": "The speech reinforced their confidence. Media often reinforces stereotypes. His actions reinforced the team's trust in him. The teacher reinforced the idea with real-life examples.",
-    "count": 0
+      "word": "reinforce (v)",
+      "meaning": "to make an idea, belief or feeling stronger (củng cố)",
+      "example": "The speech reinforced their confidence. Media often reinforces stereotypes. His actions reinforced the team's trust in him. The teacher reinforced the idea with real-life examples.",
+      "count": 0
     },
     {
-    "word": "reluctant (adj)",
-    "meaning": "not willing to do something (chần chừ, miễn cưỡng)",
-    "example": "He was reluctant to share his ideas at the meeting. She felt reluctant to accept the promotion. I’m reluctant to travel during the storm. Many employees were reluctant to adopt the new system.",
-    "count": 0
+      "word": "reluctant (adj)",
+      "meaning": "not willing to do something (chần chừ, miễn cưỡng)",
+      "example": "He was reluctant to share his ideas at the meeting. She felt reluctant to accept the promotion. I’m reluctant to travel during the storm. Many employees were reluctant to adopt the new system.",
+      "count": 0
     },
     {
-    "word": "resist (v)",
-    "meaning": "to oppose or fight against something or someone (chống cự, kháng cự)",
-    "example": "They resisted the new regulations. She couldn't resist laughing at the joke. The people resisted the invaders bravely. The Prime Minister resisted a lot of pressure to change his mind.",
-    "count": 0
+      "word": "resist (v)",
+      "meaning": "to oppose or fight against something or someone (chống cự, kháng cự)",
+      "example": "They resisted the new regulations. She couldn't resist laughing at the joke. The people resisted the invaders bravely. The Prime Minister resisted a lot of pressure to change his mind.",
+      "count": 0
     },
     {
-    "word": "resist (v)",
-    "meaning": "to stop yourself from doing something that you want to do (cưỡng lại, kìm chế)",
-    "example": "I can’t resist chocolate. He resisted the urge to speak. They couldn’t resist checking their phones. She tried to resist buying the dress.",
-    "count": 0
+      "word": "resist (v)",
+      "meaning": "to stop yourself from doing something that you want to do (cưỡng lại, kìm chế)",
+      "example": "I can’t resist chocolate. He resisted the urge to speak. They couldn’t resist checking their phones. She tried to resist buying the dress.",
+      "count": 0
     },
     {
-    "word": "restrict (v)",
-    "meaning": "to keep something within strict limits (hạn chế)",
-    "example": "Parents restrict the number of hours children watch TV. Access is restricted to authorized personnel. The policy restricts movement during lockdowns. They restricted the budget for travel expenses.",
-    "count": 0
+      "word": "restrict (v)",
+      "meaning": "to keep something within strict limits (hạn chế)",
+      "example": "Parents restrict the number of hours children watch TV. Access is restricted to authorized personnel. The policy restricts movement during lockdowns. They restricted the budget for travel expenses.",
+      "count": 0
     },
     {
-    "word": "society (n)",
-    "meaning": "people in general living together in organized communities, with laws and traditions (xã hội)",
-    "example": "Education plays a big role in modern society. Society expects everyone to follow the rules. We live in a diverse and evolving society. People have more freedom in today’s society.",
-    "count": 0
+      "word": "society (n)",
+      "meaning": "people in general living together in organized communities, with laws and traditions (xã hội)",
+      "example": "Education plays a big role in modern society. Society expects everyone to follow the rules. We live in a diverse and evolving society. People have more freedom in today’s society.",
+      "count": 0
     },
     {
-    "word": "subject (v)",
-    "meaning": "to make someone experience something unpleasant (bắt phải chịu)",
-    "example": "They were subjected to harsh criticism. The soldier was subjected to intense training. She was subjected to unfair treatment. They subjected the poor prisoner to torture.",
-    "count": 0
+      "word": "subject (v)",
+      "meaning": "to make someone experience something unpleasant (bắt phải chịu)",
+      "example": "They were subjected to harsh criticism. The soldier was subjected to intense training. She was subjected to unfair treatment. They subjected the poor prisoner to torture.",
+      "count": 0
     },
     {
-    "word": "subject (n)",
-    "meaning": "an idea, problem, situation, etc. that you discuss or think about (chủ đề, đề tài)",
-    "example": "Math is my favorite subject. That subject came up often during meetings. Have you chosen your subject for the essay? It’s a complex subject that needs research.",
-    "count": 0
+      "word": "subject (n)",
+      "meaning": "an idea, problem, situation, etc. that you discuss or think about (chủ đề, đề tài)",
+      "example": "Math is my favorite subject. That subject came up often during meetings. Have you chosen your subject for the essay? It’s a complex subject that needs research.",
+      "count": 0
     },
     {
-    "word": "subject (n)",
-    "meaning": "a citizen of a country ruled by a monarch (thần dân)",
-    "example": "He is proud to be a British subject. The Queen’s subjects attended the ceremony. All subjects must obey royal laws. She lived as a subject under the empire.",
-    "count": 0
+      "word": "subject (n)",
+      "meaning": "a citizen of a country ruled by a monarch (thần dân)",
+      "example": "He is proud to be a British subject. The Queen’s subjects attended the ceremony. All subjects must obey royal laws. She lived as a subject under the empire.",
+      "count": 0
     },
     {
-    "word": "subjective (adj)",
-    "meaning": "based on your own feelings and ideas and not on facts (chủ quan)",
-    "example": "Her review was highly subjective. Opinions on art are often subjective. That’s just your subjective view. We tried to avoid being subjective in the report.",
-    "count": 0
+      "word": "subjective (adj)",
+      "meaning": "based on your own feelings and ideas and not on facts (chủ quan)",
+      "example": "Her review was highly subjective. Opinions on art are often subjective. That’s just your subjective view. We tried to avoid being subjective in the report.",
+      "count": 0
     },
     {
-    "word": "submit (v)",
-    "meaning": "to accept that someone has defeated you and you must obey them (phục tùng, đầu hàng)",
-    "example": "They refused to submit to the enemy. The country would never submit to foreign rule. He finally submitted after hours of questioning. They submitted without a fight.",
-    "count": 0
+      "word": "submit (v)",
+      "meaning": "to accept that someone has defeated you and you must obey them (phục tùng, đầu hàng)",
+      "example": "They refused to submit to the enemy. The country would never submit to foreign rule. He finally submitted after hours of questioning. They submitted without a fight.",
+      "count": 0
     },
     {
-    "word": "submit (v)",
-    "meaning": "to formally give something to someone in authority (nộp)",
-    "example": "You must submit your application by Friday. She submitted the report late. They stopped listening when he submitted. He was asked to submit the design proposal.",
-    "count": 0
+      "word": "submit (v)",
+      "meaning": "to formally give something to someone in authority (nộp)",
+      "example": "You must submit your application by Friday. She submitted the report late. They stopped listening when he submitted. He was asked to submit the design proposal.",
+      "count": 0
     },
     {
-    "word": "summon (v)",
-    "meaning": "to officially order someone to come to a place, especially a court of law (triệu tập)",
-    "example": "The witness was summoned to court. He was summoned for questioning. The king summoned his advisors. I was suddenly summoned to the boss’s office.",
-    "count": 0
+      "word": "summon (v)",
+      "meaning": "to officially order someone to come to a place, especially a court of law (triệu tập)",
+      "example": "The witness was summoned to court. He was summoned for questioning. The king summoned his advisors. I was suddenly summoned to the boss’s office.",
+      "count": 0
     },
     {
-    "word": "superior (adj)",
-    "meaning": "better than someone or something else in quality or skill (vượt trội)",
-    "example": "His work is vastly superior to mine. This version is technically superior. She thinks her cooking is superior. The latest model is superior in design.",
-    "count": 0
+      "word": "superior (adj)",
+      "meaning": "better than someone or something else in quality or skill (vượt trội)",
+      "example": "His work is vastly superior to mine. This version is technically superior. She thinks her cooking is superior. The latest model is superior in design.",
+      "count": 0
     },
     {
-    "word": "undermine (v)",
-    "meaning": "to make something become gradually less effective or successful (làm suy yếu)",
-    "example": "His actions undermined the team’s trust. Criticism can undermine your confidence. The scandal undermined the leader’s credibility. This unfortunate event undermined morale.",
-    "count": 0
+      "word": "undermine (v)",
+      "meaning": "to make something become gradually less effective or successful (làm suy yếu)",
+      "example": "His actions undermined the team’s trust. Criticism can undermine your confidence. The scandal undermined the leader’s credibility. This unfortunate event undermined morale.",
+      "count": 0
     },
     {
-    "word": "unrest (n)",
-    "meaning": "angry or violent behavior by people who are protesting (tình trạng bất ổn)",
-    "example": "The policy led to civil unrest. Political unrest spread quickly. There’s growing unrest among workers. The protest ended in unrest across the city.",
-    "count": 0
+      "word": "unrest (n)",
+      "meaning": "angry or violent behavior by people who are protesting (tình trạng bất ổn)",
+      "example": "The policy led to civil unrest. Political unrest spread quickly. There’s growing unrest among workers. The protest ended in unrest across the city.",
+      "count": 0
     },
     {
-    "word": "victimise (v)",
-    "meaning": "to treat someone in a deliberately unfair way (ngược đãi)",
-    "example": "It’s not right to victimise someone at work. He was victimised for his beliefs. Many were victimised under the regime. She felt victimised by the teacher’s comments.",
-    "count": 0
+      "word": "victimise (v)",
+      "meaning": "to treat someone in a deliberately unfair way (ngược đãi)",
+      "example": "It’s not right to victimise someone at work. He was victimised for his beliefs. Many were victimised under the regime. She felt victimised by the teacher’s comments.",
+      "count": 0
     },
     {
-    "word": "vulnerable (adj)",
-    "meaning": "weak or easy to hurt physically or mentally (dễ bị tổn thương)",
-    "example": "Children are vulnerable to online abuse. The elderly feel vulnerable living alone. She became emotionally vulnerable after the breakup. I felt vulnerable walking home late at night.",
-    "count": 0
+      "word": "vulnerable (adj)",
+      "meaning": "weak or easy to hurt physically or mentally (dễ bị tổn thương)",
+      "example": "Children are vulnerable to online abuse. The elderly feel vulnerable living alone. She became emotionally vulnerable after the breakup. I felt vulnerable walking home late at night.",
+      "count": 0
     },
     {
-    "word": "abolish (v)",
-    "meaning": "to officially get rid of a law, system, or practice (bãi bỏ)",
-    "example": "Slavery was abolished in the 19th century. They voted to abolish the tax. The law was officially abolished in 1963. Activists fought to abolish unfair policies.",
-    "count": 0
+      "word": "abolish (v)",
+      "meaning": "to officially get rid of a law, system, or practice (bãi bỏ)",
+      "example": "Slavery was abolished in the 19th century. They voted to abolish the tax. The law was officially abolished in 1963. Activists fought to abolish unfair policies.",
+      "count": 0
     },
     {
-    "word": "advocate (v)",
-    "meaning": "to publicly support a particular policy or action (ủng hộ công khai)",
-    "example": "He advocates equal pay for all employees. The article advocates reform in education. Many advocate for stronger climate action. Do you advocate capital punishment in schools?",
-    "count": 0
+      "word": "advocate (v)",
+      "meaning": "to publicly support a particular policy or action (ủng hộ công khai)",
+      "example": "He advocates equal pay for all employees. The article advocates reform in education. Many advocate for stronger climate action. Do you advocate capital punishment in schools?",
+      "count": 0
     },
     {
-    "word": "alleviate (v)",
-    "meaning": "to make something less painful, severe, or serious (giảm bớt)",
-    "example": "The new policy aims to alleviate poverty. Painkillers help alleviate headaches. These measures are designed to alleviate suffering. The medicine alleviates symptoms quickly.",
-    "count": 0
+      "word": "alleviate (v)",
+      "meaning": "to make something less painful, severe, or serious (giảm bớt)",
+      "example": "The new policy aims to alleviate poverty. Painkillers help alleviate headaches. These measures are designed to alleviate suffering. The medicine alleviates symptoms quickly.",
+      "count": 0
     },
     {
-    "word": "aggravate (v)",
-    "meaning": "to make something bad become worse, especially a situation or a medical condition (làm trầm trọng thêm)",
-    "example": "His rude comments only aggravated the situation. The dust aggravated her asthma. Loud noises can aggravate my headache. His headache was aggravated by stress.",
-    "count": 0
+      "word": "aggravate (v)",
+      "meaning": "to make something bad become worse, especially a situation or a medical condition (làm trầm trọng thêm)",
+      "example": "His rude comments only aggravated the situation. The dust aggravated her asthma. Loud noises can aggravate my headache. His headache was aggravated by stress.",
+      "count": 0
     },
     {
-    "word": "better (v)",
-    "meaning": "to achieve a better result than someone or something (vượt qua, vượt trội)",
-    "example": "She bettered her previous exam score. The new team bettered last year's record. He hopes to better his personal best. Bradman’s average of 96 has never been bettered.",
-    "count": 0
+      "word": "better (v)",
+      "meaning": "to achieve a better result than someone or something (vượt qua, vượt trội)",
+      "example": "She bettered her previous exam score. The new team bettered last year's record. He hopes to better his personal best. Bradman’s average of 96 has never been bettered.",
+      "count": 0
     },
     {
-    "word": "better (adj)",
-    "meaning": "to improve something (cải thiện)",
-    "example": "We must better our communication process. It’s an important step towards bettering relations. The city bettered its public transportation system. Efforts are being made to better the lives of workers.",
-    "count": 0
+      "word": "better (adj)",
+      "meaning": "to improve something (cải thiện)",
+      "example": "We must better our communication process. It’s an important step towards bettering relations. The city bettered its public transportation system. Efforts are being made to better the lives of workers.",
+      "count": 0
     },
     {
-    "word": "blemish (n)",
-    "meaning": "a mark or spot that spoils the appearance of something (vết nhơ, vết xấu)",
-    "example": "The mirror had a small blemish on its surface. The report was almost perfect except for one blemish. The painting was spoiled by a tiny blemish. His record has only one blemish: a late submission.",
-    "count": 0
+      "word": "blemish (n)",
+      "meaning": "a mark or spot that spoils the appearance of something (vết nhơ, vết xấu)",
+      "example": "The mirror had a small blemish on its surface. The report was almost perfect except for one blemish. The painting was spoiled by a tiny blemish. His record has only one blemish: a late submission.",
+      "count": 0
     },
     {
-    "word": "chaos (n)",
-    "meaning": "a situation in which everything is confused and in a mess (hỗn loạn)",
-    "example": "There was chaos during the blackout. Chaos broke out after the announcement. The office was in chaos during the audit. His desk is always in a state of chaos.",
-    "count": 0
+      "word": "chaos (n)",
+      "meaning": "a situation in which everything is confused and in a mess (hỗn loạn)",
+      "example": "There was chaos during the blackout. Chaos broke out after the announcement. The office was in chaos during the audit. His desk is always in a state of chaos.",
+      "count": 0
     },
     {
-    "word": "cheapen (v)",
-    "meaning": "to make someone or something seem less valuable or respected (làm mất giá trị)",
-    "example": "The scandal cheapened his reputation. These types of ads cheapen the brand. Don’t cheapen your work by rushing. This type of advertising cheapens the image of the brand.",
-    "count": 0
+      "word": "cheapen (v)",
+      "meaning": "to make someone or something seem less valuable or respected (làm mất giá trị)",
+      "example": "The scandal cheapened his reputation. These types of ads cheapen the brand. Don’t cheapen your work by rushing. This type of advertising cheapens the image of the brand.",
+      "count": 0
     },
     {
-    "word": "contaminate (v)",
-    "meaning": "to make a place or substance dirty or harmful by adding something unwanted (làm ô nhiễm)",
-    "example": "The lake was contaminated by chemicals. Don’t contaminate the samples. One drop of bleach can contaminate the entire solution. Infection can contaminate the wound.",
-    "count": 0
+      "word": "contaminate (v)",
+      "meaning": "to make a place or substance dirty or harmful by adding something unwanted (làm ô nhiễm)",
+      "example": "The lake was contaminated by chemicals. Don’t contaminate the samples. One drop of bleach can contaminate the entire solution. Infection can contaminate the wound.",
+      "count": 0
     },
     {
-    "word": "decay (v)",
-    "meaning": "to be gradually destroyed as a result of natural process or lack of care (mục nát, suy tàn)",
-    "example": "The wood began to decay after months of rain. Morals can decay without strong values. The abandoned house was slowly decaying. Without sunlight, your teeth may decay.",
-    "count": 0
+      "word": "decay (v)",
+      "meaning": "to be gradually destroyed as a result of natural process or lack of care (mục nát, suy tàn)",
+      "example": "The wood began to decay after months of rain. Morals can decay without strong values. The abandoned house was slowly decaying. Without sunlight, your teeth may decay.",
+      "count": 0
     },
     {
-    "word": "decay (n)",
-    "meaning": "the gradual destruction of something as a result of natural process (sự mục nát, suy tàn)",
-    "example": "Tooth decay can be prevented with proper hygiene. Urban decay affects many old cities. There’s been a moral decay in leadership. The paint showed signs of decay.",
-    "count": 0
+      "word": "decay (n)",
+      "meaning": "the gradual destruction of something as a result of natural process (sự mục nát, suy tàn)",
+      "example": "Tooth decay can be prevented with proper hygiene. Urban decay affects many old cities. There’s been a moral decay in leadership. The paint showed signs of decay.",
+      "count": 0
     },
     {
-    "word": "decline (v)",
-    "meaning": "to become lower in amount or less in quality (giảm sút)",
-    "example": "Sales declined in the third quarter. Attendance continues to decline. His health declined rapidly. The number of people attending has declined.",
-    "count": 0
+      "word": "decline (v)",
+      "meaning": "to become lower in amount or less in quality (giảm sút)",
+      "example": "Sales declined in the third quarter. Attendance continues to decline. His health declined rapidly. The number of people attending has declined.",
+      "count": 0
     },
     {
-    "word": "defective (adj)",
-    "meaning": "not working correctly or not made correctly (lỗi, bị lỗi)",
-    "example": "The car was recalled due to defective brakes. The batch had several defective units. A defective product can be dangerous. They refunded me for the defective item.",
-    "count": 0
+      "word": "defective (adj)",
+      "meaning": "not working correctly or not made correctly (lỗi, bị lỗi)",
+      "example": "The car was recalled due to defective brakes. The batch had several defective units. A defective product can be dangerous. They refunded me for the defective item.",
+      "count": 0
     },
     {
-    "word": "detrimental (adj)",
-    "meaning": "harmful or damaging (có hại, bất lợi)",
-    "example": "Too much screen time is detrimental to your eyes. Oversleeping may be detrimental to health. Pollution is detrimental to marine life. Sunlight can have a detrimental effect on skin.",
-    "count": 0
+      "word": "detrimental (adj)",
+      "meaning": "harmful or damaging (có hại, bất lợi)",
+      "example": "Too much screen time is detrimental to your eyes. Oversleeping may be detrimental to health. Pollution is detrimental to marine life. Sunlight can have a detrimental effect on skin.",
+      "count": 0
     },
     {
-    "word": "devastate (v)",
-    "meaning": "to seriously damage or completely destroy something (tàn phá, phá hủy)",
-    "example": "The earthquake devastated entire villages. War can devastate communities. Western India was devastated by a huge storm. The flood devastated local businesses.",
-    "count": 0
+      "word": "devastate (v)",
+      "meaning": "to seriously damage or completely destroy something (tàn phá, phá hủy)",
+      "example": "The earthquake devastated entire villages. War can devastate communities. Western India was devastated by a huge storm. The flood devastated local businesses.",
+      "count": 0
     },
     {
-    "word": "devastate (v)",
-    "meaning": "to make someone feel very shocked and upset (tàn phá về tinh thần)",
-    "example": "The news devastated her. She was devastated by her dog’s disappearance. His sudden death devastated the team. The breakup devastated him emotionally.",
-    "count": 0
+      "word": "devastate (v)",
+      "meaning": "to make someone feel very shocked and upset (tàn phá về tinh thần)",
+      "example": "The news devastated her. She was devastated by her dog’s disappearance. His sudden death devastated the team. The breakup devastated him emotionally.",
+      "count": 0
     },
     {
-    "word": "enhance (v)",
-    "meaning": "to improve something, or make it more attractive or valuable (nâng cao, cải thiện)",
-    "example": "They want to enhance the user experience. The new lighting enhances the mood. The course is designed to enhance your skills. The measures should enhance quality of life.",
-    "count": 0
+      "word": "enhance (v)",
+      "meaning": "to improve something, or make it more attractive or valuable (nâng cao, cải thiện)",
+      "example": "They want to enhance the user experience. The new lighting enhances the mood. The course is designed to enhance your skills. The measures should enhance quality of life.",
+      "count": 0
     },
     {
-    "word": "evaluate (v)",
-    "meaning": "to think carefully about something before making a judgment (đánh giá)",
-    "example": "We need to evaluate the risks before launching. She evaluated the pros and cons. The company evaluates performance every quarter. The performance of each employee is evaluated once a year.",
-    "count": 0
+      "word": "evaluate (v)",
+      "meaning": "to think carefully about something before making a judgment (đánh giá)",
+      "example": "We need to evaluate the risks before launching. She evaluated the pros and cons. The company evaluates performance every quarter. The performance of each employee is evaluated once a year.",
+      "count": 0
     },
     {
-    "word": "exacerbate (v)",
-    "meaning": "to make a problem become worse (làm trầm trọng thêm)",
-    "example": "The fire was exacerbated by the wind. His complaints only exacerbate the tension. Bad weather exacerbated the delay. Complaining will only exacerbate an already difficult situation.",
-    "count": 0
+      "word": "exacerbate (v)",
+      "meaning": "to make a problem become worse (làm trầm trọng thêm)",
+      "example": "The fire was exacerbated by the wind. His complaints only exacerbate the tension. Bad weather exacerbated the delay. Complaining will only exacerbate an already difficult situation.",
+      "count": 0
     },
     {
-    "word": "exquisite (adj)",
-    "meaning": "extremely beautiful and delicate (tinh xảo)",
-    "example": "She wore an exquisite silk dress. The artist created an exquisite sculpture. That’s an exquisite piece of jewelry. It was an exquisite hand-painted vase from China.",
-    "count": 0
+      "word": "exquisite (adj)",
+      "meaning": "extremely beautiful and delicate (tinh xảo)",
+      "example": "She wore an exquisite silk dress. The artist created an exquisite sculpture. That’s an exquisite piece of jewelry. It was an exquisite hand-painted vase from China.",
+      "count": 0
     },
     {
-    "word": "first-rate (adj)",
-    "meaning": "of the highest quality (hàng đầu, xuất sắc)",
-    "example": "The hotel service was first-rate. She’s a first-rate designer. This is a first-rate opportunity for growth. The service is first-rate.",
-    "count": 0
+      "word": "first-rate (adj)",
+      "meaning": "of the highest quality (hàng đầu, xuất sắc)",
+      "example": "The hotel service was first-rate. She’s a first-rate designer. This is a first-rate opportunity for growth. The service is first-rate.",
+      "count": 0
     },
     {
-    "word": "flaw (n)",
-    "meaning": "a mistake or fault in something that makes it useless, less effective or beautiful (lỗi, khuyết điểm)",
-    "example": "There’s a flaw in the software design. Her logic had a major flaw. The mirror had no visible flaw. There are serious flaws in the way we train our teachers.",
-    "count": 0
+      "word": "flaw (n)",
+      "meaning": "a mistake or fault in something that makes it useless, less effective or beautiful (lỗi, khuyết điểm)",
+      "example": "There’s a flaw in the software design. Her logic had a major flaw. The mirror had no visible flaw. There are serious flaws in the way we train our teachers.",
+      "count": 0
     },
     {
-    "word": "bureaucracy (n)",
-    "meaning": "a complicated and annoying system of rules and processes (quan liêu)",
-    "example": "I tried to start my own business but there was too much bureaucracy. The new policy created additional bureaucracy. Bureaucracy slows down decision-making. He's frustrated by the school bureaucracy.",
-    "count": 0
+      "word": "bureaucracy (n)",
+      "meaning": "a complicated and annoying system of rules and processes (quan liêu)",
+      "example": "I tried to start my own business but there was too much bureaucracy. The new policy created additional bureaucracy. Bureaucracy slows down decision-making. He's frustrated by the school bureaucracy.",
+      "count": 0
     },
     {
-    "word": "charity (n)",
-    "meaning": "an organisation to which you give money so it can help people in need (tổ chức từ thiện)",
-    "example": "She donates to local charities every year. The charity supports homeless children. They set up a charity for disaster relief. There are one or two charities that I make regular donations to.",
-    "count": 0
+      "word": "charity (n)",
+      "meaning": "an organisation to which you give money so it can help people in need (tổ chức từ thiện)",
+      "example": "She donates to local charities every year. The charity supports homeless children. They set up a charity for disaster relief. There are one or two charities that I make regular donations to.",
+      "count": 0
     },
     {
-    "word": "class (n)",
-    "meaning": "a group into which people in a society are divided based on family background, income, or education (giai cấp, tầng lớp)",
-    "example": "My family are very middle class in a lot of ways. There’s a big gap between the rich and the working class. He moved up from the lower class. Education often reflects social class.",
-    "count": 0
+      "word": "class (n)",
+      "meaning": "a group into which people in a society are divided based on family background, income, or education (giai cấp, tầng lớp)",
+      "example": "My family are very middle class in a lot of ways. There’s a big gap between the rich and the working class. He moved up from the lower class. Education often reflects social class.",
+      "count": 0
     },
     {
-    "word": "community (n)",
-    "meaning": "the people who live in an area (cộng đồng)",
-    "example": "Politics should begin in the local community. She volunteers in her immigrant community. The school is central to the rural community. We need stronger ties in our online community.",
-    "count": 0
+      "word": "community (n)",
+      "meaning": "the people who live in an area (cộng đồng)",
+      "example": "Politics should begin in the local community. She volunteers in her immigrant community. The school is central to the rural community. We need stronger ties in our online community.",
+      "count": 0
     },
     {
-    "word": "convict (v)",
-    "meaning": "to prove in court that someone is guilty of a crime (kết tội)",
-    "example": "He was convicted of arson. The jury convicted her quickly. They were convicted despite weak evidence. A court must convict someone beyond doubt.",
-    "count": 0
+      "word": "convict (v)",
+      "meaning": "to prove in court that someone is guilty of a crime (kết tội)",
+      "example": "He was convicted of arson. The jury convicted her quickly. They were convicted despite weak evidence. A court must convict someone beyond doubt.",
+      "count": 0
     },
     {
-    "word": "convict (n)",
-    "meaning": "someone who is in prison because they committed a crime (tù nhân)",
-    "example": "Two convicts have escaped from the local prison. The convict was transferred to maximum security. Former convicts often struggle to find work. The convict was granted parole.",
-    "count": 0
+      "word": "convict (n)",
+      "meaning": "someone who is in prison because they committed a crime (tù nhân)",
+      "example": "Two convicts have escaped from the local prison. The convict was transferred to maximum security. Former convicts often struggle to find work. The convict was granted parole.",
+      "count": 0
     },
     {
-    "word": "corruption (n)",
-    "meaning": "dishonest or illegal behaviour by officials or people in power (sự tham nhũng)",
-    "example": "They’ve started an investigation into corruption. Corruption in the police force was exposed. The government vowed to end corruption. Bribery is a common form of corruption.",
-    "count": 0
+      "word": "corruption (n)",
+      "meaning": "dishonest or illegal behaviour by officials or people in power (sự tham nhũng)",
+      "example": "They’ve started an investigation into corruption. Corruption in the police force was exposed. The government vowed to end corruption. Bribery is a common form of corruption.",
+      "count": 0
     },
     {
-    "word": "deterrent (n)",
-    "meaning": "something that makes people decide not to do something by making them realise that something unpleasant could happen to them (răn đe)",
-    "example": "I think capital punishment serves as a deterrent. Alarm systems are a good deterrent to thieves. Fear of fines is a deterrent. Cameras act as a strong deterrent.",
-    "count": 0
+      "word": "deterrent (n)",
+      "meaning": "something that makes people decide not to do something by making them realise that something unpleasant could happen to them (răn đe)",
+      "example": "I think capital punishment serves as a deterrent. Alarm systems are a good deterrent to thieves. Fear of fines is a deterrent. Cameras act as a strong deterrent.",
+      "count": 0
     },
     {
-    "word": "heritage (n)",
-    "meaning": "the art, buildings, and traditions that are important to a society’s culture and history (di sản)",
-    "example": "It’s important that we preserve our national heritage. UNESCO protects world heritage sites. The museum showcases cultural heritage. We must protect our architectural heritage.",
-    "count": 0
+      "word": "heritage (n)",
+      "meaning": "the art, buildings, and traditions that are important to a society’s culture and history (di sản)",
+      "example": "It’s important that we preserve our national heritage. UNESCO protects world heritage sites. The museum showcases cultural heritage. We must protect our architectural heritage.",
+      "count": 0
     },
     {
-    "word": "immigration (n)",
-    "meaning": "the process of people entering a country to live permanently (sự nhập cư)",
-    "example": "Is the level of immigration actually rising, or is it falling? Immigration laws are often debated. Canada supports skilled immigration. Immigration affects the economy and housing.",
-    "count": 0
+      "word": "immigration (n)",
+      "meaning": "the process of people entering a country to live permanently (sự nhập cư)",
+      "example": "Is the level of immigration actually rising, or is it falling? Immigration laws are often debated. Canada supports skilled immigration. Immigration affects the economy and housing.",
+      "count": 0
     },
     {
-    "word": "industrial action (n phr)",
-    "meaning": "a protest in which workers disagree with employer policy, often by striking (trừng phạt lao động)",
-    "example": "Unless something changes, we’ll be taking industrial action. Teachers are threatening industrial action. The union voted for industrial action. Train workers announced new industrial action.",
-    "count": 0
+      "word": "industrial action (n phr)",
+      "meaning": "a protest in which workers disagree with employer policy, often by striking (trừng phạt lao động)",
+      "example": "Unless something changes, we’ll be taking industrial action. Teachers are threatening industrial action. The union voted for industrial action. Train workers announced new industrial action.",
+      "count": 0
     },
     {
-    "word": "institution (n)",
-    "meaning": "a large organisation like a bank, hospital, or prison (cơ quan, tổ chức)",
-    "example": "It’s hard spending all your life inside an institution like a children’s home. The university is a respected institution. Mental health institutions need more funding. Banks are financial institutions.",
-    "count": 0
+      "word": "institution (n)",
+      "meaning": "a large organisation like a bank, hospital, or prison (cơ quan, tổ chức)",
+      "example": "It’s hard spending all your life inside an institution like a children’s home. The university is a respected institution. Mental health institutions need more funding. Banks are financial institutions.",
+      "count": 0
     },
     {
-    "word": "legislation (n)",
-    "meaning": "a law or set of laws (pháp luật)",
-    "example": "There is already legislation to prevent that. New legislation was passed yesterday. The minister proposed new legislation. Environmental legislation is now stricter.",
-    "count": 0
+      "word": "legislation (n)",
+      "meaning": "a law or set of laws (pháp luật)",
+      "example": "There is already legislation to prevent that. New legislation was passed yesterday. The minister proposed new legislation. Environmental legislation is now stricter.",
+      "count": 0
     },
     {
-    "word": "prejudice (n)",
-    "meaning": "an unreasonable opinion or feeling, especially dislike for people in a particular group (định kiến)",
-    "example": "Many women have had to deal with prejudice in the workplace. We must fight racial prejudice. He was a victim of religious prejudice. Prejudice often stems from ignorance.",
-    "count": 0
+      "word": "prejudice (n)",
+      "meaning": "an unreasonable opinion or feeling, especially dislike for people in a particular group (định kiến)",
+      "example": "Many women have had to deal with prejudice in the workplace. We must fight racial prejudice. He was a victim of religious prejudice. Prejudice often stems from ignorance.",
+      "count": 0
     },
     {
-    "word": "prison reform (n phr)",
-    "meaning": "changes to make the prison system fairer or more effective (cải cách nhà tù)",
-    "example": "I’m a great believer in prison reform. The minister proposed prison reform. Prison reform aims to reduce repeat offenses. Activists are calling for urgent prison reform.",
-    "count": 0
+      "word": "prison reform (n phr)",
+      "meaning": "changes to make the prison system fairer or more effective (cải cách nhà tù)",
+      "example": "I’m a great believer in prison reform. The minister proposed prison reform. Prison reform aims to reduce repeat offenses. Activists are calling for urgent prison reform.",
+      "count": 0
     },
     {
-    "word": "privileged (adj)",
-    "meaning": "having advantages and opportunities that other people do not have (được ưu tiên)",
-    "example": "I suppose I come from quite a privileged background. He grew up in a privileged family. Privileged students get better access. She's aware of her privileged position.",
-    "count": 0
+      "word": "privileged (adj)",
+      "meaning": "having advantages and opportunities that other people do not have (được ưu tiên)",
+      "example": "I suppose I come from quite a privileged background. He grew up in a privileged family. Privileged students get better access. She's aware of her privileged position.",
+      "count": 0
     },
     {
-    "word": "prosecute (v)",
-    "meaning": "to officially accuse someone of a crime in court (khởi tố)",
-    "example": "The police decided not to prosecute and let him off with a warning. They prosecuted him for fraud. Few corporations are prosecuted for pollution. She was prosecuted for tax evasion.",
-    "count": 0
+      "word": "prosecute (v)",
+      "meaning": "to officially accuse someone of a crime in court (khởi tố)",
+      "example": "The police decided not to prosecute and let him off with a warning. They prosecuted him for fraud. Few corporations are prosecuted for pollution. She was prosecuted for tax evasion.",
+      "count": 0
     },
     {
-    "word": "state (n)",
-    "meaning": "the government of a country (nhà nước); also, a condition something is in (tình trạng)",
-    "example": "The health system is the state’s responsibility. The building was in a poor state. He works for a state agency. Her mental state was concerning.",
-    "count": 0
+      "word": "state (n)",
+      "meaning": "the government of a country (nhà nước); also, a condition something is in (tình trạng)",
+      "example": "The health system is the state’s responsibility. The building was in a poor state. He works for a state agency. Her mental state was concerning.",
+      "count": 0
     },
     {
       "word": "leverage",
@@ -14772,5191 +14771,5194 @@
       "count": 0
     },
     {
-    "word": "force (v) /fɔːs/",
-    "meaning": "to use physical force to move something in a particular direction; đẩy",
-    "example": "She forced the package through the slot.",
-    "count": 0
+      "word": "force (v) /fɔːs/",
+      "meaning": "to use physical force to move something in a particular direction; đẩy",
+      "example": "She forced the package through the slot.",
+      "count": 0
     },
     {
-    "word": "fraction (n) /ˈfrækʃən/",
-    "meaning": "a small part or amount of something; phần",
-    "example": "His shares are now worth a fraction of their former value.",
-    "count": 0
+      "word": "fraction (n) /ˈfrækʃən/",
+      "meaning": "a small part or amount of something; phần",
+      "example": "His shares are now worth a fraction of their former value.",
+      "count": 0
     },
     {
-    "word": "fraction (n) /ˈfrækʃən/",
-    "meaning": "a division or part of a whole number, for example 1/2 or 3/4; phân số",
-    "example": "0.5 can also be written as a fraction: 1/2.",
-    "count": 0
+      "word": "fraction (n) /ˈfrækʃən/",
+      "meaning": "a division or part of a whole number, for example 1/2 or 3/4; phân số",
+      "example": "0.5 can also be written as a fraction: 1/2.",
+      "count": 0
     },
     {
-    "word": "heap (n) /hiːp/",
-    "meaning": "a large pile of something, especially an untidy pile; đống",
-    "example": "His clothes were in a crumpled heap on the floor.",
-    "count": 0
+      "word": "heap (n) /hiːp/",
+      "meaning": "a large pile of something, especially an untidy pile; đống",
+      "example": "His clothes were in a crumpled heap on the floor.",
+      "count": 0
     },
     {
-    "word": "heap (v) /hiːp/",
-    "meaning": "to make a big untidy pile of things; chất đống",
-    "example": "Bundles of clothing were heaped on the floor.",
-    "count": 0
+      "word": "heap (v) /hiːp/",
+      "meaning": "to make a big untidy pile of things; chất đống",
+      "example": "Bundles of clothing were heaped on the floor.",
+      "count": 0
     },
     {
-    "word": "imbalance (n) /ɪmˈbæləns/",
-    "meaning": "a situation in which the balance between two things is not equal or fair; sự mất cân bằng",
-    "example": "There’s an increasing social imbalance in recruitment to higher education.",
-    "count": 0
+      "word": "imbalance (n) /ɪmˈbæləns/",
+      "meaning": "a situation in which the balance between two things is not equal or fair; sự mất cân bằng",
+      "example": "There’s an increasing social imbalance in recruitment to higher education.",
+      "count": 0
     },
     {
-    "word": "immense (adj) /ɪˈmens/",
-    "meaning": "extremely large; vô hạn",
-    "example": "An immense amount of time and effort went into the project.",
-    "count": 0
+      "word": "immense (adj) /ɪˈmens/",
+      "meaning": "extremely large; vô hạn",
+      "example": "An immense amount of time and effort went into the project.",
+      "count": 0
     },
     {
-    "word": "intensity (n) /ɪnˈtensəti/",
-    "meaning": "strength; cường độ",
-    "example": "The cross-examination increased in intensity.",
-    "count": 0
+      "word": "intensity (n) /ɪnˈtensəti/",
+      "meaning": "strength; cường độ",
+      "example": "The cross-examination increased in intensity.",
+      "count": 0
     },
     {
-    "word": "magnitude (n) /ˈmæɡnɪtjuːd/",
-    "meaning": "great size, importance or effect; tầm cỡ",
-    "example": "We hadn’t grasped the magnitude of the task we were facing.",
-    "count": 0
+      "word": "magnitude (n) /ˈmæɡnɪtjuːd/",
+      "meaning": "great size, importance or effect; tầm cỡ",
+      "example": "We hadn’t grasped the magnitude of the task we were facing.",
+      "count": 0
     },
     {
-    "word": "major (adj) /ˈmeɪdʒə(r)/",
-    "meaning": "important, serious, or significant; lớn",
-    "example": "The economy is a major factor affecting consumers’ confidence.",
-    "count": 0
+      "word": "major (adj) /ˈmeɪdʒə(r)/",
+      "meaning": "important, serious, or significant; lớn",
+      "example": "The economy is a major factor affecting consumers’ confidence.",
+      "count": 0
     },
     {
-    "word": "mass (n) /mæs/",
-    "meaning": "a large amount of a substance that does not have a definite shape or form; khối",
-    "example": "The food had congealed into a sticky mass.",
-    "count": 0
+      "word": "mass (n) /mæs/",
+      "meaning": "a large amount of a substance that does not have a definite shape or form; khối",
+      "example": "The food had congealed into a sticky mass.",
+      "count": 0
     },
     {
-    "word": "masses (n pl) /ˈmæsɪz/",
-    "meaning": "a large amount or number of something; nhiều",
-    "example": "I’ve got masses of work to do.",
-    "count": 0
+      "word": "masses (n pl) /ˈmæsɪz/",
+      "meaning": "a large amount or number of something; nhiều",
+      "example": "I’ve got masses of work to do.",
+      "count": 0
     },
     {
-    "word": "meagre (adj) /ˈmiːɡə(r)/",
-    "meaning": "smaller or less than you want or need; ít ỏi",
-    "example": "She supplements her meagre income by cleaning at night.",
-    "count": 0
+      "word": "meagre (adj) /ˈmiːɡə(r)/",
+      "meaning": "smaller or less than you want or need; ít ỏi",
+      "example": "She supplements her meagre income by cleaning at night.",
+      "count": 0
     },
     {
-    "word": "minor (adj) /ˈmaɪnə(r)/",
-    "meaning": "not very important or serious; nhỏ",
-    "example": "Some minor changes may be necessary.",
-    "count": 0
+      "word": "minor (adj) /ˈmaɪnə(r)/",
+      "meaning": "not very important or serious; nhỏ",
+      "example": "Some minor changes may be necessary.",
+      "count": 0
     },
     {
-    "word": "multiple (adj) /ˈmʌltɪpl/",
-    "meaning": "many in number; nhiều",
-    "example": "Words can have multiple meanings.",
-    "count": 0
+      "word": "multiple (adj) /ˈmʌltɪpl/",
+      "meaning": "many in number; nhiều",
+      "example": "Words can have multiple meanings.",
+      "count": 0
     },
     {
-    "word": "rate (n) /reɪt/",
-    "meaning": "the speed at which something happens; tốc độ",
-    "example": "The population was growing at an alarming rate.",
-    "count": 0
+      "word": "rate (n) /reɪt/",
+      "meaning": "the speed at which something happens; tốc độ",
+      "example": "The population was growing at an alarming rate.",
+      "count": 0
     },
     {
-    "word": "rate (v) /reɪt/",
-    "meaning": "to consider that someone or something has a particular quality or standard; đánh giá",
-    "example": "The match didn’t rate high on my list of priorities.",
-    "count": 0
+      "word": "rate (v) /reɪt/",
+      "meaning": "to consider that someone or something has a particular quality or standard; đánh giá",
+      "example": "The match didn’t rate high on my list of priorities.",
+      "count": 0
     },
     {
-    "word": "ratio (n) /ˈreɪʃiəʊ/",
-    "meaning": "a relationship between two things in numbers; tỉ lệ",
-    "example": "The ratio of expenditure to income is worrying.",
-    "count": 0
+      "word": "ratio (n) /ˈreɪʃiəʊ/",
+      "meaning": "a relationship between two things in numbers; tỉ lệ",
+      "example": "The ratio of expenditure to income is worrying.",
+      "count": 0
     },
     {
-    "word": "shrink (v) /ʃrɪŋk/",
-    "meaning": "to become smaller or to make something smaller; co lại",
-    "example": "The city continued to shrink.",
-    "count": 0
+      "word": "shrink (v) /ʃrɪŋk/",
+      "meaning": "to become smaller or to make something smaller; co lại",
+      "example": "The city continued to shrink.",
+      "count": 0
     },
     {
-    "word": "sum (n) /sʌm/",
-    "meaning": "an amount of money; khoản tiền",
-    "example": "He sold the house for a tidy sum.",
-    "count": 0
+      "word": "sum (n) /sʌm/",
+      "meaning": "an amount of money; khoản tiền",
+      "example": "He sold the house for a tidy sum.",
+      "count": 0
     },
     {
-    "word": "uneven (adj) /ʌnˈiːvn/",
-    "meaning": "not smooth, flat or level; không bằng phẳng",
-    "example": "The floor felt uneven under his feet.",
-    "count": 0
+      "word": "uneven (adj) /ʌnˈiːvn/",
+      "meaning": "not smooth, flat or level; không bằng phẳng",
+      "example": "The floor felt uneven under his feet.",
+      "count": 0
     },
     {
-    "word": "vast (adj) /vɑːst/",
-    "meaning": "extremely large; mênh mông",
-    "example": "A vast audience watched the broadcast.",
-    "count": 0
+      "word": "vast (adj) /vɑːst/",
+      "meaning": "extremely large; mênh mông",
+      "example": "A vast audience watched the broadcast.",
+      "count": 0
     },
     {
-    "word": "volume (n) /ˈvɒljuːm/",
-    "meaning": "an amount of something; thể tích",
-    "example": "Traffic volume is increasing on the roads.",
-    "count": 0
+      "word": "volume (n) /ˈvɒljuːm/",
+      "meaning": "an amount of something; thể tích",
+      "example": "Traffic volume is increasing on the roads.",
+      "count": 0
     },
     {
-    "word": "widespread (adj) /ˈwaɪdspred/",
-    "meaning": "happening in many places or to many people; lan rộng",
-    "example": "There is widespread support for the new policies.",
-    "count": 0
+      "word": "widespread (adj) /ˈwaɪdspred/",
+      "meaning": "happening in many places or to many people; lan rộng",
+      "example": "There is widespread support for the new policies.",
+      "count": 0
     },
     {
-    "word": "weight (n) /weɪt/",
-    "meaning": "how heavy something is; trọng lượng",
-    "example": "The bag was heavy in weight.",
-    "count": 0
+      "word": "weight (n) /weɪt/",
+      "meaning": "how heavy something is; trọng lượng",
+      "example": "The bag was heavy in weight.",
+      "count": 0
     },
     {
-    "word": "weight (n) /weɪt/",
-    "meaning": "the importance or influence of something; sức nặng",
-    "example": "His opinion carried a lot of weight.",
-    "count": 0
+      "word": "weight (n) /weɪt/",
+      "meaning": "the importance or influence of something; sức nặng",
+      "example": "His opinion carried a lot of weight.",
+      "count": 0
     },
     {
-    "word": "benefit of the doubt (phrase)",
-    "meaning": "to decide to believe or trust someone; quyết định tin tưởng",
-    "example": "I gave him the benefit of the doubt and assumed he was right.",
-    "count": 0
-    }, 
+      "word": "benefit of the doubt (phrase)",
+      "meaning": "to decide to believe or trust someone; quyết định tin tưởng",
+      "example": "I gave him the benefit of the doubt and assumed he was right.",
+      "count": 0
+    },
     {
-    "word": "force (v) /fɔːs/",
-    "meaning": "to use physical force to move something in a particular direction; đẩy",
-    "example": "She forced the package through the slot.",
-    "count": 0
+      "word": "force (v) /fɔːs/",
+      "meaning": "to use physical force to move something in a particular direction; đẩy",
+      "example": "She forced the package through the slot.",
+      "count": 0
     },
     {
-    "word": "fraction (n) /ˈfrækʃən/",
-    "meaning": "a small part or amount of something; phần",
-    "example": "His shares are now worth a fraction of their former value.",
-    "count": 0
+      "word": "fraction (n) /ˈfrækʃən/",
+      "meaning": "a small part or amount of something; phần",
+      "example": "His shares are now worth a fraction of their former value.",
+      "count": 0
     },
     {
-    "word": "fraction (n) /ˈfrækʃən/",
-    "meaning": "a division or part of a whole number, for example 1/2 or 3/4; phân số",
-    "example": "0.5 can also be written as a fraction: 1/2.",
-    "count": 0
+      "word": "fraction (n) /ˈfrækʃən/",
+      "meaning": "a division or part of a whole number, for example 1/2 or 3/4; phân số",
+      "example": "0.5 can also be written as a fraction: 1/2.",
+      "count": 0
     },
     {
-    "word": "heap (n) /hiːp/",
-    "meaning": "a large pile of something, especially an untidy pile; đống",
-    "example": "His clothes were in a crumpled heap on the floor.",
-    "count": 0
+      "word": "heap (n) /hiːp/",
+      "meaning": "a large pile of something, especially an untidy pile; đống",
+      "example": "His clothes were in a crumpled heap on the floor.",
+      "count": 0
     },
     {
-    "word": "heap (v) /hiːp/",
-    "meaning": "to make a big untidy pile of things; chất đống",
-    "example": "Bundles of clothing were heaped on the floor.",
-    "count": 0
+      "word": "heap (v) /hiːp/",
+      "meaning": "to make a big untidy pile of things; chất đống",
+      "example": "Bundles of clothing were heaped on the floor.",
+      "count": 0
     },
     {
-    "word": "imbalance (n) /ɪmˈbæləns/",
-    "meaning": "a situation in which the balance between two things is not equal or fair; sự mất cân bằng",
-    "example": "There’s an increasing social imbalance in recruitment to higher education.",
-    "count": 0
+      "word": "imbalance (n) /ɪmˈbæləns/",
+      "meaning": "a situation in which the balance between two things is not equal or fair; sự mất cân bằng",
+      "example": "There’s an increasing social imbalance in recruitment to higher education.",
+      "count": 0
     },
     {
-    "word": "immense (adj) /ɪˈmens/",
-    "meaning": "extremely large; vô hạn",
-    "example": "An immense amount of time and effort went into the project.",
-    "count": 0
+      "word": "immense (adj) /ɪˈmens/",
+      "meaning": "extremely large; vô hạn",
+      "example": "An immense amount of time and effort went into the project.",
+      "count": 0
     },
     {
-    "word": "intensity (n) /ɪnˈtensəti/",
-    "meaning": "strength; cường độ",
-    "example": "The cross-examination increased in intensity.",
-    "count": 0
+      "word": "intensity (n) /ɪnˈtensəti/",
+      "meaning": "strength; cường độ",
+      "example": "The cross-examination increased in intensity.",
+      "count": 0
     },
     {
-    "word": "magnitude (n) /ˈmæɡnɪtjuːd/",
-    "meaning": "great size, importance or effect; tầm cỡ",
-    "example": "We hadn’t grasped the magnitude of the task we were facing.",
-    "count": 0
+      "word": "magnitude (n) /ˈmæɡnɪtjuːd/",
+      "meaning": "great size, importance or effect; tầm cỡ",
+      "example": "We hadn’t grasped the magnitude of the task we were facing.",
+      "count": 0
     },
     {
-    "word": "major (adj) /ˈmeɪdʒə(r)/",
-    "meaning": "important, serious, or significant; lớn",
-    "example": "The economy is a major factor affecting consumers’ confidence.",
-    "count": 0
+      "word": "major (adj) /ˈmeɪdʒə(r)/",
+      "meaning": "important, serious, or significant; lớn",
+      "example": "The economy is a major factor affecting consumers’ confidence.",
+      "count": 0
     },
     {
-    "word": "mass (n) /mæs/",
-    "meaning": "a large amount of a substance that does not have a definite shape or form; khối",
-    "example": "The food had congealed into a sticky mass.",
-    "count": 0
+      "word": "mass (n) /mæs/",
+      "meaning": "a large amount of a substance that does not have a definite shape or form; khối",
+      "example": "The food had congealed into a sticky mass.",
+      "count": 0
     },
     {
-    "word": "masses (n pl) /ˈmæsɪz/",
-    "meaning": "a large amount or number of something; nhiều",
-    "example": "I’ve got masses of work to do.",
-    "count": 0
+      "word": "masses (n pl) /ˈmæsɪz/",
+      "meaning": "a large amount or number of something; nhiều",
+      "example": "I’ve got masses of work to do.",
+      "count": 0
     },
     {
-    "word": "meagre (adj) /ˈmiːɡə(r)/",
-    "meaning": "smaller or less than you want or need; ít ỏi",
-    "example": "She supplements her meagre income by cleaning at night.",
-    "count": 0
+      "word": "meagre (adj) /ˈmiːɡə(r)/",
+      "meaning": "smaller or less than you want or need; ít ỏi",
+      "example": "She supplements her meagre income by cleaning at night.",
+      "count": 0
     },
     {
-    "word": "minor (adj) /ˈmaɪnə(r)/",
-    "meaning": "not very important or serious; nhỏ",
-    "example": "Some minor changes may be necessary.",
-    "count": 0
+      "word": "minor (adj) /ˈmaɪnə(r)/",
+      "meaning": "not very important or serious; nhỏ",
+      "example": "Some minor changes may be necessary.",
+      "count": 0
     },
     {
-    "word": "multiple (adj) /ˈmʌltɪpl/",
-    "meaning": "many in number; nhiều",
-    "example": "Words can have multiple meanings.",
-    "count": 0
+      "word": "multiple (adj) /ˈmʌltɪpl/",
+      "meaning": "many in number; nhiều",
+      "example": "Words can have multiple meanings.",
+      "count": 0
     },
     {
-    "word": "rate (n) /reɪt/",
-    "meaning": "the speed at which something happens; tốc độ",
-    "example": "The population was growing at an alarming rate.",
-    "count": 0
+      "word": "rate (n) /reɪt/",
+      "meaning": "the speed at which something happens; tốc độ",
+      "example": "The population was growing at an alarming rate.",
+      "count": 0
     },
     {
-    "word": "rate (v) /reɪt/",
-    "meaning": "to consider that someone or something has a particular quality or standard; đánh giá",
-    "example": "The match didn’t rate high on my list of priorities.",
-    "count": 0
+      "word": "rate (v) /reɪt/",
+      "meaning": "to consider that someone or something has a particular quality or standard; đánh giá",
+      "example": "The match didn’t rate high on my list of priorities.",
+      "count": 0
     },
     {
-    "word": "ratio (n) /ˈreɪʃiəʊ/",
-    "meaning": "a relationship between two things in numbers; tỉ lệ",
-    "example": "The ratio of expenditure to income is worrying.",
-    "count": 0
+      "word": "ratio (n) /ˈreɪʃiəʊ/",
+      "meaning": "a relationship between two things in numbers; tỉ lệ",
+      "example": "The ratio of expenditure to income is worrying.",
+      "count": 0
     },
     {
-    "word": "shrink (v) /ʃrɪŋk/",
-    "meaning": "to become smaller or to make something smaller; co lại",
-    "example": "The city continued to shrink.",
-    "count": 0
+      "word": "shrink (v) /ʃrɪŋk/",
+      "meaning": "to become smaller or to make something smaller; co lại",
+      "example": "The city continued to shrink.",
+      "count": 0
     },
     {
-    "word": "sum (n) /sʌm/",
-    "meaning": "an amount of money; khoản tiền",
-    "example": "He sold the house for a tidy sum.",
-    "count": 0
+      "word": "sum (n) /sʌm/",
+      "meaning": "an amount of money; khoản tiền",
+      "example": "He sold the house for a tidy sum.",
+      "count": 0
     },
     {
-    "word": "uneven (adj) /ʌnˈiːvn/",
-    "meaning": "not smooth, flat or level; không bằng phẳng",
-    "example": "The floor felt uneven under his feet.",
-    "count": 0
+      "word": "uneven (adj) /ʌnˈiːvn/",
+      "meaning": "not smooth, flat or level; không bằng phẳng",
+      "example": "The floor felt uneven under his feet.",
+      "count": 0
     },
     {
-    "word": "vast (adj) /vɑːst/",
-    "meaning": "extremely large; mênh mông",
-    "example": "A vast audience watched the broadcast.",
-    "count": 0
+      "word": "vast (adj) /vɑːst/",
+      "meaning": "extremely large; mênh mông",
+      "example": "A vast audience watched the broadcast.",
+      "count": 0
     },
     {
-    "word": "volume (n) /ˈvɒljuːm/",
-    "meaning": "an amount of something; thể tích",
-    "example": "Traffic volume is increasing on the roads.",
-    "count": 0
+      "word": "volume (n) /ˈvɒljuːm/",
+      "meaning": "an amount of something; thể tích",
+      "example": "Traffic volume is increasing on the roads.",
+      "count": 0
     },
     {
-    "word": "widespread (adj) /ˈwaɪdspred/",
-    "meaning": "happening in many places or to many people; lan rộng",
-    "example": "There is widespread support for the new policies.",
-    "count": 0
+      "word": "widespread (adj) /ˈwaɪdspred/",
+      "meaning": "happening in many places or to many people; lan rộng",
+      "example": "There is widespread support for the new policies.",
+      "count": 0
     },
     {
-    "word": "weight (n) /weɪt/",
-    "meaning": "how heavy something is; trọng lượng",
-    "example": "The bag was heavy in weight.",
-    "count": 0
+      "word": "weight (n) /weɪt/",
+      "meaning": "how heavy something is; trọng lượng",
+      "example": "The bag was heavy in weight.",
+      "count": 0
     },
     {
-    "word": "weight (n) /weɪt/",
-    "meaning": "the importance or influence of something; sức nặng",
-    "example": "His opinion carried a lot of weight.",
-    "count": 0
+      "word": "weight (n) /weɪt/",
+      "meaning": "the importance or influence of something; sức nặng",
+      "example": "His opinion carried a lot of weight.",
+      "count": 0
     },
     {
-    "word": "benefit of the doubt (phrase)",
-    "meaning": "to decide to believe or trust someone; quyết định tin tưởng",
-    "example": "I gave him the benefit of the doubt and assumed he was right.",
-    "count": 0
+      "word": "benefit of the doubt (phrase)",
+      "meaning": "to decide to believe or trust someone; quyết định tin tưởng",
+      "example": "I gave him the benefit of the doubt and assumed he was right.",
+      "count": 0
     },
     {
-    "word": "ratio (n) /ˈreɪʃiəʊ/",
-    "meaning": "relationship between two numbers or amounts; tỉ lệ",
-    "example": "The ratio of expenditure to revenue was an alarming 4:1.",
-    "count": 0
+      "word": "ratio (n) /ˈreɪʃiəʊ/",
+      "meaning": "relationship between two numbers or amounts; tỉ lệ",
+      "example": "The ratio of expenditure to revenue was an alarming 4:1.",
+      "count": 0
     },
     {
-    "word": "ration (n) /ˈræʃn/",
-    "meaning": "limited amount you are allowed to have; khẩu phần",
-    "example": "There's a ration of two eggs per person.",
-    "count": 0
+      "word": "ration (n) /ˈræʃn/",
+      "meaning": "limited amount you are allowed to have; khẩu phần",
+      "example": "There's a ration of two eggs per person.",
+      "count": 0
     },
     {
-    "word": "ration (v) /ˈreɪʃn/",
-    "meaning": "to control supply so people get a fixed amount; chia phần, hạn chế",
-    "example": "During the strike, petrol had to be rationed.",
-    "count": 0
+      "word": "ration (v) /ˈreɪʃn/",
+      "meaning": "to control supply so people get a fixed amount; chia phần, hạn chế",
+      "example": "During the strike, petrol had to be rationed.",
+      "count": 0
     },
     {
-    "word": "shrink (v) /ʃrɪŋk/",
-    "meaning": "become or make smaller in size; co lại",
-    "example": "Do you think this dress will shrink if I handwash it?",
-    "count": 0
+      "word": "shrink (v) /ʃrɪŋk/",
+      "meaning": "become or make smaller in size; co lại",
+      "example": "Do you think this dress will shrink if I handwash it?",
+      "count": 0
     },
     {
-    "word": "sufficient (adj) /səˈfɪʃənt/",
-    "meaning": "as much as is needed; đủ",
-    "example": "Bedside lighting alone is not sufficient for most bedrooms.",
-    "count": 0
+      "word": "sufficient (adj) /səˈfɪʃənt/",
+      "meaning": "as much as is needed; đủ",
+      "example": "Bedside lighting alone is not sufficient for most bedrooms.",
+      "count": 0
     },
     {
-    "word": "sum (n) /sʌm/",
-    "meaning": "an amount of money; khoản tiền",
-    "example": "He was fined a sum of £1,000.",
-    "count": 0
+      "word": "sum (n) /sʌm/",
+      "meaning": "an amount of money; khoản tiền",
+      "example": "He was fined a sum of £1,000.",
+      "count": 0
     },
     {
-    "word": "sum (n) /sʌm/",
-    "meaning": "a simple calculation; phép toán",
-    "example": "John's just starting to do sums at school.",
-    "count": 0
+      "word": "sum (n) /sʌm/",
+      "meaning": "a simple calculation; phép toán",
+      "example": "John's just starting to do sums at school.",
+      "count": 0
     },
     {
-    "word": "uneven (adj) /ʌnˈiːvən/",
-    "meaning": "not regular in size, length or quality; thất thường",
-    "example": "The economy has prospered, but growth has been uneven.",
-    "count": 0
+      "word": "uneven (adj) /ʌnˈiːvən/",
+      "meaning": "not regular in size, length or quality; thất thường",
+      "example": "The economy has prospered, but growth has been uneven.",
+      "count": 0
     },
     {
-    "word": "vast (adj) /vɑːst/",
-    "meaning": "extremely large; bao la",
-    "example": "We found ourselves on a vast empty plain.",
-    "count": 0
+      "word": "vast (adj) /vɑːst/",
+      "meaning": "extremely large; bao la",
+      "example": "We found ourselves on a vast empty plain.",
+      "count": 0
     },
     {
-    "word": "volume (n) /ˈvɒljʊm/",
-    "meaning": "amount of something; lượng",
-    "example": "The total volume of trade has reached £800 million.",
-    "count": 0
+      "word": "volume (n) /ˈvɒljʊm/",
+      "meaning": "amount of something; lượng",
+      "example": "The total volume of trade has reached £800 million.",
+      "count": 0
     },
     {
-    "word": "volume (n) /ˈvɒljʊm/",
-    "meaning": "space something takes up; khối lượng",
-    "example": "The petrol tank has a volume of over 20 gallons.",
-    "count": 0
+      "word": "volume (n) /ˈvɒljʊm/",
+      "meaning": "space something takes up; khối lượng",
+      "example": "The petrol tank has a volume of over 20 gallons.",
+      "count": 0
     },
     {
-    "word": "widespread (adj) /ˌwaɪdˈspred/",
-    "meaning": "existing in many places; lan rộng, phổ biến",
-    "example": "The project has received widespread public support.",
-    "count": 0
+      "word": "widespread (adj) /ˌwaɪdˈspred/",
+      "meaning": "existing in many places; lan rộng, phổ biến",
+      "example": "The project has received widespread public support.",
+      "count": 0
     },
     {
-    "word": "benefit (n) /ˈbenɪfɪt/",
-    "meaning": "money/help from the government; tiền trợ cấp",
-    "example": "There has been an increase in the number of people claiming benefit.",
-    "count": 0
+      "word": "benefit (n) /ˈbenɪfɪt/",
+      "meaning": "money/help from the government; tiền trợ cấp",
+      "example": "There has been an increase in the number of people claiming benefit.",
+      "count": 0
     },
     {
-    "word": "benefit (n) /ˈbenɪfɪt/",
-    "meaning": "an advantage of a situation; lợi ích",
-    "example": "The new sports centre will bring lasting benefit to the community.",
-    "count": 0
+      "word": "benefit (n) /ˈbenɪfɪt/",
+      "meaning": "an advantage of a situation; lợi ích",
+      "example": "The new sports centre will bring lasting benefit to the community.",
+      "count": 0
     },
     {
-    "word": "benefit (v) /bəˈnefɪt/",
-    "meaning": "to get help or advantage from something; hưởng lợi",
-    "example": "Thousands of households could benefit under the scheme.",
-    "count": 0
+      "word": "benefit (v) /bəˈnefɪt/",
+      "meaning": "to get help or advantage from something; hưởng lợi",
+      "example": "Thousands of households could benefit under the scheme.",
+      "count": 0
     },
     {
-    "word": "compensation (n) /ˌkɒmpenˈseɪʃən/",
-    "meaning": "money received when something bad happens; khoản bồi thường",
-    "example": "Victims of the world's largest industrial accident were paid $470 million compensation.",
-    "count": 0
+      "word": "compensation (n) /ˌkɒmpenˈseɪʃən/",
+      "meaning": "money received when something bad happens; khoản bồi thường",
+      "example": "Victims of the world's largest industrial accident were paid $470 million compensation.",
+      "count": 0
     },
     {
-    "word": "damages (n) /ˈdæmɪdʒɪz/",
-    "meaning": "money a court orders you to pay for harm; tiền bồi thường thiệt hại",
-    "example": "The jury awarded damages of over $9 million to the victims.",
-    "count": 0
+      "word": "damages (n) /ˈdæmɪdʒɪz/",
+      "meaning": "money a court orders you to pay for harm; tiền bồi thường thiệt hại",
+      "example": "The jury awarded damages of over $9 million to the victims.",
+      "count": 0
     },
     {
-    "word": "debt (n) /det/",
-    "meaning": "an amount of money you owe; khoản nợ",
-    "example": "By this time we had debts of over £15,000.",
-    "count": 0
+      "word": "debt (n) /det/",
+      "meaning": "an amount of money you owe; khoản nợ",
+      "example": "By this time we had debts of over £15,000.",
+      "count": 0
     },
     {
-    "word": "deduct (v) /dɪˈdʌkt/",
-    "meaning": "to take an amount from a total; khấu trừ",
-    "example": "Nothing will be deducted from your pay.",
-    "count": 0
+      "word": "deduct (v) /dɪˈdʌkt/",
+      "meaning": "to take an amount from a total; khấu trừ",
+      "example": "Nothing will be deducted from your pay.",
+      "count": 0
     },
     {
-    "word": "deposit (n) /dɪˈpɒzɪt/",
-    "meaning": "first payment when buying or renting; tiền đặt cọc",
-    "example": "She paid a £500 deposit and agreed to pay the balance within six months.",
-    "count": 0
+      "word": "deposit (n) /dɪˈpɒzɪt/",
+      "meaning": "first payment when buying or renting; tiền đặt cọc",
+      "example": "She paid a £500 deposit and agreed to pay the balance within six months.",
+      "count": 0
     },
     {
-    "word": "deposit (n) /dɪˈpɒzɪt/",
-    "meaning": "money you put into a bank account; tiền gửi (ngân hàng)",
-    "example": "He made a £2,000 cash deposit on April 5th.",
-    "count": 0
+      "word": "deposit (n) /dɪˈpɒzɪt/",
+      "meaning": "money you put into a bank account; tiền gửi (ngân hàng)",
+      "example": "He made a £2,000 cash deposit on April 5th.",
+      "count": 0
     },
     {
-    "word": "deposit (v) /dɪˈpɒzɪt/",
-    "meaning": "to put money into a bank account; gửi tiền (ngân hàng)",
-    "example": "Billions of dollars are deposited in banks every day.",
-    "count": 0
+      "word": "deposit (v) /dɪˈpɒzɪt/",
+      "meaning": "to put money into a bank account; gửi tiền (ngân hàng)",
+      "example": "Billions of dollars are deposited in banks every day.",
+      "count": 0
     },
     {
-    "word": "direct debit (n) /ˌdaɪˈrekt ˈdebɪt/",
-    "meaning": "order to bank to pay regularly; ủy nhiệm chi",
-    "example": "I pay all my bills by direct debit.",
-    "count": 0
+      "word": "direct debit (n) /ˌdaɪˈrekt ˈdebɪt/",
+      "meaning": "order to bank to pay regularly; ủy nhiệm chi",
+      "example": "I pay all my bills by direct debit.",
+      "count": 0
     },
     {
-    "word": "dividend (n) /ˈdɪvɪˌdend/",
-    "meaning": "share of company profits; cổ tức",
-    "example": "The company will not be paying shareholders a dividend this year.",
-    "count": 0
+      "word": "dividend (n) /ˈdɪvɪˌdend/",
+      "meaning": "share of company profits; cổ tức",
+      "example": "The company will not be paying shareholders a dividend this year.",
+      "count": 0
     },
     {
-    "word": "down payment (n) /ˈdaʊn ˈpeɪmənt/",
-    "meaning": "first payment when buying, rest later; khoản trả trước",
-    "example": "She made a £500 down payment and agreed to pay the balance within six months.",
-    "count": 0
+      "word": "down payment (n) /ˈdaʊn ˈpeɪmənt/",
+      "meaning": "first payment when buying, rest later; khoản trả trước",
+      "example": "She made a £500 down payment and agreed to pay the balance within six months.",
+      "count": 0
     },
     {
-    "word": "finance (n) /ˈfaɪnæns/",
-    "meaning": "decisions on spending or investing money; tài chính",
-    "example": "He's now studying international banking and finance.",
-    "count": 0
+      "word": "finance (n) /ˈfaɪnæns/",
+      "meaning": "decisions on spending or investing money; tài chính",
+      "example": "He's now studying international banking and finance.",
+      "count": 0
     },
     {
-    "word": "finance (n) /ˈfaɪnæns/",
-    "meaning": "money used for a large project; vốn",
-    "example": "The college has had to close due to lack of finance.",
-    "count": 0
+      "word": "finance (n) /ˈfaɪnæns/",
+      "meaning": "money used for a large project; vốn",
+      "example": "The college has had to close due to lack of finance.",
+      "count": 0
     },
     {
-    "word": "finance (v) /faɪˈnæns/",
-    "meaning": "to pay for something; cấp tiền",
-    "example": "The scheme is being financed by the Arts Council.",
-    "count": 0
+      "word": "finance (v) /faɪˈnæns/",
+      "meaning": "to pay for something; cấp tiền",
+      "example": "The scheme is being financed by the Arts Council.",
+      "count": 0
     },
     {
-    "word": "insurance (n) /ɪnˈʃʊərəns/",
-    "meaning": "arrangement to cover loss/damage; hợp đồng bảo hiểm",
-    "example": "You have to take out building and contents insurance as a condition of the mortgage.",
-    "count": 0
+      "word": "insurance (n) /ɪnˈʃʊərəns/",
+      "meaning": "arrangement to cover loss/damage; hợp đồng bảo hiểm",
+      "example": "You have to take out building and contents insurance as a condition of the mortgage.",
+      "count": 0
     },
     {
-    "word": "interest (n) /ˈɪntrəst/",
-    "meaning": "charge for lending money; lãi suất cho vay",
-    "example": "You will repay the money with interest as agreed in the contract.",
-    "count": 0
+      "word": "interest (n) /ˈɪntrəst/",
+      "meaning": "charge for lending money; lãi suất cho vay",
+      "example": "You will repay the money with interest as agreed in the contract.",
+      "count": 0
     },
     {
-    "word": "investment (n) /ɪnˈvestmənt/",
-    "meaning": "money used to earn more (e.g. property/shares); khoản đầu tư",
-    "example": "Her investments were mainly in technology stocks.",
-    "count": 0
+      "word": "investment (n) /ɪnˈvestmənt/",
+      "meaning": "money used to earn more (e.g. property/shares); khoản đầu tư",
+      "example": "Her investments were mainly in technology stocks.",
+      "count": 0
     },
     {
-    "word": "investment (n) /ɪnˈvestmənt/",
-    "meaning": "process of spending money to improve something; sự đầu tư",
-    "example": "Lack of investment had led to a decline in public services.",
-    "count": 0
+      "word": "investment (n) /ɪnˈvestmənt/",
+      "meaning": "process of spending money to improve something; sự đầu tư",
+      "example": "Lack of investment had led to a decline in public services.",
+      "count": 0
     },
     {
-    "word": "lump sum (n) /lʌmp sʌm/",
-    "meaning": "one large payment instead of many; trả một cục",
-    "example": "Are you going to pay the whole amount in one lump sum?",
-    "count": 0
+      "word": "lump sum (n) /lʌmp sʌm/",
+      "meaning": "one large payment instead of many; trả một cục",
+      "example": "Are you going to pay the whole amount in one lump sum?",
+      "count": 0
     },
     {
-    "word": "mortgage (n) /ˈmɔːɡɪdʒ/",
-    "meaning": "borrowed money to buy a house; khoản vay mua nhà",
-    "example": "On my present salary I can’t get a mortgage.",
-    "count": 0
+      "word": "mortgage (n) /ˈmɔːɡɪdʒ/",
+      "meaning": "borrowed money to buy a house; khoản vay mua nhà",
+      "example": "On my present salary I can’t get a mortgage.",
+      "count": 0
     },
     {
-    "word": "overdraft (n) /ˈəʊvədrɑːft/",
-    "meaning": "bank agreement to spend over balance; thấu chi",
-    "example": "Hefty fines are payable for those who exceed their overdraft limit.",
-    "count": 0
+      "word": "overdraft (n) /ˈəʊvədrɑːft/",
+      "meaning": "bank agreement to spend over balance; thấu chi",
+      "example": "Hefty fines are payable for those who exceed their overdraft limit.",
+      "count": 0
     },
     {
-    "word": "pension (n) /ˈpenʃən/",
-    "meaning": "regular payment after you stop working; tiền lương hưu",
-    "example": "He started drawing his pension last year.",
-    "count": 0
+      "word": "pension (n) /ˈpenʃən/",
+      "meaning": "regular payment after you stop working; tiền lương hưu",
+      "example": "He started drawing his pension last year.",
+      "count": 0
     },
     {
-    "word": "block (v) /blɒk/",
-    "meaning": "to stop something from moving through or along something else; chặn lại",
-    "example": "A large rock blocked our way.",
-    "count": 0
+      "word": "block (v) /blɒk/",
+      "meaning": "to stop something from moving through or along something else; chặn lại",
+      "example": "A large rock blocked our way.",
+      "count": 0
     },
     {
-    "word": "block (n) /blɒk/",
-    "meaning": "a solid piece of wood, stone, ice, etc with straight sides; khối",
-    "example": "Have you ever seen someone make a swan out of a block of ice?",
-    "count": 0
+      "word": "block (n) /blɒk/",
+      "meaning": "a solid piece of wood, stone, ice, etc with straight sides; khối",
+      "example": "Have you ever seen someone make a swan out of a block of ice?",
+      "count": 0
     },
     {
-    "word": "brittle (adj) /ˈbrɪtl/",
-    "meaning": "a brittle substance or object is hard and can easily break into pieces; giòn",
-    "example": "The plastic had gone brittle from sitting in the sun.",
-    "count": 0
+      "word": "brittle (adj) /ˈbrɪtl/",
+      "meaning": "a brittle substance or object is hard and can easily break into pieces; giòn",
+      "example": "The plastic had gone brittle from sitting in the sun.",
+      "count": 0
     },
     {
-    "word": "chip (v) /tʃɪp/",
-    "meaning": "if something hard chips, or you chip it, a small piece of it breaks off; làm sứt mẻ",
-    "example": "I’ve chipped a tooth.",
-    "count": 0
+      "word": "chip (v) /tʃɪp/",
+      "meaning": "if something hard chips, or you chip it, a small piece of it breaks off; làm sứt mẻ",
+      "example": "I’ve chipped a tooth.",
+      "count": 0
     },
     {
-    "word": "chip (n) /tʃɪp/",
-    "meaning": "a small piece of something such as wood or glass; mảnh vụn",
-    "example": "Be careful because there might be chips of glass on the floor.",
-    "count": 0
+      "word": "chip (n) /tʃɪp/",
+      "meaning": "a small piece of something such as wood or glass; mảnh vụn",
+      "example": "Be careful because there might be chips of glass on the floor.",
+      "count": 0
     },
     {
-    "word": "compact (v) /kəmˈpækt/",
-    "meaning": "to make something smaller or firmer by pressing it; nén lại",
-    "example": "The machine compacted the rubbish into blocks.",
-    "count": 0
+      "word": "compact (v) /kəmˈpækt/",
+      "meaning": "to make something smaller or firmer by pressing it; nén lại",
+      "example": "The machine compacted the rubbish into blocks.",
+      "count": 0
     },
     {
-    "word": "compact (adj) /ˈkɒmpækt/",
-    "meaning": "smaller than most things of the same kind; chặt",
-    "example": "Our flat is quite compact.",
-    "count": 0
+      "word": "compact (adj) /ˈkɒmpækt/",
+      "meaning": "smaller than most things of the same kind; chặt",
+      "example": "Our flat is quite compact.",
+      "count": 0
     },
     {
-    "word": "concentrate (v) /ˈkɒnsəntreɪt/",
-    "meaning": "to make a solution stronger by removing water; cô đặc",
-    "example": "You can concentrate the solution by heating it.",
-    "count": 0
+      "word": "concentrate (v) /ˈkɒnsəntreɪt/",
+      "meaning": "to make a solution stronger by removing water; cô đặc",
+      "example": "You can concentrate the solution by heating it.",
+      "count": 0
     },
     {
-    "word": "crack (v) /kræk/",
-    "meaning": "if something cracks, a line appears on its surface but it does not break into pieces; làm vỡ",
-    "example": "Who cracked the window?",
-    "count": 0
+      "word": "crack (v) /kræk/",
+      "meaning": "if something cracks, a line appears on its surface but it does not break into pieces; làm vỡ",
+      "example": "Who cracked the window?",
+      "count": 0
     },
     {
-    "word": "crack (n) /kræk/",
-    "meaning": "a line on a surface where something is beginning to break apart; vết nứt",
-    "example": "How long has that crack in the ceiling been there?",
-    "count": 0
+      "word": "crack (n) /kræk/",
+      "meaning": "a line on a surface where something is beginning to break apart; vết nứt",
+      "example": "How long has that crack in the ceiling been there?",
+      "count": 0
     },
     {
-    "word": "crumb (n) /krʌm/",
-    "meaning": "a very small piece that falls off a dry food such as bread or cake; vụn",
-    "example": "Don’t get crumbs on the carpet.",
-    "count": 0
+      "word": "crumb (n) /krʌm/",
+      "meaning": "a very small piece that falls off a dry food such as bread or cake; vụn",
+      "example": "Don’t get crumbs on the carpet.",
+      "count": 0
     },
     {
-    "word": "crush (v) /krʌʃ/",
-    "meaning": "to press or squeeze something so hard that it is damaged; nghiền",
-    "example": "Crush the can and put it in the recycling bin.",
-    "count": 0
+      "word": "crush (v) /krʌʃ/",
+      "meaning": "to press or squeeze something so hard that it is damaged; nghiền",
+      "example": "Crush the can and put it in the recycling bin.",
+      "count": 0
     },
     {
-    "word": "crush (n) /krʌʃ/",
-    "meaning": "a crowd of people pressed close together; đám đông chen chúc",
-    "example": "There was quite a crush in the club last night.",
-    "count": 0
+      "word": "crush (n) /krʌʃ/",
+      "meaning": "a crowd of people pressed close together; đám đông chen chúc",
+      "example": "There was quite a crush in the club last night.",
+      "count": 0
     },
     {
-    "word": "dense (adj) /dens/",
-    "meaning": "a dense substance is very heavy in relation to its size; có tỷ trọng nặng",
-    "example": "Lead is a very dense metal.",
-    "count": 0
+      "word": "dense (adj) /dens/",
+      "meaning": "a dense substance is very heavy in relation to its size; có tỷ trọng nặng",
+      "example": "Lead is a very dense metal.",
+      "count": 0
     },
     {
-    "word": "dilute (v) /daɪˈluːt/",
-    "meaning": "to make a liquid less strong by adding water or another liquid; pha loãng",
-    "example": "If the sauce is too thick, dilute it with some water.",
-    "count": 0
+      "word": "dilute (v) /daɪˈluːt/",
+      "meaning": "to make a liquid less strong by adding water or another liquid; pha loãng",
+      "example": "If the sauce is too thick, dilute it with some water.",
+      "count": 0
     },
     {
-    "word": "dilute (adj) /daɪˈluːt/",
-    "meaning": "a dilute liquid has been mixed with another liquid to make it less strong; loãng",
-    "example": "Use dilute bleach to clean the table.",
-    "count": 0
+      "word": "dilute (adj) /daɪˈluːt/",
+      "meaning": "a dilute liquid has been mixed with another liquid to make it less strong; loãng",
+      "example": "Use dilute bleach to clean the table.",
+      "count": 0
     },
     {
-    "word": "dissolve (v) /dɪˈzɒlv/",
-    "meaning": "if a solid substance dissolves in a liquid, it is mixed into the liquid so that it becomes included in it; hòa tan",
-    "example": "Salt dissolves quite easily in water.",
-    "count": 0
+      "word": "dissolve (v) /dɪˈzɒlv/",
+      "meaning": "if a solid substance dissolves in a liquid, it is mixed into the liquid so that it becomes included in it; hòa tan",
+      "example": "Salt dissolves quite easily in water.",
+      "count": 0
     },
     {
-    "word": "fabric (n) /ˈfæbrɪk/",
-    "meaning": "cloth used for making things such as clothes or curtains; vải",
-    "example": "We need to choose the fabric we want for the curtains.",
-    "count": 0
+      "word": "fabric (n) /ˈfæbrɪk/",
+      "meaning": "cloth used for making things such as clothes or curtains; vải",
+      "example": "We need to choose the fabric we want for the curtains.",
+      "count": 0
     },
     {
-    "word": "firm (adj) /fɜːm/",
-    "meaning": "solid but not hard; chắc",
-    "example": "The cake feels firm, remove it from the oven.",
-    "count": 0
+      "word": "firm (adj) /fɜːm/",
+      "meaning": "solid but not hard; chắc",
+      "example": "The cake feels firm, remove it from the oven.",
+      "count": 0
     },
     {
-    "word": "flake (v) /fleɪk/",
-    "meaning": "to come off a surface in small flat pieces; bong tróc",
-    "example": "The paint on the door is beginning to flake.",
-    "count": 0
+      "word": "flake (v) /fleɪk/",
+      "meaning": "to come off a surface in small flat pieces; bong tróc",
+      "example": "The paint on the door is beginning to flake.",
+      "count": 0
     },
     {
-    "word": "flake (n) /fleɪk/",
-    "meaning": "a small flat piece of something; vảy",
-    "example": "The floor was covered in flakes of paint from the old walls.",
-    "count": 0
+      "word": "flake (n) /fleɪk/",
+      "meaning": "a small flat piece of something; vảy",
+      "example": "The floor was covered in flakes of paint from the old walls.",
+      "count": 0
     },
     {
-    "word": "fragile (adj) /ˈfrædʒaɪl/",
-    "meaning": "easy to break or damage; dễ vỡ",
-    "example": "Be careful with that ornament because it’s very fragile.",
-    "count": 0
+      "word": "fragile (adj) /ˈfrædʒaɪl/",
+      "meaning": "easy to break or damage; dễ vỡ",
+      "example": "Be careful with that ornament because it’s very fragile.",
+      "count": 0
     },
     {
-    "word": "friction (n) /ˈfrɪkʃən/",
-    "meaning": "the physical force that makes it difficult for one surface to move over another; lực ma sát",
-    "example": "If you rub your hands together, friction makes them get warm.",
-    "count": 0
+      "word": "friction (n) /ˈfrɪkʃən/",
+      "meaning": "the physical force that makes it difficult for one surface to move over another; lực ma sát",
+      "example": "If you rub your hands together, friction makes them get warm.",
+      "count": 0
     },
     {
-    "word": "grain (n) /ɡreɪn/",
-    "meaning": "a very small piece of a substance such as sand or salt; hạt",
-    "example": "Each grain of salt is really a tiny cube.",
-    "count": 0
+      "word": "grain (n) /ɡreɪn/",
+      "meaning": "a very small piece of a substance such as sand or salt; hạt",
+      "example": "Each grain of salt is really a tiny cube.",
+      "count": 0
     },
     {
-    "word": "gravity (n) /ˈɡrævəti/",
-    "meaning": "the force that makes something fall to the ground; trọng lực",
-    "example": "How does zero gravity affect astronauts?",
-    "count": 0
+      "word": "gravity (n) /ˈɡrævəti/",
+      "meaning": "the force that makes something fall to the ground; trọng lực",
+      "example": "How does zero gravity affect astronauts?",
+      "count": 0
     },
     {
-    "word": "grind (v) /ɡraɪnd/",
-    "meaning": "to break something into very small pieces or powder; nghiền, mài",
-    "example": "I prefer to grind my own spices.",
-    "count": 0
+      "word": "grind (v) /ɡraɪnd/",
+      "meaning": "to break something into very small pieces or powder; nghiền, mài",
+      "example": "I prefer to grind my own spices.",
+      "count": 0
     },
     {
-    "word": "hollow (adj) /ˈhɒləʊ/",
-    "meaning": "empty inside; rỗng",
-    "example": "I was surprised to find that the tree was hollow.",
-    "count": 0
+      "word": "hollow (adj) /ˈhɒləʊ/",
+      "meaning": "empty inside; rỗng",
+      "example": "I was surprised to find that the tree was hollow.",
+      "count": 0
     },
     {
-    "word": "liquid (n) /ˈlɪkwɪd/",
-    "meaning": "a substance that can flow and has no fixed shape; chất lỏng",
-    "example": "You have to be careful when handling liquid explosives.",
-    "count": 0
+      "word": "liquid (n) /ˈlɪkwɪd/",
+      "meaning": "a substance that can flow and has no fixed shape; chất lỏng",
+      "example": "You have to be careful when handling liquid explosives.",
+      "count": 0
     },
     {
-    "word": "liquid (adj) /ˈlɪkwɪd/",
-    "meaning": "in the form of a liquid; ở dạng lỏng",
-    "example": "The soap is sold in both liquid and bar forms.",
-    "count": 0
+      "word": "liquid (adj) /ˈlɪkwɪd/",
+      "meaning": "in the form of a liquid; ở dạng lỏng",
+      "example": "The soap is sold in both liquid and bar forms.",
+      "count": 0
     },
     {
-    "word": "lump (v) /lʌmp/",
-    "meaning": "to put people or things into the same group even though they do not belong together; gộp chung",
-    "example": "You can’t just lump all disabled people together.",
-    "count": 0
+      "word": "lump (v) /lʌmp/",
+      "meaning": "to put people or things into the same group even though they do not belong together; gộp chung",
+      "example": "You can’t just lump all disabled people together.",
+      "count": 0
     },
     {
-    "word": "lump (n) /lʌmp/",
-    "meaning": "a solid piece of something that does not have a regular shape; tảng",
-    "example": "He tripped over a lump of concrete.",
-    "count": 0
+      "word": "lump (n) /lʌmp/",
+      "meaning": "a solid piece of something that does not have a regular shape; tảng",
+      "example": "He tripped over a lump of concrete.",
+      "count": 0
     },
     {
-    "word": "mineral (n) /ˈmɪnərəl/",
-    "meaning": "a natural substance in the earth; khoáng chất",
-    "example": "This area is very rich in minerals.",
-    "count": 0
+      "word": "mineral (n) /ˈmɪnərəl/",
+      "meaning": "a natural substance in the earth; khoáng chất",
+      "example": "This area is very rich in minerals.",
+      "count": 0
     },
     {
-    "word": "mould (v) /məʊld/",
-    "meaning": "to shape something by putting it into a mould; đúc",
-    "example": "Mould the clay into the shape of a person.",
-    "count": 0
+      "word": "mould (v) /məʊld/",
+      "meaning": "to shape something by putting it into a mould; đúc",
+      "example": "Mould the clay into the shape of a person.",
+      "count": 0
     },
     {
-    "word": "mould (n) /məʊld/",
-    "meaning": "a container into which liquid is poured to shape it; khuôn",
-    "example": "Pour the jelly into the mould and then put it in the fridge.",
-    "count": 0
+      "word": "mould (n) /məʊld/",
+      "meaning": "a container into which liquid is poured to shape it; khuôn",
+      "example": "Pour the jelly into the mould and then put it in the fridge.",
+      "count": 0
     },
     {
-    "word": "opaque (adj) /əʊˈpeɪk/",
-    "meaning": "not transparent or hard to see through; mờ",
-    "example": "We had opaque glass put into the bathroom.",
-    "count": 0
+      "word": "opaque (adj) /əʊˈpeɪk/",
+      "meaning": "not transparent or hard to see through; mờ",
+      "example": "We had opaque glass put into the bathroom.",
+      "count": 0
     },
     {
-    "word": "pat (v) /pæt/",
-    "meaning": "to touch someone gently with a flat hand; vỗ",
-    "example": "He patted me on the shoulder and told me not to worry.",
-    "count": 0
+      "word": "pat (v) /pæt/",
+      "meaning": "to touch someone gently with a flat hand; vỗ",
+      "example": "He patted me on the shoulder and told me not to worry.",
+      "count": 0
     },
     {
-    "word": "pat (n) /pæt/",
-    "meaning": "the action of gently touching someone or something several times with a flat hand; cái vỗ",
-    "example": "I felt a pat on my back and turned around.",
-    "count": 0
+      "word": "pat (n) /pæt/",
+      "meaning": "the action of gently touching someone or something several times with a flat hand; cái vỗ",
+      "example": "I felt a pat on my back and turned around.",
+      "count": 0
     },
     {
-    "word": "pile (v) /paɪl/",
-    "meaning": "to put a large number of things on top of each other; chất đống",
-    "example": "Don’t just pile your clothes on the bed.",
-    "count": 0
+      "word": "pile (v) /paɪl/",
+      "meaning": "to put a large number of things on top of each other; chất đống",
+      "example": "Don’t just pile your clothes on the bed.",
+      "count": 0
     },
     {
-    "word": "share (n) /ʃeə(r)/",
-    "meaning": "one of the equal parts of a company that you can buy; cổ phiếu",
-    "example": "The scheme allows employees to buy shares in the company.",
-    "count": 0
+      "word": "share (n) /ʃeə(r)/",
+      "meaning": "one of the equal parts of a company that you can buy; cổ phiếu",
+      "example": "The scheme allows employees to buy shares in the company.",
+      "count": 0
     },
     {
-    "word": "speculate (v) /ˈspekjuleɪt/",
-    "meaning": "to take the risk of investing your money in a company in the hope that you can make a big profit; đầu cơ",
-    "example": "Have you been speculating on the stock market?",
-    "count": 0
+      "word": "speculate (v) /ˈspekjuleɪt/",
+      "meaning": "to take the risk of investing your money in a company in the hope that you can make a big profit; đầu cơ",
+      "example": "Have you been speculating on the stock market?",
+      "count": 0
     },
     {
-    "word": "withdraw (v) /wɪðˈdrɔː/",
-    "meaning": "to take money from a bank account; rút tiền",
-    "example": "You can withdraw cash at any of our branches.",
-    "count": 0
+      "word": "withdraw (v) /wɪðˈdrɔː/",
+      "meaning": "to take money from a bank account; rút tiền",
+      "example": "You can withdraw cash at any of our branches.",
+      "count": 0
     },
     {
-    "word": "pile (n) /paɪl/",
-    "meaning": "a number of things put on top of each other; đống, chồng",
-    "example": "Could you help me carry this pile of books?",
-    "count": 0
+      "word": "pile (n) /paɪl/",
+      "meaning": "a number of things put on top of each other; đống, chồng",
+      "example": "Could you help me carry this pile of books?",
+      "count": 0
     },
     {
-    "word": "polish (v) /ˈpɒlɪʃ/",
-    "meaning": "to rub the surface of something to make it shine; đánh bóng",
-    "example": "The maid polished the table and then cleaned the floor.",
-    "count": 0
+      "word": "polish (v) /ˈpɒlɪʃ/",
+      "meaning": "to rub the surface of something to make it shine; đánh bóng",
+      "example": "The maid polished the table and then cleaned the floor.",
+      "count": 0
     },
     {
-    "word": "polish (n) /ˈpɒlɪʃ/",
-    "meaning": "a chemical substance that you rub onto an object to make it shine; chất đánh bóng",
-    "example": "Put some polish on your cloth and then rub, like this.",
-    "count": 0
+      "word": "polish (n) /ˈpɒlɪʃ/",
+      "meaning": "a chemical substance that you rub onto an object to make it shine; chất đánh bóng",
+      "example": "Put some polish on your cloth and then rub, like this.",
+      "count": 0
     },
     {
-    "word": "scratch (v) /skrætʃ/",
-    "meaning": "to pull your nails along your skin, especially because it itches; gãi",
-    "example": "If you scratch it, it might get worse.",
-    "count": 0
+      "word": "scratch (v) /skrætʃ/",
+      "meaning": "to pull your nails along your skin, especially because it itches; gãi",
+      "example": "If you scratch it, it might get worse.",
+      "count": 0
     },
     {
-    "word": "scratch (v) /skrætʃ/",
-    "meaning": "to damage a surface by marking it with something sharp or rough; cào",
-    "example": "How did you scratch your violin?",
-    "count": 0
+      "word": "scratch (v) /skrætʃ/",
+      "meaning": "to damage a surface by marking it with something sharp or rough; cào",
+      "example": "How did you scratch your violin?",
+      "count": 0
     },
     {
-    "word": "scratch (n) /skrætʃ/",
-    "meaning": "a mark on a surface made by scratching; vết xước",
-    "example": "There’s a scratch on my new CD!",
-    "count": 0
+      "word": "scratch (n) /skrætʃ/",
+      "meaning": "a mark on a surface made by scratching; vết xước",
+      "example": "There’s a scratch on my new CD!",
+      "count": 0
     },
     {
-    "word": "scrub (v) /skrʌb/",
-    "meaning": "to wash or clean something by rubbing it hard; chà xát, lau chùi",
-    "example": "I’ve been scrubbing the floor all day.",
-    "count": 0
+      "word": "scrub (v) /skrʌb/",
+      "meaning": "to wash or clean something by rubbing it hard; chà xát, lau chùi",
+      "example": "I’ve been scrubbing the floor all day.",
+      "count": 0
     },
     {
-    "word": "scrub (n) /skrʌb/",
-    "meaning": "an act of cleaning by rubbing; sự cọ rửa",
-    "example": "What your fingernails need is a good scrub.",
-    "count": 0
+      "word": "scrub (n) /skrʌb/",
+      "meaning": "an act of cleaning by rubbing; sự cọ rửa",
+      "example": "What your fingernails need is a good scrub.",
+      "count": 0
     },
     {
-    "word": "smash (v) /smæʃ/",
-    "meaning": "to break something noisily into many pieces; đập vỡ",
-    "example": "You’ll break the glass if you smash it down like that!",
-    "count": 0
+      "word": "smash (v) /smæʃ/",
+      "meaning": "to break something noisily into many pieces; đập vỡ",
+      "example": "You’ll break the glass if you smash it down like that!",
+      "count": 0
     },
     {
-    "word": "solid (n) /ˈsɒlɪd/",
-    "meaning": "a substance that is not a liquid or a gas; chất rắn",
-    "example": "Water is a liquid, but ice is a solid.",
-    "count": 0
+      "word": "solid (n) /ˈsɒlɪd/",
+      "meaning": "a substance that is not a liquid or a gas; chất rắn",
+      "example": "Water is a liquid, but ice is a solid.",
+      "count": 0
     },
     {
-    "word": "solid (adj) /ˈsɒlɪd/",
-    "meaning": "a solid is firm and has a fixed shape; rắn",
-    "example": "This table feels very solid.",
-    "count": 0
+      "word": "solid (adj) /ˈsɒlɪd/",
+      "meaning": "a solid is firm and has a fixed shape; rắn",
+      "example": "This table feels very solid.",
+      "count": 0
     },
     {
-    "word": "speck (n) /spek/",
-    "meaning": "a very small spot or mark; vết, lốm đốm",
-    "example": "There’s not a speck of dust in here.",
-    "count": 0
+      "word": "speck (n) /spek/",
+      "meaning": "a very small spot or mark; vết, lốm đốm",
+      "example": "There’s not a speck of dust in here.",
+      "count": 0
     },
     {
-    "word": "squash (v) /skwɒʃ/",
-    "meaning": "to damage something by pressing or crushing it; làm bẹp",
-    "example": "She sat on my glasses and squashed them!",
-    "count": 0
+      "word": "squash (v) /skwɒʃ/",
+      "meaning": "to damage something by pressing or crushing it; làm bẹp",
+      "example": "She sat on my glasses and squashed them!",
+      "count": 0
     },
     {
-    "word": "squash (n) /skwɒʃ/",
-    "meaning": "a situation in which there are too many people in a small space; tình trạng chen chúc",
-    "example": "It’ll be a bit of a squash, but we can all sit on one sofa.",
-    "count": 0
+      "word": "squash (n) /skwɒʃ/",
+      "meaning": "a situation in which there are too many people in a small space; tình trạng chen chúc",
+      "example": "It’ll be a bit of a squash, but we can all sit on one sofa.",
+      "count": 0
     },
     {
-    "word": "squeeze (v) /skwiːz/",
-    "meaning": "to press something firmly, especially with your hands; nén, ép",
-    "example": "Squeeze every last drop out of the lemon.",
-    "count": 0
+      "word": "squeeze (v) /skwiːz/",
+      "meaning": "to press something firmly, especially with your hands; nén, ép",
+      "example": "Squeeze every last drop out of the lemon.",
+      "count": 0
     },
     {
-    "word": "squeeze (n) /skwiːz/",
-    "meaning": "the action of squeezing something; sự nén, ép, bóp",
-    "example": "She gave my hand a quick squeeze.",
-    "count": 0
+      "word": "squeeze (n) /skwiːz/",
+      "meaning": "the action of squeezing something; sự nén, ép, bóp",
+      "example": "She gave my hand a quick squeeze.",
+      "count": 0
     },
     {
-    "word": "stack (v) /stæk/",
-    "meaning": "to arrange things so that they stand one on top of another; xếp",
-    "example": "The assistant was stacking boxes when I walked into the shop.",
-    "count": 0
+      "word": "stack (v) /stæk/",
+      "meaning": "to arrange things so that they stand one on top of another; xếp",
+      "example": "The assistant was stacking boxes when I walked into the shop.",
+      "count": 0
     },
     {
-    "word": "stack (n) /stæk/",
-    "meaning": "a pile of things placed one on top of another; đống, cụm",
-    "example": "I can’t believe you knocked over that stack of tins!",
-    "count": 0
+      "word": "stack (n) /stæk/",
+      "meaning": "a pile of things placed one on top of another; đống, cụm",
+      "example": "I can’t believe you knocked over that stack of tins!",
+      "count": 0
     },
     {
-    "word": "stuff (adj) /stʌf/",
-    "meaning": "firm and difficult to bend; cứng",
-    "example": "Take a stiff piece of card and cut a hole in it.",
-    "count": 0
+      "word": "stuff (adj) /stʌf/",
+      "meaning": "firm and difficult to bend; cứng",
+      "example": "Take a stiff piece of card and cut a hole in it.",
+      "count": 0
     },
     {
-    "word": "stroke (v) /strəʊk/",
-    "meaning": "to move your hand over skin, hair, or fur gently; vuốt ve",
-    "example": "I was only trying to stroke the dog!",
-    "count": 0
+      "word": "stroke (v) /strəʊk/",
+      "meaning": "to move your hand over skin, hair, or fur gently; vuốt ve",
+      "example": "I was only trying to stroke the dog!",
+      "count": 0
     },
     {
-    "word": "stroke (n) /strəʊk/",
-    "meaning": "a gentle movement of your hand across skin, hair or fur; động tác vuốt ve",
-    "example": "I fell asleep while my mum was stroking my hair.",
-    "count": 0
+      "word": "stroke (n) /strəʊk/",
+      "meaning": "a gentle movement of your hand across skin, hair or fur; động tác vuốt ve",
+      "example": "I fell asleep while my mum was stroking my hair.",
+      "count": 0
     },
     {
-    "word": "stuff (v) /stʌf/",
-    "meaning": "to push something soft into a space or container; nhồi nhét",
-    "example": "I stuffed a few things into a suitcase and set off.",
-    "count": 0
+      "word": "stuff (v) /stʌf/",
+      "meaning": "to push something soft into a space or container; nhồi nhét",
+      "example": "I stuffed a few things into a suitcase and set off.",
+      "count": 0
     },
     {
-    "word": "stuff (n) /stʌf/",
-    "meaning": "a variety of objects or things; món, thứ (đồ)",
-    "example": "What’s all this stuff on your desk?",
-    "count": 0
+      "word": "stuff (n) /stʌf/",
+      "meaning": "a variety of objects or things; món, thứ (đồ)",
+      "example": "What’s all this stuff on your desk?",
+      "count": 0
     },
     {
-    "word": "substance (n) /ˈsʌbstəns/",
-    "meaning": "a particular type of liquid, solid or gas; chất",
-    "example": "You’re not allowed to take certain substances on a plane.",
-    "count": 0
+      "word": "substance (n) /ˈsʌbstəns/",
+      "meaning": "a particular type of liquid, solid or gas; chất",
+      "example": "You’re not allowed to take certain substances on a plane.",
+      "count": 0
     },
     {
-    "word": "synthetic (adj) /sɪnˈθetɪk/",
-    "meaning": "made from artificial materials or substances, not from natural ones; tổng hợp, nhân tạo",
-    "example": "Nylon is a synthetic material.",
-    "count": 0
+      "word": "synthetic (adj) /sɪnˈθetɪk/",
+      "meaning": "made from artificial materials or substances, not from natural ones; tổng hợp, nhân tạo",
+      "example": "Nylon is a synthetic material.",
+      "count": 0
     },
     {
-    "word": "tear (v) /teə(r)/",
-    "meaning": "to pull something so that it separates into pieces or gets a hole in it; xé",
-    "example": "You’ve torn your T-shirt on the door handle.",
-    "count": 0
+      "word": "tear (v) /teə(r)/",
+      "meaning": "to pull something so that it separates into pieces or gets a hole in it; xé",
+      "example": "You’ve torn your T-shirt on the door handle.",
+      "count": 0
     },
     {
-    "word": "tear (n) /teə(r)/",
-    "meaning": "a hole in a piece of paper, cloth, etc where it has been torn; vết rách",
-    "example": "There’s a big tear in my jeans.",
-    "count": 0
+      "word": "tear (n) /teə(r)/",
+      "meaning": "a hole in a piece of paper, cloth, etc where it has been torn; vết rách",
+      "example": "There’s a big tear in my jeans.",
+      "count": 0
     },
     {
-    "word": "texture (n) /ˈtekstʃə(r)/",
-    "meaning": "the way something feels when you touch it; kết cấu, bề mặt",
-    "example": "The bread has a very dense texture.",
-    "count": 0
+      "word": "texture (n) /ˈtekstʃə(r)/",
+      "meaning": "the way something feels when you touch it; kết cấu, bề mặt",
+      "example": "The bread has a very dense texture.",
+      "count": 0
     },
     {
-    "word": "transparent (adj) /trænˈspærənt/",
-    "meaning": "a transparent object is clear or thin enough for you to see through; trong suốt",
-    "example": "Glass is transparent.",
-    "count": 0
+      "word": "transparent (adj) /trænˈspærənt/",
+      "meaning": "a transparent object is clear or thin enough for you to see through; trong suốt",
+      "example": "Glass is transparent.",
+      "count": 0
     },
     {
-    "word": "built-up (adj) /ˌbɪlt ˈʌp/",
-    "meaning": "a built-up area has a lot of buildings in it; có nhà cửa san sát",
-    "example": "This area has become very built-up over the last few years.",
-    "count": 0
+      "word": "built-up (adj) /ˌbɪlt ˈʌp/",
+      "meaning": "a built-up area has a lot of buildings in it; có nhà cửa san sát",
+      "example": "This area has become very built-up over the last few years.",
+      "count": 0
     },
     {
-    "word": "bypass (v) /ˈbaɪpɑːs/",
-    "meaning": "to avoid the centre of a town or city by using a road that goes round it; đi vòng",
-    "example": "If we take the next left, we can bypass Reading altogether.",
-    "count": 0
+      "word": "bypass (v) /ˈbaɪpɑːs/",
+      "meaning": "to avoid the centre of a town or city by using a road that goes round it; đi vòng",
+      "example": "If we take the next left, we can bypass Reading altogether.",
+      "count": 0
     },
     {
-    "word": "bypass (n) /ˈbaɪpɑːs/",
-    "meaning": "a road that goes around a town or city to avoid it; đường vòng",
-    "example": "I don’t think they’ll ever finish the new bypass.",
-    "count": 0
+      "word": "bypass (n) /ˈbaɪpɑːs/",
+      "meaning": "a road that goes around a town or city to avoid it; đường vòng",
+      "example": "I don’t think they’ll ever finish the new bypass.",
+      "count": 0
     },
     {
-    "word": "construct (v) /kənˈstrʌkt/",
-    "meaning": "to build something large or complicated; xây dựng",
-    "example": "We plan to construct a new warehouse to expand our storage capacity.",
-    "count": 0
+      "word": "construct (v) /kənˈstrʌkt/",
+      "meaning": "to build something large or complicated; xây dựng",
+      "example": "We plan to construct a new warehouse to expand our storage capacity.",
+      "count": 0
     },
     {
-    "word": "demolish (v) /dɪˈmɒlɪʃ/",
-    "meaning": "to destroy a building completely; dỡ bỏ",
-    "example": "They demolished my old school.",
-    "count": 0
+      "word": "demolish (v) /dɪˈmɒlɪʃ/",
+      "meaning": "to destroy a building completely; dỡ bỏ",
+      "example": "They demolished my old school.",
+      "count": 0
     },
     {
-    "word": "district (n) /ˈdɪstrɪkt/",
-    "meaning": "an area of a town or country; khu vực, quận/huyện",
-    "example": "It’s quite a nice district to live in.",
-    "count": 0
+      "word": "district (n) /ˈdɪstrɪkt/",
+      "meaning": "an area of a town or country; khu vực, quận/huyện",
+      "example": "It’s quite a nice district to live in.",
+      "count": 0
     },
     {
-    "word": "dwell (v) /dwel/",
-    "meaning": "to live somewhere; sinh sống",
-    "example": "The little old man dwelled in a run-down cottage.",
-    "count": 0
+      "word": "dwell (v) /dwel/",
+      "meaning": "to live somewhere; sinh sống",
+      "example": "The little old man dwelled in a run-down cottage.",
+      "count": 0
     },
     {
-    "word": "estate (n) /ɪˈsteɪt/",
-    "meaning": "an area where there are many houses, usually built at the same time; khu dân cư",
-    "example": "There’s been a lot of crime on this estate.",
-    "count": 0
+      "word": "estate (n) /ɪˈsteɪt/",
+      "meaning": "an area where there are many houses, usually built at the same time; khu dân cư",
+      "example": "There’s been a lot of crime on this estate.",
+      "count": 0
     },
     {
-    "word": "evict (v) /ɪˈvɪkt/",
-    "meaning": "to legally force someone to leave their house; đuổi khỏi",
-    "example": "The letter says they’re going to evict us next week.",
-    "count": 0
+      "word": "evict (v) /ɪˈvɪkt/",
+      "meaning": "to legally force someone to leave their house; đuổi khỏi",
+      "example": "The letter says they’re going to evict us next week.",
+      "count": 0
     },
     {
-    "word": "high-rise (adj) /ˈhaɪˌraɪz/",
-    "meaning": "a high-rise building is very tall with many floors or levels; cao tầng",
-    "example": "She lives in a high-rise in the city centre.",
-    "count": 0
+      "word": "high-rise (adj) /ˈhaɪˌraɪz/",
+      "meaning": "a high-rise building is very tall with many floors or levels; cao tầng",
+      "example": "She lives in a high-rise in the city centre.",
+      "count": 0
     },
     {
-    "word": "housing (n) /ˈhaʊzɪŋ/",
-    "meaning": "buildings for people to live in; nhà ở",
-    "example": "The government has announced more housing for the poor.",
-    "count": 0
+      "word": "housing (n) /ˈhaʊzɪŋ/",
+      "meaning": "buildings for people to live in; nhà ở",
+      "example": "The government has announced more housing for the poor.",
+      "count": 0
     },
     {
-    "word": "infrastructure (n) /ˈɪnfrəstrʌktʃə(r)/",
-    "meaning": "the basic systems and services that a country or organization uses; cơ sở hạ tầng",
-    "example": "During the war, a lot of the infrastructure of the country was destroyed.",
-    "count": 0
+      "word": "infrastructure (n) /ˈɪnfrəstrʌktʃə(r)/",
+      "meaning": "the basic systems and services that a country or organization uses; cơ sở hạ tầng",
+      "example": "During the war, a lot of the infrastructure of the country was destroyed.",
+      "count": 0
     },
     {
-    "word": "inner city (n phr) /ˌɪnə ˈsɪti/",
-    "meaning": "the central part of a large city where there is a lot of poverty and social problems; nội đô, khu ổ chuột",
-    "example": "There are some very interesting music coming out of the inner city these days.",
-    "count": 0
+      "word": "inner city (n phr) /ˌɪnə ˈsɪti/",
+      "meaning": "the central part of a large city where there is a lot of poverty and social problems; nội đô, khu ổ chuột",
+      "example": "There are some very interesting music coming out of the inner city these days.",
+      "count": 0
     },
     {
-    "word": "occupy (v) /ˈɒkjʊpaɪ/",
-    "meaning": "to live in or use a space or building; chiếm giữ, cư trú",
-    "example": "Patients with minor illnesses are occupying beds that are needed for more serious cases.",
-    "count": 0
+      "word": "occupy (v) /ˈɒkjʊpaɪ/",
+      "meaning": "to live in or use a space or building; chiếm giữ, cư trú",
+      "example": "Patients with minor illnesses are occupying beds that are needed for more serious cases.",
+      "count": 0
     },
     {
-    "word": "stuff (n) /stʌf/",
-    "meaning": "firm and difficult to bend; cứng",
-    "example": "Take a stiff piece of card and cut a hole in it.",
-    "count": 0
+      "word": "stuff (n) /stʌf/",
+      "meaning": "firm and difficult to bend; cứng",
+      "example": "Take a stiff piece of card and cut a hole in it.",
+      "count": 0
     },
     {
-    "word": "tear (n) /teə(r)/",
-    "meaning": "a hole in a piece of paper, cloth, etc where it has been torn; vết rách",
-    "example": "There’s a big tear in my jeans.",
-    "count": 0
+      "word": "tear (n) /teə(r)/",
+      "meaning": "a hole in a piece of paper, cloth, etc where it has been torn; vết rách",
+      "example": "There’s a big tear in my jeans.",
+      "count": 0
     },
     {
-    "word": "high-rise (adj) /ˈhaɪˌraɪz/",
-    "meaning": "a high-rise building is very tall with many floors or levels; cao tầng",
-    "example": "She lives in a high-rise in the city centre.",
-    "count": 0
+      "word": "high-rise (adj) /ˈhaɪˌraɪz/",
+      "meaning": "a high-rise building is very tall with many floors or levels; cao tầng",
+      "example": "She lives in a high-rise in the city centre.",
+      "count": 0
     },
     {
-    "word": "glum (adj) /ɡlʌm/",
-    "meaning": "looking sad, as if you expect something bad to happen; rầu rĩ",
-    "example": "You look a bit glum. Has something happened?",
-    "count": 0
+      "word": "glum (adj) /ɡlʌm/",
+      "meaning": "looking sad, as if you expect something bad to happen; rầu rĩ",
+      "example": "You look a bit glum. Has something happened?",
+      "count": 0
     },
     {
-    "word": "grimace (n) /ˈɡrɪməs/",
-    "meaning": "an ugly expression made by twisting your face, often because you are in pain or do not like something; biểu hiện nhăn nhó",
-    "example": "His tortured grimace showed he was in pain.",
-    "count": 0
+      "word": "grimace (n) /ˈɡrɪməs/",
+      "meaning": "an ugly expression made by twisting your face, often because you are in pain or do not like something; biểu hiện nhăn nhó",
+      "example": "His tortured grimace showed he was in pain.",
+      "count": 0
     },
     {
-    "word": "grimace (v) /ˈɡrɪməs/",
-    "meaning": "to make an ugly expression by twisting your face, for example because you are in pain or do not like something; nhăn mặt",
-    "example": "She grimaced as the needle went in.",
-    "count": 0
+      "word": "grimace (v) /ˈɡrɪməs/",
+      "meaning": "to make an ugly expression by twisting your face, for example because you are in pain or do not like something; nhăn mặt",
+      "example": "She grimaced as the needle went in.",
+      "count": 0
     },
     {
-    "word": "grin (n) /ɡrɪn/",
-    "meaning": "a big smile that shows your teeth; nụ cười tươi",
-    "example": "Mike said nothing, but just sat there with a big grin.",
-    "count": 0
+      "word": "grin (n) /ɡrɪn/",
+      "meaning": "a big smile that shows your teeth; nụ cười tươi",
+      "example": "Mike said nothing, but just sat there with a big grin.",
+      "count": 0
     },
     {
-    "word": "grin (v) /ɡrɪn/",
-    "meaning": "to smile showing your teeth; cười tươi",
-    "example": "Ruth grinned at him as she waved goodbye.",
-    "count": 0
+      "word": "grin (v) /ɡrɪn/",
+      "meaning": "to smile showing your teeth; cười tươi",
+      "example": "Ruth grinned at him as she waved goodbye.",
+      "count": 0
     },
     {
-    "word": "handle (v) /ˈhændl/",
-    "meaning": "to take action to deal with a difficult situation; xử lý",
-    "example": "The government was criticised for how it handled the crisis.",
-    "count": 0
+      "word": "handle (v) /ˈhændl/",
+      "meaning": "to take action to deal with a difficult situation; xử lý",
+      "example": "The government was criticised for how it handled the crisis.",
+      "count": 0
     },
     {
-    "word": "impatient (adj) /ɪmˈpeɪʃnt/",
-    "meaning": "annoyed because something is not happening as quickly as you want or in the way you want; thiếu kiên nhẫn",
-    "example": "‘Come on!’ said Maggie, becoming impatient.",
-    "count": 0
+      "word": "impatient (adj) /ɪmˈpeɪʃnt/",
+      "meaning": "annoyed because something is not happening as quickly as you want or in the way you want; thiếu kiên nhẫn",
+      "example": "‘Come on!’ said Maggie, becoming impatient.",
+      "count": 0
     },
     {
-    "word": "inertia (n) /ɪˈnɜːʃə/",
-    "meaning": "a situation in which something does not change for a long time; sự trì trệ",
-    "example": "There’s so much inertia in the system.",
-    "count": 0
+      "word": "inertia (n) /ɪˈnɜːʃə/",
+      "meaning": "a situation in which something does not change for a long time; sự trì trệ",
+      "example": "There’s so much inertia in the system.",
+      "count": 0
     },
     {
-    "word": "manners (n) /ˈmænəz/",
-    "meaning": "traditionally accepted behaviour that shows politeness; tác phong",
-    "example": "Children learn manners from their parents.",
-    "count": 0
+      "word": "manners (n) /ˈmænəz/",
+      "meaning": "traditionally accepted behaviour that shows politeness; tác phong",
+      "example": "Children learn manners from their parents.",
+      "count": 0
     },
     {
-    "word": "manoeuvre (n) /məˈnuːvə(r)/",
-    "meaning": "an action or movement that you need care or skill to do; động tác khéo léo",
-    "example": "Expert driving manoeuvres are key when reversing the truck.",
-    "count": 0
+      "word": "manoeuvre (n) /məˈnuːvə(r)/",
+      "meaning": "an action or movement that you need care or skill to do; động tác khéo léo",
+      "example": "Expert driving manoeuvres are key when reversing the truck.",
+      "count": 0
     },
     {
-    "word": "manoeuvre (v) /məˈnuːvə(r)/",
-    "meaning": "to move someone or something in a situation that needs care or skill; điều khiển khéo léo",
-    "example": "Katherine’s good at manoeuvring her car through narrow gaps.",
-    "count": 0
+      "word": "manoeuvre (v) /məˈnuːvə(r)/",
+      "meaning": "to move someone or something in a situation that needs care or skill; điều khiển khéo léo",
+      "example": "Katherine’s good at manoeuvring her car through narrow gaps.",
+      "count": 0
     },
     {
-    "word": "moan (n) /məʊn/",
-    "meaning": "a long low sound you make because of pain, sadness or pleasure; tiếng rên",
-    "example": "He let out a moan of anguish.",
-    "count": 0
+      "word": "moan (n) /məʊn/",
+      "meaning": "a long low sound you make because of pain, sadness or pleasure; tiếng rên",
+      "example": "He let out a moan of anguish.",
+      "count": 0
     },
     {
-    "word": "moan (v) /məʊn/",
-    "meaning": "to complain about something in an annoying way; than vãn",
-    "example": "Ben was moaning about his job again.",
-    "count": 0
+      "word": "moan (v) /məʊn/",
+      "meaning": "to complain about something in an annoying way; than vãn",
+      "example": "Ben was moaning about his job again.",
+      "count": 0
     },
     {
-    "word": "mock (v) /mɒk/",
-    "meaning": "to make someone or something look stupid by laughing at them; chế giễu",
-    "example": "Are you trying to mock me?",
-    "count": 0
+      "word": "mock (v) /mɒk/",
+      "meaning": "to make someone or something look stupid by laughing at them; chế giễu",
+      "example": "Are you trying to mock me?",
+      "count": 0
     },
     {
-    "word": "neglect (n) /nɪˈɡlekt/",
-    "meaning": "failure to give someone or something the care or attention they need; sự bỏ bê",
-    "example": "There is an important need to protect children from abuse and neglect.",
-    "count": 0
+      "word": "neglect (n) /nɪˈɡlekt/",
+      "meaning": "failure to give someone or something the care or attention they need; sự bỏ bê",
+      "example": "There is an important need to protect children from abuse and neglect.",
+      "count": 0
     },
     {
-    "word": "neglect (v) /nɪˈɡlekt/",
-    "meaning": "to fail to look after someone when you should do so; bỏ bê",
-    "example": "What should we do about parents who neglect their children?",
-    "count": 0
+      "word": "neglect (v) /nɪˈɡlekt/",
+      "meaning": "to fail to look after someone when you should do so; bỏ bê",
+      "example": "What should we do about parents who neglect their children?",
+      "count": 0
     },
     {
-    "word": "neglect (v) /nɪˈɡlekt/",
-    "meaning": "to fail to do something you should do; sao nhãng",
-    "example": "He couldn’t neglect his duties as an officer.",
-    "count": 0
+      "word": "neglect (v) /nɪˈɡlekt/",
+      "meaning": "to fail to do something you should do; sao nhãng",
+      "example": "He couldn’t neglect his duties as an officer.",
+      "count": 0
     },
     {
-    "word": "peep (n) /piːp/",
-    "meaning": "a quick look at something; cái nhìn trộm",
-    "example": "I’ll just take a peep inside.",
-    "count": 0
+      "word": "peep (n) /piːp/",
+      "meaning": "a quick look at something; cái nhìn trộm",
+      "example": "I’ll just take a peep inside.",
+      "count": 0
     },
     {
-    "word": "peep (v) /piːp/",
-    "meaning": "to look at something quickly and secretly; nhìn trộm",
-    "example": "She tried to peep through the door into the garden.",
-    "count": 0
+      "word": "peep (v) /piːp/",
+      "meaning": "to look at something quickly and secretly; nhìn trộm",
+      "example": "She tried to peep through the door into the garden.",
+      "count": 0
     },
     {
-    "word": "peer (v) /pɪə(r)/",
-    "meaning": "to look very carefully, especially because something is difficult to see; nhìn săm soi",
-    "example": "She was peering at the screen trying to read the small print.",
-    "count": 0
+      "word": "peer (v) /pɪə(r)/",
+      "meaning": "to look very carefully, especially because something is difficult to see; nhìn săm soi",
+      "example": "She was peering at the screen trying to read the small print.",
+      "count": 0
     },
     {
-    "word": "populated (adj) /ˈpɒpjʊleɪtɪd/",
-    "meaning": "a populated area has people living there; đông dân",
-    "example": "Luckily, the fire didn’t spread to populated areas.",
-    "count": 0
+      "word": "populated (adj) /ˈpɒpjʊleɪtɪd/",
+      "meaning": "a populated area has people living there; đông dân",
+      "example": "Luckily, the fire didn’t spread to populated areas.",
+      "count": 0
     },
     {
-    "word": "skyline (n) /ˈskaɪlaɪn/",
-    "meaning": "the shapes made by buildings or mountains against the sky; hình dáng in lên nền trời",
-    "example": "I love the London skyline.",
-    "count": 0
+      "word": "skyline (n) /ˈskaɪlaɪn/",
+      "meaning": "the shapes made by buildings or mountains against the sky; hình dáng in lên nền trời",
+      "example": "I love the London skyline.",
+      "count": 0
     },
     {
-    "word": "skyscraper (n) /ˈskaɪskreɪpə(r)/",
-    "meaning": "a very tall building containing offices or flats; tòa nhà chọc trời",
-    "example": "Skyscrapers started to appear in the 1930s.",
-    "count": 0
+      "word": "skyscraper (n) /ˈskaɪskreɪpə(r)/",
+      "meaning": "a very tall building containing offices or flats; tòa nhà chọc trời",
+      "example": "Skyscrapers started to appear in the 1930s.",
+      "count": 0
     },
     {
-    "word": "structure (n) /ˈstrʌktʃə(r)/",
-    "meaning": "something large such as a building or bridge built from different parts; cấu trúc",
-    "example": "The large structure outside town is going to be the new stadium.",
-    "count": 0
+      "word": "structure (n) /ˈstrʌktʃə(r)/",
+      "meaning": "something large such as a building or bridge built from different parts; cấu trúc",
+      "example": "The large structure outside town is going to be the new stadium.",
+      "count": 0
     },
     {
-    "word": "suburban (adj) /səˈbɜː(r)bən/",
-    "meaning": "relating to an area on the edge of a city; ngoại ô",
-    "example": "Many people would love to live in suburban areas but can’t afford it.",
-    "count": 0
+      "word": "suburban (adj) /səˈbɜː(r)bən/",
+      "meaning": "relating to an area on the edge of a city; ngoại ô",
+      "example": "Many people would love to live in suburban areas but can’t afford it.",
+      "count": 0
     },
     {
-    "word": "surroundings (n pl) /səˈraʊndɪŋz/",
-    "meaning": "all things present in a place that form the experience of being there; môi trường xung quanh",
-    "example": "I wish I lived in more pleasant surroundings.",
-    "count": 0
+      "word": "surroundings (n pl) /səˈraʊndɪŋz/",
+      "meaning": "all things present in a place that form the experience of being there; môi trường xung quanh",
+      "example": "I wish I lived in more pleasant surroundings.",
+      "count": 0
     },
     {
-    "word": "urban (adj) /ˈɜː(r)bən/",
-    "meaning": "relating to towns and cities; thành thị",
-    "example": "There needs to be more investment in urban areas.",
-    "count": 0
+      "word": "urban (adj) /ˈɜː(r)bən/",
+      "meaning": "relating to towns and cities; thành thị",
+      "example": "There needs to be more investment in urban areas.",
+      "count": 0
     },
     {
-    "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
-    "meaning": "to accept or admit that something exists or is true; công nhận, thừa nhận",
-    "example": "He never acknowledges his mistakes.",
-    "count": 0
+      "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
+      "meaning": "to accept or admit that something exists or is true; công nhận, thừa nhận",
+      "example": "He never acknowledges his mistakes.",
+      "count": 0
     },
     {
-    "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
-    "meaning": "to thank someone for something they have done; bày tỏ lòng biết ơn",
-    "example": "We gratefully acknowledge the contributions of everyone who helped us.",
-    "count": 0
+      "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
+      "meaning": "to thank someone for something they have done; bày tỏ lòng biết ơn",
+      "example": "We gratefully acknowledge the contributions of everyone who helped us.",
+      "count": 0
     },
     {
-    "word": "acknowledge (v) /ækˈnɒlɪdʒ/",
-    "meaning": "to show you have seen someone, for example by smiling; tỏ ra đã nhận ra",
-    "example": "They barely acknowledge each other in public.",
-    "count": 0
+      "word": "acknowledge (v) /ækˈnɒlɪdʒ/",
+      "meaning": "to show you have seen someone, for example by smiling; tỏ ra đã nhận ra",
+      "example": "They barely acknowledge each other in public.",
+      "count": 0
     },
     {
-    "word": "agonise (v) /ˈæɡənaɪz/",
-    "meaning": "to spend a long time worrying or being upset about something; chịu lo lắng, khổ sở",
-    "example": "For years I agonised over whether I could have helped my daughter.",
-    "count": 0
+      "word": "agonise (v) /ˈæɡənaɪz/",
+      "meaning": "to spend a long time worrying or being upset about something; chịu lo lắng, khổ sở",
+      "example": "For years I agonised over whether I could have helped my daughter.",
+      "count": 0
     },
     {
-    "word": "apathy (n) /ˈæpəθi/",
-    "meaning": "a feeling of having no interest or enthusiasm; sự lãnh đạm",
-    "example": "Few people voted in the election, presumably just because of apathy.",
-    "count": 0
+      "word": "apathy (n) /ˈæpəθi/",
+      "meaning": "a feeling of having no interest or enthusiasm; sự lãnh đạm",
+      "example": "Few people voted in the election, presumably just because of apathy.",
+      "count": 0
     },
     {
-    "word": "avoid (v) /əˈvɔɪd/",
-    "meaning": "to try to prevent something from happening; ngăn ngừa",
-    "example": "Try to avoid confrontation.",
-    "count": 0
+      "word": "avoid (v) /əˈvɔɪd/",
+      "meaning": "to try to prevent something from happening; ngăn ngừa",
+      "example": "Try to avoid confrontation.",
+      "count": 0
     },
     {
-    "word": "avoid (v) /əˈvɔɪd/",
-    "meaning": "to try not to go near someone or something; tránh xa",
-    "example": "We went early to avoid the crowds.",
-    "count": 0
+      "word": "avoid (v) /əˈvɔɪd/",
+      "meaning": "to try not to go near someone or something; tránh xa",
+      "example": "We went early to avoid the crowds.",
+      "count": 0
     },
     {
-    "word": "avoid (adj) /ədˈvaɪdəbl/",
-    "meaning": "to choose not to do something to achieve a better result; nên tránh",
-    "example": "When taking this medication it is advisable to avoid alcohol.",
-    "count": 0
+      "word": "avoid (adj) /ədˈvaɪdəbl/",
+      "meaning": "to choose not to do something to achieve a better result; nên tránh",
+      "example": "When taking this medication it is advisable to avoid alcohol.",
+      "count": 0
     },
     {
-    "word": "behaviour (n) /bɪˈheɪvjə(r)/",
-    "meaning": "the way that someone behaves; hành vi",
-    "example": "Anna was sick of her brother’s behaviour.",
-    "count": 0
+      "word": "behaviour (n) /bɪˈheɪvjə(r)/",
+      "meaning": "the way that someone behaves; hành vi",
+      "example": "Anna was sick of her brother’s behaviour.",
+      "count": 0
     },
     {
-    "word": "chuckle (n) /ˈtʃʌkl/",
-    "meaning": "a quiet laugh; nụ cười thầm",
-    "example": "There were a couple of chuckles from one member of the audience.",
-    "count": 0
+      "word": "chuckle (n) /ˈtʃʌkl/",
+      "meaning": "a quiet laugh; nụ cười thầm",
+      "example": "There were a couple of chuckles from one member of the audience.",
+      "count": 0
     },
     {
-    "word": "chuckle (v) /ˈtʃʌkl/",
-    "meaning": "to laugh quietly; cười thầm",
-    "example": "As she read her book, she chuckled softly.",
-    "count": 0
+      "word": "chuckle (v) /ˈtʃʌkl/",
+      "meaning": "to laugh quietly; cười thầm",
+      "example": "As she read her book, she chuckled softly.",
+      "count": 0
     },
     {
-    "word": "comfort (n) /ˈkʌmfət/",
-    "meaning": "a physically relaxed state, without any pain or unpleasant feelings; sự an nhiên",
-    "example": "The airline is keen to improve passenger comfort.",
-    "count": 0
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a physically relaxed state, without any pain or unpleasant feelings; sự an nhiên",
+      "example": "The airline is keen to improve passenger comfort.",
+      "count": 0
     },
     {
-    "word": "comfort (n) /ˈkʌmfət/",
-    "meaning": "a feeling of being less sad or worried about something than before; sự an ủi",
-    "example": "My mother was always there to offer comfort.",
-    "count": 0
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a feeling of being less sad or worried about something than before; sự an ủi",
+      "example": "My mother was always there to offer comfort.",
+      "count": 0
     },
     {
-    "word": "comfort (n) /ˈkʌmfət/",
-    "meaning": "a pleasant way of life in which you have everything you need; sung túc",
-    "example": "Now he can live in comfort for the rest of his life.",
-    "count": 0
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a pleasant way of life in which you have everything you need; sung túc",
+      "example": "Now he can live in comfort for the rest of his life.",
+      "count": 0
     },
     {
-    "word": "comfort (v) /ˈkʌmfət/",
-    "meaning": "to make someone feel less sad, worried or disappointed; an ủi",
-    "example": "He went upstairs to comfort the baby.",
-    "count": 0
+      "word": "comfort (v) /ˈkʌmfət/",
+      "meaning": "to make someone feel less sad, worried or disappointed; an ủi",
+      "example": "He went upstairs to comfort the baby.",
+      "count": 0
     },
     {
-    "word": "conduct (n) /kənˈdʌkt/",
-    "meaning": "the way someone behaves in relation to particular rules; cách đạo đức",
-    "example": "Two players were sent off for violent conduct.",
-    "count": 0
+      "word": "conduct (n) /kənˈdʌkt/",
+      "meaning": "the way someone behaves in relation to particular rules; cách đạo đức",
+      "example": "Two players were sent off for violent conduct.",
+      "count": 0
     },
     {
-    "word": "conduct (v) /kənˈdʌkt/",
-    "meaning": "to do something in an organised way; thực hiện",
-    "example": "The agreement doesn’t allow you to conduct business from your home.",
-    "count": 0
+      "word": "conduct (v) /kənˈdʌkt/",
+      "meaning": "to do something in an organised way; thực hiện",
+      "example": "The agreement doesn’t allow you to conduct business from your home.",
+      "count": 0
     },
     {
-    "word": "consequence (n) /ˈkɒnsɪkwəns/",
-    "meaning": "a result or effect of something; hậu quả",
-    "example": "She said exactly what she felt, without fear of the consequences.",
-    "count": 0
+      "word": "consequence (n) /ˈkɒnsɪkwəns/",
+      "meaning": "a result or effect of something; hậu quả",
+      "example": "She said exactly what she felt, without fear of the consequences.",
+      "count": 0
     },
     {
-    "word": "contentment (n) /kənˈtentmənt/",
-    "meaning": "the happiness you feel when you have everything you want; sự mãn nguyện",
-    "example": "He has found contentment and satisfaction in his work.",
-    "count": 0
+      "word": "contentment (n) /kənˈtentmənt/",
+      "meaning": "the happiness you feel when you have everything you want; sự mãn nguyện",
+      "example": "He has found contentment and satisfaction in his work.",
+      "count": 0
     },
     {
-    "word": "cross (adj) /krɒs/",
-    "meaning": "angry; bực mình, cáu",
-    "example": "The neighbours got cross every time we put our music on.",
-    "count": 0
+      "word": "cross (adj) /krɒs/",
+      "meaning": "angry; bực mình, cáu",
+      "example": "The neighbours got cross every time we put our music on.",
+      "count": 0
     },
     {
-    "word": "dignity (n) /ˈdɪgnəti/",
-    "meaning": "impressive behaviour of someone who controls their emotions; phẩm giá",
-    "example": "She faced all her problems with dignity.",
-    "count": 0
+      "word": "dignity (n) /ˈdɪgnəti/",
+      "meaning": "impressive behaviour of someone who controls their emotions; phẩm giá",
+      "example": "She faced all her problems with dignity.",
+      "count": 0
     },
     {
-    "word": "disgust (n) /dɪsˈɡʌst/",
-    "meaning": "a very strong feeling of not liking something; sự ghê tởm",
-    "example": "The idea of eating meat fills me with disgust.",
-    "count": 0
+      "word": "disgust (n) /dɪsˈɡʌst/",
+      "meaning": "a very strong feeling of not liking something; sự ghê tởm",
+      "example": "The idea of eating meat fills me with disgust.",
+      "count": 0
     },
     {
-    "word": "disgust (v) /dɪsˈɡʌst/",
-    "meaning": "to make someone angry and upset; làm ghê tởm",
-    "example": "Your whole attitude disgusts me.",
-    "count": 0
+      "word": "disgust (v) /dɪsˈɡʌst/",
+      "meaning": "to make someone angry and upset; làm ghê tởm",
+      "example": "Your whole attitude disgusts me.",
+      "count": 0
     },
     {
-    "word": "disillusioned (adj) /ˌdɪsɪˈluːʒənd/",
-    "meaning": "disappointed because something is not as good as you believed; vỡ mộng",
-    "example": "Voters are very disillusioned with the democratic process.",
-    "count": 0
+      "word": "disillusioned (adj) /ˌdɪsɪˈluːʒənd/",
+      "meaning": "disappointed because something is not as good as you believed; vỡ mộng",
+      "example": "Voters are very disillusioned with the democratic process.",
+      "count": 0
     },
     {
-    "word": "fed up (adj) /ˈfed ʌp/",
-    "meaning": "annoyed or bored with something you have accepted for too long; chán ghét",
-    "example": "I’m fed up with this job.",
-    "count": 0
+      "word": "fed up (adj) /ˈfed ʌp/",
+      "meaning": "annoyed or bored with something you have accepted for too long; chán ghét",
+      "example": "I’m fed up with this job.",
+      "count": 0
     },
     {
-    "word": "giggle (n) /ˈgɪgəl/",
-    "meaning": "a high laugh, especially a nervous or silly one; cười khúc khích",
-    "example": "The sound of giggles came from the girls’ room.",
-    "count": 0
+      "word": "giggle (n) /ˈgɪgəl/",
+      "meaning": "a high laugh, especially a nervous or silly one; cười khúc khích",
+      "example": "The sound of giggles came from the girls’ room.",
+      "count": 0
     },
     {
-    "word": "giggle (v) /ˈgɪgəl/",
-    "meaning": "to laugh in a nervous or silly way; cười khúc khích",
-    "example": "The children whispered and giggled all the way through the film.",
-    "count": 0
+      "word": "giggle (v) /ˈgɪgəl/",
+      "meaning": "to laugh in a nervous or silly way; cười khúc khích",
+      "example": "The children whispered and giggled all the way through the film.",
+      "count": 0
     },
     {
-    "word": "glance (n) /ɡlɑːns/",
-    "meaning": "a quick look at someone or something; cái liếc mắt",
-    "example": "She had a quick glance at the newspaper as she gulped down her coffee.",
-    "count": 0
+      "word": "glance (n) /ɡlɑːns/",
+      "meaning": "a quick look at someone or something; cái liếc mắt",
+      "example": "She had a quick glance at the newspaper as she gulped down her coffee.",
+      "count": 0
     },
     {
-    "word": "glance (v) /ɡlɑːns/",
-    "meaning": "to look somewhere quickly then look away; liếc",
-    "example": "He glanced over his shoulder nervously.",
-    "count": 0
+      "word": "glance (v) /ɡlɑːns/",
+      "meaning": "to look somewhere quickly then look away; liếc",
+      "example": "He glanced over his shoulder nervously.",
+      "count": 0
     },
     {
-    "word": "glimpse (n) /ɡlɪmps/",
-    "meaning": "an occasion when you see someone or something for a moment; cái nhìn thoáng qua",
-    "example": "The crowd were anxious for a glimpse of the President.",
-    "count": 0
+      "word": "glimpse (n) /ɡlɪmps/",
+      "meaning": "an occasion when you see someone or something for a moment; cái nhìn thoáng qua",
+      "example": "The crowd were anxious for a glimpse of the President.",
+      "count": 0
     },
     {
-    "word": "glimpse (v) /ɡlɪmps/",
-    "meaning": "to see someone or something for a moment or not completely; nhìn thoáng qua",
-    "example": "He glimpsed a short white-haired figure heading for the back gate.",
-    "count": 0
+      "word": "glimpse (v) /ɡlɪmps/",
+      "meaning": "to see someone or something for a moment or not completely; nhìn thoáng qua",
+      "example": "He glimpsed a short white-haired figure heading for the back gate.",
+      "count": 0
     },
     {
-    "word": "gloat (v) /ɡloʊt/",
-    "meaning": "to show you are happy and proud at someone else’s failure; hách dịch",
-    "example": "He was there to gloat over their defeat.",
-    "count": 0
+      "word": "gloat (v) /ɡloʊt/",
+      "meaning": "to show you are happy and proud at someone else’s failure; hách dịch",
+      "example": "He was there to gloat over their defeat.",
+      "count": 0
     },
     {
-    "word": "prevent (v) /prɪˈvent/",
-    "meaning": "to stop something from happening or stop someone from doing something; cản, ngăn",
-    "example": "Regular cleaning may help prevent infection.",
-    "count": 0
+      "word": "prevent (v) /prɪˈvent/",
+      "meaning": "to stop something from happening or stop someone from doing something; cản, ngăn",
+      "example": "Regular cleaning may help prevent infection.",
+      "count": 0
     },
     {
-    "word": "rejoice (v) /rɪˈdʒɔɪs/",
-    "meaning": "to feel very happy about something; vui mừng",
-    "example": "Montenegro seemed to rejoice in the humiliation of others.",
-    "count": 0
+      "word": "rejoice (v) /rɪˈdʒɔɪs/",
+      "meaning": "to feel very happy about something; vui mừng",
+      "example": "Montenegro seemed to rejoice in the humiliation of others.",
+      "count": 0
     },
     {
-    "word": "resent (v) /rɪˈzent/",
-    "meaning": "to experience anger or bitterness because you think you have been treated unfairly; bực tức",
-    "example": "The family resented all the attention their pets were getting.",
-    "count": 0
+      "word": "resent (v) /rɪˈzent/",
+      "meaning": "to experience anger or bitterness because you think you have been treated unfairly; bực tức",
+      "example": "The family resented all the attention their pets were getting.",
+      "count": 0
     },
     {
-    "word": "resolve (v) /rɪˈzɒlv/",
-    "meaning": "to formally decide; kiên quyết",
-    "example": "We’re resolved to win the contract.",
-    "count": 0
+      "word": "resolve (v) /rɪˈzɒlv/",
+      "meaning": "to formally decide; kiên quyết",
+      "example": "We’re resolved to win the contract.",
+      "count": 0
     },
     {
-    "word": "smirk (n) /smɜːk/",
-    "meaning": "an unpleasant way of smiling because something bad has happened to someone else; nụ cười nhếch mép",
-    "example": "Wipe that smirk off your face!",
-    "count": 0
+      "word": "smirk (n) /smɜːk/",
+      "meaning": "an unpleasant way of smiling because something bad has happened to someone else; nụ cười nhếch mép",
+      "example": "Wipe that smirk off your face!",
+      "count": 0
     },
     {
-    "word": "smirk (v) /smɜːk/",
-    "meaning": "to smile in an unpleasant way because something bad has happened to someone else; cười nhếch mép",
-    "example": "I know you’ve won, but there’s no need to smirk.",
-    "count": 0
+      "word": "smirk (v) /smɜːk/",
+      "meaning": "to smile in an unpleasant way because something bad has happened to someone else; cười nhếch mép",
+      "example": "I know you’ve won, but there’s no need to smirk.",
+      "count": 0
     },
     {
-    "word": "snap (v) /snæp/",
-    "meaning": "to suddenly lose control and speak or act angrily; nổi cáu",
-    "example": "‘What do you want now?’ he snapped angrily.",
-    "count": 0
+      "word": "snap (v) /snæp/",
+      "meaning": "to suddenly lose control and speak or act angrily; nổi cáu",
+      "example": "‘What do you want now?’ he snapped angrily.",
+      "count": 0
     },
     {
-    "word": "snap (v) /snæp/",
-    "meaning": "to speak to someone in a sudden angry way; quát tháo",
-    "example": "The governor’s tactics involved snapping at those who were too liberal.",
-    "count": 0
+      "word": "snap (v) /snæp/",
+      "meaning": "to speak to someone in a sudden angry way; quát tháo",
+      "example": "The governor’s tactics involved snapping at those who were too liberal.",
+      "count": 0
     },
     {
-    "word": "tactic (n) /ˈtæktɪk/",
-    "meaning": "a particular method or plan for achieving something; chiến thuật",
-    "example": "The governor’s tactics involved a mix of discipline and support.",
-    "count": 0
+      "word": "tactic (n) /ˈtæktɪk/",
+      "meaning": "a particular method or plan for achieving something; chiến thuật",
+      "example": "The governor’s tactics involved a mix of discipline and support.",
+      "count": 0
     },
     {
-    "word": "terror (n) /ˈterə(r)/",
-    "meaning": "a strong feeling of fear; sự kinh hoàng",
-    "example": "Thousands of residents fled in terror yesterday as the volcano erupted.",
-    "count": 0
+      "word": "terror (n) /ˈterə(r)/",
+      "meaning": "a strong feeling of fear; sự kinh hoàng",
+      "example": "Thousands of residents fled in terror yesterday as the volcano erupted.",
+      "count": 0
     },
     {
-    "word": "terror (n) /ˈterə(r)/",
-    "meaning": "violence used for making people very frightened in order to achieve political aims; sự khủng bố",
-    "example": "This is a deliberate campaign of terror.",
-    "count": 0
+      "word": "terror (n) /ˈterə(r)/",
+      "meaning": "violence used for making people very frightened in order to achieve political aims; sự khủng bố",
+      "example": "This is a deliberate campaign of terror.",
+      "count": 0
     },
     {
-    "word": "administer (v) /ədˈmɪnɪstə(r)/",
-    "meaning": "to give someone a drug or medical treatment; phát thuốc",
-    "example": "The drugs are administered intravenously.",
-    "count": 0
+      "word": "administer (v) /ədˈmɪnɪstə(r)/",
+      "meaning": "to give someone a drug or medical treatment; phát thuốc",
+      "example": "The drugs are administered intravenously.",
+      "count": 0
     },
     {
-    "word": "admit (v) /ədˈmɪt/",
-    "meaning": "to take someone into hospital for medical treatment; tiếp nhận vào viện",
-    "example": "After collapsing, she was rushed to hospital, where she was admitted.",
-    "count": 0
+      "word": "admit (v) /ədˈmɪt/",
+      "meaning": "to take someone into hospital for medical treatment; tiếp nhận vào viện",
+      "example": "After collapsing, she was rushed to hospital, where she was admitted.",
+      "count": 0
     },
     {
-    "word": "agony (n) /ˈæɡəni/",
-    "meaning": "great pain; cơn đau đớn",
-    "example": "William fell to the ground, writhing in agony.",
-    "count": 0
+      "word": "agony (n) /ˈæɡəni/",
+      "meaning": "great pain; cơn đau đớn",
+      "example": "William fell to the ground, writhing in agony.",
+      "count": 0
     },
     {
-    "word": "agony (n) /ˈæɡəni/",
-    "meaning": "a strong and unpleasant feeling, especially great worry or sadness; sự đau khổ",
-    "example": "Waiting for the results was agony.",
-    "count": 0
+      "word": "agony (n) /ˈæɡəni/",
+      "meaning": "a strong and unpleasant feeling, especially great worry or sadness; sự đau khổ",
+      "example": "Waiting for the results was agony.",
+      "count": 0
     },
     {
-    "word": "antidote (n) /ˈæntidəʊt/",
-    "meaning": "a substance that prevents a poison from having bad effects; thuốc giải độc",
-    "example": "It’s a snake bite. Quick — get the antidote!",
-    "count": 0
+      "word": "antidote (n) /ˈæntidəʊt/",
+      "meaning": "a substance that prevents a poison from having bad effects; thuốc giải độc",
+      "example": "It’s a snake bite. Quick — get the antidote!",
+      "count": 0
     },
     {
-    "word": "consultant (n) /kənˈsʌltənt/",
-    "meaning": "a senior doctor in a hospital who is an expert in a particular medical subject; bác sĩ tham vấn",
-    "example": "She’s a consultant cardiologist.",
-    "count": 0
+      "word": "consultant (n) /kənˈsʌltənt/",
+      "meaning": "a senior doctor in a hospital who is an expert in a particular medical subject; bác sĩ tham vấn",
+      "example": "She’s a consultant cardiologist.",
+      "count": 0
     }
   ],
-  "grammar": [    
+  "grammar": [
     {
-    "word": "Passives n Causations - The passive",
-    "meaning": "The passive is used when the doer is unknown, obvious, unimportant, or to create a formal tone. (Câu bị động dùng khi không rõ, không quan trọng hoặc không muốn nhắc tới chủ thể hành động)",
-    "example": "The car was stolen at approximately 1.30 am. / The XL500 was designed with young families in mind. / This type of submarine was developed during WWII. / We were surprised by the number of people trying to leave the city. / All passengers are required to present their ticket.",
-    "count": 0
+      "word": "Passives n Causations - The passive",
+      "meaning": "The passive is used when the doer is unknown, obvious, unimportant, or to create a formal tone. (Câu bị động dùng khi không rõ, không quan trọng hoặc không muốn nhắc tới chủ thể hành động)",
+      "example": "The car was stolen at approximately 1.30 am. / The XL500 was designed with young families in mind. / This type of submarine was developed during WWII. / We were surprised by the number of people trying to leave the city. / All passengers are required to present their ticket.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Impersonal passive",
-    "meaning": "Used to express general beliefs, expectations, or assumptions. Often starts with 'It is thought...', 'Tourism is expected to...', etc. (Dùng bị động vô danh để nói về suy nghĩ/quan điểm chung)",
-    "example": "Tourism is expected to become a major part of the country’s economy. / It is thought that the new railway will provide employment opportunities. / There are reported to have been a record number of accidents.",
-    "count": 0
+      "word": "Passives n Causations - Impersonal passive",
+      "meaning": "Used to express general beliefs, expectations, or assumptions. Often starts with 'It is thought...', 'Tourism is expected to...', etc. (Dùng bị động vô danh để nói về suy nghĩ/quan điểm chung)",
+      "example": "Tourism is expected to become a major part of the country’s economy. / It is thought that the new railway will provide employment opportunities. / There are reported to have been a record number of accidents.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Direct and indirect object",
-    "meaning": "Some verbs allow two objects (person + thing). In passive, either object can become subject. (Dùng bị động với câu có 2 tân ngữ — trực tiếp và gián tiếp)",
-    "example": "Michael gave the plane tickets to Jill. / Jill was given the plane tickets (by Michael). / The plane tickets were given to Jill (by Michael). / How to drive the train was explained to me.",
-    "count": 0
+      "word": "Passives n Causations - Direct and indirect object",
+      "meaning": "Some verbs allow two objects (person + thing). In passive, either object can become subject. (Dùng bị động với câu có 2 tân ngữ — trực tiếp và gián tiếp)",
+      "example": "Michael gave the plane tickets to Jill. / Jill was given the plane tickets (by Michael). / The plane tickets were given to Jill (by Michael). / How to drive the train was explained to me.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Avoiding the passive",
-    "meaning": "Used when passive is awkward or not natural in continuous/perfect tenses. We use prepositional phrases instead. (Tránh dùng bị động bằng cách dùng cụm giới từ phù hợp hơn)",
-    "example": "Preparations for the flight will be in progress as the President arrives. / At the end of this year, I will have been in training as a pilot for four years. / Vintage cars have been on display in the town centre. / The problem had been under consideration. / The railway station has been under construction for two years now.",
-    "count": 0
+      "word": "Passives n Causations - Avoiding the passive",
+      "meaning": "Used when passive is awkward or not natural in continuous/perfect tenses. We use prepositional phrases instead. (Tránh dùng bị động bằng cách dùng cụm giới từ phù hợp hơn)",
+      "example": "Preparations for the flight will be in progress as the President arrives. / At the end of this year, I will have been in training as a pilot for four years. / Vintage cars have been on display in the town centre. / The problem had been under consideration. / The railway station has been under construction for two years now.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Causative: get/have something done",
-    "meaning": "Used when someone arranges for someone else to do something for them. (Cấu trúc nhờ ai đó làm gì cho mình)",
-    "example": "Did you finally get your bike fixed? / I heard that Susie had her motorbike stolen. / I’d like those cars washed by this evening. / We’ll set off as soon as I’ve got the car fixed.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get/have something done",
+      "meaning": "Used when someone arranges for someone else to do something for them. (Cấu trúc nhờ ai đó làm gì cho mình)",
+      "example": "Did you finally get your bike fixed? / I heard that Susie had her motorbike stolen. / I’d like those cars washed by this evening. / We’ll set off as soon as I’ve got the car fixed.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Causative: get sb to do / have sb do",
-    "meaning": "Used to say someone persuades or arranges for someone else to do something. (Dùng khi khiến ai đó làm việc gì)",
-    "example": "Did you get Alex to drive you all the way to London? / I had my assistant book the tickets.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get sb to do / have sb do",
+      "meaning": "Used to say someone persuades or arranges for someone else to do something. (Dùng khi khiến ai đó làm việc gì)",
+      "example": "Did you get Alex to drive you all the way to London? / I had my assistant book the tickets.",
+      "count": 0
     },
     {
-    "word": "Passives n Causations - Causative: get/have sb doing",
-    "meaning": "Used to say someone starts someone else doing something. (Dùng khi khiến ai đó bắt đầu làm gì đó)",
-    "example": "Don’t worry. We’ll soon have your car running like new. / That film got me thinking about my childhood.",
-    "count": 0
-    },      
-    {
-    "word": "Passives n Causations - The passive",
-    "meaning": "The passive is used when the doer is unknown, obvious, unimportant, or to create a formal tone. (Câu bị động dùng khi không rõ, không quan trọng hoặc không muốn nhắc tới chủ thể hành động)",
-    "example": "The car was stolen at approximately 1.30 am. / The XL500 was designed with young families in mind. / This type of submarine was developed during WWII. / We were surprised by the number of people trying to leave the city. / All passengers are required to present their ticket.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Impersonal passive",
-    "meaning": "Used to express general beliefs, expectations, or assumptions. Often starts with 'It is thought...', 'Tourism is expected to...', etc. (Dùng bị động vô danh để nói về suy nghĩ/quan điểm chung)",
-    "example": "Tourism is expected to become a major part of the country’s economy. / It is thought that the new railway will provide employment opportunities. / There are reported to have been a record number of accidents.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Direct and indirect object",
-    "meaning": "Some verbs allow two objects (person + thing). In passive, either object can become subject. (Dùng bị động với câu có 2 tân ngữ — trực tiếp và gián tiếp)",
-    "example": "Michael gave the plane tickets to Jill. / Jill was given the plane tickets (by Michael). / The plane tickets were given to Jill (by Michael). / How to drive the train was explained to me.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Avoiding the passive",
-    "meaning": "Used when passive is awkward or not natural in continuous/perfect tenses. We use prepositional phrases instead. (Tránh dùng bị động bằng cách dùng cụm giới từ phù hợp hơn)",
-    "example": "Preparations for the flight will be in progress as the President arrives. / At the end of this year, I will have been in training as a pilot for four years. / Vintage cars have been on display in the town centre. / The problem had been under consideration. / The railway station has been under construction for two years now.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Causative: get/have something done",
-    "meaning": "Used when someone arranges for someone else to do something for them. (Cấu trúc nhờ ai đó làm gì cho mình)",
-    "example": "Did you finally get your bike fixed? / I heard that Susie had her motorbike stolen. / I’d like those cars washed by this evening. / We’ll set off as soon as I’ve got the car fixed.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Causative: get sb to do / have sb do",
-    "meaning": "Used to say someone persuades or arranges for someone else to do something. (Dùng khi khiến ai đó làm việc gì)",
-    "example": "Did you get Alex to drive you all the way to London? / I had my assistant book the tickets.",
-    "count": 0
-    },
-    {
-    "word": "Passives n Causations - Causative: get/have sb doing",
-    "meaning": "Used to say someone starts someone else doing something. (Dùng khi khiến ai đó bắt đầu làm gì đó)",
-    "example": "Don’t worry. We’ll soon have your car running like new. / That film got me thinking about my childhood.",
-    "count": 0
-    },      
-
-    {
-    "word": "Modals n semi-modals - Overview and structure",
-    "meaning": "Modals (will, would, can, could, may, might, shall, should, must) have only one form and are followed by bare infinitives. Semi-modals (need to, ought to, had better, have to) behave similarly but may vary in structure. (Tổng quan về động từ khiếm khuyết và bán khiếm khuyết, cấu trúc theo sau là động từ nguyên mẫu)",
-    "example": "Modals: could + do, be doing, have done, have been doing. / Passive: could + be done, have been done. / Semi-modals: need to, ought to, had better, have (got) to.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Criticising past behaviour",
-    "meaning": "Used to express disapproval of something that happened in the past. (Dùng để chỉ trích hành vi đã xảy ra trong quá khứ) Modals: should have, shouldn’t have, ought to have, oughtn’t to have.",
-    "example": "You shouldn’t have spoken to Mrs Todd like that.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Expressing annoyance at past behaviour",
-    "meaning": "Used to express irritation or frustration about something that happened. (Dùng để thể hiện sự khó chịu với hành vi trong quá khứ) Modals: could have, might have.",
-    "example": "You could/might have told me you were going to be late!",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Criticising general behaviour",
-    "meaning": "Used to describe repeated or habitual negative behaviour. (Chỉ trích hành vi lặp lại hoặc quen thuộc) Modal: will.",
-    "example": "He will slam the door every time he goes out.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Criticising a specific example of someone's general behaviour",
-    "meaning": "Used to highlight a particular instance of a known habit or behaviour. (Dùng để chỉ trích một ví dụ cụ thể về hành vi quen thuộc) Modal: would.",
-    "example": "You would take the car just when I wanted to go out.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Suggesting criticism with might as well",
-    "meaning": "Might as well can be used sarcastically to suggest someone doesn’t care. (Might as well có thể dùng mang hàm ý phê phán hoặc chua chát)",
-    "example": "I might as well be dead for all you care.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Current or general obligation",
-    "meaning": "Used to describe what is necessary or required in general. (Dùng để chỉ nghĩa vụ hoặc yêu cầu chung) Modals: must, mustn’t, have (got) to, need (to).",
-    "example": "You have to be a good communicator to be a press spokesperson.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Lack of current or general obligation",
-    "meaning": "Used to say something is not necessary or required. (Dùng để nói điều gì đó không bắt buộc) Modals: don’t have to, haven’t got to, needn’t, don’t need (to).",
-    "example": "You don’t always need to have a degree to become a journalist.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Future obligation",
-    "meaning": "Used to talk about something that must be done in the future. (Dùng để nói về nghĩa vụ trong tương lai) Modals: will have to, must, mustn’t, have (got) to, will need (to).",
-    "example": "You’ll have to do quite a lot of research before you write this report.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Lack of future obligation",
-    "meaning": "Used to talk about things that will not be necessary. (Dùng để nói về điều không bắt buộc trong tương lai) Modals: don’t/won’t have to, haven’t got to, needn’t, won’t need (to).",
-    "example": "I’m glad we won’t have to write any more essays on this course.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Past obligation",
-    "meaning": "Used to describe something that had to be done in the past. (Dùng để nói về nghĩa vụ trong quá khứ) Modals: had to, needed (to).",
-    "example": "We had to come up with three questions each.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Lack of past obligation",
-    "meaning": "Used to say that something wasn’t necessary in the past. (Dùng để nói rằng điều gì đó đã không bắt buộc trong quá khứ) Modals: didn’t have to, didn’t need (to), needn’t have.",
-    "example": "In the past, politicians didn’t have to deal with being in a 24-hour media spotlight.",
-    "count": 0
-    },            
-    {
-    "word": "Modals n semi-modals - Ability",
-    "meaning": "Modals like can, could, be able to express current, past, future, or hypothetical ability. (Dùng để diễn tả khả năng hiện tại, quá khứ, tương lai hoặc giả định)",
-    "example": "You can’t really speak seven languages fluently, can you? / There’s no way you could read when you were two! / One day, maybe, all adults will be able to read and write. / I couldn’t go on a quiz show – I’d be too nervous. / They could have asked the Prime Minister much more searching questions.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Permission",
-    "meaning": "Modals such as can, could, may, might are used to ask for or give/refuse permission. (Dùng để xin hoặc cho phép làm điều gì đó)",
-    "example": "Can I finish watching this before I go to bed? / No, you can’t. / Mum said we could buy one comic each. / We were allowed to buy one comic each.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Advice",
-    "meaning": "Modals like should, ought to, had better are used to give advice or make suggestions. (Dùng để đưa ra lời khuyên hoặc gợi ý)",
-    "example": "You should try to get that poem published. / Hadn’t you better check these facts are actually true? / We may as well watch this as there’s nothing else on.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Criticism",
-    "meaning": "Modals are used to criticize past actions or express annoyance. (Dùng để chỉ trích hành động trong quá khứ hoặc thể hiện sự khó chịu)",
-    "example": "You shouldn’t have spoken to Mrs Todd like that. / You could/might have told me you were going to be late! / He will slam the door every time he goes out. / You would take the car just when I wanted to go out. / I might as well be dead for all you care.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Obligation",
-    "meaning": "Modals such as must, have to, need to are used to express present, future or past obligation. (Dùng để nói về nghĩa vụ ở hiện tại, tương lai hoặc quá khứ)",
-    "example": "You have to be a good communicator. / You don’t always need to have a degree. / You’ll have to do quite a lot of research. / I’m glad we won’t have to write essays. / We had to come up with three questions each. / In the past, politicians didn’t have to deal with 24-hour media.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Certainty about now, the future or generally",
-    "meaning": "Used to express strong certainty or near-certainty about something now or in the future. (Dùng để diễn tả điều gần như chắc chắn ở hiện tại hoặc tương lai) Modals: will, would, must, can, can’t, could, couldn’t.",
-    "example": "There’s someone at the door. / That’ll be the postman. / It can’t be. He’s already been.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Certainty about the past",
-    "meaning": "Used to express strong certainty or deduction about a past event. (Dùng để suy luận chắc chắn điều gì đã xảy ra trong quá khứ) Modals: will have, won’t have, would have, wouldn’t have, must have, can’t have, couldn’t have.",
-    "example": "They won’t have heard the news, will they? / They must have heard by now, surely.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Probability about now, the future or generally",
-    "meaning": "Used to express something likely to happen or probably true now or in the future. (Dùng để nói điều có khả năng xảy ra hoặc đúng ở hiện tại/tương lai) Modals: should, shouldn’t, ought to, may/might well, could well, might easily.",
-    "example": "The weather should be good tomorrow, shouldn’t it? / Actually, the forecast said it may well rain.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Probability about the past",
-    "meaning": "Used to say what was probably true or likely in the past. (Dùng để diễn tả điều có lẽ đúng trong quá khứ) Modals: should have, shouldn’t have, ought to have, oughtn’t to have, may/might well have, might easily have.",
-    "example": "Jan should have finished writing her article by now, shouldn’t she? / She may well have done, but I haven’t seen it yet.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Possibility about now, the future or generally",
-    "meaning": "Used to express a possible situation in the present or future. (Dùng để nói về một khả năng có thể xảy ra ở hiện tại hoặc tương lai) Modals: could, may, might, may/might/could just.",
-    "example": "I might (just) have time to get to the library before it closes.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Possibility about the real past",
-    "meaning": "Used to express a real past possibility that might or might not have happened. (Dùng để nói về khả năng thực tế trong quá khứ) Modals: could have, may have, might have.",
-    "example": "Jim might not have checked his email yet.",
-    "count": 0
-    },
-    {
-    "word": "Modals n semi-modals - Overview and structure",
-    "meaning": "Modals (will, would, can, could, may, might, shall, should, must) have only one form and are followed by bare infinitives. Semi-modals (need to, ought to, had better, have to) behave similarly but may vary in structure. (Tổng quan về động từ khiếm khuyết và bán khiếm khuyết, cấu trúc theo sau là động từ nguyên mẫu)",
-    "example": "Modals: could + do, be doing, have done, have been doing. / Passive: could + be done, have been done. / Semi-modals: need to, ought to, had better, have (got) to.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Position of adjectives",
-    "meaning": "Adjectives usually appear before a noun, or after verbs such as appear, become, feel, get, grow, look, seem, smell, sound, taste, and turn. (Tính từ thường đứng trước danh từ hoặc sau một số động từ chỉ trạng thái)",
-    "example": "I love your new house. / The material this dress is made out of feels rough. / She looked angrily at the man behind the counter.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Position of multiple adjectives",
-    "meaning": "When more than one adjective is used before a noun, they appear in the order: opinion, size, age, shape, colour, origin, material, purpose. (Thứ tự tính từ khi có nhiều tính từ đi trước danh từ)",
-    "example": "We've got a lovely little wooden cabin in the mountains. / You love your long, red, Chinese, silk curtains. / What you need for your living room is a large oak dining table.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Adjectives used as nouns",
-    "meaning": "Adjectives can function as nouns to refer to social groups, specific groups, or nationalities. (Tính từ có thể dùng như danh từ để chỉ nhóm người hoặc quốc tịch)",
-    "example": "We need to provide better housing for the poor. / When the building collapsed, the injured were rushed to hospital. / The French have introduced new housing regulations in Paris.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Position of adverbs",
-    "meaning": "Adverbs can appear at the beginning, middle, or end of a clause. Their position varies by type. (Trạng từ có thể đứng đầu, giữa hoặc cuối mệnh đề tùy loại)",
-    "example": "They built the house very quickly. / Our house will probably have been decorated by the time you get there. / I'm rarely in the city centre. / I rarely go to the city centre. / We bought it as an investment; then, all the property prices in the area fell.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Comparisons",
-    "meaning": "Comparatives and superlatives are used to compare people or things. (Dùng để so sánh các người hoặc vật)",
-    "example": "Your flat is much bigger and more comfortable than ours. / Mexico City is probably my least favourite city. / I think my home town is the best place in the world.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Comparative and superlative modifiers",
-    "meaning": "Modifiers such as quite, far, much, easily, etc., can strengthen comparatives and superlatives. (Các từ bổ nghĩa dùng để nhấn mạnh tính từ so sánh)",
-    "example": "This area has become considerably more crowded and far noisier in the last ten years. / If you ask me, Ladybridge is easily the nicest area of town to live in.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Structures used to make comparisons",
-    "meaning": "We can use structures like 'as ... as', 'not nearly as ... as', 'the ... the ...', etc. to express comparisons. (Các cấu trúc so sánh phức như the more ... the more ... hoặc not nearly as ...)",
-    "example": "Platinum is about twice as expensive as gold. / Iron is not nearly as hard as diamond. / Iron is nothing like as hard as diamond. / The taller the building, the greater the fire risk.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Gradable and ungradable adjectives",
-    "meaning": "Gradable adjectives can vary in degree and take modifiers like 'very'; ungradable adjectives express extremes and take words like 'absolutely'. (Tính từ chia làm loại có mức độ và loại tuyệt đối)",
-    "example": "Pete was a bit tired after working on the building site all day, but it wasn’t too bad. / After working on the building site all day, Tim was absolutely exhausted. / The balconies are quite splendid.",
-    "count": 0
-    },
-    {
-    "word": "Adjectives n Adverbs - Confusing cases",
-    "meaning": "Some words have forms that look like both adjectives and adverbs (e.g., fast, hard, late), or take -ly with different meanings. (Một số từ có thể là cả tính từ và trạng từ, đôi khi nghĩa khác nhau)",
-    "example": "Sandstone is not a very hard material. ✓ Hit it too hard and you’ll break it. ✗ Hit-it-too-hardly-and-you’ll-break-it. / I could hardly hear the music. / She looked at me in a very friendly way.",
-    "count": 0
-    },      
-    {
-    "word": "Clauses - Relative pronouns in relative clauses",
-    "meaning": "Relative pronouns are used to link a relative clause to a noun. (Đại từ quan hệ dùng để nối mệnh đề quan hệ với danh từ chính) Includes: who, which, whom, that, when, where, why, whose, what.",
-    "example": "There are a lot of people who hate having injections. / This is the prescription which the doctor gave me. / That’s the consultant with whom I spoke. / This is the prescription that the doctor gave me. / I’ll never forget the day when I broke my finger. / Harley Street, where she was born, is famous for its clinics. / That’s the reason why I wanted to become a vet. / There are several kids in my class whose parents are doctors. / What I don’t understand is why she didn’t take her pills.",
-    "count": 0
-    },      
-    {
-    "word": "Clauses - Defining and non-defining relative clauses",
-    "meaning": "Defining clauses identify which person/thing is meant; non-defining add extra information. (Mệnh đề quan hệ xác định và không xác định)",
-    "example": "Defining: The doctor who did Karen’s operation. / I’ll never forget the day when I broke my arm. Non-defining: Dr Lake, who has been working here for over ten years, is a very experienced surgeon. / Harley Street, where she was born, is famous for its clinics.",
-    "count": 0
-    },
-    {
-    "word": "Clauses - Participle clauses",
-    "meaning": "Used to replace relative clauses or add information using -ing, past participle, or having + V3. (Mệnh đề rút gọn dùng phân từ hiện tại/quá khứ)",
-    "example": "After giving blood, I went home. / Being frightened of needles, Tony was not looking forward to the injection. / Given the chance, I’d definitely study pharmacology.",
-    "count": 0
-    },
-    {
-    "word": "Clauses - Infinitive clauses",
-    "meaning": "Infinitive clauses can express purpose or follow certain verbs like 'be'. (Mệnh đề với động từ nguyên mẫu dùng để thể hiện mục đích hoặc theo sau một số động từ nhất định)",
-    "example": "To be a successful surgeon is the dream of many young children. / My job was to give the patients their lunch.",
-    "count": 0
-    },
-    {
-    "word": "Clauses - Concession clauses",
-    "meaning": "Concession clauses express contrast or unexpected results. (Mệnh đề nhượng bộ dùng để diễn tả sự trái ngược hoặc bất ngờ) Common phrases: although, even though, in spite of, despite, while, however, much as, etc.",
-    "example": "Even though she’d put on sun cream, Tamsin got burnt. / In spite of the fact that she put on sun cream, Tamsin still got burnt. / However hard he tried, he couldn’t put up with the pain.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Time",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: in an hour, in a second; Definite article: in the 1840s, in the winter, in the afternoon; Zero article: in 2010, in winter, in December, on Tuesday, at night",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For People and Work",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: have a job, work as a teacher, I met a very nice American last night; Definite article: the King, the Principal, the President, the British; Zero article: Russians, become President, go to work, be at work, have work to do",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Places",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: Is there a beach near here?; Definite article: the Himalayas, the Pacific Ocean, the Seine, the Earth, the Antarctic, the USA, the UK, the Scilly Isles; Zero article: Mount Everest, Berlin, America, Antarctica, Jupiter, Fleet Street, Lake Michigan, Mykonos",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Public Buildings",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: Is there a bank near here?; Definite article: the bank, the post office, go to the hospital/prison/school (as a visitor); Zero article: go to school/hospital/prison (as a student/patient/prisoner)",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Entertainment and Sport",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: Play us a song!, I’ve got a tennis ball; Definite article: play the guitar, the media, on the radio, go to the cinema, watch the TV; Zero article: play tennis, play guitar, listen to music, on television, watch TV",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Organisations",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: Does Switzerland have an army?; Definite article: the BBC, the police, the emergency services, the United Nations; Zero article: NATO",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Education",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: have a lesson, take an exam; Definite article: be in the first year; Zero article: geography, be in class/year/form 5",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Travel",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: take a taxi, catch a bus/train; Definite article: in the car/taxi, on the bus/plane; Zero article: on foot, go home, go by car/plane",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Articles by category and set phrases (usage) - For Health",
-    "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
-    "example": "Indefinite article: have a cold/cough/headache/toothache/stomach ache; Definite article: have the flu/measles; Zero article: have flu/measles/toothache/stomach ache",
-    "count": 0
-    },      
-    {
-    "word": "Noun phrase - Countable nouns (structure)",
-    "meaning": "Countable nouns have both singular and plural forms, and can be used with a/an or numbers. (Danh từ đếm được có dạng số ít và số nhiều, dùng với a/an hoặc số đếm) Examples: painting, paintings, idea, books. Some have irregular plurals (e.g. people, mice, men).",
-    "example": "That painting is amazing. / Those paintings are dreadful. / The sheep are in the field. / The government is/are not doing anything to help the arts.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Singular uncountable nouns (structure)",
-    "meaning": "These nouns only have a singular form and take singular verbs. (Danh từ không đếm được chỉ có dạng số ít và đi với động từ số ít) Includes: advice, blood, bread, furniture, hair, information, jewellery, knowledge, luggage, money, news, permission, respect, water.",
-    "example": "Is the information reliable? / The table is made of wood. / It's a picture of a local wood.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Plural uncountable nouns (structure)",
-    "meaning": "These uncountable nouns have a plural form and take plural verbs. (Một số danh từ không đếm được có dạng số nhiều và đi với động từ số nhiều) Includes: arms, binoculars, clothes, congratulations, earnings, glasses, goods, groceries, jeans, pajamas, scales, surroundings, scissors, trousers, etc.",
-    "example": "The scissors aren't on the table. / A pair of binoculars is on the desk.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Quantifiers for countable and uncountable nouns (usage)",
-    "meaning": "Some quantifiers are used only with countable nouns, others with uncountable, and some with both. (Một số từ chỉ định lượng chỉ dùng với danh từ đếm được, không đếm được, hoặc cả hai)",
-    "example": "A few friends (countable) / A little milk (uncountable) / A lot of people (all nouns) / Only a few of them came. / Only a little of it was useful.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Indefinite articles: a/an (usage)",
-    "meaning": "Used with singular countable nouns to refer to something not specific or mentioned for the first time. (Dùng với danh từ đếm được số ít, để nói về một vật chưa xác định hoặc mới nhắc đến lần đầu)",
-    "example": "I'd like to go to a concert tonight. / I've had a great idea! / A poet sees the world differently.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Definite article: the (usage)",
-    "meaning": "Used to refer to specific things or when both speaker and listener know what is being talked about. (Dùng để nói về điều đã biết hoặc xác định được)",
-    "example": "Is that the band you were talking about? / The scales are balanced to symbolise equality. / The young often rebel against the old.",
-    "count": 0
-    },
-    {
-    "word": "Noun phrase - Zero article: no article at all (usage)",
-    "meaning": "Used with plural or uncountable nouns when talking generally or in idiomatic expressions. (Không dùng mạo từ khi nói chung hoặc trong các cụm thành ngữ)",
-    "example": "Don't let your young child use scissors unsupervised. / An artist always needs inspiration.",
-    "count": 0
-    },
-
-    {
-    "word": "Verbal complements - Verb + -ing form (structure)",
-    "meaning": "Certain verbs are followed by the -ing form. (Một số động từ đi với dạng V-ing) Verbs include: admit, adore, advocate, appreciate, avoid, can't help, carry on, compare, consider, contemplate, delay, deny, detest, discuss, dislike, endure, enjoy, escape, face, fancy, feel like, finish, foresee, give up, include, involve, justify, keep (on), mention, mind, miss, postpone, practise, put off, recommend, resent, resist, risk, suggest, take up.",
-    "example": "Sue admitted feeling rather upset. / Damien insisted on going to the party. / I'm looking forward to meeting your brother.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb + object + -ing form (structure)",
-    "meaning": "Some verbs take an object followed by an -ing form. (Một số động từ đi với tân ngữ + V-ing) Verbs include: catch, find, glimpse, hear, notice, observe, overhear, see, smell, watch.",
-    "example": "They caught him taking money from the till.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb + full infinitive (structure)",
-    "meaning": "Many verbs are followed by the full infinitive (to + V). (Nhiều động từ đi với to + V nguyên mẫu) Verbs include: afford, agree, aim, appear, apply, arrange, aspire, attempt, beg, cease, choose, claim, come, dare, decide, demand, deserve, desire, expect, fail, happen, help, hesitate, hope, learn, manage, need, neglect, offer, plan, prepare, pretend, promise, refuse, resolve, rush, seek, seem, strive, tend, undertake, volunteer, vote, wait, want, wish, would like, yearn.",
-    "example": "Can you afford to buy that car? / I hope to pass the exam. / They promised to call later.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb + object + full infinitive (structure)",
-    "meaning": "Some verbs require both an object and a full infinitive. (Một số động từ cần cả tân ngữ và to + V) Verbs include: advise, allow, ask, assist, authorise, beg, cause, challenge, choose, command, compel, convince, dare, decide, defy, desire, employ, enable, empower, encourage, expect, force, free, help, hire, inspire, instruct, intend, invite, lead, motivate, move, need, nominate, order, permit, persuade, pick, prepare, prompt, qualify, raise, recommend, recruit, request, require, select, send, signal, teach, tell, tempt, trust, want, warn.",
-    "example": "My sister advised me to tell Jim the truth.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb + object + bare infinitive (structure)",
-    "meaning": "Verbs like let, make, help are followed by object + bare infinitive (V without to). (Một số động từ theo sau là tân ngữ + V không 'to') Verbs include: help, let, make, feel, hear, notice, overhear, see, watch.",
-    "example": "The teacher let the class leave early.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb (+ object) + infinitive or -ing form with little or no change in meaning (structure)",
-    "meaning": "Some verbs can be followed by either an infinitive or -ing form without significant change in meaning. (Một số động từ đi với to V hoặc V-ing mà không thay đổi nghĩa nhiều) Verbs include: begin, bother, can't bear/stand, continue, hate, intend, like, love, prefer, start.",
-    "example": "I love to read. / I love reading. / They continued to work. / They continued working.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Verb (+ object) + infinitive or -ing form with a change in meaning (structure)",
-    "meaning": "Some verbs change meaning depending on whether they are followed by an infinitive or -ing. (Một số động từ thay đổi nghĩa tùy thuộc vào to V hay V-ing theo sau) Verbs include: consider, forget, go on, hear, imagine, like, mean, regret, remember, see, stop, try.",
-    "example": "I forgot to ask Brian. / I’ll never forget asking Helen. / I stopped to think. / Please stop telling me what to do. / Try to not forget her birthday. / You could try buying her some flowers.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Preparatory it (structure)",
-    "meaning": "Some verbs like find, think, and consider can use 'it' as preparatory subject. (Dùng 'it' như chủ ngữ giả với các động từ như find, think, consider) Common verbs: find, think, consider, make, believe, feel.",
-    "example": "I consider it incredible that James and Alice are still together.",
-    "count": 0
-    },
-    {
-    "word": "Verbal complements - Subjunctive (structure)",
-    "meaning": "Used in that-clauses after verbs suggesting necessity or importance; uses base form of verb (no -s in 3rd person). (Câu giả định dùng để diễn tả điều cần thiết, quan trọng hoặc mong muốn, dùng động từ nguyên mẫu) Typical verbs: suggest, recommend, insist, demand, ask, require, propose, important that..., essential that..., vital that..., necessary that....",
-    "example": "The doctor suggested that Sam take some time off work. / It’s very important that Greg not know about this. / It’s absolutely essential that I be informed.",
-    "count": 0
-    },      
-    {
-    "word": "Unreal time - conditional (n) /kənˈdɪʃənəl/",
-    "meaning": "a sentence that expresses a condition and its result, often used for hypothetical or unlikely situations. (câu điều kiện)",
-    "example": "If I had known, I would have taken some dollars with me.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - imagine (v) /ɪˈmædʒɪn/",
-    "meaning": "to think about something that is not real or is unlikely to happen. (tưởng tượng)",
-    "example": "Suppose you were given ten million euros, what would you spend it on?",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - suppose (v) /səˈpəʊz/",
-    "meaning": "to assume something is true for the purpose of argument or explanation. (giả sử)",
-    "example": "Suppose you had won the lottery last night. What would you have done?",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - as if (phrase)",
-    "meaning": "used to describe a situation that is not true or real. (như thể là)",
-    "example": "She acts as if she were a millionaire.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - as though (phrase)",
-    "meaning": "used in the same way as 'as if', to make unreal comparisons. (như thể là)",
-    "example": "Tony looks as if someone had just handed him a million euros.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - Questions and requests (phrase)",
-    "meaning": "Used to make requests and questions sound more polite. (Cách nói lịch sự hơn khi yêu cầu hoặc đặt câu hỏi)",
-    "example": "I was wondering whether you might be able to give me some advice.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - It’s (high/about) time (phrase)",
-    "meaning": "Used to suggest that something should be done now or in the immediate future. (Đã đến lúc làm điều gì đó)",
-    "example": "It’s (high/about) time we were leaving.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - Would rather/sooner (phrase)",
-    "meaning": "Used to express current, general or future preference, or past preference. (Diễn tả sự ưu tiên, mong muốn)",
-    "example": "We’d rather/sooner you hadn’t lent Kurdip the money.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - Wish / if only (phrase)",
-    "meaning": "Used to express regrets or unreal desires about present or past situations. (Ước hoặc tiếc nuối về điều không có thật ở hiện tại hoặc quá khứ)",
-    "example": "If only I was earning a reasonable salary.",
-    "count": 0
-    },
-    {
-    "word": "Unreal time - Other structures with wish / if only (phrase)",
-    "meaning": "Structures used to express criticism, inability, formal desires, or to wish someone success. (Các cấu trúc dùng với wish để phê phán, thể hiện ước muốn hoặc chúc ai đó)",
-    "example": "I wish I could find a job that pays well.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Tense changes (phrase)",
-    "meaning": "When the reporting verb is in the past, we usually shift the original tense back. (Khi động từ tường thuật ở thì quá khứ, thì của câu gốc thường bị lùi lại một thì)",
-    "example": "Sam doesn’t play hockey → Fiona said that Sam didn’t play hockey.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Modal and semi-modal changes (phrase)",
-    "meaning": "When reporting speech with modals, some modal verbs change form. (Một số động từ khuyết thiếu thay đổi trong câu tường thuật)",
-    "example": "'I could swim,' she said → She said she could swim.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Modal and semi-modal change table (reference)",
-    "meaning": "Detailed list of modal/semi-modal verb changes in reported speech. (Danh sách các động từ khuyết thiếu thay đổi trong câu tường thuật)",
-    "example": "will/shall → would; can → could; must → had to / be to / should; have to → had to; don’t/doesn’t have to → didn’t have to; mustn’t → mustn’t / were not to / shouldn’t; may → might; am/is/are going to → was/were going to. Example 1: 'I will call you,' she said. → She said she would call me. Example 2: 'You must finish the work,' he said. → He said I had to finish the work.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Must and mustn’t changes (phrase)",
-    "meaning": "‘Must’ becomes ‘had to’, ‘were to’, or ‘should’ when expressing obligation. ‘Mustn’t’ becomes ‘mustn’t’, ‘were not to’, or ‘shouldn’t’. (Must → had to / should; Mustn’t → mustn’t / shouldn’t)",
-    "example": "‘You mustn’t cheat,’ said the coach. → We were told that we mustn’t / were not to / shouldn’t cheat.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Pronoun and determiner changes (phrase)",
-    "meaning": "Pronouns and determiners often change to reflect the new speaker or perspective. (Đại từ và từ xác định thường thay đổi để phản ánh người nói mới)",
-    "example": "It’s my turn. → Eddie pointed out that it was his turn.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Time and place changes (phrase)",
-    "meaning": "Time/place words are often shifted back in reported speech. (Các từ chỉ thời gian/địa điểm thường bị lùi lại)",
-    "example": "We’ll meet here tomorrow. → He said they would meet there the next day.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Reported questions (phrase)",
-    "meaning": "Questions lose question marks and follow normal word order. (Câu hỏi gián tiếp không dùng dấu hỏi và theo trật tự câu khẳng định)",
-    "example": "‘What time did the match start?’ → Jimmy asked what time the match had started.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Reported commands and requests (phrase)",
-    "meaning": "Commands use tell/order/ask + to-infinitive in reported speech. (Mệnh lệnh và yêu cầu dùng tell/order/ask + to V trong câu tường thuật)",
-    "example": "Put the cricket bats away! → Alex told me to put the cricket bats away.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Reporting verbs (phrase)",
-    "meaning": "Different reporting verbs follow different grammatical patterns. (Các động từ tường thuật khác nhau đi với các cấu trúc ngữ pháp khác nhau)",
-    "example": "Verbs include: accuse, admit, advise, agree, deny, explain, insist, suggest, tell, warn.",
-    "count": 0
-    },
-    {
-    "word": "Reporting - Modal and semi-modal change table (reference)",
-    "meaning": "Detailed list of modal/semi-modal verb changes in reported speech. (Danh sách các động từ khuyết thiếu thay đổi trong câu tường thuật)",
-    "example": "will/shall → would; can → could; must → had to / be to / should; have to → had to; don’t/doesn’t have to → didn’t have to; mustn’t → mustn’t / were not to / shouldn’t; may → might; am/is/are going to → was/were going to. Example 1: 'I will call you,' she said. → She said she would call me. Example 2: 'You must finish the work,' he said. → He said I had to finish the work.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Cleft sentences (structure)",
-    "meaning": "Used to emphasize a particular part of a sentence by placing it at the beginning. (Dùng để nhấn mạnh một phần nào đó trong câu)",
-    "example": "All that Keith wanted was to get his money back. / The person who stole the money was Thomas. / The day when this government came to power was 2006.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - It is/was ... who/which/that (structure)",
-    "meaning": "Used for emphasizing a person or thing responsible for an action. (Nhấn mạnh người hoặc vật thực hiện hành động)",
-    "example": "It was Carol who called the police. / It was the year in which this government came to power. / It was me that stole the money.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - So / Such / Too / Enough (adverbial structure)",
-    "meaning": "Used to express degree or intensity, often followed by a result clause. (Dùng để diễn tả mức độ và kết quả)",
-    "example": "There is so much crime around here that I’m thinking of moving. / It was such a terrible crime that the judge sentenced him to life in prison. / The police didn’t respond quickly enough to catch the burglar.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - So (adverb)",
-    "meaning": "Used to express intensity and result. (Dùng để nhấn mạnh mức độ dẫn đến kết quả)",
-    "example": "It all happened so quickly that I didn’t have time to see the man’s face. / This problem has gone on for so long that I don’t think they’ll ever find a solution.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Such (determiner)",
-    "meaning": "Used before nouns to emphasize extreme characteristics. (Dùng trước danh từ để nhấn mạnh)",
-    "example": "It was such a terrible crime that the judge sentenced him to life in prison. / There is such a lot of crime around here that I’m thinking of moving.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Too (adverb)",
-    "meaning": "Used to indicate more than what is wanted or needed. (Dùng để chỉ mức độ vượt quá)",
-    "example": "I had too little time to get a good look at his face. / The police responded too slowly to have any chance of catching the burglar.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Enough (adverb/determiner)",
-    "meaning": "Used to show a sufficient degree or amount. (Dùng để chỉ mức độ hoặc số lượng đủ)",
-    "example": "There just aren’t enough police officers on the streets. / The police weren’t quick enough to catch the burglar.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Inversions with negative adverbials (structure)",
-    "meaning": "Used for emphasis, these begin with negative adverbs and require subject-verb inversion. (Cấu trúc đảo ngữ với trạng từ phủ định để nhấn mạnh)",
-    "example": "Hardly had the new law been introduced when the mistake was realised. / Barely had we solved one problem when another one arose. / Never had I heard such a ridiculous suggestion.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Not until / Only when / Only after (inversion)",
-    "meaning": "Inversion is used after time clauses with ‘not until’, ‘only when’, or ‘only after’. (Dùng đảo ngữ sau các cụm thời gian để nhấn mạnh)",
-    "example": "Not until the next election will we know how the public feel about this news. / Only when we agree what measures are needed will we be able to solve the problem.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Inversions with place expressions (+ verb of movement) (structure)",
-    "meaning": "Used when place expressions begin the sentence, followed by inversion. (Đảo ngữ khi câu bắt đầu bằng cụm chỉ nơi chốn và động từ di chuyển)",
-    "example": "Here comes the Minister now. / At the top of society are the aristocracy. / Running down the road was a young man with a woman’s handbag under his arm.",
-    "count": 0
-    },
-    {
-    "word": "Complex sentence - Other inversions (structure)",
-    "meaning": "Used in short answers and with phrases like ‘neither/nor’, ‘so’, ‘such’, etc. (Các kiểu đảo ngữ khác với so/such/neither/nor)",
-    "example": "‘Did you?’ – So did I. / ‘I don’t believe a word this government says.’ – ‘No, neither do I.’ / So rare is burglary here that many people don’t lock their doors.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - will",
-    "meaning": "Used for predictions, future facts, decisions made at the moment, promises, offers, and requests. (Dùng cho dự đoán, sự thật tương lai, quyết định tức thì, hứa hẹn, đề nghị, và yêu cầu). Will is generally more formal than going to.",
-    "example": "It looks as if Jake will lose his job. / The factory will open in July. / I’ll ask for a pay rise tomorrow. / I’ll help you with the advertising campaign. / I promise you won’t lose your job. / Will you give a presentation on the sales figures? / No, I won’t give a presentation on the sales figures.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - be going to",
-    "meaning": "Used to express predictions based on present evidence and intentions already formed. (Dùng để dự đoán có cơ sở hiện tại và diễn đạt ý định đã có sẵn). Less formal than 'will'.",
-    "example": "Look at that wall. It looks as if it’s going to fall down. / I’m going to get my degree, then get a well-paid job.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Present continuous",
-    "meaning": "Used to describe definite arrangements and scheduled events in the near future. (Dùng cho các kế hoạch cụ thể sắp diễn ra). Often used with a time reference (e.g. tomorrow, on Friday).",
-    "example": "I’m meeting Fiona on Friday to discuss the advertising campaign. / I’m asking for a pay rise tomorrow.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Present simple",
-    "meaning": "Used for fixed future events such as timetables and schedules. (Dùng để nói về lịch trình hoặc sự kiện cố định trong tương lai). Often used in official contexts.",
-    "example": "The shop closes at 3 pm next Saturday. / The bus departs at 8:00 AM sharp.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Future perfect simple",
-    "meaning": "Describes actions that will be completed before a specific time in the future or situations continuing up to that point. (Dùng cho hành động hoàn tất hoặc tiếp diễn đến một thời điểm xác định trong tương lai).",
-    "example": "It looks as if Jake will have lost his job by the end of the week. / This time next month, I’ll have worked at the company for exactly 25 years.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Future perfect continuous",
-    "meaning": "Focuses on the duration of actions continuing up to a point in the future. (Nhấn mạnh khoảng thời gian của hành động kéo dài đến tương lai).",
-    "example": "This time next month, I’ll have been working at the company for exactly 25 years.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Future continuous",
-    "meaning": "Used for actions in progress at a specific future time, or regular events that are expected in the future. (Dùng cho hành động đang diễn ra hoặc thói quen dự kiến ở tương lai).",
-    "example": "This time next week I’ll be travelling round Russia on business. / The company Chairperson will be arriving on Thursday. / More people will be commuting to work by plane in the future.",
-    "count": 0
-    },
-    {
-    "word": "Future Time - Time clauses",
-    "meaning": "Used after time expressions (when, as soon as, until, before, after, once, etc.) to describe conditions for future actions. (Dùng mệnh đề thời gian để mô tả điều kiện cho hành động tương lai).",
-    "example": "I’ll give you a pay rise when you start working harder. / I’ll give you a pay rise once you’ve proved you’re a hard worker. / I’ll give you a pay rise as soon as you’ve brought in three new customers. / I won’t give you a pay rise until you’ve been working here for three years.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get/have sb doing",
+      "meaning": "Used to say someone starts someone else doing something. (Dùng khi khiến ai đó bắt đầu làm gì đó)",
+      "example": "Don’t worry. We’ll soon have your car running like new. / That film got me thinking about my childhood.",
+      "count": 0
     },
     {
-    "word": "Future Time - Other ways to express the future",
-    "meaning": "Additional future expressions using phrases like 'be about to', 'be due to', and modal verbs. These convey plans, near-future actions, formality, obligations, or probability. (Các cấu trúc diễn tả tương lai gần, kế hoạch, nghĩa vụ, hoặc khả năng xảy ra).",
-    "example": "• I'm just about to ask for my pay rise. / She's about to leave for the airport. \n• I'm just on the point/verge of asking for my pay rise. / He was on the verge of quitting. \n• I'm due to meet my boss at eleven o’clock. / The train is due to arrive in ten minutes. \n• You're to get those reports written before Friday! / The Prime Minister is to visit Japan next week. \n• I might ask for a pay rise tomorrow. / They may announce the results tonight. / The conference could be postponed due to weather.",
-    "count": 0
-    },      
-    {
-    "word": "Future Time - Future in the past",
-    "meaning": "Used when describing past thoughts or statements about the future. (Dùng khi nói về điều trong quá khứ được xem là tương lai). Will becomes would, and present tenses shift to past tenses.",
-    "example": "Then: I think the factory will open in September. → Now: I thought the factory would open in September. / Then: I’m in a rush because the train leaves at 4. → Now: I was in a rush because the train left at 4.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past simple",
-    "meaning": "Used for completed actions, habits, general truths, permanent situations, or background in stories. (Dùng cho hành động hoàn tất, thói quen, sự thật, tình huống cố định trong quá khứ)",
-    "example": "Sony and Philips invented the CD in the early 1980s. / We moved house a lot when I was a kid. / Early clocks were usually very unreliable. / Frank turned on the TV and sat on the sofa. / I’d rather Michael didn’t waste so much time playing video games.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Emphatic past simple",
-    "meaning": "Used to stress or emphasise actions or contrast with other past situations. (Dùng để nhấn mạnh hoặc đối lập hành động quá khứ)",
-    "example": "Perhaps our grandparents didn’t have e-mail, but they did have the telephone. / I did enjoy our visit to the Science Museum last summer.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past simple vs Present perfect simple",
-    "meaning": "Past simple is for finished time periods; present perfect is for recent actions or time periods that continue. (So sánh giữa hành động đã hoàn tất và hành động liên quan đến hiện tại)",
-    "example": "I sent my first e-mail six months ago. / Have you ever sent an e-mail before? / There have been many technological advances in recent years. / Did the ancient Egyptians have more advanced technology?",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past continuous",
-    "meaning": "Used for actions in progress at a time in the past, background events, temporary actions, and repeated actions. (Dùng cho hành động đang diễn ra hoặc lặp lại trong quá khứ)",
-    "example": "Were you chatting to Matt online at midnight last night? / I was working for a large software company. / She was always taking things apart to see how they worked. / It was raining outside and people were making their way home. / While I was playing a computer game, my brother was doing his homework.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past continuous vs Past simple",
-    "meaning": "Past continuous describes background in progress; past simple describes main events. (Dùng past continuous cho bối cảnh, past simple cho hành động chính)",
-    "example": "We were talking about MP3s when Andrea mentioned her new music website. / When I was a child, I visited my grandmother every week.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past continuous vs Present perfect continuous",
-    "meaning": "Past continuous is used for past progress; present perfect continuous links past to present. (So sánh hành động quá khứ đang diễn ra và hành động kéo dài đến hiện tại)",
-    "example": "We were working on my computer for four hours yesterday. / We have been working on my computer for four hours so far.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past perfect simple",
-    "meaning": "Describes actions completed before another point in the past. (Dùng cho hành động hoàn tất trước một hành động khác trong quá khứ)",
-    "example": "Had you had your computer long before it broke down? / When Dimitra called, I had managed to fix her computer. / By the time of his death, Thomas Edison had invented a number of things. / I beat Jason because I’d played a lot with my brother.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - Past perfect continuous",
-    "meaning": "Describes actions or states continuing up to a point in the past. (Dùng cho hành động kéo dài đến một thời điểm trong quá khứ)",
-    "example": "She’d been writing computer games for over ten years before she had a hit.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - would (past habit)",
-    "meaning": "Used to describe repeated actions in the distant past. (Dùng để diễn tả thói quen đã xảy ra trong quá khứ)",
-    "example": "The ancient Greeks would rely on the power of slaves. / Whenever I went to James’s house, he would usually be playing on his computer.",
-    "count": 0
-    },
-    {
-    "word": "Past Time - used to",
-    "meaning": "Used to describe past habits or states that are no longer true. (Dùng cho hành động hoặc trạng thái đã từng xảy ra trong quá khứ)",
-    "example": "It used to seem strange to be able to communicate over long distances. / At first, people found it strange sending messages by mobile, but now everyone’s used to it. / We got used to travelling by train quickly.",
-    "count": 0
-    },   
-    {
-    "word": "Present Time - Present simple",
-    "meaning": "Used for general truths, habits, permanent states, live commentary, instructions, newspaper headlines, reviews, and scheduled events. (Thì hiện tại đơn dùng cho sự thật, thói quen, tình trạng cố định, tiêu đề, lịch trình)",
-    "example": "The left-hand side of the brain controls the right-hand side of the body. / I don’t always go to lectures that are early in the morning. / Angie teaches French at a local adult education centre. / So, a man goes to see his psychiatrist. / HAWWKING WINS NOBEL PRIZE. / The film ends with us not knowing the result. / Tom turns left at the end of the road. / Term ends on 21st December. / I’ll be so relieved when I finish this crossword.",
-    "count": 0
-    },
-    {
-    "word": "Present Time - Emphatic present simple",
-    "meaning": "Used to express strong emotion or to contrast with another idea. (Dùng để nhấn mạnh cảm xúc hoặc sự tương phản)",
-    "example": "Adam doesn’t know much about psychiatry but he does know quite a lot about psychology. / I do like playing word games!",
-    "count": 0
-    },
-    {
-    "word": "Present Time - Present continuous",
-    "meaning": "Used for actions happening now, changing situations, temporary states, fixed future plans, and habits with always. (Dùng cho hành động đang xảy ra, tình huống thay đổi, sắp xếp tương lai, hoặc thói quen gây phiền)",
-    "example": "The boys are doing their homework right now. / What book are you doing in English? / We aren’t having any exams while the lecturers are on strike. / More and more people are recognising the advantages of learning a foreign language. / Dan’s always coming up with the craziest ideas! / He’s carrying a bag full of honey. / When are you taking your driving test? / I’ll probably be a bit scared when I’m waiting outside for the exam.",
-    "count": 0
-    },
-    {
-    "word": "Present Time - Present perfect simple",
-    "meaning": "Used for actions/states from past to present, recent actions, experiences, and present results. (Dùng cho hành động từ quá khứ kéo dài tới hiện tại, hoặc ảnh hưởng tới hiện tại)",
-    "example": "I’ve been a member of MENSA for over five years. / She’s done a BA, an MA and a PhD. / Have you ever read any books by Edward De Bono? / She’s been awarded a scholarship to Harvard. / I’ve just received my exam results. / Tell me when you’ve finished the report. / US: I already found the answer. UK: Have you found the answer yet?",
-    "count": 0
-    },
-    {
-    "word": "Present Time - Present perfect continuous",
-    "meaning": "Used for actions in progress from the past up to now, especially to emphasize duration. (Dùng cho hành động đang diễn ra từ quá khứ và nhấn mạnh thời lượng)",
-    "example": "We’ve all been wondering what to get Tony for his birthday. / I won’t take my driving test until I’ve been having lessons for at least two months. / I’ve worked here for five years. / I’ve been working here for five years.",
-    "count": 0
-    },
-    {
-    "word": "Present Time - Stative and non-stative verb uses",
-    "meaning": "Stative verbs (describe states, not actions) are usually not used in continuous tenses. (Động từ chỉ trạng thái thường không dùng ở thì tiếp diễn)",
-    "example": "I think it’s important to know how to use a computer. (state: think = believe) / I’m thinking about going on a computer course. (action: think = consider)",
-    "count": 0
-    }      
-            
-  ],
-  "phrases, collocations": [   
-    {
-    "word": "pay /peɪ/",
-    "meaning": "pay dearly for, pay sb a compliment, pay your way, pay your respects, pay the price, pay rise",
-    "example": "He paid dearly for his mistake. She paid me a compliment on my work. I always pay my way when dining out. We went to pay our respects at the memorial. He paid the price for ignoring the warning. He asked for a pay rise.",
-    "count": 0
-    },
-    {
-    "word": "peer /pɪə(r)/",
-    "meaning": "peer group, peer pressure",
-    "example": "Teenagers are easily influenced by their peer group. He started smoking due to peer pressure.",
-    "count": 0
-    },
-    {
-    "word": "pen /pen/",
-    "meaning": "put pen to paper, the pen is mightier than the sword, pen-pusher",
-    "example": "She finally put pen to paper and wrote the letter. The pen is mightier than the sword. He’s just another pen-pusher in the office.",
-    "count": 0
-    },
-    {
-    "word": "person /ˈpɜːsn/",
-    "meaning": "do sth in person, meet sb in person",
-    "example": "You’ll need to apply in person. I’d love to meet the author in person someday.",
-    "count": 0
-    },
-    {
-    "word": "perspective /pəˈspektɪv/",
-    "meaning": "put into perspective, from the perspective of, a sense of perspective",
-    "example": "The tragedy really put things into perspective. From the perspective of a teacher, the system needs reform. Losing gave me a better sense of perspective.",
-    "count": 0
-    },
-    {
-    "word": "place /pleɪs/",
-    "meaning": "change/swap places with, take the place of, take sb’s place, put in place, in place of, out of place, place of work/residence/birth",
-    "example": "I wouldn’t change places with him for anything. Machines have taken the place of many workers. Can you take my place at the meeting? The new rules are now in place. Use vinegar in place of lemon juice. He looked out of place at the party. Please write your place of residence.",
-    "count": 0
-    },
-    {
-    "word": "play /pleɪ/",
-    "meaning": "play against/for, play a part/role in, play the fool, play along, play by the rules, play fair",
-    "example": "They played against Brazil in the finals. He played a key role in negotiations. He was just playing the fool to avoid blame. I decided to play along with the prank. In business, we play by the rules. Let’s play fair and square.",
-    "count": 0
-    },
-    {
-    "word": "point /pɔɪnt/",
-    "meaning": "point at/to/towards, get to the point, make a point of doing sth, beside the point, up to a point, make your point, see/take sb’s point, there’s no point in",
-    "example": "She pointed towards the building. Let’s get to the point. He made a point of checking everything twice. That’s beside the point. I agree with you up to a point. You’ve made your point clear. I take your point, but I disagree. There’s no point in arguing further.",
-    "count": 0
-    },
-    {
-    "word": "polite /pəˈlaɪt/",
-    "meaning": "polite to sb, polite of sb to do, just/only being polite, polite conversation/society",
-    "example": "Please be polite to the guests. It was polite of her to say thank you. He was only being polite. They had some polite conversation over dinner. He’s not used to polite society.",
-    "count": 0
-    },
-    {
-    "word": "poor /pɔː(r)/",
-    "meaning": "come a poor second, poor loser, poor girl/boy/etc, poor relation, poor health, the rich and the poor",
-    "example": "He came a poor second in the race. Don’t be a poor loser. The poor boy had no shoes. The charity is a poor relation of bigger ones. She has suffered from poor health. The gap between the rich and the poor is widening.",
-    "count": 0
-    },
-    {
-    "word": "power /ˈpaʊə(r)/",
-    "meaning": "take/seize/hold/exercise/exert/wield/abuse power, power to do, power over, beyond sb’s power, the powers that be, power structure/base",
-    "example": "The army seized power overnight. He exercised his power wisely. She has the power to make that decision. He holds power over the region. It’s beyond my power to change it. The powers that be decided to cancel the project. The power structure is too rigid.",
-    "count": 0
-    },
-    {
-    "word": "praise /preɪz/",
-    "meaning": "praise sb for doing, win/receive/earn praise, full of praise for, in praise of",
-    "example": "She praised him for helping. The project received a lot of praise. Everyone was full of praise for her speech. The painting was created in praise of freedom.",
-    "count": 0
-    },
-    {
-    "word": "prefer /prɪˈfɜː(r)/",
-    "meaning": "prefer sb to do, prefer sth to, prefer doing, would prefer",
-    "example": "I’d prefer him to call later. I prefer coffee to tea. She prefers working alone. I would prefer to stay home tonight.",
-    "count": 0
-    },
-    {
-    "word": "principle /ˈprɪnsəpl/",
-    "meaning": "have principles, against sb’s principles, principle of sth, a matter/issue of principle",
-    "example": "He’s a man of strong principles. It’s against my principles to lie. The principle of gravity is universal. I can’t agree, it’s a matter of principle.",
-    "count": 0
-    },
-    {
-    "word": "print /prɪnt/",
-    "meaning": "print sth out/off, in print, out of print",
-    "example": "Please print out the tickets. The book is still in print. That novel is out of print now.",
-    "count": 0
-    },
-    {
-    "word": "prison /ˈprɪzn/",
-    "meaning": "go to prison, serve a sentence, prison term, prison reform, prison officer",
-    "example": "He went to prison for theft. He’s serving a ten-year sentence. It was a long prison term. The law aims at prison reform. The prison officer escorted the inmate.",
-    "count": 0
-    },
-    {
-    "word": "process /ˈprəʊses/",
-    "meaning": "in the process of doing, peace/election/judicial/legal process, due process",
-    "example": "We’re in the process of hiring. The peace process has stalled. The election process is underway. He didn’t receive due process.",
-    "count": 0
-    },
-    {
-    "word": "provoke /prəˈvəʊk/",
-    "meaning": "provoke sb into doing, provoke a reaction/protest/outcry",
-    "example": "His insult provoked her into quitting. The speech provoked a strong reaction. It provoked widespread protest.",
-    "count": 0
-    },
-    {
-    "word": "purpose /ˈpɜːpəs/",
-    "meaning": "serve a purpose, purpose of doing, on purpose, for the purpose of, escape sb’s purpose",
-    "example": "This feature serves no purpose. The purpose of doing this is safety. I did it on purpose. He was hired for the purpose of expanding the team. Her point escaped my purpose.",
-    "count": 0
-    },
-    {
-    "word": "quality /ˈkwɒləti/",
-    "meaning": "high/good/top quality, poor/bad/low quality, personal/professional qualities, quality of life/time",
-    "example": "They produce high-quality goods. The video was poor quality. His honesty is one of his best qualities. We want to improve quality of life. I enjoy spending quality time with my kids.",
-    "count": 0
-    },
-    {
-    "word": "question /ˈkwestʃən/",
-    "meaning": "beg the question, a/no question of, in question, out of the question, without question, beyond question, some question over/as to/about, awkward question",
-    "example": "This begs the question—why now? There’s no question of him resigning. His future is in question. It’s out of the question to cancel now. He’s guilty without question. Her loyalty is beyond question. There’s some question over the deal. That was an awkward question.",
-    "count": 0
-    },
-    {
-    "word": "rain /reɪn/",
-    "meaning": "rain hard/heavily, pour with rain, heavy/light rain, get caught in the rain",
-    "example": "It rained heavily last night. It’s pouring with rain today. We had light rain this morning. I got caught in the rain on the way home.",
-    "count": 0
-    },      
-    {
-    "word": "raise /reɪz/",
-    "meaning": "raise your hand, raise sth with sb, raise an objection, raise your voice/eyebrows, raise a child/family, raise sb’s hopes/expectations, raise awareness, raise money",
-    "example": "Please raise your hand to speak. She raised the issue with her manager. I’d like to raise an objection. He raised his voice in anger. They raised four children. That comment raised everyone’s hopes. The ad campaign raised awareness about the issue. We raised money for the shelter.",
-    "count": 0
-    },
-    {
-    "word": "react /riˈækt/",
-    "meaning": "react by doing, react accordingly/inappropriately, react to sth, react against",
-    "example": "He reacted by slamming the door. They reacted accordingly to the new rules. She reacted strongly to the news. The crowd reacted against the unfair policy.",
-    "count": 0
-    },
-    {
-    "word": "reaction /riˈækʃn/",
-    "meaning": "cause/produce/provoke/trigger a reaction, reaction against, reaction to",
-    "example": "The announcement triggered a strong reaction. The book is a reaction against modern trends. Her reaction to the surprise was priceless.",
-    "count": 0
-    },
-    {
-    "word": "read /riːd/",
-    "meaning": "read sb’s mind, read sb like a book, read between the lines, read out loud, read from cover to cover",
-    "example": "She can read your mind. I can read him like a book. You need to read between the lines here. Please read this paragraph out loud. I read the novel from cover to cover.",
-    "count": 0
-    },
-    {
-    "word": "reality /riˈæləti/",
-    "meaning": "escape from reality, face reality, in reality, reality TV",
-    "example": "Some people drink to escape from reality. You must face reality at some point. In reality, the plan was flawed. She appears on a reality TV show.",
-    "count": 0
-    },
-    {
-    "word": "record /ˈrekɔːd/",
-    "meaning": "keep/maintain/copy a record of, set/break a record, on record, off the record",
-    "example": "We keep a record of all payments. She broke the world record in 100m. The hottest year on record was 2016. He spoke off the record.",
-    "count": 0
-    },
-    {
-    "word": "relative /ˈrelətɪv/",
-    "meaning": "a relative of yours, distant/close relative, a relative newcomer/unknown, relative clause/pronoun",
-    "example": "She’s a close relative of mine. That man is a distant relative. He’s a relative newcomer to politics. The sentence contains a relative clause.",
-    "count": 0
-    },
-    {
-    "word": "respect /rɪˈspekt/",
-    "meaning": "respect sb for sth, lose/win sb’s respect, have/show respect for, in this/that respect, with respect to",
-    "example": "I respect her for her honesty. He lost everyone’s respect after the scandal. We should show respect for elders. In this respect, I agree. With respect to your concerns, we’re working on it.",
-    "count": 0
-    },
-    {
-    "word": "response /rɪˈspɒns/",
-    "meaning": "response to sth, in response to, no response",
-    "example": "His response to the news was calm. In response to your request, we will issue a refund. There was no response after we called.",
-    "count": 0
-    },
-    {
-    "word": "rest /rest/",
-    "meaning": "rest on/against, rest assured that, take/have a rest, come to rest",
-    "example": "He rested his head on her shoulder. Rest assured that we will deliver on time. I need to take a rest after that hike. The car came to rest in a ditch.",
-    "count": 0
-    },
-    {
-    "word": "rich /rɪtʃ/",
-    "meaning": "rich in, filthy/stinking rich, rich and famous, the rich and the poor",
-    "example": "Avocados are rich in healthy fats. They became stinking rich overnight. She dreams of becoming rich and famous. The film contrasts the lives of the rich and the poor.",
-    "count": 0
-    },
-    {
-    "word": "right /raɪt/",
-    "meaning": "have a/the/no/every right to do, give sb the right to do, right and wrong, right in doing, right of sb to do, human/animal rights",
-    "example": "You have every right to speak up. The law gives us the right to vote. Kids must learn right and wrong. He was right in refusing the offer. It’s not right of you to blame her. They campaign for human rights.",
-    "count": 0
-    },
-    {
-    "word": "risk /rɪsk/",
-    "meaning": "run the risk of doing, risk sth on, pose a risk to, at the risk of doing, put sth at risk, take a risk, at risk",
-    "example": "He ran the risk of losing his job. She risked everything on one bet. Smoking poses a risk to your health. At the risk of sounding rude, I disagree. You put our plans at risk. We took a risk investing early. The species is at risk.",
-    "count": 0
-    },
-    {
-    "word": "rule /ruːl/",
-    "meaning": "break/follow/bend the rules, against the rules, rule of law, rule book, rule out the possibility, rule of thumb",
-    "example": "You must follow the rules. It’s against the rules to cheat. Democracy relies on the rule of law. He lives by the rule book. They ruled out the possibility of fraud. As a rule of thumb, don’t spend more than you earn.",
-    "count": 0
-    },
-    {
-    "word": "run /rʌn/",
-    "meaning": "run a business/campaign, run wild, run riot, run sb a bath, run on, run through sth, run the risk of doing, run into trouble",
-    "example": "She runs her own business. The children ran wild at the park. Emotions ran riot after the game. He ran me a warm bath. The meeting ran on for hours. Let’s run through the plan. You run the risk of failure. We ran into trouble halfway.",
-    "count": 0
-    },
-    {
-    "word": "rush /rʌʃ/",
-    "meaning": "rush to do, rush sb into, in a rush, rush hour, do sth in a rush",
-    "example": "Don’t rush to conclusions. Don’t rush me into a decision. I’m in a rush, sorry! Traffic’s bad during rush hour. I packed everything in a rush.",
-    "count": 0
+      "word": "Passives n Causations - The passive",
+      "meaning": "The passive is used when the doer is unknown, obvious, unimportant, or to create a formal tone. (Câu bị động dùng khi không rõ, không quan trọng hoặc không muốn nhắc tới chủ thể hành động)",
+      "example": "The car was stolen at approximately 1.30 am. / The XL500 was designed with young families in mind. / This type of submarine was developed during WWII. / We were surprised by the number of people trying to leave the city. / All passengers are required to present their ticket.",
+      "count": 0
     },
     {
-    "word": "say /seɪ/",
-    "meaning": "have your say, say the word, say for certain, say your piece, nothing to say",
-    "example": "Everyone will have their say. Just say the word and I’ll help. I can’t say for certain. She said her piece and left. I have nothing to say about that.",
-    "count": 0
+      "word": "Passives n Causations - Impersonal passive",
+      "meaning": "Used to express general beliefs, expectations, or assumptions. Often starts with 'It is thought...', 'Tourism is expected to...', etc. (Dùng bị động vô danh để nói về suy nghĩ/quan điểm chung)",
+      "example": "Tourism is expected to become a major part of the country’s economy. / It is thought that the new railway will provide employment opportunities. / There are reported to have been a record number of accidents.",
+      "count": 0
     },
     {
-    "word": "second /ˈsekənd/",
-    "meaning": "give/take a second to do, a split second, second hand, second best",
-    "example": "Give me a second to think. It happened in a split second. He bought a second-hand bike. I don’t want to settle for second best.",
-    "count": 0
+      "word": "Passives n Causations - Direct and indirect object",
+      "meaning": "Some verbs allow two objects (person + thing). In passive, either object can become subject. (Dùng bị động với câu có 2 tân ngữ — trực tiếp và gián tiếp)",
+      "example": "Michael gave the plane tickets to Jill. / Jill was given the plane tickets (by Michael). / The plane tickets were given to Jill (by Michael). / How to drive the train was explained to me.",
+      "count": 0
     },
     {
-    "word": "sense /sens/",
-    "meaning": "make sense of, see sense, have the sense to do, common sense",
-    "example": "I can’t make sense of these instructions. I hope he’ll see sense and apologize. She had the sense to leave early. Use your common sense in emergencies.",
-    "count": 0
+      "word": "Passives n Causations - Avoiding the passive",
+      "meaning": "Used when passive is awkward or not natural in continuous/perfect tenses. We use prepositional phrases instead. (Tránh dùng bị động bằng cách dùng cụm giới từ phù hợp hơn)",
+      "example": "Preparations for the flight will be in progress as the President arrives. / At the end of this year, I will have been in training as a pilot for four years. / Vintage cars have been on display in the town centre. / The problem had been under consideration. / The railway station has been under construction for two years now.",
+      "count": 0
     },
     {
-    "word": "sentence /ˈsentəns/",
-    "meaning": "pass sentence on, serve a sentence, prison/jail sentence, death/life sentence",
-    "example": "The judge passed sentence on the thief. He served a five-year sentence. The crime led to a jail sentence. She received a life sentence.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get/have something done",
+      "meaning": "Used when someone arranges for someone else to do something for them. (Cấu trúc nhờ ai đó làm gì cho mình)",
+      "example": "Did you finally get your bike fixed? / I heard that Susie had her motorbike stolen. / I’d like those cars washed by this evening. / We’ll set off as soon as I’ve got the car fixed.",
+      "count": 0
     },
     {
-    "word": "shape /ʃeɪp/",
-    "meaning": "get/stay in shape, take shape, out of shape, in the shape of",
-    "example": "I exercise to stay in shape. Plans are starting to take shape. I’m so out of shape lately. The island is in the shape of a star.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get sb to do / have sb do",
+      "meaning": "Used to say someone persuades or arranges for someone else to do something. (Dùng khi khiến ai đó làm việc gì)",
+      "example": "Did you get Alex to drive you all the way to London? / I had my assistant book the tickets.",
+      "count": 0
     },
     {
-    "word": "share /ʃeə(r)/",
-    "meaning": "share with/between/among, shareholder, share index, share option",
-    "example": "He shared the cake with his friends. The shareholders met yesterday. The share index rose sharply. She received share options at her job.",
-    "count": 0
+      "word": "Passives n Causations - Causative: get/have sb doing",
+      "meaning": "Used to say someone starts someone else doing something. (Dùng khi khiến ai đó bắt đầu làm gì đó)",
+      "example": "Don’t worry. We’ll soon have your car running like new. / That film got me thinking about my childhood.",
+      "count": 0
     },
     {
-    "word": "sharp /ʃɑːp/",
-    "meaning": "keep a sharp eye on, sharp rise/drop/increase, sharp criticism",
-    "example": "Keep a sharp eye on your belongings. There was a sharp rise in prices. His speech drew sharp criticism.",
-    "count": 0
+      "word": "Modals n semi-modals - Overview and structure",
+      "meaning": "Modals (will, would, can, could, may, might, shall, should, must) have only one form and are followed by bare infinitives. Semi-modals (need to, ought to, had better, have to) behave similarly but may vary in structure. (Tổng quan về động từ khiếm khuyết và bán khiếm khuyết, cấu trúc theo sau là động từ nguyên mẫu)",
+      "example": "Modals: could + do, be doing, have done, have been doing. / Passive: could + be done, have been done. / Semi-modals: need to, ought to, had better, have (got) to.",
+      "count": 0
     },
     {
-    "word": "short /ʃɔːt/",
-    "meaning": "run short, short-term/notice/while/period/spell, be short of sth, short-list",
-    "example": "We’re running short on time. It’s a short-term fix. She was hired on short notice. Stay for a short while. I’m short of cash right now. They short-listed five candidates.",
-    "count": 0
-    },      
-    {
-    "word": "law /lɔː/",
-    "meaning": "become law, break/follow/uphold the law, pass/amend/repeal a law, lay down the law, law and order, against the law, under the law, follow the law",
-    "example": "The bill became law last year. He broke the law and was fined. Police must uphold the law. Parliament passed a new traffic law. The law was amended last session. Parents can't just lay down the law. The protest was against the law. Everyone is equal under the law. You must follow the law.",
-    "count": 0
-    },
-    {
-    "word": "lead /liːd/",
-    "meaning": "lead sb into, lead the way, lead the world in, lead sb to believe, take/hold the lead, follow sb’s lead, in the lead",
-    "example": "He led us into a dangerous area. She will lead the way on climate reform. This firm leads the world in biotech. He led me to believe we had a deal. She took the lead early in the race. We followed his lead and stopped arguing. Our team is currently in the lead.",
-    "count": 0
-    },
-    {
-    "word": "leisure /ˈleʒə(r)/",
-    "meaning": "have the leisure to do, at your leisure, leisure centre, leisure time/pursuits",
-    "example": "She doesn’t have the leisure to read these days. Please complete this at your leisure. We joined the local leisure centre. Watching movies is my favourite leisure pursuit.",
-    "count": 0
-    },
-    {
-    "word": "length /leŋkθ/",
-    "meaning": "go to great lengths, run the length of, in length, of (un)equal length, length of time",
-    "example": "He went to great lengths to impress her. The pipe runs the length of the building. The documentary was 45 minutes in length. These tables are of equal length. It took a long length of time to finish.",
-    "count": 0
-    },
-    {
-    "word": "letter /ˈletə(r)/",
-    "meaning": "get/receive a letter from, write/send sb a letter, letter bomb",
-    "example": "I got a letter from my cousin. I wrote a letter to the council. Police intercepted a letter bomb at the embassy.",
-    "count": 0
-    },
-    {
-    "word": "life /laɪf/",
-    "meaning": "put sb’s life at risk, bring sth to life, come to life, save sb’s life, take sb’s life, lose a life, quality of life",
-    "example": "Speeding puts lives at risk. The story was brought to life on stage. The city centre came to life at night. The doctor saved his life. The suspect took his own life. The crash claimed three lives. They enjoy a high quality of life.",
-    "count": 0
-    },
-    {
-    "word": "lightning /ˈlaɪtnɪŋ/",
-    "meaning": "lightning bolt/flash, struck by lightning, lightning speed",
-    "example": "A bolt of lightning hit the tree. He was struck by lightning during the storm. She responded with lightning speed.",
-    "count": 0
-    },
-    {
-    "word": "like /laɪk/",
-    "meaning": "like doing/to do, anything/nothing like, alike/in like manner, just like, be like sb to do",
-    "example": "I like playing guitar in my free time. There’s nothing like a warm bath. They look alike. She sings just like her mother. It’s like him to show up late.",
-    "count": 0
-    },
-    {
-    "word": "link /lɪŋk/",
-    "meaning": "link to/with, find/prove/establish a link, click/follow a link",
-    "example": "This disease is linked to poor diet. They found a link between stress and heart disease. Click this link to join the call.",
-    "count": 0
-    },
-    {
-    "word": "live /lɪv/",
-    "meaning": "live a life of crime/luxury, live to do, live and let live, live in hope/fear, live to tell the tale",
-    "example": "He lived a life of crime before reform. She lives to help others. I say live and let live. We live in hope that things improve. He survived the crash and lived to tell the tale.",
-    "count": 0
-    },
-    {
-    "word": "load /ləʊd/",
-    "meaning": "load sth with/into, take a load off, a (whole) load of, loads of, a heavy load to bear/carry",
-    "example": "She loaded the cart with groceries. Sit down and take a load off your feet. We had a whole load of laundry. He’s got loads of work today. Caring for his family is a heavy load to carry.",
-    "count": 0
-    },
-    {
-    "word": "lock /lɒk/",
-    "meaning": "lock sth in/behind/under, lock horns with, locksmith",
-    "example": "He locked the files in a drawer. They locked horns during the debate. Call a locksmith if you're locked out.",
-    "count": 0
-    },
-    {
-    "word": "long /lɒŋ/",
-    "meaning": "last long, take a long time, all day long, long way, long distance, at long last, long and hard, long time ago",
-    "example": "The meeting didn’t last long. It took a long time to recover. They talked all day long. He walked a long way home. They maintained a long-distance relationship. At long last, they found peace. She thought long and hard about it. That happened a long time ago.",
-    "count": 0
-    },
-    {
-    "word": "lot /lɒt/",
-    "meaning": "a lot of, lots of, a lot on, a lot to do with, the lot",
-    "example": "There are a lot of options. We have lots of time. He’s got a lot on his mind. Her mood has a lot to do with stress. They ate the lot in one sitting.",
-    "count": 0
-    },
-    {
-    "word": "love /lʌv/",
-    "meaning": "love doing/to do, fall in love with, be in love, love affair, love for",
-    "example": "She loves baking cakes. He fell in love with Paris. They are still in love after 20 years. Their romance started as a love affair. She has a deep love for animals.",
-    "count": 0
-    },
-    {
-    "word": "luck /lʌk/",
-    "meaning": "push your luck, be in luck, lucky charm, bring/leave luck, wish sb luck",
-    "example": "Don’t push your luck asking for more. You’re in luck—we have one left. This ring is my lucky charm. That cat brings bad luck. I wished her luck before the test.",
-    "count": 0
-    },
-    {
-    "word": "mark /mɑːk/",
-    "meaning": "mark sb/sth on, leave a mark, mark the occasion, make a mark on, be quick/slow off the mark, hit the mark",
-    "example": "The teacher marked us on clarity. The war left a mark on him. We planted a tree to mark the occasion. He made his mark on politics. She’s always quick off the mark. Her speech really hit the mark.",
-    "count": 0
-    },
-    {
-    "word": "marriage /ˈmærɪdʒ/",
-    "meaning": "related by marriage, marriage guidance, marriage vows",
-    "example": "They are related by marriage. They sought marriage guidance. They exchanged heartfelt marriage vows.",
-    "count": 0
-    },
-    {
-    "word": "material /məˈtɪəriəl/",
-    "meaning": "material goods/possessions, material wealth, material resources, raw materials",
-    "example": "He owns few material possessions. They pursued material wealth above all. The region has limited material resources. The factory imports raw materials from abroad.",
-    "count": 0
-    },
-    {
-    "word": "matter /ˈmætə(r)/",
-    "meaning": "a matter of, in a matter of (days/etc), to make matters worse, to no matter, no matter what/how/etc, no laughing matter, a matter of opinion, a matter of urgency",
-    "example": "It’s a matter of principle. In a matter of days, everything changed. To make matters worse, it rained. It’s over—no matter. No matter what happens, I’ll stay. This is no laughing matter. Whether it's art is a matter of opinion. This is a matter of urgency.",
-    "count": 0
-    },
-    {
-    "word": "medicine /ˈmedsn/",
-    "meaning": "take medicine, alternative/complementary medicine, herbal medicine",
-    "example": "She took the medicine after lunch. He practices alternative medicine. I use herbal medicine for colds.",
-    "count": 0
-    },
-    {
-    "word": "mental /ˈmentl/",
-    "meaning": "make a mental note, mental arithmetic, mental illness/health",
-    "example": "I made a mental note to call her. He’s good at mental arithmetic. She’s recovering from a mental illness.",
-    "count": 0
-    },
-    {
-    "word": "metal /ˈmetl/",
-    "meaning": "precious metal, metal detector",
-    "example": "Gold is a precious metal. The metal detector beeped at the airport.",
-    "count": 0
-    },      
-    {
-    "word": "sick /sɪk/",
-    "meaning": "call in sick, feel sick, make sb sick, sick as a parrot, sick and tired of, sick with fear/worry/etc, sick at heart, sick bag",
-    "example": "He had to call in sick today. I feel sick after that ride. That movie made me sick. She was sick as a parrot when she lost. I'm sick and tired of cleaning up after them. She’s sick with worry about her exam. He was sick at heart after the news. Please use a sick bag during turbulence.",
-    "count": 0
-    },
-    {
-    "word": "side /saɪd/",
-    "meaning": "side with sb, take sides, see both sides of an argument, the other side, on either side, on the plus/minus side, side by side",
-    "example": "She always sides with her brother. Don’t take sides in their argument. Try to see both sides of the argument. I’ll be waiting on the other side. Houses stood on either side of the street. On the plus side, it’s cheaper. They walked side by side in silence.",
-    "count": 0
-    },
-    {
-    "word": "size /saɪz/",
-    "meaning": "that’s about the size of it, cut sth to size, in size, of a certain size, increase/reduce in size",
-    "example": "So we lost the contract? That’s about the size of it. Cut the wood to size. The fish was large in size. We need envelopes of a certain size. The company reduced in size last year.",
-    "count": 0
-    },
-    {
-    "word": "small /smɔːl/",
-    "meaning": "feel small, in a small way, it’s a small world, small talk, small change, small number/amount/etc, small business",
-    "example": "His insult made me feel small. She contributed in a small way. We ran into each other – it’s a small world! We had some small talk before the meeting. I paid with small change. Only a small number of people attended. He runs a small business in town.",
-    "count": 0
-    },
-    {
-    "word": "smooth /smuːð/",
-    "meaning": "smooth the way for, smooth-talking, smooth sailing",
-    "example": "The manager helped smooth the way for my promotion. He’s a smooth-talking salesman. After the repairs, it was smooth sailing.",
-    "count": 0
-    },
-    {
-    "word": "social /ˈsəʊʃl/",
-    "meaning": "social conditions, social contact, social security, social services, social call, social worker",
-    "example": "Poor social conditions can lead to unrest. He avoids all social contact. Many retirees depend on social security. She works in social services. He dropped by on a social call. The social worker helped the family with housing.",
-    "count": 0
-    },
-    {
-    "word": "speaking /ˈspiːkɪŋ/",
-    "meaning": "speak well/highly/badly/ill of, speak your mind, speak out, speak the same language, so to speak",
-    "example": "Everyone spoke highly of her work. I decided to speak my mind about the changes. He spoke out against injustice. We speak the same language on this topic. We are partners, so to speak.",
-    "count": 0
-    },
-    {
-    "word": "start /stɑːt/",
-    "meaning": "make a good/bad/etc start, get off to a good/flying/head/etc start, head start, start from scratch, for a start, right from the start, from the start of",
-    "example": "She made a good start on the project. We got off to a flying start. That gave me a head start. I had to start from scratch. For a start, we’ll need more staff. He was honest right from the start. It was clear from the start of the lesson.",
-    "count": 0
-    },
-    {
-    "word": "steady /ˈstedi/",
-    "meaning": "steady yourself, steady your nerves, hold sth steady, steady relationship, steady growth, steady look, steady pace",
-    "example": "She steadied herself before going on stage. He tried to steady his nerves. Hold the ladder steady. They’re in a steady relationship. The company has shown steady growth. He gave her a steady look. They walked at a steady pace.",
-    "count": 0
-    },
-    {
-    "word": "straight /streɪt/",
-    "meaning": "set/put sb straight, get sth straight, think/see straight, straight talking, straight answer",
-    "example": "Let me set you straight about the rules. I want to get this straight. I was so tired I couldn’t think straight. I like his style of straight talking. Just give me a straight answer.",
-    "count": 0
-    },
-    {
-    "word": "style /staɪl/",
-    "meaning": "style sth/yourself as, in style, style of, out of style, with style",
-    "example": "He styled himself as a reformer. She always arrives in style. That’s not my style of writing. Bell-bottoms are out of style now. She completed the performance with style.",
-    "count": 0
-    },
-    {
-    "word": "subject /ˈsʌbdʒɪkt/",
-    "meaning": "subject to, bring up a subject, get onto a subject, drop a subject, subject sb to, the subject of, British subject",
-    "example": "Prices are subject to change. She brought up the subject of bonuses. Let’s get onto the next subject. Let’s drop the subject. The manager subjected us to a long lecture. The subject of today’s meeting is safety. He is a British subject by birth.",
-    "count": 0
-    },
-    {
-    "word": "sun /sʌn/",
-    "meaning": "sun yourself, in the sun, in the shade/sunlight/sunshine, sunset",
-    "example": "He lay on the beach to sun himself. We sat in the sun all day. They stayed in the shade. The room was full of sunlight. They watched the beautiful sunset together.",
-    "count": 0
-    },
-    {
-    "word": "support /səˈpɔːt/",
-    "meaning": "support doing sth, support sb, support sth, support sb financially/emotionally/etc, support a team",
-    "example": "I support limiting emissions. Her family supported her throughout. I fully support the plan. He supports his parents financially. I support the national team.",
-    "count": 0
-    },
-    {
-    "word": "surface /ˈsɜːfɪs/",
-    "meaning": "on the surface, beneath/under the surface, surface area, kitchen surface, smooth surface",
-    "example": "On the surface it seemed fine. Beneath the surface, tensions grew. The paint covers a large surface area. Wipe down the kitchen surface. The floor had a smooth surface.",
-    "count": 0
-    },
-    {
-    "word": "table /ˈteɪbl/",
-    "meaning": "set/clear/lay the table, table a proposal, table manners, on the table, under the table",
-    "example": "She set the table for dinner. They tabled a proposal for discussion. His table manners are excellent. That offer is still on the table. They paid under the table.",
-    "count": 0
-    },
-    {
-    "word": "talk /tɔːk/",
-    "meaning": "talk sb into/out of doing, talk sense, talk the same language, talk is cheap, talk your way into/out of",
-    "example": "She talked me into applying. You’re finally talking sense. We talk the same language about values. Talk is cheap—actions matter more. He talked his way out of trouble.",
-    "count": 0
-    },
-    {
-    "word": "taste /teɪst/",
-    "meaning": "develop/have/acquire a taste for, in good/bad taste, sense of taste",
-    "example": "He developed a taste for jazz. That joke was in bad taste. I lost my sense of taste when I was sick.",
-    "count": 0
-    },
-    {
-    "word": "tell /tel/",
-    "meaning": "tell the truth/a lie, tell yourself, tell the difference, tell sb to do sth, tell sb what, be told, tell that, tell on",
-    "example": "Please tell the truth. I told myself it was okay. Can you tell the difference between them? He told me to wait. She told him what happened. I was told to leave. I can tell that she’s lying. His lies will tell on him eventually.",
-    "count": 0
-    },
-    {
-    "word": "term /tɜːm/",
-    "meaning": "in the long/short term, term of/in office, prison/jail term, fixed term, term time, long/short-term",
-    "example": "In the short term, sales may fall. He served a term in office. He was sentenced to a long prison term. The job has a fixed term of 2 years. During term time, the library is busy. It’s a short-term fix.",
-    "count": 0
-    },
-    {
-    "word": "thin /θɪn/",
-    "meaning": "have thin skin, thin on top, thin on the ground, out of thin air, into thin air",
-    "example": "She has thin skin and gets offended easily. He’s a bit thin on top these days. Volunteers were thin on the ground. He appeared out of thin air. The documents vanished into thin air.",
-    "count": 0
-    },
-    {
-    "word": "threat /θret/",
-    "meaning": "pose a threat to, under threat, threat of, bomb/death threat",
-    "example": "Pollution poses a threat to wildlife. The species is under threat. There’s a threat of war. She received a death threat online.",
-    "count": 0
-    },
-    {
-    "word": "time /taɪm/",
-    "meaning": "pass the time, spend time doing, make time, find time, take time, in time, on time, time limit",
-    "example": "We played cards to pass the time. I spent time reading. Try to make time for your hobbies. Can you find time for lunch? Take your time with the project. I arrived just in time. The train was on time. There’s a time limit for submissions.",
-    "count": 0
-    },      
-    {
-    "word": "want /wɒnt/",
-    "meaning": "want (sb) to do, want sth done, for want of",
-    "example": "I want you to help me move this. I want this report finished by Friday. The plan failed for want of support.",
-    "count": 0
-    },
-    {
-    "word": "way /weɪ/",
-    "meaning": "get in sb’s way, know the way, lose your way, get sth out of the way, in the way, on the/your/their way, in this way, way of doing",
-    "example": "Try not to get in his way. Do you know the way to the beach? We lost our way in the forest. Let’s get this task out of the way. The chair is in the way. I met her on the way to work. We solve problems in this way. This is her way of teaching grammar.",
-    "count": 0
-    },
-    {
-    "word": "weak /wiːk/",
-    "meaning": "weak at the knees, weak on, weak argument, weak point/spot, weak-willed",
-    "example": "She felt weak at the knees when he smiled. I’m a bit weak on statistics. That’s a weak argument. Patience is my weak spot. He’s too weak-willed to stand up for himself.",
-    "count": 0
-    },
-    {
-    "word": "weather /ˈweðə(r)/",
-    "meaning": "good/bad/etc weather, freak weather, in all weathers, under the weather, weather forecast, weatherproof",
-    "example": "We had such good weather for the trip. A freak weather event damaged the town. He works outside in all weathers. I feel a bit under the weather today. Did you hear the weather forecast? This jacket is completely weatherproof.",
-    "count": 0
-    },
-    {
-    "word": "web /web/",
-    "meaning": "surf the Web, on the Web, website, webcam, World Wide Web, web page",
-    "example": "She spent hours surfing the Web. I found this on the Web. The website was down for maintenance. Turn on your webcam, please. He teaches about the World Wide Web. This web page isn’t loading correctly.",
-    "count": 0
+      "word": "Modals n semi-modals - Criticising past behaviour",
+      "meaning": "Used to express disapproval of something that happened in the past. (Dùng để chỉ trích hành vi đã xảy ra trong quá khứ) Modals: should have, shouldn’t have, ought to have, oughtn’t to have.",
+      "example": "You shouldn’t have spoken to Mrs Todd like that.",
+      "count": 0
     },
     {
-    "word": "wedding /ˈwedɪŋ/",
-    "meaning": "wedding anniversary, wedding cake, wedding ceremony, wedding dress, wedding invitation, wedding present",
-    "example": "Today is our wedding anniversary. The wedding cake was beautiful. The wedding ceremony took place in a garden. She wore a traditional wedding dress. We got a lovely wedding invitation. They bought them a wedding present.",
-    "count": 0
+      "word": "Modals n semi-modals - Expressing annoyance at past behaviour",
+      "meaning": "Used to express irritation or frustration about something that happened. (Dùng để thể hiện sự khó chịu với hành vi trong quá khứ) Modals: could have, might have.",
+      "example": "You could/might have told me you were going to be late!",
+      "count": 0
     },
     {
-    "word": "wheel /wiːl/",
-    "meaning": "take the wheel, behind the wheel, wheel of fortune",
-    "example": "She asked me to take the wheel. He was behind the wheel during the crash. Winning the lottery felt like spinning the wheel of fortune.",
-    "count": 0
+      "word": "Modals n semi-modals - Criticising general behaviour",
+      "meaning": "Used to describe repeated or habitual negative behaviour. (Chỉ trích hành vi lặp lại hoặc quen thuộc) Modal: will.",
+      "example": "He will slam the door every time he goes out.",
+      "count": 0
     },
     {
-    "word": "wind /wɪnd/",
-    "meaning": "high/strong wind, light wind, against the wind, in the wind, out of the wind, wind blows, gust of wind, the winds of change",
-    "example": "High wind caused delays at the airport. A light wind cooled the afternoon. We cycled against the wind. Leaves floated in the wind. Sit out of the wind to stay warm. The wind blows hard in winter. A gust of wind slammed the door. The winds of change are coming.",
-    "count": 0
+      "word": "Modals n semi-modals - Criticising a specific example of someone's general behaviour",
+      "meaning": "Used to highlight a particular instance of a known habit or behaviour. (Dùng để chỉ trích một ví dụ cụ thể về hành vi quen thuộc) Modal: would.",
+      "example": "You would take the car just when I wanted to go out.",
+      "count": 0
     },
     {
-    "word": "window /ˈwɪndəʊ/",
-    "meaning": "window-shopping, window display, window dresser, out the window, a window on/onto/into",
-    "example": "We went window-shopping downtown. The window display featured summer clothes. She works as a window dresser. His good mood went out the window. The novel offers a window into ancient life.",
-    "count": 0
+      "word": "Modals n semi-modals - Suggesting criticism with might as well",
+      "meaning": "Might as well can be used sarcastically to suggest someone doesn’t care. (Might as well có thể dùng mang hàm ý phê phán hoặc chua chát)",
+      "example": "I might as well be dead for all you care.",
+      "count": 0
     },
     {
-    "word": "word /wɜːd/",
-    "meaning": "put in a (good) word for, have a word with, spread the word, from the word go, in other words",
-    "example": "Can you put in a good word for me? I need to have a word with you. We’re spreading the word about the event. I knew from the word go it was trouble. In other words, it’s time to leave.",
-    "count": 0
+      "word": "Modals n semi-modals - Current or general obligation",
+      "meaning": "Used to describe what is necessary or required in general. (Dùng để chỉ nghĩa vụ hoặc yêu cầu chung) Modals: must, mustn’t, have (got) to, need (to).",
+      "example": "You have to be a good communicator to be a press spokesperson.",
+      "count": 0
     },
     {
-    "word": "work /wɜːk/",
-    "meaning": "work on/in/with/as/at/for, work like magic/a charm, work both ways, work a treat, work wonders, work your way up/to/through",
-    "example": "She works in finance. That remedy worked like a charm. Respect works both ways. The new design works a treat. This medicine works wonders. He worked his way up from clerk to manager.",
-    "count": 0
+      "word": "Modals n semi-modals - Lack of current or general obligation",
+      "meaning": "Used to say something is not necessary or required. (Dùng để nói điều gì đó không bắt buộc) Modals: don’t have to, haven’t got to, needn’t, don’t need (to).",
+      "example": "You don’t always need to have a degree to become a journalist.",
+      "count": 0
     },
     {
-    "word": "worse /wɜːs/",
-    "meaning": "get worse, make matters/things worse, worse for wear, for the worse, if (the) worst comes to (the) worst",
-    "example": "My headache is getting worse. He made matters worse by shouting. The sofa looks worse for wear. His health has changed for the worse. If the worst comes to the worst, we’ll call for help.",
-    "count": 0
+      "word": "Modals n semi-modals - Future obligation",
+      "meaning": "Used to talk about something that must be done in the future. (Dùng để nói về nghĩa vụ trong tương lai) Modals: will have to, must, mustn’t, have (got) to, will need (to).",
+      "example": "You’ll have to do quite a lot of research before you write this report.",
+      "count": 0
     },
     {
-    "word": "worst /wɜːst/",
-    "meaning": "do your worst, fear the worst, be your own worst enemy, if the worst comes to the worst, at worst",
-    "example": "Go ahead—do your worst! I feared the worst when he didn’t call. She’s her own worst enemy. If the worst comes to the worst, we’ll cancel. At worst, we’ll have to wait another day.",
-    "count": 0
+      "word": "Modals n semi-modals - Lack of future obligation",
+      "meaning": "Used to talk about things that will not be necessary. (Dùng để nói về điều không bắt buộc trong tương lai) Modals: don’t/won’t have to, haven’t got to, needn’t, won’t need (to).",
+      "example": "I’m glad we won’t have to write any more essays on this course.",
+      "count": 0
     },
     {
-    "word": "write /raɪt/",
-    "meaning": "write for a magazine/etc, have sth be written all over your face, write about, write of, write on, write sb/sth off, writer’s block",
-    "example": "He writes for a travel magazine. Guilt was written all over her face. I’m writing about AI ethics. She wrote of her childhood. He’s writing on climate change. They wrote the car off as a loss. She’s struggling with writer’s block.",
-    "count": 0
+      "word": "Modals n semi-modals - Past obligation",
+      "meaning": "Used to describe something that had to be done in the past. (Dùng để nói về nghĩa vụ trong quá khứ) Modals: had to, needed (to).",
+      "example": "We had to come up with three questions each.",
+      "count": 0
     },
     {
-    "word": "year /jɪə(r)/",
-    "meaning": "years of age, year on year, for years, year after year, never in a million years, year (noun)",
-    "example": "She’s 10 years of age. Profits increased year on year. We’ve lived here for years. He wins that race year after year. Never in a million years did I expect this. It was a year full of challenges.",
-    "count": 0
-    },       
-    {
-    "word": "tool /tuːl/",
-    "meaning": "a tool for (doing), a tool of (vũ khí, công cụ), toolbar (thanh công cụ), tool kit (bộ dụng cụ), power tool (dụng cụ điện)",
-    "example": "This wrench is a tool for fixing bikes. Language is a powerful tool of communication. Click the icon in the toolbar to proceed. He opened the tool kit to find a screwdriver. Power tools can be dangerous if misused.",
-    "count": 0
-    },
-    {
-    "word": "top /tɒp/",
-    "meaning": "come out on top, get on top of sth, be on top of, on top (of), off the top of your head, from the top, at the top (of), top of the world, top priority, top secret",
-    "example": "She came out on top in the final round. I need to get on top of these emails. He’s really on top of his job. There was a vase on top of the table. Off the top of my head, I’d say ten. Start from the top and work your way down. They live at the top of the hill. After the win, he felt on top of the world. Health is our top priority. This information is top secret.",
-    "count": 0
+      "word": "Modals n semi-modals - Lack of past obligation",
+      "meaning": "Used to say that something wasn’t necessary in the past. (Dùng để nói rằng điều gì đó đã không bắt buộc trong quá khứ) Modals: didn’t have to, didn’t need (to), needn’t have.",
+      "example": "In the past, politicians didn’t have to deal with being in a 24-hour media spotlight.",
+      "count": 0
     },
     {
-    "word": "tough /tʌf/",
-    "meaning": "get tough with, tough on, tough luck, tough love, tough guy",
-    "example": "The manager decided to get tough with underperformers. The law is tough on repeat offenders. It’s tough luck we missed the train. His parents used tough love to guide him. He acts like a tough guy but is kind inside.",
-    "count": 0
+      "word": "Modals n semi-modals - Ability",
+      "meaning": "Modals like can, could, be able to express current, past, future, or hypothetical ability. (Dùng để diễn tả khả năng hiện tại, quá khứ, tương lai hoặc giả định)",
+      "example": "You can’t really speak seven languages fluently, can you? / There’s no way you could read when you were two! / One day, maybe, all adults will be able to read and write. / I couldn’t go on a quiz show – I’d be too nervous. / They could have asked the Prime Minister much more searching questions.",
+      "count": 0
     },
     {
-    "word": "town /taʊn/",
-    "meaning": "town planning, the town of, in town, the outskirts/edge of town, town centre",
-    "example": "She studied town planning at university. The town of Hoi An is famous for its lanterns. Are you in town this weekend? They live on the outskirts of town. Let’s meet in the town centre.",
-    "count": 0
+      "word": "Modals n semi-modals - Permission",
+      "meaning": "Modals such as can, could, may, might are used to ask for or give/refuse permission. (Dùng để xin hoặc cho phép làm điều gì đó)",
+      "example": "Can I finish watching this before I go to bed? / No, you can’t. / Mum said we could buy one comic each. / We were allowed to buy one comic each.",
+      "count": 0
     },
     {
-    "word": "track /træk/",
-    "meaning": "keep track of, lose track of, on track, track sb/sth, off the beaten track",
-    "example": "I keep track of my expenses using an app. I lost track of time while reading. We’re on track to meet the deadline. The police are tracking the suspect. We camped somewhere off the beaten track.",
-    "count": 0
+      "word": "Modals n semi-modals - Advice",
+      "meaning": "Modals like should, ought to, had better are used to give advice or make suggestions. (Dùng để đưa ra lời khuyên hoặc gợi ý)",
+      "example": "You should try to get that poem published. / Hadn’t you better check these facts are actually true? / We may as well watch this as there’s nothing else on.",
+      "count": 0
     },
     {
-    "word": "treat /triːt/",
-    "meaning": "treat cruelly/badly/fairly/unjustly, treat sb for (bệnh), treat sb to (chiêu đãi), treat sb with, treat sb like/as, treat a disease/illness/injury/patient",
-    "example": "They treated him unfairly. The doctor treated her for the flu. I’ll treat you to lunch today. Treat animals with respect. He treated her like a child. This hospital treats cancer patients.",
-    "count": 0
+      "word": "Modals n semi-modals - Criticism",
+      "meaning": "Modals are used to criticize past actions or express annoyance. (Dùng để chỉ trích hành động trong quá khứ hoặc thể hiện sự khó chịu)",
+      "example": "You shouldn’t have spoken to Mrs Todd like that. / You could/might have told me you were going to be late! / He will slam the door every time he goes out. / You would take the car just when I wanted to go out. / I might as well be dead for all you care.",
+      "count": 0
     },
     {
-    "word": "turn /tɜːn/",
-    "meaning": "turn to sb/sth, turn a gun/etc on sb, turn to sb for help/advice, turn cold/nasty/etc, turn 40/etc",
-    "example": "She turned to her best friend for advice. He turned a gun on himself. I turned to my mentor for help. The weather turned cold overnight. He turned 40 last week.",
-    "count": 0
+      "word": "Modals n semi-modals - Obligation",
+      "meaning": "Modals such as must, have to, need to are used to express present, future or past obligation. (Dùng để nói về nghĩa vụ ở hiện tại, tương lai hoặc quá khứ)",
+      "example": "You have to be a good communicator. / You don’t always need to have a degree. / You’ll have to do quite a lot of research. / I’m glad we won’t have to write essays. / We had to come up with three questions each. / In the past, politicians didn’t have to deal with 24-hour media.",
+      "count": 0
     },
     {
-    "word": "understanding /ˌʌndəˈstændɪŋ/",
-    "meaning": "come to/reach an understanding, have an understanding with, an understanding of",
-    "example": "We came to an understanding after the meeting. I have an understanding with my boss about working hours. He has a deep understanding of physics.",
-    "count": 0
+      "word": "Modals n semi-modals - Certainty about now, the future or generally",
+      "meaning": "Used to express strong certainty or near-certainty about something now or in the future. (Dùng để diễn tả điều gần như chắc chắn ở hiện tại hoặc tương lai) Modals: will, would, must, can, can’t, could, couldn’t.",
+      "example": "There’s someone at the door. / That’ll be the postman. / It can’t be. He’s already been.",
+      "count": 0
     },
     {
-    "word": "use /juːz/",
-    "meaning": "use sth for doing, use sth to do, use sth properly, have many uses, in use, of (no) use, it's no/little/some use doing, what's the use of doing",
-    "example": "We use knives for cutting vegetables. I used my phone to take the photo. Make sure you use this properly. This tool has many uses. Is the printer still in use? That method is of no use here. It’s no use crying over spilt milk. What’s the use of worrying now?",
-    "count": 0
+      "word": "Modals n semi-modals - Certainty about the past",
+      "meaning": "Used to express strong certainty or deduction about a past event. (Dùng để suy luận chắc chắn điều gì đã xảy ra trong quá khứ) Modals: will have, won’t have, would have, wouldn’t have, must have, can’t have, couldn’t have.",
+      "example": "They won’t have heard the news, will they? / They must have heard by now, surely.",
+      "count": 0
     },
     {
-    "word": "view /vjuː/",
-    "meaning": "take the view that, have a dim/poor view of, come into view, in view of, view on/about, take a view, in sb’s view, view from sth, viewpoint",
-    "example": "I take the view that honesty is best. I have a poor view of that policy. The mountains came into view. In view of the situation, we canceled the event. What’s your view on this issue? I’d like to take a longer view. In her view, we acted rightly. The view from here is amazing. His viewpoint is always interesting.",
-    "count": 0
-    },      
-    {
-    "word": "mind /maɪnd/",
-    "meaning": "make up your mind (quyết định), cross/slip your mind (quên), bear/keep in mind (nhớ trong đầu), have a one-track mind (luôn nghĩ về một thứ), in two minds about (phân vân), on your mind (bận tâm), take your mind off (nghĩ sang chuyện khác), bring to mind (gợi nhớ), never mind (đừng bận tâm), narrow/broad/open/absent-minded (đầu óc hẹp hòi/rộng mở/lơ đãng)",
-    "example": "I haven’t made up my mind yet. That name brings to mind a funny memory. Never mind the mess — come in!",
-    "count": 0
+      "word": "Modals n semi-modals - Probability about now, the future or generally",
+      "meaning": "Used to express something likely to happen or probably true now or in the future. (Dùng để nói điều có khả năng xảy ra hoặc đúng ở hiện tại/tương lai) Modals: should, shouldn’t, ought to, may/might well, could well, might easily.",
+      "example": "The weather should be good tomorrow, shouldn’t it? / Actually, the forecast said it may well rain.",
+      "count": 0
     },
     {
-    "word": "misapprehension /ˌmɪsæprɪˈhenʃn/",
-    "meaning": "under the misapprehension that (hiểu sai rằng)",
-    "example": "She was under the misapprehension that I lived alone.",
-    "count": 0
+      "word": "Modals n semi-modals - Probability about the past",
+      "meaning": "Used to say what was probably true or likely in the past. (Dùng để diễn tả điều có lẽ đúng trong quá khứ) Modals: should have, shouldn’t have, ought to have, oughtn’t to have, may/might well have, might easily have.",
+      "example": "Jan should have finished writing her article by now, shouldn’t she? / She may well have done, but I haven’t seen it yet.",
+      "count": 0
     },
     {
-    "word": "moment /ˈməʊmənt/",
-    "meaning": "take/be a moment (mất chút thời gian), just/wait a moment (chờ một chút), at the moment (hiện tại), at this/that moment in time (ngay lúc này), in a moment (trong giây lát), the moment of truth (thời khắc quyết định), for (the) moment (tạm thời)",
-    "example": "Wait a moment while I check. At the moment, we’re not hiring. This is the moment of truth.",
-    "count": 0
+      "word": "Modals n semi-modals - Possibility about now, the future or generally",
+      "meaning": "Used to express a possible situation in the present or future. (Dùng để nói về một khả năng có thể xảy ra ở hiện tại hoặc tương lai) Modals: could, may, might, may/might/could just.",
+      "example": "I might (just) have time to get to the library before it closes.",
+      "count": 0
     },
     {
-    "word": "money /ˈmʌni/",
-    "meaning": "make/earn/spend/cost/get money (kiếm/tiêu tiền), save/have money (tiết kiệm/có tiền), do sth for money (làm vì tiền), put your money where your mouth is (làm thay vì nói), get your money’s worth (xứng đáng), pay good money for (trả nhiều tiền)",
-    "example": "He makes good money selling cars. I just want to get my money’s worth. She paid good money for that dress.",
-    "count": 0
+      "word": "Modals n semi-modals - Possibility about the real past",
+      "meaning": "Used to express a real past possibility that might or might not have happened. (Dùng để nói về khả năng thực tế trong quá khứ) Modals: could have, may have, might have.",
+      "example": "Jim might not have checked his email yet.",
+      "count": 0
     },
     {
-    "word": "mother /ˈmʌðə(r)/",
-    "meaning": "mother of (mẹ của), single/working mother (mẹ đơn thân/làm việc), mother-to-be (mẹ tương lai), mother figure (người mẹ tinh thần), mother country/tongue (mẫu quốc/tiếng mẹ đẻ), in-law (mẹ chồng), Mother Nature (Mẹ Thiên nhiên)",
-    "example": "She’s a single mother with two children. Vietnamese is my mother tongue.",
-    "count": 0
+      "word": "Modals n semi-modals - Overview and structure",
+      "meaning": "Modals (will, would, can, could, may, might, shall, should, must) have only one form and are followed by bare infinitives. Semi-modals (need to, ought to, had better, have to) behave similarly but may vary in structure. (Tổng quan về động từ khiếm khuyết và bán khiếm khuyết, cấu trúc theo sau là động từ nguyên mẫu)",
+      "example": "Modals: could + do, be doing, have done, have been doing. / Passive: could + be done, have been done. / Semi-modals: need to, ought to, had better, have (got) to.",
+      "count": 0
     },
     {
-    "word": "move /muːv/",
-    "meaning": "move to (chuyển đến), get a move on (nhanh lên), follow sb's every move (theo dõi), make a move (hành động), on the move (đang di chuyển/tiến triển)",
-    "example": "We decided to move to Da Nang. Let’s get a move on or we’ll be late. This company is constantly on the move.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Position of adjectives",
+      "meaning": "Adjectives usually appear before a noun, or after verbs such as appear, become, feel, get, grow, look, seem, smell, sound, taste, and turn. (Tính từ thường đứng trước danh từ hoặc sau một số động từ chỉ trạng thái)",
+      "example": "I love your new house. / The material this dress is made out of feels rough. / She looked angrily at the man behind the counter.",
+      "count": 0
     },
     {
-    "word": "national /ˈnæʃnəl/",
-    "meaning": "national anthem (quốc ca), national costume (trang phục truyền thống), national debt (nợ quốc gia), national holiday (ngày lễ toàn quốc)",
-    "example": "Everyone stood for the national anthem. Tet is a national holiday in Vietnam.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Position of multiple adjectives",
+      "meaning": "When more than one adjective is used before a noun, they appear in the order: opinion, size, age, shape, colour, origin, material, purpose. (Thứ tự tính từ khi có nhiều tính từ đi trước danh từ)",
+      "example": "We've got a lovely little wooden cabin in the mountains. / You love your long, red, Chinese, silk curtains. / What you need for your living room is a large oak dining table.",
+      "count": 0
     },
     {
-    "word": "native /ˈneɪtɪv/",
-    "meaning": "native to (bản địa), a native of (người bản địa), native speaker (người nói bản ngữ), non-native (không bản địa), native land/tongue (quê hương/tiếng mẹ đẻ), native species (loài sinh vật bản địa)",
-    "example": "The panda is native to China. He’s a native speaker of English. That bird is a native species of Vietnam.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Adjectives used as nouns",
+      "meaning": "Adjectives can function as nouns to refer to social groups, specific groups, or nationalities. (Tính từ có thể dùng như danh từ để chỉ nhóm người hoặc quốc tịch)",
+      "example": "We need to provide better housing for the poor. / When the building collapsed, the injured were rushed to hospital. / The French have introduced new housing regulations in Paris.",
+      "count": 0
     },
     {
-    "word": "natural /ˈnætʃrəl/",
-    "meaning": "natural causes (nguyên nhân tự nhiên), natural ability (năng lực bẩm sinh), natural resource (tài nguyên thiên nhiên), natural selection (chọn lọc tự nhiên)",
-    "example": "She has a natural ability for music. The country is rich in natural resources.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Position of adverbs",
+      "meaning": "Adverbs can appear at the beginning, middle, or end of a clause. Their position varies by type. (Trạng từ có thể đứng đầu, giữa hoặc cuối mệnh đề tùy loại)",
+      "example": "They built the house very quickly. / Our house will probably have been decorated by the time you get there. / I'm rarely in the city centre. / I rarely go to the city centre. / We bought it as an investment; then, all the property prices in the area fell.",
+      "count": 0
     },
     {
-    "word": "nature /ˈneɪtʃə(r)/",
-    "meaning": "the nature of sth (bản chất của...), in nature (về bản chất), Nature (Mẹ Thiên nhiên), human nature (bản chất con người), second nature (trở thành thói quen tự nhiên)",
-    "example": "The nature of the problem is complex. Spending time outdoors helps you reconnect with nature.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Comparisons",
+      "meaning": "Comparatives and superlatives are used to compare people or things. (Dùng để so sánh các người hoặc vật)",
+      "example": "Your flat is much bigger and more comfortable than ours. / Mexico City is probably my least favourite city. / I think my home town is the best place in the world.",
+      "count": 0
     },
     {
-    "word": "near /nɪə(r)/",
-    "meaning": "near to doing sth (sắp làm gì), the near future (tương lai gần), from near and far (từ khắp nơi), near thing (việc suýt thất bại), the nearest thing to (gần giống nhất với), nearest and dearest (người thân cận)",
-    "example": "He came near to quitting. We’ll see each other in the near future. They traveled from near and far to attend.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Comparative and superlative modifiers",
+      "meaning": "Modifiers such as quite, far, much, easily, etc., can strengthen comparatives and superlatives. (Các từ bổ nghĩa dùng để nhấn mạnh tính từ so sánh)",
+      "example": "This area has become considerably more crowded and far noisier in the last ten years. / If you ask me, Ladybridge is easily the nicest area of town to live in.",
+      "count": 0
     },
     {
-    "word": "need /niːd/",
-    "meaning": "need (sb) to do (cần ai làm gì), need doing (cần được làm), meet a need (đáp ứng nhu cầu), have no need of (không cần), in need (đang cần)",
-    "example": "We need to fix the roof. The plan needs reviewing. She helped a family in need.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Structures used to make comparisons",
+      "meaning": "We can use structures like 'as ... as', 'not nearly as ... as', 'the ... the ...', etc. to express comparisons. (Các cấu trúc so sánh phức như the more ... the more ... hoặc not nearly as ...)",
+      "example": "Platinum is about twice as expensive as gold. / Iron is not nearly as hard as diamond. / Iron is nothing like as hard as diamond. / The taller the building, the greater the fire risk.",
+      "count": 0
     },
     {
-    "word": "never /ˈnevə(r)/",
-    "meaning": "you never know (ai mà biết được), never again (không bao giờ nữa), never mind (đừng bận tâm), never-ending (không có hồi kết)",
-    "example": "Never again will I trust him. This winter feels never-ending. You never know who’s watching.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Gradable and ungradable adjectives",
+      "meaning": "Gradable adjectives can vary in degree and take modifiers like 'very'; ungradable adjectives express extremes and take words like 'absolutely'. (Tính từ chia làm loại có mức độ và loại tuyệt đối)",
+      "example": "Pete was a bit tired after working on the building site all day, but it wasn’t too bad. / After working on the building site all day, Tim was absolutely exhausted. / The balconies are quite splendid.",
+      "count": 0
     },
     {
-    "word": "new /njuː/",
-    "meaning": "new to (chưa quen), brand new (mới toanh), whole new (hoàn toàn mới), good as new (như mới), new to sb (ai đó mới với cái gì), new look (diện mạo mới), new age/music/etc (phong cách hiện đại)",
-    "example": "I’m new to this job. The phone looks as good as new. He’s into new age music.",
-    "count": 0
+      "word": "Adjectives n Adverbs - Confusing cases",
+      "meaning": "Some words have forms that look like both adjectives and adverbs (e.g., fast, hard, late), or take -ly with different meanings. (Một số từ có thể là cả tính từ và trạng từ, đôi khi nghĩa khác nhau)",
+      "example": "Sandstone is not a very hard material. ✓ Hit it too hard and you’ll break it. ✗ Hit-it-too-hardly-and-you’ll-break-it. / I could hardly hear the music. / She looked at me in a very friendly way.",
+      "count": 0
     },
     {
-    "word": "nice /naɪs/",
-    "meaning": "nice to sb (tốt với ai), nice of sb to do (ai đó tốt khi làm gì), nice for sb to do (ai đó tốt khi làm gì), nice to meet/hear/see/sb (rất vui gặp/nghe/thấy ai), nice and clean/safe/warm/etc (rất sạch/safe/ấm...)",
-    "example": "It was nice of you to help. This blanket is nice and warm. Nice to meet you!",
-    "count": 0
+      "word": "Clauses - Relative pronouns in relative clauses",
+      "meaning": "Relative pronouns are used to link a relative clause to a noun. (Đại từ quan hệ dùng để nối mệnh đề quan hệ với danh từ chính) Includes: who, which, whom, that, when, where, why, whose, what.",
+      "example": "There are a lot of people who hate having injections. / This is the prescription which the doctor gave me. / That’s the consultant with whom I spoke. / This is the prescription that the doctor gave me. / I’ll never forget the day when I broke my finger. / Harley Street, where she was born, is famous for its clinics. / That’s the reason why I wanted to become a vet. / There are several kids in my class whose parents are doctors. / What I don’t understand is why she didn’t take her pills.",
+      "count": 0
     },
     {
-    "word": "notice /ˈnəʊtɪs/",
-    "meaning": "notice sb doing/do sth (để ý thấy ai làm gì), bring sth to sb’s notice (nhắc nhở ai điều gì), come to sb’s notice (ai đó chú ý), escape sb’s notice (ai đó không để ý), take notice of (chú ý đến), at short notice (gấp), until further notice (cho đến khi có thông báo tiếp theo)",
-    "example": "She didn’t notice him come in. It came to my notice that she was late. We canceled the meeting at short notice.",
-    "count": 0
+      "word": "Clauses - Defining and non-defining relative clauses",
+      "meaning": "Defining clauses identify which person/thing is meant; non-defining add extra information. (Mệnh đề quan hệ xác định và không xác định)",
+      "example": "Defining: The doctor who did Karen’s operation. / I’ll never forget the day when I broke my arm. Non-defining: Dr Lake, who has been working here for over ten years, is a very experienced surgeon. / Harley Street, where she was born, is famous for its clinics.",
+      "count": 0
     },
     {
-    "word": "now /naʊ/",
-    "meaning": "now is the time to do (lúc để làm gì), from now on (từ giờ trở đi), for now (hiện tại), now that (bởi vì giờ đây), just now (mới đây), any day/moment now (bất cứ lúc nào)",
-    "example": "Now is the time to act. From now on, I’ll be more careful. She’ll be here any moment now.",
-    "count": 0
+      "word": "Clauses - Participle clauses",
+      "meaning": "Used to replace relative clauses or add information using -ing, past participle, or having + V3. (Mệnh đề rút gọn dùng phân từ hiện tại/quá khứ)",
+      "example": "After giving blood, I went home. / Being frightened of needles, Tony was not looking forward to the injection. / Given the chance, I’d definitely study pharmacology.",
+      "count": 0
     },
     {
-    "word": "odds /ɒdz/",
-    "meaning": "odds are (that) (rất có khả năng là), the odds of doing (khả năng xảy ra), the odds are in favor/against (khả năng ủng hộ/chống lại), against all odds (bất chấp mọi khó khăn), take a chance/chances/guess (đoán/bắt lấy cơ hội)",
-    "example": "The odds are he’ll arrive late. She succeeded against all odds.",
-    "count": 0
+      "word": "Clauses - Infinitive clauses",
+      "meaning": "Infinitive clauses can express purpose or follow certain verbs like 'be'. (Mệnh đề với động từ nguyên mẫu dùng để thể hiện mục đích hoặc theo sau một số động từ nhất định)",
+      "example": "To be a successful surgeon is the dream of many young children. / My job was to give the patients their lunch.",
+      "count": 0
     },
     {
-    "word": "off /ɒf/",
-    "meaning": "have/take/be given the day off (nghỉ làm), off work/college/etc (nghỉ làm), off duty (hết ca trực), off the top of your head (ngay lập tức), off and on/on and off (lúc có lúc không), off balance (mất thăng bằng), off limits (cấm vào)",
-    "example": "I’m off duty now. He’s off work due to illness. This room is off limits.",
-    "count": 0
+      "word": "Clauses - Concession clauses",
+      "meaning": "Concession clauses express contrast or unexpected results. (Mệnh đề nhượng bộ dùng để diễn tả sự trái ngược hoặc bất ngờ) Common phrases: although, even though, in spite of, despite, while, however, much as, etc.",
+      "example": "Even though she’d put on sun cream, Tamsin got burnt. / In spite of the fact that she put on sun cream, Tamsin still got burnt. / However hard he tried, he couldn’t put up with the pain.",
+      "count": 0
     },
     {
-    "word": "office /ˈɒfɪs/",
-    "meaning": "take office (nhậm chức), run for office (tranh cử), hold office (giữ chức), head office (trụ sở chính), office holder (người nắm giữ chức vụ), office job (công việc văn phòng), office hours (giờ làm việc)",
-    "example": "He took office last year. She’s running for public office.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Time",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: in an hour, in a second; Definite article: in the 1840s, in the winter, in the afternoon; Zero article: in 2010, in winter, in December, on Tuesday, at night",
+      "count": 0
     },
     {
-    "word": "old /əʊld/",
-    "meaning": "get/grow old (trở nên già), old age (tuổi già), old folks (người già), old hand (người dày dạn), old-fashioned (cổ hủ), old money (gia đình giàu lâu đời), old flame (tình cũ), old-fashioned ideas (tư tưởng cổ hủ)",
-    "example": "He’s getting old but still strong. She’s an old hand at negotiation.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For People and Work",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: have a job, work as a teacher, I met a very nice American last night; Definite article: the King, the Principal, the President, the British; Zero article: Russians, become President, go to work, be at work, have work to do",
+      "count": 0
     },
     {
-    "word": "on /ɒn/",
-    "meaning": "on purpose (cố tình), on your own (tự mình), on and on (dài dòng mãi), on the one/other hand (một mặt/mặt khác), on top (trên đầu), on time (đúng giờ), on demand (khi cần), on loan (cho mượn)",
-    "example": "I didn’t do it on purpose. She arrived on time. This book is on loan from the library.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Places",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: Is there a beach near here?; Definite article: the Himalayas, the Pacific Ocean, the Seine, the Earth, the Antarctic, the USA, the UK, the Scilly Isles; Zero article: Mount Everest, Berlin, America, Antarctica, Jupiter, Fleet Street, Lake Michigan, Mykonos",
+      "count": 0
     },
     {
-    "word": "opt /ɒpt/",
-    "meaning": "opt for (chọn thứ gì), opt to do (chọn làm gì)",
-    "example": "She opted for the vegetarian dish. I opted to stay at home.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Public Buildings",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: Is there a bank near here?; Definite article: the bank, the post office, go to the hospital/prison/school (as a visitor); Zero article: go to school/hospital/prison (as a student/patient/prisoner)",
+      "count": 0
     },
     {
-    "word": "option /ˈɒpʃn/",
-    "meaning": "have no option (but to) (không còn lựa chọn nào), consider your options (cân nhắc lựa chọn), keep/leave your options open (giữ lựa chọn), the option of doing (lựa chọn làm việc gì), the option to do (lựa chọn để làm gì)",
-    "example": "We had no option but to leave. I’m keeping my options open for now.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Entertainment and Sport",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: Play us a song!, I’ve got a tennis ball; Definite article: play the guitar, the media, on the radio, go to the cinema, watch the TV; Zero article: play tennis, play guitar, listen to music, on television, watch TV",
+      "count": 0
     },
-    {
-    "word": "paper /ˈpeɪpə(r)/",
-    "meaning": "piece/sheet of paper (mảnh/giấy), present/write/set a paper on (trình bày/viết đề tài), paper round (nghề phát báo), paper qualifications (bằng cấp giấy), paperwork (công việc giấy tờ)",
-    "example": "Please fill out this sheet of paper. He gave a paper on renewable energy.",
-    "count": 0
-    },      
     {
-    "word": "end /end/",
-    "meaning": "come to an end (kết thúc), bring sth to an end (kết thúc việc gì), put an end to sth (chấm dứt), at an end (đã kết thúc), (for) hours/weeks/etc on end (liên tục hàng giờ/ngày/tuần...)",
-    "example": "The meeting finally came to an end. We must put an end to this behavior. She studied for hours on end.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Organisations",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: Does Switzerland have an army?; Definite article: the BBC, the police, the emergency services, the United Nations; Zero article: NATO",
+      "count": 0
     },
     {
-    "word": "energy /ˈenədʒi/",
-    "meaning": "have/lack the energy to do (có/thiếu năng lượng làm gì), put/energy into (dồn năng lượng vào), source of energy (nguồn năng lượng), nuclear/alternative/renewable energy (năng lượng hạt nhân/thay thế/tái tạo)",
-    "example": "I didn’t have the energy to cook. He puts a lot of energy into his work. Solar power is a renewable energy source.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Education",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: have a lesson, take an exam; Definite article: be in the first year; Zero article: geography, be in class/year/form 5",
+      "count": 0
     },
     {
-    "word": "equal /ˈiːkwəl/",
-    "meaning": "call for/equal/same quality/value (có chất lượng/tương đương), equal in size/etc (bằng kích thước...), roughly equal to (tương đương với), of equal size/quality/value (có cùng kích thước/chất lượng)",
-    "example": "Both tasks are equal in difficulty. His salary is roughly equal to mine. These shoes are of equal size.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Travel",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: take a taxi, catch a bus/train; Definite article: in the car/taxi, on the bus/plane; Zero article: on foot, go home, go by car/plane",
+      "count": 0
     },
     {
-    "word": "erect /ɪˈrekt/",
-    "meaning": "erect (a statue/monument/etc) (dựng tượng), erect posture (tư thế thẳng)",
-    "example": "They erected a statue in her honor. He stood with an erect posture during the ceremony.",
-    "count": 0
+      "word": "Noun phrase - Articles by category and set phrases (usage) - For Health",
+      "meaning": "Certain categories have typical article usage. (Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng)",
+      "example": "Indefinite article: have a cold/cough/headache/toothache/stomach ache; Definite article: have the flu/measles; Zero article: have flu/measles/toothache/stomach ache",
+      "count": 0
     },
     {
-    "word": "ever /ˈevə(r)/",
-    "meaning": "hardly ever (hầu như không bao giờ), if ever (nếu có thì cũng hiếm), first/only/last time ever (lần đầu/duy nhất/cuối cùng), bigger/better/etc than ever (lớn hơn/tốt hơn bao giờ hết), as ever (như thường lệ)",
-    "example": "I hardly ever go to the gym. It was the first time ever I met him. She's as friendly as ever.",
-    "count": 0
+      "word": "Noun phrase - Countable nouns (structure)",
+      "meaning": "Countable nouns have both singular and plural forms, and can be used with a/an or numbers. (Danh từ đếm được có dạng số ít và số nhiều, dùng với a/an hoặc số đếm) Examples: painting, paintings, idea, books. Some have irregular plurals (e.g. people, mice, men).",
+      "example": "That painting is amazing. / Those paintings are dreadful. / The sheep are in the field. / The government is/are not doing anything to help the arts.",
+      "count": 0
     },
     {
-    "word": "example /ɪɡˈzɑːmpl/",
-    "meaning": "an example of (một ví dụ về), follow an example (làm gương), set an example (làm gương), classic/prime example (ví dụ điển hình/điển hình nhất)",
-    "example": "He set a good example for his peers. This is a classic example of poor planning.",
-    "count": 0
+      "word": "Noun phrase - Singular uncountable nouns (structure)",
+      "meaning": "These nouns only have a singular form and take singular verbs. (Danh từ không đếm được chỉ có dạng số ít và đi với động từ số ít) Includes: advice, blood, bread, furniture, hair, information, jewellery, knowledge, luggage, money, news, permission, respect, water.",
+      "example": "Is the information reliable? / The table is made of wood. / It's a picture of a local wood.",
+      "count": 0
     },
     {
-    "word": "fall /fɔːl/",
-    "meaning": "fall ill (ngã bệnh), fall in love (yêu), fall into a category (thuộc loại), fall short (thiếu hụt), fall asleep (ngủ gật), fall to pieces (sụp đổ)",
-    "example": "She fell in love while traveling. He fell asleep during the movie. The plan fell to pieces at the last moment.",
-    "count": 0
+      "word": "Noun phrase - Plural uncountable nouns (structure)",
+      "meaning": "These uncountable nouns have a plural form and take plural verbs. (Một số danh từ không đếm được có dạng số nhiều và đi với động từ số nhiều) Includes: arms, binoculars, clothes, congratulations, earnings, glasses, goods, groceries, jeans, pajamas, scales, surroundings, scissors, trousers, etc.",
+      "example": "The scissors aren't on the table. / A pair of binoculars is on the desk.",
+      "count": 0
     },
     {
-    "word": "family /ˈfæməli/",
-    "meaning": "start a family (bắt đầu một gia đình), nuclear/extended family (gia đình hạt nhân/mở rộng), close/near/distant relative (họ hàng gần/xa), family friend (bạn của gia đình), family name (họ), family tree (cây gia phả)",
-    "example": "They plan to start a family next year. She drew her family tree. He’s a close family friend.",
-    "count": 0
+      "word": "Noun phrase - Quantifiers for countable and uncountable nouns (usage)",
+      "meaning": "Some quantifiers are used only with countable nouns, others with uncountable, and some with both. (Một số từ chỉ định lượng chỉ dùng với danh từ đếm được, không đếm được, hoặc cả hai)",
+      "example": "A few friends (countable) / A little milk (uncountable) / A lot of people (all nouns) / Only a few of them came. / Only a little of it was useful.",
+      "count": 0
     },
     {
-    "word": "fat /fæt/",
-    "meaning": "get/grow fat (trở nên giàu có/mập), fat chance (khó có thể xảy ra), a fat lot of good (không hề hữu ích)",
-    "example": "Fat chance he’ll agree to it! That expensive car did a fat lot of good stuck in traffic.",
-    "count": 0
+      "word": "Noun phrase - Indefinite articles: a/an (usage)",
+      "meaning": "Used with singular countable nouns to refer to something not specific or mentioned for the first time. (Dùng với danh từ đếm được số ít, để nói về một vật chưa xác định hoặc mới nhắc đến lần đầu)",
+      "example": "I'd like to go to a concert tonight. / I've had a great idea! / A poet sees the world differently.",
+      "count": 0
     },
     {
-    "word": "feature /ˈfiːtʃə(r)/",
-    "meaning": "feature in sth (nổi bật trong), a feature of (đặc điểm của), distinguishing feature (đặc điểm nổi bật), safety feature (tính năng an toàn), feature writer (tác giả bài nổi bật)",
-    "example": "The curved roof is a feature of this design. She works as a feature writer for the magazine.",
-    "count": 0
+      "word": "Noun phrase - Definite article: the (usage)",
+      "meaning": "Used to refer to specific things or when both speaker and listener know what is being talked about. (Dùng để nói về điều đã biết hoặc xác định được)",
+      "example": "Is that the band you were talking about? / The scales are balanced to symbolise equality. / The young often rebel against the old.",
+      "count": 0
     },
     {
-    "word": "feel /fiːl/",
-    "meaning": "feel like doing (cảm thấy muốn làm), feel as if/though (cảm giác như), feel strongly about (cảm thấy mạnh mẽ về), feel the effects/benefits (cảm nhận ảnh hưởng/lợi ích), feel guilty/nervous/etc (cảm thấy tội lỗi...), feel at home (cảm thấy tự nhiên)",
-    "example": "I feel like taking a nap. I feel as if I’ve forgotten something. She felt the benefits of the new workout.",
-    "count": 0
+      "word": "Noun phrase - Zero article: no article at all (usage)",
+      "meaning": "Used with plural or uncountable nouns when talking generally or in idiomatic expressions. (Không dùng mạo từ khi nói chung hoặc trong các cụm thành ngữ)",
+      "example": "Don't let your young child use scissors unsupervised. / An artist always needs inspiration.",
+      "count": 0
     },
     {
-    "word": "find /faɪnd/",
-    "meaning": "find yourself doing (tự dưng làm gì), find sb doing sth (bắt gặp ai đó), find it difficult to do (gặp khó khăn khi làm), find your way (tìm đường/giải pháp)",
-    "example": "I found myself staring at the stars. She found him sleeping on the sofa. I can’t find my way in this city.",
-    "count": 0
+      "word": "Verbal complements - Verb + -ing form (structure)",
+      "meaning": "Certain verbs are followed by the -ing form. (Một số động từ đi với dạng V-ing) Verbs include: admit, adore, advocate, appreciate, avoid, can't help, carry on, compare, consider, contemplate, delay, deny, detest, discuss, dislike, endure, enjoy, escape, face, fancy, feel like, finish, foresee, give up, include, involve, justify, keep (on), mention, mind, miss, postpone, practise, put off, recommend, resent, resist, risk, suggest, take up.",
+      "example": "Sue admitted feeling rather upset. / Damien insisted on going to the party. / I'm looking forward to meeting your brother.",
+      "count": 0
     },
     {
-    "word": "fine /faɪn/",
-    "meaning": "cut it fine (xoay sở làm vừa kịp), fine sb for sth (phạt vì...), a heavy/small fine (mức phạt nặng/nhẹ)",
-    "example": "He was fined for speeding. They cut it fine but still made the train.",
-    "count": 0
+      "word": "Verbal complements - Verb + object + -ing form (structure)",
+      "meaning": "Some verbs take an object followed by an -ing form. (Một số động từ đi với tân ngữ + V-ing) Verbs include: catch, find, glimpse, hear, notice, observe, overhear, see, smell, watch.",
+      "example": "They caught him taking money from the till.",
+      "count": 0
     },
     {
-    "word": "floor /flɔː(r)/",
-    "meaning": "take the floor (lên phát biểu), floor show (buổi biểu diễn trên sàn), ground/first/etc floor (tầng trệt/thứ nhất...), floor plan (sơ đồ tầng)",
-    "example": "He took the floor to address the issue. The apartment is on the second floor.",
-    "count": 0
+      "word": "Verbal complements - Verb + full infinitive (structure)",
+      "meaning": "Many verbs are followed by the full infinitive (to + V). (Nhiều động từ đi với to + V nguyên mẫu) Verbs include: afford, agree, aim, appear, apply, arrange, aspire, attempt, beg, cease, choose, claim, come, dare, decide, demand, deserve, desire, expect, fail, happen, help, hesitate, hope, learn, manage, need, neglect, offer, plan, prepare, pretend, promise, refuse, resolve, rush, seek, seem, strive, tend, undertake, volunteer, vote, wait, want, wish, would like, yearn.",
+      "example": "Can you afford to buy that car? / I hope to pass the exam. / They promised to call later.",
+      "count": 0
     },
     {
-    "word": "fly /flaɪ/",
-    "meaning": "fly a flag/kite (treo cờ/thả diều), fly at sb (tấn công ai), fly open (mở toang), fly by (trôi qua nhanh chóng)",
-    "example": "The kite flew high in the sky. Time flew by during the holidays.",
-    "count": 0
+      "word": "Verbal complements - Verb + object + full infinitive (structure)",
+      "meaning": "Some verbs require both an object and a full infinitive. Verbs include: advise, allow, ask, assist, authorise, beg, cause, challenge, choose, command, compel, convince, dare, decide, defy, desire, employ, enable, empower, encourage, expect, force, free, help, hire, inspire, instruct, intend, invite, lead, motivate, move, need, nominate, order, permit, persuade, pick, prepare, prompt, qualify, raise, recommend, recruit, request, require, select, send, signal, teach, tell, tempt, want, warn.",
+      "example": "My sister advised me to tell Jim the truth.",
+      "count": 0
     },
     {
-    "word": "focus /ˈfəʊkəs/",
-    "meaning": "focus on (tập trung vào), the focus of (tiêu điểm của...), in focus/out of focus (rõ/mờ), focus group (nhóm thảo luận)",
-    "example": "Let’s focus on the task at hand. The main focus of the meeting was safety.",
-    "count": 0
+      "word": "Verbal complements - Verb + object + bare infinitive (structure)",
+      "meaning": "Verbs like let, make, help are followed by object + bare infinitive (V without to). (Một số động từ theo sau là tân ngữ + V không 'to') Verbs include: help, let, make, feel, hear, notice, overhear, see, watch.",
+      "example": "The teacher let the class leave early.",
+      "count": 0
     },
     {
-    "word": "fold /fəʊld/",
-    "meaning": "fold sth in half/two (gấp đôi), fold sth neatly/carefully (gấp gọn/gấp cẩn thận), fold flat (gấp phẳng)",
-    "example": "Fold the paper in half. Please fold your clothes neatly.",
-    "count": 0
+      "word": "Verbal complements - Verb (+ object) + infinitive or -ing form with little or no change in meaning (structure)",
+      "meaning": "Some verbs can be followed by either an infinitive or -ing form without significant change in meaning. (Một số động từ đi với to V hoặc V-ing mà không thay đổi nghĩa nhiều) Verbs include: begin, bother, can't bear/stand, continue, hate, intend, like, love, prefer, start.",
+      "example": "I love to read. / I love reading. / They continued to work. / They continued working.",
+      "count": 0
     },
     {
-    "word": "follow /ˈfɒləʊ/",
-    "meaning": "follow sb's advice (nghe lời ai), follow sb's argument (hiểu luận điểm), follow sb's lead (theo sau), follow sb's example (noi gương), as follows (như sau), follow suit (làm theo)",
-    "example": "He followed her advice and succeeded. The team followed suit after the leader’s move.",
-    "count": 0
+      "word": "Verbal complements - Verb (+ object) + infinitive or -ing form with a change in meaning (structure)",
+      "meaning": "Some verbs change meaning depending on whether they are followed by an infinitive or -ing. (Một số động từ thay đổi nghĩa tùy thuộc vào to V hay V-ing theo sau) Verbs include: consider, forget, go on, hear, imagine, like, mean, regret, remember, see, stop, try.",
+      "example": "I forgot to ask Brian. / I’ll never forget asking Helen. / I stopped to think. / Please stop telling me what to do. / Try to not forget her birthday. / You could try buying her some flowers.",
+      "count": 0
     },
     {
-    "word": "form /fɔːm/",
-    "meaning": "form an impression of (hình thành ấn tượng), take/assume the form of (có hình dạng...), in the form of (dưới dạng...), application form (mẫu đơn), good/bad form (cách hành xử tốt/xấu)",
-    "example": "I formed a good impression of her. Please complete this application form.",
-    "count": 0
+      "word": "Verbal complements - Preparatory it (structure)",
+      "meaning": "Some verbs like find, think, and consider can use 'it' as preparatory subject. (Dùng 'it' như chủ ngữ giả với các động từ như find, think, consider) Common verbs: find, think, consider, make, believe, feel.",
+      "example": "I consider it incredible that James and Alice are still together.",
+      "count": 0
     },
     {
-    "word": "foundation /faʊnˈdeɪʃn/",
-    "meaning": "lay the foundations (đặt nền móng), foundation course (khóa học cơ sở), foundation stone (viên đá nền tảng)",
-    "example": "They laid the foundations for future success. I’m taking a foundation course in art.",
-    "count": 0
+      "word": "Verbal complements - Subjunctive (structure)",
+      "meaning": "Used in that-clauses after verbs suggesting necessity or importance; uses base form of verb (no -s in 3rd person). (Câu giả định dùng để diễn tả điều cần thiết, quan trọng hoặc mong muốn, dùng động từ nguyên mẫu) Typical verbs: suggest, recommend, insist, demand, ask, require, propose, important that..., essential that..., vital that..., necessary that....",
+      "example": "The doctor suggested that Sam take some time off work. / It’s very important that Greg not know about this. / It’s absolutely essential that I be informed.",
+      "count": 0
     },
     {
-    "word": "free /friː/",
-    "meaning": "set sb free (thả ai đó tự do), let sb go free (thả ai), walk free (tự do đi lại), free sb from sth (giải thoát), free to do (tự do làm gì), free and easy (thoải mái), feel free (cứ tự nhiên)",
-    "example": "They were finally set free. Feel free to contact us anytime.",
-    "count": 0
+      "word": "Unreal time - conditional (n) /kənˈdɪʃənəl/",
+      "meaning": "a sentence that expresses a condition and its result, often used for hypothetical or unlikely situations. (câu điều kiện)",
+      "example": "If I had known, I would have taken some dollars with me.",
+      "count": 0
     },
     {
-    "word": "fresh /freʃ/",
-    "meaning": "fresh air (không khí trong lành), fresh-faced (tươi tắn), fresh start (khởi đầu mới), fresh from (vừa mới từ), fresh out of (vừa hết), fresh water (nước ngọt)",
-    "example": "Let’s go outside for some fresh air. She’s fresh from university.",
-    "count": 0
+      "word": "Unreal time - imagine (v) /ɪˈmædʒɪn/",
+      "meaning": "to think about something that is not real or is unlikely to happen. (tưởng tượng)",
+      "example": "Suppose you were given ten million euros, what would you spend it on?",
+      "count": 0
     },
     {
-    "word": "friend /frend/",
-    "meaning": "be/friend sb (kết bạn), close/good/great friend (bạn thân), mutual friend (bạn chung), circle of friends (vòng bạn bè), friends with sb (là bạn với ai)",
-    "example": "He’s a close friend of mine. We met through a mutual friend.",
-    "count": 0
+      "word": "Unreal time - suppose (v) /səˈpəʊz/",
+      "meaning": "to assume something is true for the purpose of argument or explanation. (giả sử)",
+      "example": "Suppose you had won the lottery last night. What would you have done?",
+      "count": 0
     },
     {
-    "word": "generation /ˌdʒenəˈreɪʃn/",
-    "meaning": "the older/younger generation (thế hệ già/trẻ), generation gap (khoảng cách thế hệ), generation X (thế hệ X), future generations (những thế hệ tương lai)",
-    "example": "There’s a clear generation gap in values. We must protect the environment for future generations.",
-    "count": 0
-    },      
-    {
-    "word": "consequence /ˈkɒnsɪkwəns/",
-    "meaning": "accept/face the consequences (chấp nhận/hứng chịu hậu quả), serious/disastrous/negative consequences (hậu quả nghiêm trọng), direct consequence of (hậu quả trực tiếp), in consequence of (vì lý do), of no/little consequence (không/không quá quan trọng)",
-    "example": "You must face the consequences of your actions. The accident was a direct consequence of poor planning. His opinion is of no consequence to me.",
-    "count": 0
+      "word": "Unreal time - as if (phrase)",
+      "meaning": "used to describe a situation that is not true or real. (như thể là)",
+      "example": "She acts as if she were a millionaire.",
+      "count": 0
     },
     {
-    "word": "consideration /kənˌsɪdəˈreɪʃn/",
-    "meaning": "take into consideration (cân nhắc), give consideration to (xem xét), show consideration for (quan tâm tới), under consideration (được xem xét), for consideration (để cân nhắc), out of consideration for (vì cân nhắc tới ai)",
-    "example": "We must take all factors into consideration before deciding. She always shows consideration for others. Your suggestion is under consideration.",
-    "count": 0
+      "word": "Unreal time - as though (phrase)",
+      "meaning": "used in the same way as 'as if', to make unreal comparisons. (như thể là)",
+      "example": "Tony looks as if someone had just handed him a million euros.",
+      "count": 0
     },
     {
-    "word": "course /kɔːs/",
-    "meaning": "in the course of (trong suốt quá trình), course of action/events (diễn biến hành động/sự kiện)",
-    "example": "In the course of the investigation, new evidence came to light. We must decide the best course of action.",
-    "count": 0
+      "word": "Unreal time - Questions and requests (phrase)",
+      "meaning": "Used to make requests and questions sound more polite. (Cách nói lịch sự hơn khi yêu cầu hoặc đặt câu hỏi)",
+      "example": "I was wondering whether you might be able to give me some advice.",
+      "count": 0
     },
     {
-    "word": "crime /kraɪm/",
-    "meaning": "commit/permit/witness/solve a crime (thực hiện/cho phép/chứng kiến/giải quyết một tội ác), fight/combat crime (chống tội phạm), crime rate (tỉ lệ tội phạm), organised crime (tội phạm có tổ chức)",
-    "example": "He committed a serious crime last year. The government is taking steps to combat organised crime. The city’s crime rate has dropped.",
-    "count": 0
+      "word": "Unreal time - It’s (high/about) time (phrase)",
+      "meaning": "Used to suggest that something should be done now or in the immediate future. (Đã đến lúc làm điều gì đó)",
+      "example": "It’s (high/about) time we were leaving.",
+      "count": 0
     },
     {
-    "word": "cry /kraɪ/",
-    "meaning": "cry with pain/happiness/laughter (khóc vì...), cry over/about (khóc vì), cry for help (kêu cứu), cry your eyes/heart out (khóc nhiều), have a good cry (khóc thỏa thích), burst into tears (bật khóc)",
-    "example": "She burst into tears at the news. He cried for help when he fell. I needed to have a good cry after the breakup.",
-    "count": 0
+      "word": "Unreal time - Would rather/sooner (phrase)",
+      "meaning": "Used to express current, general or future preference, or past preference. (Diễn tả sự ưu tiên, mong muốn)",
+      "example": "We’d rather/sooner you hadn’t lent Kurdip the money.",
+      "count": 0
     },
     {
-    "word": "date /deɪt/",
-    "meaning": "date from (bắt đầu xuất hiện từ), date back to (có từ khi), keep sth up to date (cập nhật), set/fix a date (chọn ngày), go on/make a date with sb (hẹn hò), at a later/future date (một ngày nào đó trong tương lai), to date (đến nay)",
-    "example": "The building dates back to the 18th century. Please keep your records up to date. We haven’t set a date for the wedding yet.",
-    "count": 0
+      "word": "Unreal time - Wish / if only (phrase)",
+      "meaning": "Used to express regrets or unreal desires about present or past situations. (Ước hoặc tiếc nuối về điều không có thật ở hiện tại hoặc quá khứ)",
+      "example": "If only I was earning a reasonable salary.",
+      "count": 0
     },
     {
-    "word": "day /deɪ/",
-    "meaning": "make sb’s day (khiến ai đó hạnh phúc), by day (ban ngày), any day now (sắp tới, bất cứ lúc nào), from day to day (từng ngày), day by day (ngày qua ngày), day off (ngày nghỉ), day trip (chuyến đi trong ngày)",
-    "example": "The kind words really made my day. He works by day and studies by night. We're planning a day trip to the countryside.",
-    "count": 0
+      "word": "Unreal time - Other structures with wish / if only (phrase)",
+      "meaning": "Structures used to express criticism, inability, formal desires, or to wish someone success. (Các cấu trúc dùng với wish để phê phán, thể hiện ước muốn hoặc chúc ai đó)",
+      "example": "I wish I could find a job that pays well.",
+      "count": 0
     },
     {
-    "word": "dead /ded/",
-    "meaning": "go dead (tắt, ngừng hoạt động), drop dead (đột nhiên lăn ra chết), dead silence (sự im lặng tuyệt đối), dead tired (mệt lả), dead and gone (biến mất, không còn nữa), dead ahead (ngay phía trước mặt)",
-    "example": "The phone line suddenly went dead. I was dead tired after the hike. There was dead silence in the room.",
-    "count": 0
+      "word": "Reporting - Tense changes (phrase)",
+      "meaning": "When the reporting verb is in the past, we usually shift the original tense back. (Khi động từ tường thuật ở thì quá khứ, thì của câu gốc thường bị lùi lại một thì)",
+      "example": "Sam doesn’t play hockey → Fiona said that Sam didn’t play hockey.",
+      "count": 0
     },
     {
-    "word": "deal /diːl/",
-    "meaning": "deal in (buôn bán), deal with (giải quyết), deal a blow to (giáng một đòn vào), get a good deal on (mua được giá tốt), give sb a good deal (cho ai đó thỏa thuận tốt), great deal of sth (rất nhiều)",
-    "example": "She deals in antiques. We need to deal with this problem quickly. He got a good deal on his new car.",
-    "count": 0
+      "word": "Reporting - Modal and semi-modal changes (phrase)",
+      "meaning": "When reporting speech with modals, some modal verbs change form. (Một số động từ khuyết thiếu thay đổi trong câu tường thuật)",
+      "example": "'I could swim,' she said → She said she could swim.",
+      "count": 0
     },
-    {
-    "word": "decide /dɪˈsaɪd/",
-    "meaning": "decide on sb/sth (quyết định chọn), decide against (quyết định không), decide in favour of (quyết định ủng hộ), decide for yourself (tự quyết định), decision to do (quyết định làm gì)",
-    "example": "They decided against buying the house. You need to decide for yourself. We made the decision to expand the business.",
-    "count": 0
-    }, 
     {
-    "word": "about /əˈbaʊt/",
-    "meaning": "partly/mainly/all about (một phần/đa phần/toàn bộ về), do sth about (làm gì đó để xử lý), about to do (sắp làm gì)",
-    "example": "She was about to leave when the phone rang. This book is all about courage and persistence. What are you going to do about the issue?",
-    "count": 0
+      "word": "Reporting - Modal and semi-modal change table (reference)",
+      "meaning": "Detailed list of modal/semi-modal verb changes in reported speech. (Danh sách các động từ khuyết thiếu thay đổi trong câu tường thuật)",
+      "example": "will/shall → would; can → could; must → had to / be to / should; have to → had to; don’t/doesn’t have to → didn’t have to; mustn’t → mustn’t / were not to / shouldn’t; may → might; am/is/are going to → was/were going to. Example 1: 'I will call you,' she said. → She said she would call me. Example 2: 'You must finish the work,' he said. → He said I had to finish the work.",
+      "count": 0
     },
     {
-    "word": "access /ˈækses/",
-    "meaning": "have/gain/provide access to (có/đạt được/cung cấp sự tiếp cận), Internet access (truy cập mạng Internet), wheelchair access (lối đi dành cho xe lăn)",
-    "example": "Students have access to all library materials online. Wheelchair access is available at the entrance. Only members can gain access to the archive.",
-    "count": 0
+      "word": "Reporting - Must and mustn’t changes (phrase)",
+      "meaning": "‘Must’ becomes ‘had to’, ‘were to’, or ‘should’ when expressing obligation. ‘Mustn’t’ becomes ‘mustn’t’, ‘were not to’, or ‘shouldn’t’. (Must → had to / should; Mustn’t → mustn’t / shouldn’t)",
+      "example": "‘You mustn’t cheat,’ said the coach. → We were told that we mustn’t / were not to / shouldn’t cheat.",
+      "count": 0
     },
     {
-    "word": "account /əˈkaʊnt/",
-    "meaning": "account for (chiếm), give an account of (kể lại/thuat lai), take into account (tính đến, cân nhắc), on account of (xem xét, chiếu cố), on account of (bởi vì), by all accounts (theo những gì thu thập được), on sb’s account (theo như ý kiến của họ)",
-    "example": "He gave an account of his experience to the class. We must take weather conditions into account.By all accounts, she’s a talented writer.",
-    "count": 0
+      "word": "Reporting - Pronoun and determiner changes (phrase)",
+      "meaning": "Pronouns and determiners often change to reflect the new speaker or perspective. (Đại từ và từ xác định thường thay đổi để phản ánh người nói mới)",
+      "example": "It’s my turn. → Eddie pointed out that it was his turn.",
+      "count": 0
     },
     {
-    "word": "act /ækt/",
-    "meaning": "in good/bad faith (hành vi thiện/chưa thiện), out of desperation/necessity (hành động tuyệt vọng/cần thiết), act on sb’s advice/orders/behalf (hành động dựa vào lời khuyên/mệnh lệnh/thay mặt ai), act out of (hành động vì lý do gì), act the part/role of (đóng vai), act like (cư xử như), act your age (cư xử đúng tuổi), in the act of doing (đang làm việc gì đó thì bị bắt gặp)",
-    "example": "He was caught in the act of stealing. She acted on her lawyer’s advice. They acted out of desperation.",
-    "count": 0
+      "word": "Reporting - Time and place changes (phrase)",
+      "meaning": "Time/place words are often shifted back in reported speech. (Các từ chỉ thời gian/địa điểm thường bị lùi lại)",
+      "example": "We’ll meet here tomorrow. → He said they would meet there the next day.",
+      "count": 0
     },
     {
-    "word": "age /eɪdʒ/",
-    "meaning": "act your age (hành động đúng độ tuổi), under age (chưa đủ tuổi), old age (tuổi già), working/retirement age (độ tuổi đi làm/nghỉ hưu), age limit (độ tuổi giới hạn), age bracket/group (nhóm tuổi), in Stone/Bronze/Iron Age (Vào thời kỳ Đồ Đá/Đồ Đồng/Đồ Sắt)",
-    "example": "She retired at the age of 65. He's not allowed in; he's under age. We studied tools from the Bronze Age.",
-    "count": 0
+      "word": "Reporting - Reported questions (phrase)",
+      "meaning": "Questions lose question marks and follow normal word order. (Câu hỏi gián tiếp không dùng dấu hỏi và theo trật tự câu khẳng định)",
+      "example": "‘What time did the match start?’ → Jimmy asked what time the match had started.",
+      "count": 0
     },
     {
-    "word": "ages",
-    "meaning": "take/spend ages (doing) (tốn nhiều thời gian làm gì); ages ago (rất lâu về trước); seems/feels like ages (có vẻ đã lâu lắm rồi kể từ khi)",
-    "example": "I spent ages trying to fix that bug before I finally gave up. They moved here ages ago and still love it. It feels like ages since we last spoke. She thinks it’s been ages since her last vacation.",
-    "count": 0
+      "word": "Reporting - Reported commands and requests (phrase)",
+      "meaning": "Commands use tell/order/ask + to-infinitive in reported speech. (Mệnh lệnh và yêu cầu dùng tell/order/ask + to V trong câu tường thuật)",
+      "example": "Put the cricket bats away! → Alex told me to put the cricket bats away.",
+      "count": 0
     },
     {
-    "word": "answer",
-    "meaning": "answer to sb (trả lời ai đó); give sb an answer (đáp lại lời); answer sb’s prayers (đáp lại lời cầu nguyện); answer the description of (rất giống với); have a lot to answer for (chịu trách nhiệm về)",
-    "example": "Could you please answer my question about the API design? He finally answered her prayers by approving the budget. His work answers the description of an ideal solution. The manager will have a lot to answer for if the project fails.",
-    "count": 0
+      "word": "Reporting - Reporting verbs (phrase)",
+      "meaning": "Different reporting verbs follow different grammatical patterns. (Các động từ tường thuật khác nhau đi với các cấu trúc ngữ pháp khác nhau)",
+      "example": "Verbs include: accuse, admit, advise, agree, deny, explain, insist, suggest, tell, warn.",
+      "count": 0
     },
     {
-    "word": "argument",
-    "meaning": "argument (with sb) (cãi vã với ai); win/lose an argument (thắng/thua một cuộc tranh cãi); argument about/over (cuộc tranh luận về); argument for/against (lập luận ủng hộ/chống); without an argument (không cần bàn cãi)",
-    "example": "They had an argument about which framework to use. She won the argument by presenting clear data. There’s a strong argument for adopting microservices. We resolved the issue without an argument.",
-    "count": 0
+      "word": "Reporting - Modal and semi-modal change table (reference)",
+      "meaning": "Detailed list of modal/semi-modal verb changes in reported speech. (Danh sách các động từ khuyết thiếu thay đổi trong câu tường thuật)",
+      "example": "will/shall → would; can → could; must → had to / be to / should; have to → had to; don’t/doesn’t have to → didn’t have to; mustn’t → mustn’t / were not to / shouldn’t; may → might; am/is/are going to → was/were going to. Example 1: 'I will call you,' she said. → She said she would call me. Example 2: 'You must finish the work,' he said. → He said I had to finish the work.",
+      "count": 0
     },
     {
-    "word": "arm",
-    "meaning": "arm sb with (trang bị cho ai đó); arm yourself against (trang bị cho bản thân để chống lại); take up arms (chuẩn bị chiến đấu); lay down arms (vứt bỏ vũ khí); arms control (kiểm soát vũ khí)",
-    "example": "The guide armed us with all the necessary credentials. They taught us how to arm ourselves against cyber attacks. Rebels decided to lay down arms and negotiate. An international treaty on arms control was signed.",
-    "count": 0
+      "word": "Complex sentence - Cleft sentences (structure)",
+      "meaning": "Used to emphasize a particular part of a sentence by placing it at the beginning. (Dùng để nhấn mạnh một phần nào đó trong câu)",
+      "example": "All that Keith wanted was to get his money back. / The person who stole the money was Thomas. / The day when this government came to power was 2006.",
+      "count": 0
     },
     {
-    "word": "art",
-    "meaning": "art of doing (nghệ thuật/kỹ thuật làm việc gì); art deco (trang trí nghệ thuật); art gallery (phòng trưng bày nghệ thuật); art house (phim nghệ thuật)",
-    "example": "He mastered the art of debugging complex code. The building’s façade is a beautiful example of art deco. Let's visit the new art gallery this weekend. They screened an indie film at the local art house.",
-    "count": 0
+      "word": "Complex sentence - It is/was ... who/which/that (structure)",
+      "meaning": "Used for emphasizing a person or thing responsible for an action. (Nhấn mạnh người hoặc vật thực hiện hành động)",
+      "example": "It was Carol who called the police. / It was the year in which this government came to power. / It was me that stole the money.",
+      "count": 0
     },
     {
-    "word": "ask",
-    "meaning": "ask yourself (tự hỏi bản thân); ask sb a favour (nhờ ai giúp đỡ); ask sb over/round (mời đến nhà chơi); ask sb in (mời ai vào nhà); asking for trouble (chắc chắn gặp rắc rối); if you ask me (theo tôi)",
-    "example": "Ask yourself what the user really needs from this feature. Could I ask you a favour and review my pull request? She asked him over for afternoon tea. If you ask me, we should refactor this module.",
-    "count": 0
+      "word": "Complex sentence - So / Such / Too / Enough (adverbial structure)",
+      "meaning": "Used to express degree or intensity, often followed by a result clause. (Dùng để diễn tả mức độ và kết quả)",
+      "example": "There is so much crime around here that I’m thinking of moving. / It was such a terrible crime that the judge sentenced him to life in prison. / The police didn’t respond quickly enough to catch the burglar.",
+      "count": 0
     },
     {
-    "word": "associate",
-    "meaning": "associate sth with (liên kết cái gì với)",
-    "example": "Most people associate JavaScript with web development. He associates deadlines with unnecessary stress. Don’t associate code quality solely with performance.",
-    "count": 0
+      "word": "Complex sentence - So (adverb)",
+      "meaning": "Used to express intensity and result. (Dùng để nhấn mạnh mức độ dẫn đến kết quả)",
+      "example": "It all happened so quickly that I didn’t have time to see the man’s face. / This problem has gone on for so long that I don’t think they’ll ever find a solution.",
+      "count": 0
     },
     {
-    "word": "authority",
-    "meaning": "have the authority to do (có thẩm quyền làm việc gì); grant sb the authority to do (trao quyền cho ai làm gì); local authority (chính quyền địa phương)",
-    "example": "Only the admin has the authority to modify user roles. The board granted her the authority to approve budgets. Please consult the local authority for compliance guidelines. He assumed authority over the new deployment process.",
-    "count": 0
+      "word": "Complex sentence - Such (determiner)",
+      "meaning": "Used before nouns to emphasize extreme characteristics. (Dùng trước danh từ để nhấn mạnh)",
+      "example": "It was such a terrible crime that the judge sentenced him to life in prison. / There is such a lot of crime around here that I’m thinking of moving.",
+      "count": 0
     },
     {
-    "word": "back",
-    "meaning": "back into sth (lùi vào chỗ nào đó); back onto sth (lùi xe lên trên cái gì); back out of (chống lưng/ứng hộ cho ai làm gì)",
-    "example": "He accidentally backed into the server rack. The car backed onto the loading dock. She refused to back out of her commitment. We need someone to back us up on this proposal.",
-    "count": 0
+      "word": "Complex sentence - Too (adverb)",
+      "meaning": "Used to indicate more than what is wanted or needed. (Dùng để chỉ mức độ vượt quá)",
+      "example": "I had too little time to get a good look at his face. / The police responded too slowly to have any chance of catching the burglar.",
+      "count": 0
     },
     {
-    "word": "bad",
-    "meaning": "go bad (thiu, hỏng); bad for sb (có hại cho ai); bad at sth (kém về cái gì); bad blood (mối quan hệ xấu)",
-    "example": "Don’t eat that milk—it’s gone bad. Smoking is bad for your health. He’s bad at estimating project timelines. There’s some bad blood between those two teams.",
-    "count": 0
+      "word": "Complex sentence - Enough (adverb/determiner)",
+      "meaning": "Used to show a sufficient degree or amount. (Dùng để chỉ mức độ hoặc số lượng đủ)",
+      "example": "There just aren’t enough police officers on the streets. / The police weren’t quick enough to catch the burglar.",
+      "count": 0
     },
     {
-    "word": "balance",
-    "meaning": "strike a balance (tìm phương án cân bằng); upset/restore the balance (phá vỡ/khôi phục cân bằng); balance between (cân bằng giữa); off balance (mất thăng bằng)",
-    "example": "We need to strike a balance between speed and quality. A sudden spike in traffic upset the balance of the system. There’s a fine balance between innovation and risk. The unexpected outage threw the team off balance.",
-    "count": 0
+      "word": "Complex sentence - Inversions with negative adverbials (structure)",
+      "meaning": "Used for emphasis, these begin with negative adverbs and require subject-verb inversion. (Cấu trúc đảo ngữ với trạng từ phủ định để nhấn mạnh)",
+      "example": "Hardly had the new law been introduced when the mistake was realised. / Barely had we solved one problem when another one arose. / Never had I heard such a ridiculous suggestion.",
+      "count": 0
     },
     {
-    "word": "basis",
-    "meaning": "on a basis (trên cơ sở); on a daily/temporary basis (hàng ngày/tạm thời); on the basis of (dựa trên cơ sở)",
-    "example": "We review performance on a monthly basis. The feature is enabled on a temporary basis. Decisions are made on the basis of user feedback.",
-    "count": 0
+      "word": "Complex sentence - Not until / Only when / Only after (inversion)",
+      "meaning": "Inversion is used after time clauses with ‘not until’, ‘only when’, or ‘only after’. (Dùng đảo ngữ sau các cụm thời gian để nhấn mạnh)",
+      "example": "Not until the next election will we know how the public feel about this news. / Only when we agree what measures are needed will we be able to solve the problem.",
+      "count": 0
     },
     {
-    "word": "behaviour",
-    "meaning": "behaviour towards (hành vi đối với); antisocial/violent behaviour (hành vi chống đối/bạo lực); exemplary behaviour (hành vi gương mẫu)",
-    "example": "His behaviour towards colleagues was exemplary. The test revealed some antisocial behaviour in the AI agent. Good behaviour is rewarded in our performance reviews.",
-    "count": 0
+      "word": "Complex sentence - Inversions with place expressions (+ verb of movement) (structure)",
+      "meaning": "Used when place expressions begin the sentence, followed by inversion. (Đảo ngữ khi câu bắt đầu bằng cụm chỉ nơi chốn và động từ di chuyển)",
+      "example": "Here comes the Minister now. / At the top of society are the aristocracy. / Running down the road was a young man with a woman’s handbag under his arm.",
+      "count": 0
     },
     {
-    "word": "belief",
-    "meaning": "express belief(s) (bộc lộ niềm tin); contrary to popular belief (ngược với niềm tin chung); firm belief (niềm tin vững chắc)",
-    "example": "The CEO expressed her firm belief in the project’s success. Contrary to popular belief, code reviews improve productivity. He couldn’t hide his belief in the new framework.",
-    "count": 0
+      "word": "Complex sentence - Other inversions (structure)",
+      "meaning": "Used in short answers and with phrases like ‘neither/nor’, ‘so’, ‘such’, etc. (Các kiểu đảo ngữ khác với so/such/neither/nor)",
+      "example": "‘Did you?’ – So did I. / ‘I don’t believe a word this government says.’ – ‘No, neither do I.’ / So rare is burglary here that many people don’t lock their doors.",
+      "count": 0
     },
     {
-    "word": "bend",
-    "meaning": "bend sth into (uốn cong thành gì); round the bend (quá tức giận); bend the rules (nới lỏng quy tắc)",
-    "example": "She bent the metal rod into a perfect circle. Waiting in line all day drove me round the bend. Managers sometimes bend the rules to meet deadlines.",
-    "count": 0
+      "word": "Future Time - will",
+      "meaning": "Used for predictions, future facts, decisions made at the moment, promises, offers, and requests. (Dùng cho dự đoán, sự thật tương lai, quyết định tức thì, hứa hẹn, đề nghị, và yêu cầu). Will is generally more formal than going to.",
+      "example": "It looks as if Jake will lose his job. / The factory will open in July. / I’ll ask for a pay rise tomorrow. / I’ll help you with the advertising campaign. / I promise you won’t lose your job. / Will you give a presentation on the sales figures? / No, I won’t give a presentation on the sales figures.",
+      "count": 0
     },
     {
-    "word": "best",
-    "meaning": "make the best of (tận dụng hết khả năng); at your best (ở tình trạng tốt nhất); best of my ability (theo khả năng tốt nhất của tôi); best friend (bạn thân nhất)",
-    "example": "We need to make the best of this opportunity. He performed at his best under pressure. I’ll help you to the best of my ability. She’s been my best friend since college.",
-    "count": 0
+      "word": "Future Time - be going to",
+      "meaning": "Used to express predictions based on present evidence and intentions already formed. (Dùng để dự đoán có cơ sở hiện tại và diễn đạt ý định đã có sẵn). Less formal than 'will'.",
+      "example": "Look at that wall. It looks as if it’s going to fall down. / I’m going to get my degree, then get a well-paid job.",
+      "count": 0
     },
     {
-    "word": "bet",
-    "meaning": "bet (sth) on (đánh cuộc thứ gì đó); make a bet (đặt cược); safe bet (điều chắc chắn thành công)",
-    "example": "I’d bet on JavaScript remaining popular for years. He made a bet with his friend about the release date. Opting for thorough tests is a safe bet.",
-    "count": 0
+      "word": "Future Time - Present continuous",
+      "meaning": "Used to describe definite arrangements and scheduled events in the near future. (Dùng cho các kế hoạch cụ thể sắp diễn ra). Often used with a time reference (e.g. tomorrow, on Friday).",
+      "example": "I’m meeting Fiona on Friday to discuss the advertising campaign. / I’m asking for a pay rise tomorrow.",
+      "count": 0
     },
     {
-    "word": "better",
-    "meaning": "get better (trở nên tốt hơn); better off (khấm khá hơn); better next time (lần sau sẽ tốt hơn); for better or (for worse) (dù tốt dù xấu)",
-    "example": "I hope the system gets better after this update. You’ll be better off using a dedicated database. Maybe we’ll have better luck next time. For better or worse, this is the final design.",
-    "count": 0
+      "word": "Future Time - Present simple",
+      "meaning": "Used for fixed future events such as timetables and schedules. (Dùng để nói về lịch trình hoặc sự kiện cố định trong tương lai). Often used in official contexts.",
+      "example": "The shop closes at 3 pm next Saturday. / The bus departs at 8:00 AM sharp.",
+      "count": 0
     },
     {
-    "word": "big",
-    "meaning": "make a big thing out of (làm quá/ làm lớn chuyện); make it big (thành công nhanh); big of sb (đã tốt khi làm gì); big on (rất thích); big business (doanh nghiệp lớn); big-hearted (hào hiệp); big name (nhiều tiền); big game (sự kiện quan trọng)",
-    "example": "They made a big thing out of the minor mistake. She hopes to make it big in Silicon Valley. It was big of you to donate so much. He’s really big on open-source software.",
-    "count": 0
+      "word": "Future Time - Future perfect simple",
+      "meaning": "Describes actions that will be completed before a specific time in the future or situations continuing up to that point. (Dùng cho hành động hoàn tất hoặc tiếp diễn đến một thời điểm xác định trong tương lai).",
+      "example": "It looks as if Jake will have lost his job by the end of the week. / This time next month, I’ll have worked at the company for exactly 25 years.",
+      "count": 0
     },
     {
-    "word": "block",
-    "meaning": "block sb’s way (chặn đường của ai); block of flats/apartment block (tòa chung cư); high-rise block (tòa nhà cao tầng); writer’s block (rào cản tâm lý)",
-    "example": "The coach blocked their way onto the field. She lives in a new apartment block downtown. That high-rise block dominates the skyline. He suffered from writer’s block all week.",
-    "count": 0
+      "word": "Future Time - Future perfect continuous",
+      "meaning": "Focuses on the duration of actions continuing up to a point in the future. (Nhấn mạnh khoảng thời gian của hành động kéo dài đến tương lai).",
+      "example": "This time next month, I’ll have been working at the company for exactly 25 years.",
+      "count": 0
     },
     {
-    "word": "book",
-    "meaning": "read sb like a book (hiểu rõ ai); (do) by the book (làm đúng chuẩn); book about/on (cuốn sách về); a closed book (câu đố bí ẩn); open book (người dễ hiểu); in my book (theo tôi); sb’s good/bad books (ai đó hài lòng/khó chịu với)",
-    "example": "I can read you like a book after all these years. She always does things by the book. He recommended a great book on algorithms. His behavior is definitely in my bad books.",
-    "count": 0
+      "word": "Future Time - Future continuous",
+      "meaning": "Used for actions in progress at a specific future time, or regular events that are expected in the future. (Dùng cho hành động đang diễn ra hoặc thói quen dự kiến ở tương lai).",
+      "example": "This time next week I’ll be travelling round Russia on business. / The company Chairperson will be arriving on Thursday. / More people will be commuting to work by plane in the future.",
+      "count": 0
     },
     {
-    "word": "born",
-    "meaning": "born to do (sinh ra để làm); born on/in (sinh vào thời gian/nơi nào); born into (sinh ra trong gia đình); born and bred (sinh ra và lớn lên); born-again (tái sinh, chuyển đạo); newborn (sơ sinh)",
-    "example": "She was born to do complex data analysis. I was born in Hanoi in 1990. He was born into a family of engineers. They are proud of their born-and-bred roots.",
-    "count": 0
+      "word": "Future Time - Time clauses",
+      "meaning": "Used after time expressions (when, as soon as, until, before, after, once, etc.) to describe conditions for future actions. (Dùng mệnh đề thời gian để mô tả điều kiện cho hành động tương lai).",
+      "example": "I’ll give you a pay rise when you start working harder. / I’ll give you a pay rise once you’ve proved you’re a hard worker. / I’ll give you a pay rise as soon as you’ve brought in three new customers. / I won’t give you a pay rise until you’ve been working here for three years.",
+      "count": 0
     },
     {
-    "word": "bottom",
-    "meaning": "come bottom (đứng cuối); get to the bottom of (tìm nguyên nhân); the bottom drops/falls out of (giảm sâu); bottom line (điểm mấu chốt)",
-    "example": "Our team came bottom in the hackathon. We need to get to the bottom of this bug. Suddenly the bottom fell out of the market. The bottom line is that we need more testing.",
-    "count": 0
+      "word": "Future Time - Other ways to express the future",
+      "meaning": "Additional future expressions using phrases like 'be about to', 'be due to', and modal verbs. These convey plans, near-future actions, formality, obligations, or probability. (Các cấu trúc diễn tả tương lai gần, kế hoạch, nghĩa vụ, hoặc khả năng xảy ra).",
+      "example": "• I'm just about to ask for my pay rise. / She's about to leave for the airport. \n• I'm just on the point/verge of asking for my pay rise. / He was on the verge of quitting. \n• I'm due to meet my boss at eleven o’clock. / The train is due to arrive in ten minutes. \n• You're to get those reports written before Friday! / The Prime Minister is to visit Japan next week. \n• I might ask for a pay rise tomorrow. / They may announce the results tonight. / The conference could be postponed due to weather.",
+      "count": 0
     },
     {
-    "word": "brain",
-    "meaning": "pick sb’s brain(s) (hỏi để biết thông tin); rack your brain(s) (vắt óc để làm); brains behind (người chịu trách nhiệm); brainless (ngu ngốc); brainstorm (động não); brainwave (cảm hứng đột ngột)",
-    "example": "Can I pick your brains about this architecture? I’ve been racking my brain for hours. She is the brain behind our new feature. We had a productive brainstorm session yesterday.",
-    "count": 0
+      "word": "Future Time - Future in the past",
+      "meaning": "Used when describing past thoughts or statements about the future. (Dùng khi nói về điều trong quá khứ được xem là tương lai). Will becomes would, and present tenses shift to past tenses.",
+      "example": "Then: I think the factory will open in September. → Now: I thought the factory would open in September. / Then: I’m in a rush because the train leaves at 4. → Now: I was in a rush because the train left at 4.",
+      "count": 0
     },
     {
-    "word": "break",
-    "meaning": "break a habit (phá vỡ thói quen); break with tradition (phá bỏ truyền thống); take/have/need a break (có thời gian nghỉ); lunch/coffee break (giờ nghỉ trưa/giữa buổi)",
-    "example": "I finally broke my habit of checking email at night. They decided to break with tradition this year. Let’s take a break and grab coffee. We only have a fifteen-minute break left.",
-    "count": 0
+      "word": "Past Time - Past simple",
+      "meaning": "Used for completed actions, habits, general truths, permanent situations, or background in stories. (Dùng cho hành động hoàn tất, thói quen, sự thật, tình huống cố định trong quá khứ)",
+      "example": "Sony and Philips invented the CD in the early 1980s. / We moved house a lot when I was a kid. / Early clocks were usually very unreliable. / Frank turned on the TV and sat on the sofa. / I’d rather Michael didn’t waste so much time playing video games.",
+      "count": 0
     },
     {
-    "word": "brick",
-    "meaning": "bricks and mortar (cửa hàng thực sự); brick wall (bức tường gạch); bricklayer (thợ nề)",
-    "example": "They opened a bricks-and-mortar store downtown. We built a small brick wall in the courtyard. The bricklayer finished the job early.",
-    "count": 0
+      "word": "Past Time - Emphatic past simple",
+      "meaning": "Used to stress or emphasise actions or contrast with other past situations. (Dùng để nhấn mạnh hoặc đối lập hành động quá khứ)",
+      "example": "Perhaps our grandparents didn’t have e-mail, but they did have the telephone. / I did enjoy our visit to the Science Museum last summer.",
+      "count": 0
     },
     {
-    "word": "certain",
-    "meaning": "know/say for certain (biết/chắc chắn); certain to do (chắc chắn làm); make certain (chắc chắn); certain of/about (chắc chắn về); a certain (amount of sth) (một lượng nhất định)",
-    "example": "I can’t say for certain when the release will be. You’re certain to succeed with that plan. Please make certain the tests pass. We need a certain amount of RAM for this VM.",
-    "count": 0
+      "word": "Past Time - Past simple vs Present perfect simple",
+      "meaning": "Past simple is for finished time periods; present perfect is for recent actions or time periods that continue. (So sánh giữa hành động đã hoàn tất và hành động liên quan đến hiện tại)",
+      "example": "I sent my first e-mail six months ago. / Have you ever sent an e-mail before? / There have been many technological advances in recent years. / Did the ancient Egyptians have more advanced technology?",
+      "count": 0
     },
     {
-    "word": "chance",
-    "meaning": "take a chance (đánh liều); leave to chance (mặc kệ); by chance (tình cờ); by any chance (phải vậy không?); second chance (cơ hội thứ hai); last chance (cơ hội cuối cùng); pure chance (ngẫu nhiên thuần túy); there’s every/no chance that (rất có/không có cơ hội)",
-    "example": "I decided to take a chance and rewrite the module. Don’t leave it to chance—write unit tests. We met by chance at the conference. There’s every chance we’ll finish early.",
-    "count": 0
+      "word": "Past Time - Past continuous",
+      "meaning": "Used for actions in progress at a time in the past, background events, temporary actions, and repeated actions. (Dùng cho hành động đang diễn ra hoặc lặp lại trong quá khứ)",
+      "example": "Were you chatting to Matt online at midnight last night? / I was working for a large software company. / She was always taking things apart to see how they worked. / It was raining outside and people were making their way home. / While I was playing a computer game, my brother was doing his homework.",
+      "count": 0
     },
     {
-    "word": "change",
-    "meaning": "change from sth to sth (đổi từ thứ gì thành); change sth into (biến thứ gì trở thành); change sth for (thay đổi cái gì đó để lấy); change for the better/worse (thay đổi tốt hơn/tệ hơn); change your mind (đổi ý); change the subject (đổi chủ đề); make a change (thay đổi); undergo a change (trải qua thay đổi)",
-    "example": "We need to change from HTTP to HTTPS. He changed his idea into a working prototype. They changed the plan for the better. After reflection, she changed her mind.",
-    "count": 0
+      "word": "Past Time - Past continuous vs Past simple",
+      "meaning": "Past continuous describes background in progress; past simple describes main events. (Dùng past continuous cho bối cảnh, past simple cho hành động chính)",
+      "example": "We were talking about MP3s when Andrea mentioned her new music website. / When I was a child, I visited my grandmother every week.",
+      "count": 0
     },
     {
-    "word": "charge",
-    "meaning": "charge sb with (buộc tội ai về); charge sb for (đòi tiền ai về); take charge (đảm nhiệm); put sb in charge (trao quyền); overall charge (toàn quyền lãnh đạo)",
-    "example": "They charged her with overseeing the new API. We were charged for extra storage. She took charge of the deployment. The CTO was put in charge of security.",
-    "count": 0
+      "word": "Past Time - Past continuous vs Present perfect continuous",
+      "meaning": "Past continuous is used for past progress; present perfect continuous links past to present. (So sánh hành động quá khứ đang diễn ra và hành động kéo dài đến hiện tại)",
+      "example": "We were working on my computer for four hours yesterday. / We have been working on my computer for four hours so far.",
+      "count": 0
     },
     {
-    "word": "child",
-    "meaning": "as a child (khi còn nhỏ); only child (con một); child of (con của); childcare (chăm sóc trẻ); child abuse (lạm dụng trẻ em); child’s play (trò chơi trẻ con)",
-    "example": "As a child, I loved playing video games. He was an only child in his family. Childcare services are expanding. That puzzle is child’s play for us.",
-    "count": 0
+      "word": "Past Time - Past perfect simple",
+      "meaning": "Describes actions completed before another point in the past. (Dùng cho hành động hoàn tất trước một hành động khác trong quá khứ)",
+      "example": "Had you had your computer long before it broke down? / When Dimitra called, I had managed to fix her computer. / By the time of his death, Thomas Edison had invented a number of things. / I beat Jason because I’d played a lot with my brother.",
+      "count": 0
     },
     {
-    "word": "choice",
-    "meaning": "make a choice (đưa ra lựa chọn); exercise choice (bầu chọn); have no choice (không có lựa chọn nào); choice between (lựa chọn giữa); informed choice (lựa chọn dựa trên thông tin); wide choice (nhiều lựa chọn); obvious choice (lựa chọn hiển nhiên)",
-    "example": "It’s time to make a choice about the framework. Users can exercise choice in their settings. We had no choice but to postpone. There’s a wide choice of libraries available.",
-    "count": 0
+      "word": "Past Time - Past perfect continuous",
+      "meaning": "Describes actions or states continuing up to a point in the past. (Dùng cho hành động kéo dài đến một thời điểm trong quá khứ)",
+      "example": "She’d been writing computer games for over ten years before she had a hit.",
+      "count": 0
     },
     {
-    "word": "choose",
-    "meaning": "choose from (chọn ra từ); choose between (chọn giữa); choose sb/sth as (chọn ai/cái gì làm); choose sb/sth out of (chọn ai/cái gì trong cả nhóm); choose to do (lựa chọn làm gì); pick and choose (cân nhắc kỹ và chọn); nothing to choose between (không có gì để chọn)",
-    "example": "You can choose from several templates. We had to choose between speed and accuracy. They chose her as team lead. There was nothing to choose between the two solutions.",
-    "count": 0
+      "word": "Past Time - would (past habit)",
+      "meaning": "Used to describe repeated actions in the distant past. (Dùng để diễn tả thói quen đã xảy ra trong quá khứ)",
+      "example": "The ancient Greeks would rely on the power of slaves. / Whenever I went to James’s house, he would usually be playing on his computer.",
+      "count": 0
     },
     {
-    "word": "class",
-    "meaning": "class sb/sth as (phân loại); social class (tầng lớp xã hội); working/middle/upper class (đẳng cấp lao động/trung lưu/thượng lưu); ruling class (giai cấp thống trị); class system (hệ thống giai cấp); class war (mâu thuẫn giai cấp)",
-    "example": "They classed the data points as anomalies. Discussions about social class remain relevant. He grew up in a working-class family. The ruling class resisted the reforms.",
-    "count": 0
+      "word": "Past Time - used to",
+      "meaning": "Used to describe past habits or states that are no longer true. (Dùng cho hành động hoặc trạng thái đã từng xảy ra trong quá khứ)",
+      "example": "It used to seem strange to be able to communicate over long distances. / At first, people found it strange sending messages by mobile, but now everyone’s used to it. / We got used to travelling by train quickly.",
+      "count": 0
     },
     {
-    "word": "clean",
-    "meaning": "give sth a (good) clean (lau dọn sạch sẽ); make a clean break (giải sạch, cắt đứt hoàn toàn); clean and tidy (sạch sẽ gọn gàng); a clean slate (một khởi đầu mới); clean sweep (dọn sạch những thứ không cần thiết)",
-    "example": "Let’s give this codebase a good clean. The team made a clean break from legacy. Keep your workspace clean and tidy. We started with a clean slate after the audit.",
-    "count": 0
+      "word": "Present Time - Present simple",
+      "meaning": "Used for general truths, habits, permanent states, live commentary, instructions, newspaper headlines, reviews, and scheduled events. (Thì hiện tại đơn dùng cho sự thật, thói quen, tình trạng cố định, tiêu đề, lịch trình)",
+      "example": "The left-hand side of the brain controls the right-hand side of the body. / I don’t always go to lectures that are early in the morning. / Angie teaches French at a local adult education centre. / So, a man goes to see his psychiatrist. / HAWWKING WINS NOBEL PRIZE. / The film ends with us not knowing the result. / Tom turns left at the end of the road. / Term ends on 21st December. / I’ll be so relieved when I finish this crossword.",
+      "count": 0
     },
     {
-    "word": "clear",
-    "meaning": "make/get sth clear (làm rõ/chứng tỏ); make yourself clear (nói rõ ý của bạn); have a clear conscience (lương tâm trong sạch); clear in your mind (hiểu rõ); clear as a bell (rõ ràng); clear as mud (khó hiểu); clear evidence (bằng chứng); clear case of (trường hợp rõ ràng)",
-    "example": "She made her expectations perfectly clear. He has a clear conscience about the decision. The objective was clear in my mind. That explanation was clear as a bell.",
-    "count": 0
+      "word": "Present Time - Emphatic present simple",
+      "meaning": "Used to express strong emotion or to contrast with another idea. (Dùng để nhấn mạnh cảm xúc hoặc sự tương phản)",
+      "example": "Adam doesn’t know much about psychiatry but he does know quite a lot about psychology. / I do like playing word games!",
+      "count": 0
     },
     {
-    "word": "clock",
-    "meaning": "set a clock (đặt báo thức); watch the clock (đếm thời gian); against the clock (chạy đua với thời gian); around the clock (suốt ngày đêm); clockwise (theo chiều kim đồng hồ); clockwork (bộ máy đồng hồ)",
-    "example": "Don’t forget to set the clock before sleeping. We’re racing against the clock to finish. The server runs around the clock. The gears turned like clockwork.",
-    "count": 0
+      "word": "Present Time - Present continuous",
+      "meaning": "Used for actions happening now, changing situations, temporary states, fixed future plans, and habits with always. (Dùng cho hành động đang xảy ra, tình huống thay đổi, sắp xếp tương lai, hoặc thói quen gây phiền)",
+      "example": "The boys are doing their homework right now. / What book are you doing in English? / We aren’t having any exams while the lecturers are on strike. / More and more people are recognising the advantages of learning a foreign language. / Dan’s always coming up with the craziest ideas! / He’s carrying a bag full of honey. / When are you taking your driving test? / I’ll probably be a bit scared when I’m waiting outside for the exam.",
+      "count": 0
     },
     {
-    "word": "come",
-    "meaning": "come to a conclusion/decision (đi tới kết luận/quyết định); come to power (lên nắm quyền); come into view (hiện ra trước mắt); come as a shock (gây sốc); come true (trở thành hiện thực)",
-    "example": "We came to a conclusion after reviewing logs. The new party came to power last year. The mountain peak finally came into view. His dream to launch the app came true.",
-    "count": 0
+      "word": "Present Time - Present perfect simple",
+      "meaning": "Used for actions/states from past to present, recent actions, experiences, and present results. (Dùng cho hành động từ quá khứ kéo dài tới hiện tại, hoặc ảnh hưởng tới hiện tại)",
+      "example": "I’ve been a member of MENSA for over five years. / She’s done a BA, an MA and a PhD. / Have you ever read any books by Edward De Bono? / She’s been awarded a scholarship to Harvard. / I’ve just received my exam results. / Tell me when you’ve finished the report. / US: I already found the answer. UK: Have you found the answer yet?",
+      "count": 0
     },
     {
-    "word": "common",
-    "meaning": "have sth in common (với ai) (có điểm chung); common for sb/sth to do (việc ai đó làm gì là khá phổ biến); common language (ngôn ngữ thường dùng); the common people (người dân); common practice (hành vi phổ biến)",
-    "example": "We have much in common regarding coding standards. It’s common for teams to hold daily stand-ups. English serves as a common language in tech. Code reviews are now common practice.",
-    "count": 0
+      "word": "Present Time - Present perfect continuous",
+      "meaning": "Used for actions in progress from the past up to now, especially to emphasize duration. (Dùng cho hành động đang diễn ra từ quá khứ và nhấn mạnh thời lượng)",
+      "example": "We’ve all been wondering what to get Tony for his birthday. / I won’t take my driving test until I’ve been having lessons for at least two months. / I’ve worked here for five years. / I’ve been working here for five years.",
+      "count": 0
     },
     {
-    "word": "conclusion",
-    "meaning": "bring sth to a conclusion (đưa cái gì đến kết luận); come to/reach a conclusion (đi đến kết luận); jump/leap to conclusions (nhảy cóc kết luận); in conclusion (kết lại); foregone conclusion (kết quả đương nhiên)",
-    "example": "Let’s bring this discussion to a conclusion. They reached a conclusion after testing. Don’t jump to conclusions too quickly. In conclusion, we recommend a staging environment.",
-    "count": 0
+      "word": "Present Time - Stative and non-stative verb uses",
+      "meaning": "Stative verbs (describe states, not actions) are usually not used in continuous tenses. (Động từ chỉ trạng thái thường không dùng ở thì tiếp diễn)",
+      "example": "I think it’s important to know how to use a computer. (state: think = believe) / I’m thinking about going on a computer course. (action: think = consider)",
+      "count": 0
     }
-  ],    
+  ],
+  "phrases, collocations": [
+    {
+      "word": "pay /peɪ/",
+      "meaning": "pay dearly for, pay sb a compliment, pay your way, pay your respects, pay the price, pay rise",
+      "example": "He paid dearly for his mistake. She paid me a compliment on my work. I always pay my way when dining out. We went to pay our respects at the memorial. He paid the price for ignoring the warning. He asked for a pay rise.",
+      "count": 0
+    },
+    {
+      "word": "peer /pɪə(r)/",
+      "meaning": "peer group, peer pressure",
+      "example": "Teenagers are easily influenced by their peer group. He started smoking due to peer pressure.",
+      "count": 0
+    },
+    {
+      "word": "pen /pen/",
+      "meaning": "put pen to paper, the pen is mightier than the sword, pen-pusher",
+      "example": "She finally put pen to paper and wrote the letter. The pen is mightier than the sword. He’s just another pen-pusher in the office.",
+      "count": 0
+    },
+    {
+      "word": "person /ˈpɜːsn/",
+      "meaning": "do sth in person, meet sb in person",
+      "example": "You’ll need to apply in person. I’d love to meet the author in person someday.",
+      "count": 0
+    },
+    {
+      "word": "perspective /pəˈspektɪv/",
+      "meaning": "put into perspective, from the perspective of, a sense of perspective",
+      "example": "The tragedy really put things into perspective. From the perspective of a teacher, the system needs reform. Losing gave me a better sense of perspective.",
+      "count": 0
+    },
+    {
+      "word": "place /pleɪs/",
+      "meaning": "change/swap places with, take the place of, take sb’s place, put in place, in place of, out of place, place of work/residence/birth",
+      "example": "I wouldn’t change places with him for anything. Machines have taken the place of many workers. Can you take my place at the meeting? The new rules are now in place. Use vinegar in place of lemon juice. He looked out of place at the party. Please write your place of residence.",
+      "count": 0
+    },
+    {
+      "word": "play /pleɪ/",
+      "meaning": "play against/for, play a part/role in, play the fool, play along, play by the rules, play fair",
+      "example": "They played against Brazil in the finals. He played a key role in negotiations. He was just playing the fool to avoid blame. I decided to play along with the prank. In business, we play by the rules. Let’s play fair and square.",
+      "count": 0
+    },
+    {
+      "word": "point /pɔɪnt/",
+      "meaning": "point at/to/towards, get to the point, make a point of doing sth, beside the point, up to a point, make your point, see/take sb’s point, there’s no point in",
+      "example": "She pointed towards the building. Let’s get to the point. He made a point of checking everything twice. That’s beside the point. I agree with you up to a point. You’ve made your point clear. I take your point, but I disagree. There’s no point in arguing further.",
+      "count": 0
+    },
+    {
+      "word": "polite /pəˈlaɪt/",
+      "meaning": "polite to sb, polite of sb to do, just/only being polite, polite conversation/society",
+      "example": "Please be polite to the guests. It was polite of her to say thank you. He was only being polite. They had some polite conversation over dinner. He’s not used to polite society.",
+      "count": 0
+    },
+    {
+      "word": "poor /pɔː(r)/",
+      "meaning": "come a poor second, poor loser, poor girl/boy/etc, poor relation, poor health, the rich and the poor",
+      "example": "He came a poor second in the race. Don’t be a poor loser. The poor boy had no shoes. The charity is a poor relation of bigger ones. She has suffered from poor health. The gap between the rich and the poor is widening.",
+      "count": 0
+    },
+    {
+      "word": "power /ˈpaʊə(r)/",
+      "meaning": "take/seize/hold/exercise/exert/wield/abuse power, power to do, power over, beyond sb’s power, the powers that be, power structure/base",
+      "example": "The army seized power overnight. He exercised his power wisely. She has the power to make that decision. He holds power over the region. It’s beyond my power to change it. The powers that be decided to cancel the project. The power structure is too rigid.",
+      "count": 0
+    },
+    {
+      "word": "praise /preɪz/",
+      "meaning": "praise sb for doing, win/receive/earn praise, full of praise for, in praise of",
+      "example": "She praised him for helping. The project received a lot of praise. Everyone was full of praise for her speech. The painting was created in praise of freedom.",
+      "count": 0
+    },
+    {
+      "word": "prefer /prɪˈfɜː(r)/",
+      "meaning": "prefer sb to do, prefer sth to, prefer doing, would prefer",
+      "example": "I’d prefer him to call later. I prefer coffee to tea. She prefers working alone. I would prefer to stay home tonight.",
+      "count": 0
+    },
+    {
+      "word": "principle /ˈprɪnsəpl/",
+      "meaning": "have principles, against sb’s principles, principle of sth, a matter/issue of principle",
+      "example": "He’s a man of strong principles. It’s against my principles to lie. The principle of gravity is universal. I can’t agree, it’s a matter of principle.",
+      "count": 0
+    },
+    {
+      "word": "print /prɪnt/",
+      "meaning": "print sth out/off, in print, out of print",
+      "example": "Please print out the tickets. The book is still in print. That novel is out of print now.",
+      "count": 0
+    },
+    {
+      "word": "prison /ˈprɪzn/",
+      "meaning": "go to prison, serve a sentence, prison term, prison reform, prison officer",
+      "example": "He went to prison for theft. He’s serving a ten-year sentence. It was a long prison term. The law aims at prison reform. The prison officer escorted the inmate.",
+      "count": 0
+    },
+    {
+      "word": "process /ˈprəʊses/",
+      "meaning": "in the process of doing, peace/election/judicial/legal process, due process",
+      "example": "We’re in the process of hiring. The peace process has stalled. The election process is underway. He didn’t receive due process.",
+      "count": 0
+    },
+    {
+      "word": "provoke /prəˈvəʊk/",
+      "meaning": "provoke sb into doing, provoke a reaction/protest/outcry",
+      "example": "His insult provoked her into quitting. The speech provoked a strong reaction. It provoked widespread protest.",
+      "count": 0
+    },
+    {
+      "word": "purpose /ˈpɜːpəs/",
+      "meaning": "serve a purpose, purpose of doing, on purpose, for the purpose of, escape sb’s purpose",
+      "example": "This feature serves no purpose. The purpose of doing this is safety. I did it on purpose. He was hired for the purpose of expanding the team. Her point escaped my purpose.",
+      "count": 0
+    },
+    {
+      "word": "quality /ˈkwɒləti/",
+      "meaning": "high/good/top quality, poor/bad/low quality, personal/professional qualities, quality of life/time",
+      "example": "They produce high-quality goods. The video was poor quality. His honesty is one of his best qualities. We want to improve quality of life. I enjoy spending quality time with my kids.",
+      "count": 0
+    },
+    {
+      "word": "question /ˈkwestʃən/",
+      "meaning": "beg the question, a/no question of, in question, out of the question, without question, beyond question, some question over/as to/about, awkward question",
+      "example": "This begs the question—why now? There’s no question of him resigning. His future is in question. It’s out of the question to cancel now. He’s guilty without question. Her loyalty is beyond question. There’s some question over the deal. That was an awkward question.",
+      "count": 0
+    },
+    {
+      "word": "rain /reɪn/",
+      "meaning": "rain hard/heavily, pour with rain, heavy/light rain, get caught in the rain",
+      "example": "It rained heavily last night. It’s pouring with rain today. We had light rain this morning. I got caught in the rain on the way home.",
+      "count": 0
+    },
+    {
+      "word": "raise /reɪz/",
+      "meaning": "raise your hand, raise sth with sb, raise an objection, raise your voice/eyebrows, raise a child/family, raise sb’s hopes/expectations, raise awareness, raise money",
+      "example": "Please raise your hand to speak. She raised the issue with her manager. I’d like to raise an objection. He raised his voice in anger. They raised four children. That comment raised everyone’s hopes. The ad campaign raised awareness about the issue. We raised money for the shelter.",
+      "count": 0
+    },
+    {
+      "word": "react /riˈækt/",
+      "meaning": "react by doing, react accordingly/inappropriately, react to sth, react against",
+      "example": "He reacted by slamming the door. They reacted accordingly to the new rules. She reacted strongly to the news. The crowd reacted against the unfair policy.",
+      "count": 0
+    },
+    {
+      "word": "reaction /riˈækʃn/",
+      "meaning": "cause/produce/provoke/trigger a reaction, reaction against, reaction to",
+      "example": "The announcement triggered a strong reaction. The book is a reaction against modern trends. Her reaction to the surprise was priceless.",
+      "count": 0
+    },
+    {
+      "word": "read /riːd/",
+      "meaning": "read sb’s mind, read sb like a book, read between the lines, read out loud, read from cover to cover",
+      "example": "She can read your mind. I can read him like a book. You need to read between the lines here. Please read this paragraph out loud. I read the novel from cover to cover.",
+      "count": 0
+    },
+    {
+      "word": "reality /riˈæləti/",
+      "meaning": "escape from reality, face reality, in reality, reality TV",
+      "example": "Some people drink to escape from reality. You must face reality at some point. In reality, the plan was flawed. She appears on a reality TV show.",
+      "count": 0
+    },
+    {
+      "word": "record /ˈrekɔːd/",
+      "meaning": "keep/maintain/copy a record of, set/break a record, on record, off the record",
+      "example": "We keep a record of all payments. She broke the world record in 100m. The hottest year on record was 2016. He spoke off the record.",
+      "count": 0
+    },
+    {
+      "word": "relative /ˈrelətɪv/",
+      "meaning": "a relative of yours, distant/close relative, a relative newcomer/unknown, relative clause/pronoun",
+      "example": "She’s a close relative of mine. That man is a distant relative. He’s a relative newcomer to politics. The sentence contains a relative clause.",
+      "count": 0
+    },
+    {
+      "word": "respect /rɪˈspekt/",
+      "meaning": "respect sb for sth, lose/win sb’s respect, have/show respect for, in this/that respect, with respect to",
+      "example": "I respect her for her honesty. He lost everyone’s respect after the scandal. We should show respect for elders. In this respect, I agree. With respect to your concerns, we’re working on it.",
+      "count": 0
+    },
+    {
+      "word": "response /rɪˈspɒns/",
+      "meaning": "response to sth, in response to, no response",
+      "example": "His response to the news was calm. In response to your request, we will issue a refund. There was no response after we called.",
+      "count": 0
+    },
+    {
+      "word": "rest /rest/",
+      "meaning": "rest on/against, rest assured that, take/have a rest, come to rest",
+      "example": "He rested his head on her shoulder. Rest assured that we will deliver on time. I need to take a rest after that hike. The car came to rest in a ditch.",
+      "count": 0
+    },
+    {
+      "word": "rich /rɪtʃ/",
+      "meaning": "rich in, filthy/stinking rich, rich and famous, the rich and the poor",
+      "example": "Avocados are rich in healthy fats. They became stinking rich overnight. She dreams of becoming rich and famous. The film contrasts the lives of the rich and the poor.",
+      "count": 0
+    },
+    {
+      "word": "right /raɪt/",
+      "meaning": "have a/the/no/every right to do, give sb the right to do, right and wrong, right in doing, right of sb to do, human/animal rights",
+      "example": "You have every right to speak up. The law gives us the right to vote. Kids must learn right and wrong. He was right in refusing the offer. It’s not right of you to blame her. They campaign for human rights.",
+      "count": 0
+    },
+    {
+      "word": "risk /rɪsk/",
+      "meaning": "run the risk of doing, risk sth on, pose a risk to, at the risk of doing, put sth at risk, take a risk, at risk",
+      "example": "He ran the risk of losing his job. She risked everything on one bet. Smoking poses a risk to your health. At the risk of sounding rude, I disagree. You put our plans at risk. We took a risk investing early. The species is at risk.",
+      "count": 0
+    },
+    {
+      "word": "rule /ruːl/",
+      "meaning": "break/follow/bend the rules, against the rules, rule of law, rule book, rule out the possibility, rule of thumb",
+      "example": "You must follow the rules. It’s against the rules to cheat. Democracy relies on the rule of law. He lives by the rule book. They ruled out the possibility of fraud. As a rule of thumb, don’t spend more than you earn.",
+      "count": 0
+    },
+    {
+      "word": "run /rʌn/",
+      "meaning": "run a business/campaign, run wild, run riot, run sb a bath, run on, run through sth, run the risk of doing, run into trouble",
+      "example": "She runs her own business. The children ran wild at the park. Emotions ran riot after the game. He ran me a warm bath. The meeting ran on for hours. Let’s run through the plan. You run the risk of failure. We ran into trouble halfway.",
+      "count": 0
+    },
+    {
+      "word": "rush /rʌʃ/",
+      "meaning": "rush to do, rush sb into, in a rush, rush hour, do sth in a rush",
+      "example": "Don’t rush to conclusions. Don’t rush me into a decision. I’m in a rush, sorry! Traffic’s bad during rush hour. I packed everything in a rush.",
+      "count": 0
+    },
+    {
+      "word": "say /seɪ/",
+      "meaning": "have your say, say the word, say for certain, say your piece, nothing to say",
+      "example": "Everyone will have their say. Just say the word and I’ll help. I can’t say for certain. She said her piece and left. I have nothing to say about that.",
+      "count": 0
+    },
+    {
+      "word": "second /ˈsekənd/",
+      "meaning": "give/take a second to do, a split second, second hand, second best",
+      "example": "Give me a second to think. It happened in a split second. He bought a second-hand bike. I don’t want to settle for second best.",
+      "count": 0
+    },
+    {
+      "word": "sense /sens/",
+      "meaning": "make sense of, see sense, have the sense to do, common sense",
+      "example": "I can’t make sense of these instructions. I hope he’ll see sense and apologize. She had the sense to leave early. Use your common sense in emergencies.",
+      "count": 0
+    },
+    {
+      "word": "sentence /ˈsentəns/",
+      "meaning": "pass sentence on, serve a sentence, prison/jail sentence, death/life sentence",
+      "example": "The judge passed sentence on the thief. He served a five-year sentence. The crime led to a jail sentence. She received a life sentence.",
+      "count": 0
+    },
+    {
+      "word": "shape /ʃeɪp/",
+      "meaning": "get/stay in shape, take shape, out of shape, in the shape of",
+      "example": "I exercise to stay in shape. Plans are starting to take shape. I’m so out of shape lately. The island is in the shape of a star.",
+      "count": 0
+    },
+    {
+      "word": "share /ʃeə(r)/",
+      "meaning": "share with/between/among, shareholder, share index, share option",
+      "example": "He shared the cake with his friends. The shareholders met yesterday. The share index rose sharply. She received share options at her job.",
+      "count": 0
+    },
+    {
+      "word": "sharp /ʃɑːp/",
+      "meaning": "keep a sharp eye on, sharp rise/drop/increase, sharp criticism",
+      "example": "Keep a sharp eye on your belongings. There was a sharp rise in prices. His speech drew sharp criticism.",
+      "count": 0
+    },
+    {
+      "word": "short /ʃɔːt/",
+      "meaning": "run short, short-term/notice/while/period/spell, be short of sth, short-list",
+      "example": "We’re running short on time. It’s a short-term fix. She was hired on short notice. Stay for a short while. I’m short of cash right now. They short-listed five candidates.",
+      "count": 0
+    },
+    {
+      "word": "law /lɔː/",
+      "meaning": "become law, break/follow/uphold the law, pass/amend/repeal a law, lay down the law, law and order, against the law, under the law, follow the law",
+      "example": "The bill became law last year. He broke the law and was fined. Police must uphold the law. Parliament passed a new traffic law. The law was amended last session. Parents can't just lay down the law. The protest was against the law. Everyone is equal under the law. You must follow the law.",
+      "count": 0
+    },
+    {
+      "word": "lead /liːd/",
+      "meaning": "lead sb into, lead the way, lead the world in, lead sb to believe, take/hold the lead, follow sb’s lead, in the lead",
+      "example": "He led us into a dangerous area. She will lead the way on climate reform. This firm leads the world in biotech. He led me to believe we had a deal. She took the lead early in the race. We followed his lead and stopped arguing. Our team is currently in the lead.",
+      "count": 0
+    },
+    {
+      "word": "leisure /ˈleʒə(r)/",
+      "meaning": "have the leisure to do, at your leisure, leisure centre, leisure time/pursuits",
+      "example": "She doesn’t have the leisure to read these days. Please complete this at your leisure. We joined the local leisure centre. Watching movies is my favourite leisure pursuit.",
+      "count": 0
+    },
+    {
+      "word": "length /leŋkθ/",
+      "meaning": "go to great lengths, run the length of, in length, of (un)equal length, length of time",
+      "example": "He went to great lengths to impress her. The pipe runs the length of the building. The documentary was 45 minutes in length. These tables are of equal length. It took a long length of time to finish.",
+      "count": 0
+    },
+    {
+      "word": "letter /ˈletə(r)/",
+      "meaning": "get/receive a letter from, write/send sb a letter, letter bomb",
+      "example": "I got a letter from my cousin. I wrote a letter to the council. Police intercepted a letter bomb at the embassy.",
+      "count": 0
+    },
+    {
+      "word": "life /laɪf/",
+      "meaning": "put sb’s life at risk, bring sth to life, come to life, save sb’s life, take sb’s life, lose a life, quality of life",
+      "example": "Speeding puts lives at risk. The story was brought to life on stage. The city centre came to life at night. The doctor saved his life. The suspect took his own life. The crash claimed three lives. They enjoy a high quality of life.",
+      "count": 0
+    },
+    {
+      "word": "lightning /ˈlaɪtnɪŋ/",
+      "meaning": "lightning bolt/flash, struck by lightning, lightning speed",
+      "example": "A bolt of lightning hit the tree. He was struck by lightning during the storm. She responded with lightning speed.",
+      "count": 0
+    },
+    {
+      "word": "like /laɪk/",
+      "meaning": "like doing/to do, anything/nothing like, alike/in like manner, just like, be like sb to do",
+      "example": "I like playing guitar in my free time. There’s nothing like a warm bath. They look alike. She sings just like her mother. It’s like him to show up late.",
+      "count": 0
+    },
+    {
+      "word": "link /lɪŋk/",
+      "meaning": "link to/with, find/prove/establish a link, click/follow a link",
+      "example": "This disease is linked to poor diet. They found a link between stress and heart disease. Click this link to join the call.",
+      "count": 0
+    },
+    {
+      "word": "live /lɪv/",
+      "meaning": "live a life of crime/luxury, live to do, live and let live, live in hope/fear, live to tell the tale",
+      "example": "He lived a life of crime before reform. She lives to help others. I say live and let live. We live in hope that things improve. He survived the crash and lived to tell the tale.",
+      "count": 0
+    },
+    {
+      "word": "load /ləʊd/",
+      "meaning": "load sth with/into, take a load off, a (whole) load of, loads of, a heavy load to bear/carry",
+      "example": "She loaded the cart with groceries. Sit down and take a load off your feet. We had a whole load of laundry. He’s got loads of work today. Caring for his family is a heavy load to carry.",
+      "count": 0
+    },
+    {
+      "word": "lock /lɒk/",
+      "meaning": "lock sth in/behind/under, lock horns with, locksmith",
+      "example": "He locked the files in a drawer. They locked horns during the debate. Call a locksmith if you're locked out.",
+      "count": 0
+    },
+    {
+      "word": "long /lɒŋ/",
+      "meaning": "last long, take a long time, all day long, long way, long distance, at long last, long and hard, long time ago",
+      "example": "The meeting didn’t last long. It took a long time to recover. They talked all day long. He walked a long way home. They maintained a long-distance relationship. At long last, they found peace. She thought long and hard about it. That happened a long time ago.",
+      "count": 0
+    },
+    {
+      "word": "lot /lɒt/",
+      "meaning": "a lot of, lots of, a lot on, a lot to do with, the lot",
+      "example": "There are a lot of options. We have lots of time. He’s got a lot on his mind. Her mood has a lot to do with stress. They ate the lot in one sitting.",
+      "count": 0
+    },
+    {
+      "word": "love /lʌv/",
+      "meaning": "love doing/to do, fall in love with, be in love, love affair, love for",
+      "example": "She loves baking cakes. He fell in love with Paris. They are still in love after 20 years. Their romance started as a love affair. She has a deep love for animals.",
+      "count": 0
+    },
+    {
+      "word": "luck /lʌk/",
+      "meaning": "push your luck, be in luck, lucky charm, bring/leave luck, wish sb luck",
+      "example": "Don’t push your luck asking for more. You’re in luck—we have one left. This ring is my lucky charm. That cat brings bad luck. I wished her luck before the test.",
+      "count": 0
+    },
+    {
+      "word": "mark /mɑːk/",
+      "meaning": "mark sb/sth on, leave a mark, mark the occasion, make a mark on, be quick/slow off the mark, hit the mark",
+      "example": "The teacher marked us on clarity. The war left a mark on him. We planted a tree to mark the occasion. He made his mark on politics. She’s always quick off the mark. Her speech really hit the mark.",
+      "count": 0
+    },
+    {
+      "word": "marriage /ˈmærɪdʒ/",
+      "meaning": "related by marriage, marriage guidance, marriage vows",
+      "example": "They are related by marriage. They sought marriage guidance. They exchanged heartfelt marriage vows.",
+      "count": 0
+    },
+    {
+      "word": "material /məˈtɪəriəl/",
+      "meaning": "material goods/possessions, material wealth, material resources, raw materials",
+      "example": "He owns few material possessions. They pursued material wealth above all. The region has limited material resources. The factory imports raw materials from abroad.",
+      "count": 0
+    },
+    {
+      "word": "matter /ˈmætə(r)/",
+      "meaning": "a matter of, in a matter of (days/etc), to make matters worse, to no matter, no matter what/how/etc, no laughing matter, a matter of opinion, a matter of urgency",
+      "example": "It’s a matter of principle. In a matter of days, everything changed. To make matters worse, it rained. It’s over—no matter. No matter what happens, I’ll stay. This is no laughing matter. Whether it's art is a matter of opinion. This is a matter of urgency.",
+      "count": 0
+    },
+    {
+      "word": "medicine /ˈmedsn/",
+      "meaning": "take medicine, alternative/complementary medicine, herbal medicine",
+      "example": "She took the medicine after lunch. He practices alternative medicine. I use herbal medicine for colds.",
+      "count": 0
+    },
+    {
+      "word": "mental /ˈmentl/",
+      "meaning": "make a mental note, mental arithmetic, mental illness/health",
+      "example": "I made a mental note to call her. He’s good at mental arithmetic. She’s recovering from a mental illness.",
+      "count": 0
+    },
+    {
+      "word": "metal /ˈmetl/",
+      "meaning": "precious metal, metal detector",
+      "example": "Gold is a precious metal. The metal detector beeped at the airport.",
+      "count": 0
+    },
+    {
+      "word": "sick /sɪk/",
+      "meaning": "call in sick, feel sick, make sb sick, sick as a parrot, sick and tired of, sick with fear/worry/etc, sick at heart, sick bag",
+      "example": "He had to call in sick today. I feel sick after that ride. That movie made me sick. She was sick as a parrot when she lost. I'm sick and tired of cleaning up after them. She’s sick with worry about her exam. He was sick at heart after the news. Please use a sick bag during turbulence.",
+      "count": 0
+    },
+    {
+      "word": "side /saɪd/",
+      "meaning": "side with sb, take sides, see both sides of an argument, the other side, on either side, on the plus/minus side, side by side",
+      "example": "She always sides with her brother. Don’t take sides in their argument. Try to see both sides of the argument. I’ll be waiting on the other side. Houses stood on either side of the street. On the plus side, it’s cheaper. They walked side by side in silence.",
+      "count": 0
+    },
+    {
+      "word": "size /saɪz/",
+      "meaning": "that’s about the size of it, cut sth to size, in size, of a certain size, increase/reduce in size",
+      "example": "So we lost the contract? That’s about the size of it. Cut the wood to size. The fish was large in size. We need envelopes of a certain size. The company reduced in size last year.",
+      "count": 0
+    },
+    {
+      "word": "small /smɔːl/",
+      "meaning": "feel small, in a small way, it’s a small world, small talk, small change, small number/amount/etc, small business",
+      "example": "His insult made me feel small. She contributed in a small way. We ran into each other – it’s a small world! We had some small talk before the meeting. I paid with small change. Only a small number of people attended. He runs a small business in town.",
+      "count": 0
+    },
+    {
+      "word": "smooth /smuːð/",
+      "meaning": "smooth the way for, smooth-talking, smooth sailing",
+      "example": "The manager helped smooth the way for my promotion. He’s a smooth-talking salesman. After the repairs, it was smooth sailing.",
+      "count": 0
+    },
+    {
+      "word": "social /ˈsəʊʃl/",
+      "meaning": "social conditions, social contact, social security, social services, social call, social worker",
+      "example": "Poor social conditions can lead to unrest. He avoids all social contact. Many retirees depend on social security. She works in social services. He dropped by on a social call. The social worker helped the family with housing.",
+      "count": 0
+    },
+    {
+      "word": "speaking /ˈspiːkɪŋ/",
+      "meaning": "speak well/highly/badly/ill of, speak your mind, speak out, speak the same language, so to speak",
+      "example": "Everyone spoke highly of her work. I decided to speak my mind about the changes. He spoke out against injustice. We speak the same language on this topic. We are partners, so to speak.",
+      "count": 0
+    },
+    {
+      "word": "start /stɑːt/",
+      "meaning": "make a good/bad/etc start, get off to a good/flying/head/etc start, head start, start from scratch, for a start, right from the start, from the start of",
+      "example": "She made a good start on the project. We got off to a flying start. That gave me a head start. I had to start from scratch. For a start, we’ll need more staff. He was honest right from the start. It was clear from the start of the lesson.",
+      "count": 0
+    },
+    {
+      "word": "steady /ˈstedi/",
+      "meaning": "steady yourself, steady your nerves, hold sth steady, steady relationship, steady growth, steady look, steady pace",
+      "example": "She steadied herself before going on stage. He tried to steady his nerves. Hold the ladder steady. They’re in a steady relationship. The company has shown steady growth. He gave her a steady look. They walked at a steady pace.",
+      "count": 0
+    },
+    {
+      "word": "straight /streɪt/",
+      "meaning": "set/put sb straight, get sth straight, think/see straight, straight talking, straight answer",
+      "example": "Let me set you straight about the rules. I want to get this straight. I was so tired I couldn’t think straight. I like his style of straight talking. Just give me a straight answer.",
+      "count": 0
+    },
+    {
+      "word": "style /staɪl/",
+      "meaning": "style sth/yourself as, in style, style of, out of style, with style",
+      "example": "He styled himself as a reformer. She always arrives in style. That’s not my style of writing. Bell-bottoms are out of style now. She completed the performance with style.",
+      "count": 0
+    },
+    {
+      "word": "subject /ˈsʌbdʒɪkt/",
+      "meaning": "subject to, bring up a subject, get onto a subject, drop a subject, subject sb to, the subject of, British subject",
+      "example": "Prices are subject to change. She brought up the subject of bonuses. Let’s get onto the next subject. Let’s drop the subject. The manager subjected us to a long lecture. The subject of today’s meeting is safety. He is a British subject by birth.",
+      "count": 0
+    },
+    {
+      "word": "sun /sʌn/",
+      "meaning": "sun yourself, in the sun, in the shade/sunlight/sunshine, sunset",
+      "example": "He lay on the beach to sun himself. We sat in the sun all day. They stayed in the shade. The room was full of sunlight. They watched the beautiful sunset together.",
+      "count": 0
+    },
+    {
+      "word": "support /səˈpɔːt/",
+      "meaning": "support doing sth, support sb, support sth, support sb financially/emotionally/etc, support a team",
+      "example": "I support limiting emissions. Her family supported her throughout. I fully support the plan. He supports his parents financially. I support the national team.",
+      "count": 0
+    },
+    {
+      "word": "surface /ˈsɜːfɪs/",
+      "meaning": "on the surface, beneath/under the surface, surface area, kitchen surface, smooth surface",
+      "example": "On the surface it seemed fine. Beneath the surface, tensions grew. The paint covers a large surface area. Wipe down the kitchen surface. The floor had a smooth surface.",
+      "count": 0
+    },
+    {
+      "word": "table /ˈteɪbl/",
+      "meaning": "set/clear/lay the table, table a proposal, table manners, on the table, under the table",
+      "example": "She set the table for dinner. They tabled a proposal for discussion. His table manners are excellent. That offer is still on the table. They paid under the table.",
+      "count": 0
+    },
+    {
+      "word": "talk /tɔːk/",
+      "meaning": "talk sb into/out of doing, talk sense, talk the same language, talk is cheap, talk your way into/out of",
+      "example": "She talked me into applying. You’re finally talking sense. We talk the same language about values. Talk is cheap—actions matter more. He talked his way out of trouble.",
+      "count": 0
+    },
+    {
+      "word": "taste /teɪst/",
+      "meaning": "develop/have/acquire a taste for, in good/bad taste, sense of taste",
+      "example": "He developed a taste for jazz. That joke was in bad taste. I lost my sense of taste when I was sick.",
+      "count": 0
+    },
+    {
+      "word": "tell /tel/",
+      "meaning": "tell the truth/a lie, tell yourself, tell the difference, tell sb to do sth, tell sb what, be told, tell that, tell on",
+      "example": "Please tell the truth. I told myself it was okay. Can you tell the difference between them? He told me to wait. She told him what happened. I was told to leave. I can tell that she’s lying. His lies will tell on him eventually.",
+      "count": 0
+    },
+    {
+      "word": "term /tɜːm/",
+      "meaning": "in the long/short term, term of/in office, prison/jail term, fixed term, term time, long/short-term",
+      "example": "In the short term, sales may fall. He served a term in office. He was sentenced to a long prison term. The job has a fixed term of 2 years. During term time, the library is busy. It’s a short-term fix.",
+      "count": 0
+    },
+    {
+      "word": "thin /θɪn/",
+      "meaning": "have thin skin, thin on top, thin on the ground, out of thin air, into thin air",
+      "example": "She has thin skin and gets offended easily. He’s a bit thin on top these days. Volunteers were thin on the ground. He appeared out of thin air. The documents vanished into thin air.",
+      "count": 0
+    },
+    {
+      "word": "threat /θret/",
+      "meaning": "pose a threat to, under threat, threat of, bomb/death threat",
+      "example": "Pollution poses a threat to wildlife. The species is under threat. There’s a threat of war. She received a death threat online.",
+      "count": 0
+    },
+    {
+      "word": "time /taɪm/",
+      "meaning": "pass the time, spend time doing, make time, find time, take time, in time, on time, time limit",
+      "example": "We played cards to pass the time. I spent time reading. Try to make time for your hobbies. Can you find time for lunch? Take your time with the project. I arrived just in time. The train was on time. There’s a time limit for submissions.",
+      "count": 0
+    },
+    {
+      "word": "want /wɒnt/",
+      "meaning": "want (sb) to do, want sth done, for want of",
+      "example": "I want you to help me move this. I want this report finished by Friday. The plan failed for want of support.",
+      "count": 0
+    },
+    {
+      "word": "way /weɪ/",
+      "meaning": "get in sb’s way, know the way, lose your way, get sth out of the way, in the way, on the/your/their way, in this way, way of doing",
+      "example": "Try not to get in his way. Do you know the way to the beach? We lost our way in the forest. Let’s get this task out of the way. The chair is in the way. I met her on the way to work. We solve problems in this way. This is her way of teaching grammar.",
+      "count": 0
+    },
+    {
+      "word": "weak /wiːk/",
+      "meaning": "weak at the knees, weak on, weak argument, weak point/spot, weak-willed",
+      "example": "She felt weak at the knees when he smiled. I’m a bit weak on statistics. That’s a weak argument. Patience is my weak spot. He’s too weak-willed to stand up for himself.",
+      "count": 0
+    },
+    {
+      "word": "weather /ˈweðə(r)/",
+      "meaning": "good/bad/etc weather, freak weather, in all weathers, under the weather, weather forecast, weatherproof",
+      "example": "We had such good weather for the trip. A freak weather event damaged the town. He works outside in all weathers. I feel a bit under the weather today. Did you hear the weather forecast? This jacket is completely weatherproof.",
+      "count": 0
+    },
+    {
+      "word": "web /web/",
+      "meaning": "surf the Web, on the Web, website, webcam, World Wide Web, web page",
+      "example": "She spent hours surfing the Web. I found this on the Web. The website was down for maintenance. Turn on your webcam, please. He teaches about the World Wide Web. This web page isn’t loading correctly.",
+      "count": 0
+    },
+    {
+      "word": "wedding /ˈwedɪŋ/",
+      "meaning": "wedding anniversary, wedding cake, wedding ceremony, wedding dress, wedding invitation, wedding present",
+      "example": "Today is our wedding anniversary. The wedding cake was beautiful. The wedding ceremony took place in a garden. She wore a traditional wedding dress. We got a lovely wedding invitation. They bought them a wedding present.",
+      "count": 0
+    },
+    {
+      "word": "wheel /wiːl/",
+      "meaning": "take the wheel, behind the wheel, wheel of fortune",
+      "example": "She asked me to take the wheel. He was behind the wheel during the crash. Winning the lottery felt like spinning the wheel of fortune.",
+      "count": 0
+    },
+    {
+      "word": "wind /wɪnd/",
+      "meaning": "high/strong wind, light wind, against the wind, in the wind, out of the wind, wind blows, gust of wind, the winds of change",
+      "example": "High wind caused delays at the airport. A light wind cooled the afternoon. We cycled against the wind. Leaves floated in the wind. Sit out of the wind to stay warm. The wind blows hard in winter. A gust of wind slammed the door. The winds of change are coming.",
+      "count": 0
+    },
+    {
+      "word": "window /ˈwɪndəʊ/",
+      "meaning": "window-shopping, window display, window dresser, out the window, a window on/onto/into",
+      "example": "We went window-shopping downtown. The window display featured summer clothes. She works as a window dresser. His good mood went out the window. The novel offers a window into ancient life.",
+      "count": 0
+    },
+    {
+      "word": "word /wɜːd/",
+      "meaning": "put in a (good) word for, have a word with, spread the word, from the word go, in other words",
+      "example": "Can you put in a good word for me? I need to have a word with you. We’re spreading the word about the event. I knew from the word go it was trouble. In other words, it’s time to leave.",
+      "count": 0
+    },
+    {
+      "word": "work /wɜːk/",
+      "meaning": "work on/in/with/as/at/for, work like magic/a charm, work both ways, work a treat, work wonders, work your way up/to/through",
+      "example": "She works in finance. That remedy worked like a charm. Respect works both ways. The new design works a treat. This medicine works wonders. He worked his way up from clerk to manager.",
+      "count": 0
+    },
+    {
+      "word": "worse /wɜːs/",
+      "meaning": "get worse, make matters/things worse, worse for wear, for the worse, if (the) worst comes to (the) worst",
+      "example": "My headache is getting worse. He made matters worse by shouting. The sofa looks worse for wear. His health has changed for the worse. If the worst comes to the worst, we’ll call for help.",
+      "count": 0
+    },
+    {
+      "word": "worst /wɜːst/",
+      "meaning": "do your worst, fear the worst, be your own worst enemy, if the worst comes to the worst, at worst",
+      "example": "Go ahead—do your worst! I feared the worst when he didn’t call. She’s her own worst enemy. If the worst comes to the worst, we’ll cancel. At worst, we’ll have to wait another day.",
+      "count": 0
+    },
+    {
+      "word": "write /raɪt/",
+      "meaning": "write for a magazine/etc, have sth be written all over your face, write about, write of, write on, write sb/sth off, writer’s block",
+      "example": "He writes for a travel magazine. Guilt was written all over her face. I’m writing about AI ethics. She wrote of her childhood. He’s writing on climate change. They wrote the car off as a loss. She’s struggling with writer’s block.",
+      "count": 0
+    },
+    {
+      "word": "year /jɪə(r)/",
+      "meaning": "years of age, year on year, for years, year after year, never in a million years, year (noun)",
+      "example": "She’s 10 years of age. Profits increased year on year. We’ve lived here for years. He wins that race year after year. Never in a million years did I expect this. It was a year full of challenges.",
+      "count": 0
+    },
+    {
+      "word": "tool /tuːl/",
+      "meaning": "a tool for (doing), a tool of (vũ khí, công cụ), toolbar (thanh công cụ), tool kit (bộ dụng cụ), power tool (dụng cụ điện)",
+      "example": "This wrench is a tool for fixing bikes. Language is a powerful tool of communication. Click the icon in the toolbar to proceed. He opened the tool kit to find a screwdriver. Power tools can be dangerous if misused.",
+      "count": 0
+    },
+    {
+      "word": "top /tɒp/",
+      "meaning": "come out on top, get on top of sth, be on top of, on top (of), off the top of your head, from the top, at the top (of), top of the world, top priority, top secret",
+      "example": "She came out on top in the final round. I need to get on top of these emails. He’s really on top of his job. There was a vase on top of the table. Off the top of my head, I’d say ten. Start from the top and work your way down. They live at the top of the hill. After the win, he felt on top of the world. Health is our top priority. This information is top secret.",
+      "count": 0
+    },
+    {
+      "word": "tough /tʌf/",
+      "meaning": "get tough with, tough on, tough luck, tough love, tough guy",
+      "example": "The manager decided to get tough with underperformers. The law is tough on repeat offenders. It’s tough luck we missed the train. His parents used tough love to guide him. He acts like a tough guy but is kind inside.",
+      "count": 0
+    },
+    {
+      "word": "town /taʊn/",
+      "meaning": "town planning, the town of, in town, the outskirts/edge of town, town centre",
+      "example": "She studied town planning at university. The town of Hoi An is famous for its lanterns. Are you in town this weekend? They live on the outskirts of town. Let’s meet in the town centre.",
+      "count": 0
+    },
+    {
+      "word": "track /træk/",
+      "meaning": "keep track of, lose track of, on track, track sb/sth, off the beaten track",
+      "example": "I keep track of my expenses using an app. I lost track of time while reading. We’re on track to meet the deadline. The police are tracking the suspect. We camped somewhere off the beaten track.",
+      "count": 0
+    },
+    {
+      "word": "treat /triːt/",
+      "meaning": "treat cruelly/badly/fairly/unjustly, treat sb for (bệnh), treat sb to (chiêu đãi), treat sb with, treat sb like/as, treat a disease/illness/injury/patient",
+      "example": "They treated him unfairly. The doctor treated her for the flu. I’ll treat you to lunch today. Treat animals with respect. He treated her like a child. This hospital treats cancer patients.",
+      "count": 0
+    },
+    {
+      "word": "turn /tɜːn/",
+      "meaning": "turn to sb/sth, turn a gun/etc on sb, turn to sb for help/advice, turn cold/nasty/etc, turn 40/etc",
+      "example": "She turned to her best friend for advice. He turned a gun on himself. I turned to my mentor for help. The weather turned cold overnight. He turned 40 last week.",
+      "count": 0
+    },
+    {
+      "word": "understanding /ˌʌndəˈstændɪŋ/",
+      "meaning": "come to/reach an understanding, have an understanding with, an understanding of",
+      "example": "We came to an understanding after the meeting. I have an understanding with my boss about working hours. He has a deep understanding of physics.",
+      "count": 0
+    },
+    {
+      "word": "use /juːz/",
+      "meaning": "use sth for doing, use sth to do, use sth properly, have many uses, in use, of (no) use, it's no/little/some use doing, what's the use of doing",
+      "example": "We use knives for cutting vegetables. I used my phone to take the photo. Make sure you use this properly. This tool has many uses. Is the printer still in use? That method is of no use here. It’s no use crying over spilt milk. What’s the use of worrying now?",
+      "count": 0
+    },
+    {
+      "word": "view /vjuː/",
+      "meaning": "take the view that, have a dim/poor view of, come into view, in view of, view on/about, take a view, in sb’s view, view from sth, viewpoint",
+      "example": "I take the view that honesty is best. I have a poor view of that policy. The mountains came into view. In view of the situation, we canceled the event. What’s your view on this issue? I’d like to take a longer view. In her view, we acted rightly. The view from here is amazing. His viewpoint is always interesting.",
+      "count": 0
+    },
+    {
+      "word": "mind /maɪnd/",
+      "meaning": "make up your mind (quyết định), cross/slip your mind (quên), bear/keep in mind (nhớ trong đầu), have a one-track mind (luôn nghĩ về một thứ), in two minds about (phân vân), on your mind (bận tâm), take your mind off (nghĩ sang chuyện khác), bring to mind (gợi nhớ), never mind (đừng bận tâm), narrow/broad/open/absent-minded (đầu óc hẹp hòi/rộng mở/lơ đãng)",
+      "example": "I haven’t made up my mind yet. That name brings to mind a funny memory. Never mind the mess — come in!",
+      "count": 0
+    },
+    {
+      "word": "misapprehension /ˌmɪsæprɪˈhenʃn/",
+      "meaning": "under the misapprehension that (hiểu sai rằng)",
+      "example": "She was under the misapprehension that I lived alone.",
+      "count": 0
+    },
+    {
+      "word": "moment /ˈməʊmənt/",
+      "meaning": "take/be a moment (mất chút thời gian), just/wait a moment (chờ một chút), at the moment (hiện tại), at this/that moment in time (ngay lúc này), in a moment (trong giây lát), the moment of truth (thời khắc quyết định), for (the) moment (tạm thời)",
+      "example": "Wait a moment while I check. At the moment, we’re not hiring. This is the moment of truth.",
+      "count": 0
+    },
+    {
+      "word": "money /ˈmʌni/",
+      "meaning": "make/earn/spend/cost/get money (kiếm/tiêu tiền), save/have money (tiết kiệm/có tiền), do sth for money (làm vì tiền), put your money where your mouth is (làm thay vì nói), get your money’s worth (xứng đáng), pay good money for (trả nhiều tiền)",
+      "example": "He makes good money selling cars. I just want to get my money’s worth. She paid good money for that dress.",
+      "count": 0
+    },
+    {
+      "word": "mother /ˈmʌðə(r)/",
+      "meaning": "mother of (mẹ của), single/working mother (mẹ đơn thân/làm việc), mother-to-be (mẹ tương lai), mother figure (người mẹ tinh thần), mother country/tongue (mẫu quốc/tiếng mẹ đẻ), in-law (mẹ chồng), Mother Nature (Mẹ Thiên nhiên)",
+      "example": "She’s a single mother with two children. Vietnamese is my mother tongue.",
+      "count": 0
+    },
+    {
+      "word": "move /muːv/",
+      "meaning": "move to (chuyển đến), get a move on (nhanh lên), follow sb's every move (theo dõi), make a move (hành động), on the move (đang di chuyển/tiến triển)",
+      "example": "We decided to move to Da Nang. Let’s get a move on or we’ll be late. This company is constantly on the move.",
+      "count": 0
+    },
+    {
+      "word": "national /ˈnæʃnəl/",
+      "meaning": "national anthem (quốc ca), national costume (trang phục truyền thống), national debt (nợ quốc gia), national holiday (ngày lễ toàn quốc)",
+      "example": "Everyone stood for the national anthem. Tet is a national holiday in Vietnam.",
+      "count": 0
+    },
+    {
+      "word": "native /ˈneɪtɪv/",
+      "meaning": "native to (bản địa), a native of (người bản địa), native speaker (người nói bản ngữ), non-native (không bản địa), native land/tongue (quê hương/tiếng mẹ đẻ), native species (loài sinh vật bản địa)",
+      "example": "The panda is native to China. He’s a native speaker of English. That bird is a native species of Vietnam.",
+      "count": 0
+    },
+    {
+      "word": "natural /ˈnætʃrəl/",
+      "meaning": "natural causes (nguyên nhân tự nhiên), natural ability (năng lực bẩm sinh), natural resource (tài nguyên thiên nhiên), natural selection (chọn lọc tự nhiên)",
+      "example": "She has a natural ability for music. The country is rich in natural resources.",
+      "count": 0
+    },
+    {
+      "word": "nature /ˈneɪtʃə(r)/",
+      "meaning": "the nature of sth (bản chất của...), in nature (về bản chất), Nature (Mẹ Thiên nhiên), human nature (bản chất con người), second nature (trở thành thói quen tự nhiên)",
+      "example": "The nature of the problem is complex. Spending time outdoors helps you reconnect with nature.",
+      "count": 0
+    },
+    {
+      "word": "near /nɪə(r)/",
+      "meaning": "near to doing sth (sắp làm gì), the near future (tương lai gần), from near and far (từ khắp nơi), near thing (việc suýt thất bại), the nearest thing to (gần giống nhất với), nearest and dearest (người thân cận)",
+      "example": "He came near to quitting. We’ll see each other in the near future. They traveled from near and far to attend.",
+      "count": 0
+    },
+    {
+      "word": "need /niːd/",
+      "meaning": "need (sb) to do (cần ai làm gì), need doing (cần được làm), meet a need (đáp ứng nhu cầu), have no need of (không cần), in need (đang cần)",
+      "example": "We need to fix the roof. The plan needs reviewing. She helped a family in need.",
+      "count": 0
+    },
+    {
+      "word": "never /ˈnevə(r)/",
+      "meaning": "you never know (ai mà biết được), never again (không bao giờ nữa), never mind (đừng bận tâm), never-ending (không có hồi kết)",
+      "example": "Never again will I trust him. This winter feels never-ending. You never know who’s watching.",
+      "count": 0
+    },
+    {
+      "word": "new /njuː/",
+      "meaning": "new to (chưa quen), brand new (mới toanh), whole new (hoàn toàn mới), good as new (như mới), new to sb (ai đó mới với cái gì), new look (diện mạo mới), new age/music/etc (phong cách hiện đại)",
+      "example": "I’m new to this job. The phone looks as good as new. He’s into new age music.",
+      "count": 0
+    },
+    {
+      "word": "nice /naɪs/",
+      "meaning": "nice to sb (tốt với ai), nice of sb to do (ai đó tốt khi làm gì), nice for sb to do (ai đó tốt khi làm gì), nice to meet/hear/see/sb (rất vui gặp/nghe/thấy ai), nice and clean/safe/warm/etc (rất sạch/safe/ấm...)",
+      "example": "It was nice of you to help. This blanket is nice and warm. Nice to meet you!",
+      "count": 0
+    },
+    {
+      "word": "notice /ˈnəʊtɪs/",
+      "meaning": "notice sb doing/do sth (để ý thấy ai làm gì), bring sth to sb’s notice (nhắc nhở ai điều gì), come to sb’s notice (ai đó chú ý), escape sb’s notice (ai đó không để ý), take notice of (chú ý đến), at short notice (gấp), until further notice (cho đến khi có thông báo tiếp theo)",
+      "example": "She didn’t notice him come in. It came to my notice that she was late. We canceled the meeting at short notice.",
+      "count": 0
+    },
+    {
+      "word": "now /naʊ/",
+      "meaning": "now is the time to do (lúc để làm gì), from now on (từ giờ trở đi), for now (hiện tại), now that (bởi vì giờ đây), just now (mới đây), any day/moment now (bất cứ lúc nào)",
+      "example": "Now is the time to act. From now on, I’ll be more careful. She’ll be here any moment now.",
+      "count": 0
+    },
+    {
+      "word": "odds /ɒdz/",
+      "meaning": "odds are (that) (rất có khả năng là), the odds of doing (khả năng xảy ra), the odds are in favor/against (khả năng ủng hộ/chống lại), against all odds (bất chấp mọi khó khăn), take a chance/chances/guess (đoán/bắt lấy cơ hội)",
+      "example": "The odds are he’ll arrive late. She succeeded against all odds.",
+      "count": 0
+    },
+    {
+      "word": "off /ɒf/",
+      "meaning": "have/take/be given the day off (nghỉ làm), off work/college/etc (nghỉ làm), off duty (hết ca trực), off the top of your head (ngay lập tức), off and on/on and off (lúc có lúc không), off balance (mất thăng bằng), off limits (cấm vào)",
+      "example": "I’m off duty now. He’s off work due to illness. This room is off limits.",
+      "count": 0
+    },
+    {
+      "word": "office /ˈɒfɪs/",
+      "meaning": "take office (nhậm chức), run for office (tranh cử), hold office (giữ chức), head office (trụ sở chính), office holder (người nắm giữ chức vụ), office job (công việc văn phòng), office hours (giờ làm việc)",
+      "example": "He took office last year. She’s running for public office.",
+      "count": 0
+    },
+    {
+      "word": "old /əʊld/",
+      "meaning": "get/grow old (trở nên già), old age (tuổi già), old folks (người già), old hand (người dày dạn), old-fashioned (cổ hủ), old money (gia đình giàu lâu đời), old flame (tình cũ), old-fashioned ideas (tư tưởng cổ hủ)",
+      "example": "He’s getting old but still strong. She’s an old hand at negotiation.",
+      "count": 0
+    },
+    {
+      "word": "on /ɒn/",
+      "meaning": "on purpose (cố tình), on your own (tự mình), on and on (dài dòng mãi), on the one/other hand (một mặt/mặt khác), on top (trên đầu), on time (đúng giờ), on demand (khi cần), on loan (cho mượn)",
+      "example": "I didn’t do it on purpose. She arrived on time. This book is on loan from the library.",
+      "count": 0
+    },
+    {
+      "word": "opt /ɒpt/",
+      "meaning": "opt for (chọn thứ gì), opt to do (chọn làm gì)",
+      "example": "She opted for the vegetarian dish. I opted to stay at home.",
+      "count": 0
+    },
+    {
+      "word": "option /ˈɒpʃn/",
+      "meaning": "have no option (but to) (không còn lựa chọn nào), consider your options (cân nhắc lựa chọn), keep/leave your options open (giữ lựa chọn), the option of doing (lựa chọn làm việc gì), the option to do (lựa chọn để làm gì)",
+      "example": "We had no option but to leave. I’m keeping my options open for now.",
+      "count": 0
+    },
+    {
+      "word": "paper /ˈpeɪpə(r)/",
+      "meaning": "piece/sheet of paper (mảnh/giấy), present/write/set a paper on (trình bày/viết đề tài), paper round (nghề phát báo), paper qualifications (bằng cấp giấy), paperwork (công việc giấy tờ)",
+      "example": "Please fill out this sheet of paper. He gave a paper on renewable energy.",
+      "count": 0
+    },
+    {
+      "word": "end /end/",
+      "meaning": "come to an end (kết thúc), bring sth to an end (kết thúc việc gì), put an end to sth (chấm dứt), at an end (đã kết thúc), (for) hours/weeks/etc on end (liên tục hàng giờ/ngày/tuần...)",
+      "example": "The meeting finally came to an end. We must put an end to this behavior. She studied for hours on end.",
+      "count": 0
+    },
+    {
+      "word": "energy /ˈenədʒi/",
+      "meaning": "have/lack the energy to do (có/thiếu năng lượng làm gì), put/energy into (dồn năng lượng vào), source of energy (nguồn năng lượng), nuclear/alternative/renewable energy (năng lượng hạt nhân/thay thế/tái tạo)",
+      "example": "I didn’t have the energy to cook. He puts a lot of energy into his work. Solar power is a renewable energy source.",
+      "count": 0
+    },
+    {
+      "word": "equal /ˈiːkwəl/",
+      "meaning": "call for/equal/same quality/value (có chất lượng/tương đương), equal in size/etc (bằng kích thước...), roughly equal to (tương đương với), of equal size/quality/value (có cùng kích thước/chất lượng)",
+      "example": "Both tasks are equal in difficulty. His salary is roughly equal to mine. These shoes are of equal size.",
+      "count": 0
+    },
+    {
+      "word": "erect /ɪˈrekt/",
+      "meaning": "erect (a statue/monument/etc) (dựng tượng), erect posture (tư thế thẳng)",
+      "example": "They erected a statue in her honor. He stood with an erect posture during the ceremony.",
+      "count": 0
+    },
+    {
+      "word": "ever /ˈevə(r)/",
+      "meaning": "hardly ever (hầu như không bao giờ), if ever (nếu có thì cũng hiếm), first/only/last time ever (lần đầu/duy nhất/cuối cùng), bigger/better/etc than ever (lớn hơn/tốt hơn bao giờ hết), as ever (như thường lệ)",
+      "example": "I hardly ever go to the gym. It was the first time ever I met him. She's as friendly as ever.",
+      "count": 0
+    },
+    {
+      "word": "example /ɪɡˈzɑːmpl/",
+      "meaning": "an example of (một ví dụ về), follow an example (làm gương), set an example (làm gương), classic/prime example (ví dụ điển hình/điển hình nhất)",
+      "example": "He set a good example for his peers. This is a classic example of poor planning.",
+      "count": 0
+    },
+    {
+      "word": "fall /fɔːl/",
+      "meaning": "fall ill (ngã bệnh), fall in love (yêu), fall into a category (thuộc loại), fall short (thiếu hụt), fall asleep (ngủ gật), fall to pieces (sụp đổ)",
+      "example": "She fell in love while traveling. He fell asleep during the movie. The plan fell to pieces at the last moment.",
+      "count": 0
+    },
+    {
+      "word": "family /ˈfæməli/",
+      "meaning": "start a family (bắt đầu một gia đình), nuclear/extended family (gia đình hạt nhân/mở rộng), close/near/distant relative (họ hàng gần/xa), family friend (bạn của gia đình), family name (họ), family tree (cây gia phả)",
+      "example": "They plan to start a family next year. She drew her family tree. He’s a close family friend.",
+      "count": 0
+    },
+    {
+      "word": "fat /fæt/",
+      "meaning": "get/grow fat (trở nên giàu có/mập), fat chance (khó có thể xảy ra), a fat lot of good (không hề hữu ích)",
+      "example": "Fat chance he’ll agree to it! That expensive car did a fat lot of good stuck in traffic.",
+      "count": 0
+    },
+    {
+      "word": "feature /ˈfiːtʃə(r)/",
+      "meaning": "feature in sth (nổi bật trong), a feature of (đặc điểm của), distinguishing feature (đặc điểm nổi bật), safety feature (tính năng an toàn), feature writer (tác giả bài nổi bật)",
+      "example": "The curved roof is a feature of this design. She works as a feature writer for the magazine.",
+      "count": 0
+    },
+    {
+      "word": "feel /fiːl/",
+      "meaning": "feel like doing (cảm thấy muốn làm), feel as if/though (cảm giác như), feel strongly about (cảm thấy mạnh mẽ về), feel the effects/benefits (cảm nhận ảnh hưởng/lợi ích), feel guilty/nervous/etc (cảm thấy tội lỗi...), feel at home (cảm thấy tự nhiên)",
+      "example": "I feel like taking a nap. I feel as if I’ve forgotten something. She felt the benefits of the new workout.",
+      "count": 0
+    },
+    {
+      "word": "find /faɪnd/",
+      "meaning": "find yourself doing (tự dưng làm gì), find sb doing sth (bắt gặp ai đó), find it difficult to do (gặp khó khăn khi làm), find your way (tìm đường/giải pháp)",
+      "example": "I found myself staring at the stars. She found him sleeping on the sofa. I can’t find my way in this city.",
+      "count": 0
+    },
+    {
+      "word": "fine /faɪn/",
+      "meaning": "cut it fine (xoay sở làm vừa kịp), fine sb for sth (phạt vì...), a heavy/small fine (mức phạt nặng/nhẹ)",
+      "example": "He was fined for speeding. They cut it fine but still made the train.",
+      "count": 0
+    },
+    {
+      "word": "floor /flɔː(r)/",
+      "meaning": "take the floor (lên phát biểu), floor show (buổi biểu diễn trên sàn), ground/first/etc floor (tầng trệt/thứ nhất...), floor plan (sơ đồ tầng)",
+      "example": "He took the floor to address the issue. The apartment is on the second floor.",
+      "count": 0
+    },
+    {
+      "word": "fly /flaɪ/",
+      "meaning": "fly a flag/kite (treo cờ/thả diều), fly at sb (tấn công ai), fly open (mở toang), fly by (trôi qua nhanh chóng)",
+      "example": "The kite flew high in the sky. Time flew by during the holidays.",
+      "count": 0
+    },
+    {
+      "word": "focus /ˈfəʊkəs/",
+      "meaning": "focus on (tập trung vào), the focus of (tiêu điểm của...), in focus/out of focus (rõ/mờ), focus group (nhóm thảo luận)",
+      "example": "Let’s focus on the task at hand. The main focus of the meeting was safety.",
+      "count": 0
+    },
+    {
+      "word": "fold /fəʊld/",
+      "meaning": "fold sth in half/two (gấp đôi), fold sth neatly/carefully (gấp gọn/gấp cẩn thận), fold flat (gấp phẳng)",
+      "example": "Fold the paper in half. Please fold your clothes neatly.",
+      "count": 0
+    },
+    {
+      "word": "follow /ˈfɒləʊ/",
+      "meaning": "follow sb's advice (nghe lời ai), follow sb's argument (hiểu luận điểm), follow sb's lead (theo sau), follow sb's example (noi gương), as follows (như sau), follow suit (làm theo)",
+      "example": "He followed her advice and succeeded. The team followed suit after the leader’s move.",
+      "count": 0
+    },
+    {
+      "word": "form /fɔːm/",
+      "meaning": "form an impression of (hình thành ấn tượng), take/assume the form of (có hình dạng...), in the form of (dưới dạng...), application form (mẫu đơn), good/bad form (cách hành xử tốt/xấu)",
+      "example": "I formed a good impression of her. Please complete this application form.",
+      "count": 0
+    },
+    {
+      "word": "foundation /faʊnˈdeɪʃn/",
+      "meaning": "lay the foundations (đặt nền móng), foundation course (khóa học cơ sở), foundation stone (viên đá nền tảng)",
+      "example": "They laid the foundations for future success. I’m taking a foundation course in art.",
+      "count": 0
+    },
+    {
+      "word": "free /friː/",
+      "meaning": "set sb free (thả ai đó tự do), let sb go free (thả ai), walk free (tự do đi lại), free sb from sth (giải thoát), free to do (tự do làm gì), free and easy (thoải mái), feel free (cứ tự nhiên)",
+      "example": "They were finally set free. Feel free to contact us anytime.",
+      "count": 0
+    },
+    {
+      "word": "fresh /freʃ/",
+      "meaning": "fresh air (không khí trong lành), fresh-faced (tươi tắn), fresh start (khởi đầu mới), fresh from (vừa mới từ), fresh out of (vừa hết), fresh water (nước ngọt)",
+      "example": "Let’s go outside for some fresh air. She’s fresh from university.",
+      "count": 0
+    },
+    {
+      "word": "friend /frend/",
+      "meaning": "be/friend sb (kết bạn), close/good/great friend (bạn thân), mutual friend (bạn chung), circle of friends (vòng bạn bè), friends with sb (là bạn với ai)",
+      "example": "He’s a close friend of mine. We met through a mutual friend.",
+      "count": 0
+    },
+    {
+      "word": "generation /ˌdʒenəˈreɪʃn/",
+      "meaning": "the older/younger generation (thế hệ già/trẻ), generation gap (khoảng cách thế hệ), generation X (thế hệ X), future generations (những thế hệ tương lai)",
+      "example": "There’s a clear generation gap in values. We must protect the environment for future generations.",
+      "count": 0
+    },
+    {
+      "word": "consequence /ˈkɒnsɪkwəns/",
+      "meaning": "accept/face the consequences (chấp nhận/hứng chịu hậu quả), serious/disastrous/negative consequences (hậu quả nghiêm trọng), direct consequence of (hậu quả trực tiếp), in consequence of (vì lý do), of no/little consequence (không/không quá quan trọng)",
+      "example": "You must face the consequences of your actions. The accident was a direct consequence of poor planning. His opinion is of no consequence to me.",
+      "count": 0
+    },
+    {
+      "word": "consideration /kənˌsɪdəˈreɪʃn/",
+      "meaning": "take into consideration (cân nhắc), give consideration to (xem xét), show consideration for (quan tâm tới), under consideration (được xem xét), for consideration (để cân nhắc), out of consideration for (vì cân nhắc tới ai)",
+      "example": "We must take all factors into consideration before deciding. She always shows consideration for others. Your suggestion is under consideration.",
+      "count": 0
+    },
+    {
+      "word": "course /kɔːs/",
+      "meaning": "in the course of (trong suốt quá trình), course of action/events (diễn biến hành động/sự kiện)",
+      "example": "In the course of the investigation, new evidence came to light. We must decide the best course of action.",
+      "count": 0
+    },
+    {
+      "word": "crime /kraɪm/",
+      "meaning": "commit/permit/witness/solve a crime (thực hiện/cho phép/chứng kiến/giải quyết một tội ác), fight/combat crime (chống tội phạm), crime rate (tỉ lệ tội phạm), organised crime (tội phạm có tổ chức)",
+      "example": "He committed a serious crime last year. The government is taking steps to combat organised crime. The city’s crime rate has dropped.",
+      "count": 0
+    },
+    {
+      "word": "cry /kraɪ/",
+      "meaning": "cry with pain/happiness/laughter (khóc vì...), cry over/about (khóc vì), cry for help (kêu cứu), cry your eyes/heart out (khóc nhiều), have a good cry (khóc thỏa thích), burst into tears (bật khóc)",
+      "example": "She burst into tears at the news. He cried for help when he fell. I needed to have a good cry after the breakup.",
+      "count": 0
+    },
+    {
+      "word": "date /deɪt/",
+      "meaning": "date from (bắt đầu xuất hiện từ), date back to (có từ khi), keep sth up to date (cập nhật), set/fix a date (chọn ngày), go on/make a date with sb (hẹn hò), at a later/future date (một ngày nào đó trong tương lai), to date (đến nay)",
+      "example": "The building dates back to the 18th century. Please keep your records up to date. We haven’t set a date for the wedding yet.",
+      "count": 0
+    },
+    {
+      "word": "day /deɪ/",
+      "meaning": "make sb’s day (khiến ai đó hạnh phúc), by day (ban ngày), any day now (sắp tới, bất cứ lúc nào), from day to day (từng ngày), day by day (ngày qua ngày), day off (ngày nghỉ), day trip (chuyến đi trong ngày)",
+      "example": "The kind words really made my day. He works by day and studies by night. We're planning a day trip to the countryside.",
+      "count": 0
+    },
+    {
+      "word": "dead /ded/",
+      "meaning": "go dead (tắt, ngừng hoạt động), drop dead (đột nhiên lăn ra chết), dead silence (sự im lặng tuyệt đối), dead tired (mệt lả), dead and gone (biến mất, không còn nữa), dead ahead (ngay phía trước mặt)",
+      "example": "The phone line suddenly went dead. I was dead tired after the hike. There was dead silence in the room.",
+      "count": 0
+    },
+    {
+      "word": "deal /diːl/",
+      "meaning": "deal in (buôn bán), deal with (giải quyết), deal a blow to (giáng một đòn vào), get a good deal on (mua được giá tốt), give sb a good deal (cho ai đó thỏa thuận tốt), great deal of sth (rất nhiều)",
+      "example": "She deals in antiques. We need to deal with this problem quickly. He got a good deal on his new car.",
+      "count": 0
+    },
+    {
+      "word": "decide /dɪˈsaɪd/",
+      "meaning": "decide on sb/sth (quyết định chọn), decide against (quyết định không), decide in favour of (quyết định ủng hộ), decide for yourself (tự quyết định), decision to do (quyết định làm gì)",
+      "example": "They decided against buying the house. You need to decide for yourself. We made the decision to expand the business.",
+      "count": 0
+    },
+    {
+      "word": "about /əˈbaʊt/",
+      "meaning": "partly/mainly/all about (một phần/đa phần/toàn bộ về), do sth about (làm gì đó để xử lý), about to do (sắp làm gì)",
+      "example": "She was about to leave when the phone rang. This book is all about courage and persistence. What are you going to do about the issue?",
+      "count": 0
+    },
+    {
+      "word": "access /ˈækses/",
+      "meaning": "have/gain/provide access to (có/đạt được/cung cấp sự tiếp cận), Internet access (truy cập mạng Internet), wheelchair access (lối đi dành cho xe lăn)",
+      "example": "Students have access to all library materials online. Wheelchair access is available at the entrance. Only members can gain access to the archive.",
+      "count": 0
+    },
+    {
+      "word": "account /əˈkaʊnt/",
+      "meaning": "account for (chiếm), give an account of (kể lại/thuat lai), take into account (tính đến, cân nhắc), on account of (xem xét, chiếu cố), on account of (bởi vì), by all accounts (theo những gì thu thập được), on sb’s account (theo như ý kiến của họ)",
+      "example": "He gave an account of his experience to the class. We must take weather conditions into account.By all accounts, she’s a talented writer.",
+      "count": 0
+    },
+    {
+      "word": "act /ækt/",
+      "meaning": "in good/bad faith (hành vi thiện/chưa thiện), out of desperation/necessity (hành động tuyệt vọng/cần thiết), act on sb’s advice/orders/behalf (hành động dựa vào lời khuyên/mệnh lệnh/thay mặt ai), act out of (hành động vì lý do gì), act the part/role of (đóng vai), act like (cư xử như), act your age (cư xử đúng tuổi), in the act of doing (đang làm việc gì đó thì bị bắt gặp)",
+      "example": "He was caught in the act of stealing. She acted on her lawyer’s advice. They acted out of desperation.",
+      "count": 0
+    },
+    {
+      "word": "age /eɪdʒ/",
+      "meaning": "act your age (hành động đúng độ tuổi), under age (chưa đủ tuổi), old age (tuổi già), working/retirement age (độ tuổi đi làm/nghỉ hưu), age limit (độ tuổi giới hạn), age bracket/group (nhóm tuổi), in Stone/Bronze/Iron Age (Vào thời kỳ Đồ Đá/Đồ Đồng/Đồ Sắt)",
+      "example": "She retired at the age of 65. He's not allowed in; he's under age. We studied tools from the Bronze Age.",
+      "count": 0
+    },
+    {
+      "word": "ages",
+      "meaning": "take/spend ages (doing) (tốn nhiều thời gian làm gì); ages ago (rất lâu về trước); seems/feels like ages (có vẻ đã lâu lắm rồi kể từ khi)",
+      "example": "I spent ages trying to fix that bug before I finally gave up. They moved here ages ago and still love it. It feels like ages since we last spoke. She thinks it’s been ages since her last vacation.",
+      "count": 0
+    },
+    {
+      "word": "answer",
+      "meaning": "answer to sb (trả lời ai đó); give sb an answer (đáp lại lời); answer sb’s prayers (đáp lại lời cầu nguyện); answer the description of (rất giống với); have a lot to answer for (chịu trách nhiệm về)",
+      "example": "Could you please answer my question about the API design? He finally answered her prayers by approving the budget. His work answers the description of an ideal solution. The manager will have a lot to answer for if the project fails.",
+      "count": 0
+    },
+    {
+      "word": "argument",
+      "meaning": "argument (with sb) (cãi vã với ai); win/lose an argument (thắng/thua một cuộc tranh cãi); argument about/over (cuộc tranh luận về); argument for/against (lập luận ủng hộ/chống); without an argument (không cần bàn cãi)",
+      "example": "They had an argument about which framework to use. She won the argument by presenting clear data. There’s a strong argument for adopting microservices. We resolved the issue without an argument.",
+      "count": 0
+    },
+    {
+      "word": "arm",
+      "meaning": "arm sb with (trang bị cho ai đó); arm yourself against (trang bị cho bản thân để chống lại); take up arms (chuẩn bị chiến đấu); lay down arms (vứt bỏ vũ khí); arms control (kiểm soát vũ khí)",
+      "example": "The guide armed us with all the necessary credentials. They taught us how to arm ourselves against cyber attacks. Rebels decided to lay down arms and negotiate. An international treaty on arms control was signed.",
+      "count": 0
+    },
+    {
+      "word": "art",
+      "meaning": "art of doing (nghệ thuật/kỹ thuật làm việc gì); art deco (trang trí nghệ thuật); art gallery (phòng trưng bày nghệ thuật); art house (phim nghệ thuật)",
+      "example": "He mastered the art of debugging complex code. The building’s façade is a beautiful example of art deco. Let's visit the new art gallery this weekend. They screened an indie film at the local art house.",
+      "count": 0
+    },
+    {
+      "word": "ask",
+      "meaning": "ask yourself (tự hỏi bản thân); ask sb a favour (nhờ ai giúp đỡ); ask sb over/round (mời đến nhà chơi); ask sb in (mời ai vào nhà); asking for trouble (chắc chắn gặp rắc rối); if you ask me (theo tôi)",
+      "example": "Ask yourself what the user really needs from this feature. Could I ask you a favour and review my pull request? She asked him over for afternoon tea. If you ask me, we should refactor this module.",
+      "count": 0
+    },
+    {
+      "word": "associate",
+      "meaning": "associate sth with (liên kết cái gì với)",
+      "example": "Most people associate JavaScript with web development. He associates deadlines with unnecessary stress. Don’t associate code quality solely with performance.",
+      "count": 0
+    },
+    {
+      "word": "authority",
+      "meaning": "have the authority to do (có thẩm quyền làm việc gì); grant sb the authority to do (trao quyền cho ai làm gì); local authority (chính quyền địa phương)",
+      "example": "Only the admin has the authority to modify user roles. The board granted her the authority to approve budgets. Please consult the local authority for compliance guidelines. He assumed authority over the new deployment process.",
+      "count": 0
+    },
+    {
+      "word": "back",
+      "meaning": "back into sth (lùi vào chỗ nào đó); back onto sth (lùi xe lên trên cái gì); back out of (chống lưng/ứng hộ cho ai làm gì)",
+      "example": "He accidentally backed into the server rack. The car backed onto the loading dock. She refused to back out of her commitment. We need someone to back us up on this proposal.",
+      "count": 0
+    },
+    {
+      "word": "bad",
+      "meaning": "go bad (thiu, hỏng); bad for sb (có hại cho ai); bad at sth (kém về cái gì); bad blood (mối quan hệ xấu)",
+      "example": "Don’t eat that milk—it’s gone bad. Smoking is bad for your health. He’s bad at estimating project timelines. There’s some bad blood between those two teams.",
+      "count": 0
+    },
+    {
+      "word": "balance",
+      "meaning": "strike a balance (tìm phương án cân bằng); upset/restore the balance (phá vỡ/khôi phục cân bằng); balance between (cân bằng giữa); off balance (mất thăng bằng)",
+      "example": "We need to strike a balance between speed and quality. A sudden spike in traffic upset the balance of the system. There’s a fine balance between innovation and risk. The unexpected outage threw the team off balance.",
+      "count": 0
+    },
+    {
+      "word": "basis",
+      "meaning": "on a basis (trên cơ sở); on a daily/temporary basis (hàng ngày/tạm thời); on the basis of (dựa trên cơ sở)",
+      "example": "We review performance on a monthly basis. The feature is enabled on a temporary basis. Decisions are made on the basis of user feedback.",
+      "count": 0
+    },
+    {
+      "word": "behaviour",
+      "meaning": "behaviour towards (hành vi đối với); antisocial/violent behaviour (hành vi chống đối/bạo lực); exemplary behaviour (hành vi gương mẫu)",
+      "example": "His behaviour towards colleagues was exemplary. The test revealed some antisocial behaviour in the AI agent. Good behaviour is rewarded in our performance reviews.",
+      "count": 0
+    },
+    {
+      "word": "belief",
+      "meaning": "express belief(s) (bộc lộ niềm tin); contrary to popular belief (ngược với niềm tin chung); firm belief (niềm tin vững chắc)",
+      "example": "The CEO expressed her firm belief in the project’s success. Contrary to popular belief, code reviews improve productivity. He couldn’t hide his belief in the new framework.",
+      "count": 0
+    },
+    {
+      "word": "bend",
+      "meaning": "bend sth into (uốn cong thành gì); round the bend (quá tức giận); bend the rules (nới lỏng quy tắc)",
+      "example": "She bent the metal rod into a perfect circle. Waiting in line all day drove me round the bend. Managers sometimes bend the rules to meet deadlines.",
+      "count": 0
+    },
+    {
+      "word": "best",
+      "meaning": "make the best of (tận dụng hết khả năng); at your best (ở tình trạng tốt nhất); best of my ability (theo khả năng tốt nhất của tôi); best friend (bạn thân nhất)",
+      "example": "We need to make the best of this opportunity. He performed at his best under pressure. I’ll help you to the best of my ability. She’s been my best friend since college.",
+      "count": 0
+    },
+    {
+      "word": "bet",
+      "meaning": "bet (sth) on (đánh cuộc thứ gì đó); make a bet (đặt cược); safe bet (điều chắc chắn thành công)",
+      "example": "I’d bet on JavaScript remaining popular for years. He made a bet with his friend about the release date. Opting for thorough tests is a safe bet.",
+      "count": 0
+    },
+    {
+      "word": "better",
+      "meaning": "get better (trở nên tốt hơn); better off (khấm khá hơn); better next time (lần sau sẽ tốt hơn); for better or (for worse) (dù tốt dù xấu)",
+      "example": "I hope the system gets better after this update. You’ll be better off using a dedicated database. Maybe we’ll have better luck next time. For better or worse, this is the final design.",
+      "count": 0
+    },
+    {
+      "word": "big",
+      "meaning": "make a big thing out of (làm quá/ làm lớn chuyện); make it big (thành công nhanh); big of sb (đã tốt khi làm gì); big on (rất thích); big business (doanh nghiệp lớn); big-hearted (hào hiệp); big name (nhiều tiền); big game (sự kiện quan trọng)",
+      "example": "They made a big thing out of the minor mistake. She hopes to make it big in Silicon Valley. It was big of you to donate so much. He’s really big on open-source software.",
+      "count": 0
+    },
+    {
+      "word": "block",
+      "meaning": "block sb’s way (chặn đường của ai); block of flats/apartment block (tòa chung cư); high-rise block (tòa nhà cao tầng); writer’s block (rào cản tâm lý)",
+      "example": "The coach blocked their way onto the field. She lives in a new apartment block downtown. That high-rise block dominates the skyline. He suffered from writer’s block all week.",
+      "count": 0
+    },
+    {
+      "word": "book",
+      "meaning": "read sb like a book (hiểu rõ ai); (do) by the book (làm đúng chuẩn); book about/on (cuốn sách về); a closed book (câu đố bí ẩn); open book (người dễ hiểu); in my book (theo tôi); sb’s good/bad books (ai đó hài lòng/khó chịu với)",
+      "example": "I can read you like a book after all these years. She always does things by the book. He recommended a great book on algorithms. His behavior is definitely in my bad books.",
+      "count": 0
+    },
+    {
+      "word": "born",
+      "meaning": "born to do (sinh ra để làm); born on/in (sinh vào thời gian/nơi nào); born into (sinh ra trong gia đình); born and bred (sinh ra và lớn lên); born-again (tái sinh, chuyển đạo); newborn (sơ sinh)",
+      "example": "She was born to do complex data analysis. I was born in Hanoi in 1990. He was born into a family of engineers. They are proud of their born-and-bred roots.",
+      "count": 0
+    },
+    {
+      "word": "bottom",
+      "meaning": "come bottom (đứng cuối); get to the bottom of (tìm nguyên nhân); the bottom drops/falls out of (giảm sâu); bottom line (điểm mấu chốt)",
+      "example": "Our team came bottom in the hackathon. We need to get to the bottom of this bug. Suddenly the bottom fell out of the market. The bottom line is that we need more testing.",
+      "count": 0
+    },
+    {
+      "word": "brain",
+      "meaning": "pick sb’s brain(s) (hỏi để biết thông tin); rack your brain(s) (vắt óc để làm); brains behind (người chịu trách nhiệm); brainless (ngu ngốc); brainstorm (động não); brainwave (cảm hứng đột ngột)",
+      "example": "Can I pick your brains about this architecture? I’ve been racking my brain for hours. She is the brain behind our new feature. We had a productive brainstorm session yesterday.",
+      "count": 0
+    },
+    {
+      "word": "break",
+      "meaning": "break a habit (phá vỡ thói quen); break with tradition (phá bỏ truyền thống); take/have/need a break (có thời gian nghỉ); lunch/coffee break (giờ nghỉ trưa/giữa buổi)",
+      "example": "I finally broke my habit of checking email at night. They decided to break with tradition this year. Let’s take a break and grab coffee. We only have a fifteen-minute break left.",
+      "count": 0
+    },
+    {
+      "word": "brick",
+      "meaning": "bricks and mortar (cửa hàng thực sự); brick wall (bức tường gạch); bricklayer (thợ nề)",
+      "example": "They opened a bricks-and-mortar store downtown. We built a small brick wall in the courtyard. The bricklayer finished the job early.",
+      "count": 0
+    },
+    {
+      "word": "certain",
+      "meaning": "know/say for certain (biết/chắc chắn); certain to do (chắc chắn làm); make certain (chắc chắn); certain of/about (chắc chắn về); a certain (amount of sth) (một lượng nhất định)",
+      "example": "I can’t say for certain when the release will be. You’re certain to succeed with that plan. Please make certain the tests pass. We need a certain amount of RAM for this VM.",
+      "count": 0
+    },
+    {
+      "word": "chance",
+      "meaning": "take a chance (đánh liều); leave to chance (mặc kệ); by chance (tình cờ); by any chance (phải vậy không?); second chance (cơ hội thứ hai); last chance (cơ hội cuối cùng); pure chance (ngẫu nhiên thuần túy); there’s every/no chance that (rất có/không có cơ hội)",
+      "example": "I decided to take a chance and rewrite the module. Don’t leave it to chance—write unit tests. We met by chance at the conference. There’s every chance we’ll finish early.",
+      "count": 0
+    },
+    {
+      "word": "change",
+      "meaning": "change from sth to sth (đổi từ thứ gì thành); change sth into (biến thứ gì trở thành); change sth for (thay đổi cái gì đó để lấy); change for the better/worse (thay đổi tốt hơn/tệ hơn); change your mind (đổi ý); change the subject (đổi chủ đề); make a change (thay đổi); undergo a change (trải qua thay đổi)",
+      "example": "We need to change from HTTP to HTTPS. He changed his idea into a working prototype. They changed the plan for the better. After reflection, she changed her mind.",
+      "count": 0
+    },
+    {
+      "word": "charge",
+      "meaning": "charge sb with (buộc tội ai về); charge sb for (đòi tiền ai về); take charge (đảm nhiệm); put sb in charge (trao quyền); overall charge (toàn quyền lãnh đạo)",
+      "example": "They charged her with overseeing the new API. We were charged for extra storage. She took charge of the deployment. The CTO was put in charge of security.",
+      "count": 0
+    },
+    {
+      "word": "child",
+      "meaning": "as a child (khi còn nhỏ); only child (con một); child of (con của); childcare (chăm sóc trẻ); child abuse (lạm dụng trẻ em); child’s play (trò chơi trẻ con)",
+      "example": "As a child, I loved playing video games. He was an only child in his family. Childcare services are expanding. That puzzle is child’s play for us.",
+      "count": 0
+    },
+    {
+      "word": "choice",
+      "meaning": "make a choice (đưa ra lựa chọn); exercise choice (bầu chọn); have no choice (không có lựa chọn nào); choice between (lựa chọn giữa); informed choice (lựa chọn dựa trên thông tin); wide choice (nhiều lựa chọn); obvious choice (lựa chọn hiển nhiên)",
+      "example": "It’s time to make a choice about the framework. Users can exercise choice in their settings. We had no choice but to postpone. There’s a wide choice of libraries available.",
+      "count": 0
+    },
+    {
+      "word": "choose",
+      "meaning": "choose from (chọn ra từ); choose between (chọn giữa); choose sb/sth as (chọn ai/cái gì làm); choose sb/sth out of (chọn ai/cái gì trong cả nhóm); choose to do (lựa chọn làm gì); pick and choose (cân nhắc kỹ và chọn); nothing to choose between (không có gì để chọn)",
+      "example": "You can choose from several templates. We had to choose between speed and accuracy. They chose her as team lead. There was nothing to choose between the two solutions.",
+      "count": 0
+    },
+    {
+      "word": "class",
+      "meaning": "class sb/sth as (phân loại); social class (tầng lớp xã hội); working/middle/upper class (đẳng cấp lao động/trung lưu/thượng lưu); ruling class (giai cấp thống trị); class system (hệ thống giai cấp); class war (mâu thuẫn giai cấp)",
+      "example": "They classed the data points as anomalies. Discussions about social class remain relevant. He grew up in a working-class family. The ruling class resisted the reforms.",
+      "count": 0
+    },
+    {
+      "word": "clean",
+      "meaning": "give sth a (good) clean (lau dọn sạch sẽ); make a clean break (giải sạch, cắt đứt hoàn toàn); clean and tidy (sạch sẽ gọn gàng); a clean slate (một khởi đầu mới); clean sweep (dọn sạch những thứ không cần thiết)",
+      "example": "Let’s give this codebase a good clean. The team made a clean break from legacy. Keep your workspace clean and tidy. We started with a clean slate after the audit.",
+      "count": 0
+    },
+    {
+      "word": "clear",
+      "meaning": "make/get sth clear (làm rõ/chứng tỏ); make yourself clear (nói rõ ý của bạn); have a clear conscience (lương tâm trong sạch); clear in your mind (hiểu rõ); clear as a bell (rõ ràng); clear as mud (khó hiểu); clear evidence (bằng chứng); clear case of (trường hợp rõ ràng)",
+      "example": "She made her expectations perfectly clear. He has a clear conscience about the decision. The objective was clear in my mind. That explanation was clear as a bell.",
+      "count": 0
+    },
+    {
+      "word": "clock",
+      "meaning": "set a clock (đặt báo thức); watch the clock (đếm thời gian); against the clock (chạy đua với thời gian); around the clock (suốt ngày đêm); clockwise (theo chiều kim đồng hồ); clockwork (bộ máy đồng hồ)",
+      "example": "Don’t forget to set the clock before sleeping. We’re racing against the clock to finish. The server runs around the clock. The gears turned like clockwork.",
+      "count": 0
+    },
+    {
+      "word": "come",
+      "meaning": "come to a conclusion/decision (đi tới kết luận/quyết định); come to power (lên nắm quyền); come into view (hiện ra trước mắt); come as a shock (gây sốc); come true (trở thành hiện thực)",
+      "example": "We came to a conclusion after reviewing logs. The new party came to power last year. The mountain peak finally came into view. His dream to launch the app came true.",
+      "count": 0
+    },
+    {
+      "word": "common",
+      "meaning": "have sth in common (với ai) (có điểm chung); common for sb/sth to do (việc ai đó làm gì là khá phổ biến); common language (ngôn ngữ thường dùng); the common people (người dân); common practice (hành vi phổ biến)",
+      "example": "We have much in common regarding coding standards. It’s common for teams to hold daily stand-ups. English serves as a common language in tech. Code reviews are now common practice.",
+      "count": 0
+    },
+    {
+      "word": "conclusion",
+      "meaning": "bring sth to a conclusion (đưa cái gì đến kết luận); come to/reach a conclusion (đi đến kết luận); jump/leap to conclusions (nhảy cóc kết luận); in conclusion (kết lại); foregone conclusion (kết quả đương nhiên)",
+      "example": "Let’s bring this discussion to a conclusion. They reached a conclusion after testing. Don’t jump to conclusions too quickly. In conclusion, we recommend a staging environment.",
+      "count": 0
+    }
+  ],
   "word formation": [
     {
-    "word": "judge",
-    "meaning": "judge(ment), /ˈdʒʌdʒmənt/: sự phán xét. judiciary, /dʒuˈdɪʃəri/: bộ máy tư pháp. judiciousness, /dʒuˈdɪʃəsnəs/: sự sáng suốt. judicious, /dʒuˈdɪʃəs/: khôn ngoan. judicial, /dʒuˈdɪʃl/: (thuộc) tòa án. judge(mental), /ˈdʒʌdʒˌmentl/: mang tính phán xét. judiciously, /dʒuˈdɪʃəsli/: một cách khôn ngoan.",
-    "example": "Her judgement was fair. The judiciary needs reform. He acted with judiciousness. It was a judicious move. The judicial process was swift. Don’t be judgmental. He responded judiciously.",
-    "count": 0
+      "word": "judge",
+      "meaning": "judge(ment), /ˈdʒʌdʒmənt/: sự phán xét. judiciary, /dʒuˈdɪʃəri/: bộ máy tư pháp. judiciousness, /dʒuˈdɪʃəsnəs/: sự sáng suốt. judicious, /dʒuˈdɪʃəs/: khôn ngoan. judicial, /dʒuˈdɪʃl/: (thuộc) tòa án. judge(mental), /ˈdʒʌdʒˌmentl/: mang tính phán xét. judiciously, /dʒuˈdɪʃəsli/: một cách khôn ngoan.",
+      "example": "Her judgement was fair. The judiciary needs reform. He acted with judiciousness. It was a judicious move. The judicial process was swift. Don’t be judgmental. He responded judiciously.",
+      "count": 0
     },
     {
-    "word": "know",
-    "meaning": "acknowledge, /əkˈnɒlɪdʒ/: công nhận. acknowledgement, /əkˈnɒlɪdʒmənt/: sự công nhận. knowledge, /ˈnɒlɪdʒ/: tri thức. knowledgeable, /ˈnɒlɪdʒəbl/: uyên bác. (un)acknowledged, /(ˌʌn)əkˈnɒlɪdʒd/: (không) được công nhận. knowing(ly), /ˈnəʊɪŋ(li)/: (một cách) thận trọng, hiểu biết.",
-    "example": "He acknowledged his mistake. They gave no acknowledgement. She has vast knowledge. He is very knowledgeable. Her help was unacknowledged. He smiled knowingly.",
-    "count": 0
+      "word": "know",
+      "meaning": "acknowledge, /əkˈnɒlɪdʒ/: công nhận. acknowledgement, /əkˈnɒlɪdʒmənt/: sự công nhận. knowledge, /ˈnɒlɪdʒ/: tri thức. knowledgeable, /ˈnɒlɪdʒəbl/: uyên bác. (un)acknowledged, /(ˌʌn)əkˈnɒlɪdʒd/: (không) được công nhận. knowing(ly), /ˈnəʊɪŋ(li)/: (một cách) thận trọng, hiểu biết.",
+      "example": "He acknowledged his mistake. They gave no acknowledgement. She has vast knowledge. He is very knowledgeable. Her help was unacknowledged. He smiled knowingly.",
+      "count": 0
     },
     {
-    "word": "land",
-    "meaning": "landing, /ˈlændɪŋ/: việc đổ bộ, hạ cánh. landed, /ˈlændɪd/: đã có đất đai. landless, /ˈlændləs/: không có đất. (re)land, /ˈlænd/: (hạ) cánh.",
-    "example": "The landing was smooth. They are landed gentry. The landless farmers protested. We will land soon.",
-    "count": 0
+      "word": "land",
+      "meaning": "landing, /ˈlændɪŋ/: việc đổ bộ, hạ cánh. landed, /ˈlændɪd/: đã có đất đai. landless, /ˈlændləs/: không có đất. (re)land, /ˈlænd/: (hạ) cánh.",
+      "example": "The landing was smooth. They are landed gentry. The landless farmers protested. We will land soon.",
+      "count": 0
     },
     {
-    "word": "large",
-    "meaning": "enlarge, /ɪnˈlɑːdʒ/: mở rộng. enlargement, /ɪnˈlɑːdʒmənt/: sự mở rộng. largely, /ˈlɑːdʒli/: phần lớn.",
-    "example": "We plan to enlarge the facility. The enlargement will take weeks. It was largely successful.",
-    "count": 0
+      "word": "large",
+      "meaning": "enlarge, /ɪnˈlɑːdʒ/: mở rộng. enlargement, /ɪnˈlɑːdʒmənt/: sự mở rộng. largely, /ˈlɑːdʒli/: phần lớn.",
+      "example": "We plan to enlarge the facility. The enlargement will take weeks. It was largely successful.",
+      "count": 0
     },
     {
-    "word": "last",
-    "meaning": "outlast, /ˌaʊtˈlɑːst/: tồn tại lâu hơn. lasting, /ˈlɑːstɪŋ/: bền vững. everlasting, /ˌevəˈlɑːstɪŋ/: vĩnh viễn. lastly, /ˈlɑːstli/: cuối cùng thì.",
-    "example": "He outlasted all rivals. The impact was lasting. Their love is everlasting. Lastly, I want to thank you.",
-    "count": 0
+      "word": "last",
+      "meaning": "outlast, /ˌaʊtˈlɑːst/: tồn tại lâu hơn. lasting, /ˈlɑːstɪŋ/: bền vững. everlasting, /ˌevəˈlɑːstɪŋ/: vĩnh viễn. lastly, /ˈlɑːstli/: cuối cùng thì.",
+      "example": "He outlasted all rivals. The impact was lasting. Their love is everlasting. Lastly, I want to thank you.",
+      "count": 0
     },
     {
-    "word": "leisure",
-    "meaning": "leisure, /ˈleʒə(r)/: nhàn hạ. leisurely, /ˈleʒəli/: một cách chậm rãi.",
-    "example": "She enjoys leisure time. They walked leisurely by the beach.",
-    "count": 0
+      "word": "leisure",
+      "meaning": "leisure, /ˈleʒə(r)/: nhàn hạ. leisurely, /ˈleʒəli/: một cách chậm rãi.",
+      "example": "She enjoys leisure time. They walked leisurely by the beach.",
+      "count": 0
     },
     {
-    "word": "logic",
-    "meaning": "(il)logical(ly), /(ɪ)ˈlɒdʒɪkl(i)/: (một cách) (không) hợp lý.",
-    "example": "His argument is logical. She reacted illogically.",
-    "count": 0
+      "word": "logic",
+      "meaning": "(il)logical(ly), /(ɪ)ˈlɒdʒɪkl(i)/: (một cách) (không) hợp lý.",
+      "example": "His argument is logical. She reacted illogically.",
+      "count": 0
     },
     {
-    "word": "long",
-    "meaning": "prolong, /prəˈlɒŋ/: kéo dài. lengthen, /ˈleŋθn/: kéo dài. long, /lɒŋ/: dài. longevity, /lɒnˈdʒevəti/: sự trường thọ. longhand, /ˈlɒŋhænd/: chữ viết tay. longing(ly), /ˈlɒŋɪŋ(li)/: (một cách) khát khao. lengthy, /ˈleŋkθi/: dài dòng. prolonged, /prəˈlɒŋd/: kéo dài thêm. lengthways, /ˈleŋkθweɪz/: theo chiều dọc. lengthwise, /ˈleŋkθwaɪz/: theo chiều dọc.",
-    "example": "Stress may prolong illness. She tried to lengthen the rope. They lived a long life. His longevity is impressive. She wrote it in longhand. He looked at her longingly. It was a lengthy discussion. The meeting was prolonged. Cut the wood lengthways. Fold it lengthwise.",
-    "count": 0
+      "word": "long",
+      "meaning": "prolong, /prəˈlɒŋ/: kéo dài. lengthen, /ˈleŋθn/: kéo dài. long, /lɒŋ/: dài. longevity, /lɒnˈdʒevəti/: sự trường thọ. longhand, /ˈlɒŋhænd/: chữ viết tay. longing(ly), /ˈlɒŋɪŋ(li)/: (một cách) khát khao. lengthy, /ˈleŋkθi/: dài dòng. prolonged, /prəˈlɒŋd/: kéo dài thêm. lengthways, /ˈleŋkθweɪz/: theo chiều dọc. lengthwise, /ˈleŋkθwaɪz/: theo chiều dọc.",
+      "example": "Stress may prolong illness. She tried to lengthen the rope. They lived a long life. His longevity is impressive. She wrote it in longhand. He looked at her longingly. It was a lengthy discussion. The meeting was prolonged. Cut the wood lengthways. Fold it lengthwise.",
+      "count": 0
     },
     {
-    "word": "lot",
-    "meaning": "allot, /əˈlɒt/: phân công. allotment, /əˈlɒtmənt/: sự phân công.",
-    "example": "The manager will allot tasks. Each team received their allotment.",
-    "count": 0
+      "word": "lot",
+      "meaning": "allot, /əˈlɒt/: phân công. allotment, /əˈlɒtmənt/: sự phân công.",
+      "example": "The manager will allot tasks. Each team received their allotment.",
+      "count": 0
     },
     {
-    "word": "loyal",
-    "meaning": "(dis)loyalty, /(dɪs)ˈlɔɪəlti/: (không) trung thành. (dis)loyal(ly), /(dɪs)ˈlɔɪəli/: (một cách) (không) trung thành.",
-    "example": "His loyalty was admirable. She acted disloyally.",
-    "count": 0
+      "word": "loyal",
+      "meaning": "(dis)loyalty, /(dɪs)ˈlɔɪəlti/: (không) trung thành. (dis)loyal(ly), /(dɪs)ˈlɔɪəli/: (một cách) (không) trung thành.",
+      "example": "His loyalty was admirable. She acted disloyally.",
+      "count": 0
     },
     {
-    "word": "magnify",
-    "meaning": "magnificence, /mæɡˈnɪfɪsns/: sự nguy nga. magnification, /ˌmæɡnɪfɪˈkeɪʃn/: sự phóng đại. magnificent(ly), /mæɡˈnɪfɪsnt(li)/: (một cách) tráng lệ.",
-    "example": "The palace was a scene of magnificence. Use 10x magnification. She was magnificently dressed.",
-    "count": 0
+      "word": "magnify",
+      "meaning": "magnificence, /mæɡˈnɪfɪsns/: sự nguy nga. magnification, /ˌmæɡnɪfɪˈkeɪʃn/: sự phóng đại. magnificent(ly), /mæɡˈnɪfɪsnt(li)/: (một cách) tráng lệ.",
+      "example": "The palace was a scene of magnificence. Use 10x magnification. She was magnificently dressed.",
+      "count": 0
     },
     {
-    "word": "major",
-    "meaning": "majorette, /ˌmeɪdʒəˈret/: nữ đội trưởng diễu hành.",
-    "example": "The majorette led the parade confidently.",
-    "count": 0
+      "word": "major",
+      "meaning": "majorette, /ˌmeɪdʒəˈret/: nữ đội trưởng diễu hành.",
+      "example": "The majorette led the parade confidently.",
+      "count": 0
     },
     {
-    "word": "manage",
-    "meaning": "mismanage, /ˌmɪsˈmænɪdʒ/: quản lý kém. management, /ˈmænɪdʒmənt/: quản lý. manager, /ˈmænɪdʒə(r)/: người quản lý. (mis)management, /(ˌmɪs)ˈmænɪdʒmənt/: (sự) (kém) quản lý. (un)manageable, /ˌʌnˈmænɪdʒəbl/: (không) có thể quản lý. mismanaged, /ˌmɪsˈmænɪdʒd/: bị quản lý kém. managerial(ly), /ˌmænəˈdʒɪəriəli/: (thuộc) quản lý.",
-    "example": "He mismanaged the project. She works in management. The manager arrived late. Poor management hurt the company. The problem is unmanageable. The funds were mismanaged. She has strong managerial skills.",
-    "count": 0
+      "word": "manage",
+      "meaning": "mismanage, /ˌmɪsˈmænɪdʒ/: quản lý kém. management, /ˈmænɪdʒmənt/: quản lý. manager, /ˈmænɪdʒə(r)/: người quản lý. (mis)management, /(ˌmɪs)ˈmænɪdʒmənt/: (sự) (kém) quản lý. (un)manageable, /ˌʌnˈmænɪdʒəbl/: (không) có thể quản lý. mismanaged, /ˌmɪsˈmænɪdʒd/: bị quản lý kém. managerial(ly), /ˌmænəˈdʒɪəriəli/: (thuộc) quản lý.",
+      "example": "He mismanaged the project. She works in management. The manager arrived late. Poor management hurt the company. The problem is unmanageable. The funds were mismanaged. She has strong managerial skills.",
+      "count": 0
     },
     {
-    "word": "manufacture",
-    "meaning": "manufacturer, /ˌmænjuˈfæktʃərə(r)/: nhà sản xuất. manufacturing, /ˌmænjuˈfæktʃərɪŋ/: sự sản xuất.",
-    "example": "The manufacturer recalled the product. Manufacturing costs rose.",
-    "count": 0
+      "word": "manufacture",
+      "meaning": "manufacturer, /ˌmænjuˈfæktʃərə(r)/: nhà sản xuất. manufacturing, /ˌmænjuˈfæktʃərɪŋ/: sự sản xuất.",
+      "example": "The manufacturer recalled the product. Manufacturing costs rose.",
+      "count": 0
     },
     {
-    "word": "match",
-    "meaning": "matchmaker, /ˈmætʃmeɪkə(r)/: bà mối. matchmaking, /ˈmætʃmeɪkɪŋ/: công việc mối lái. matchstick, /ˈmætʃstɪk/: que diêm. matchwood, /ˈmætʃwʊd/: gỗ diêm. matchbook, /ˈmætʃbʊk/: hộp diêm. matchless, /ˈmætʃləs/: vô song. matching, /ˈmætʃɪŋ/: hợp. unmatched, /ʌnˈmætʃt/: lệch, không sánh bằng.",
-    "example": "She worked as a matchmaker. Matchmaking takes skill. He struck a matchstick. The desk was reduced to matchwood. The matchbook was empty. Her beauty is matchless. They wore matching outfits. His talent is unmatched.",
-    "count": 0
+      "word": "match",
+      "meaning": "matchmaker, /ˈmætʃmeɪkə(r)/: bà mối. matchmaking, /ˈmætʃmeɪkɪŋ/: công việc mối lái. matchstick, /ˈmætʃstɪk/: que diêm. matchwood, /ˈmætʃwʊd/: gỗ diêm. matchbook, /ˈmætʃbʊk/: hộp diêm. matchless, /ˈmætʃləs/: vô song. matching, /ˈmætʃɪŋ/: hợp. unmatched, /ʌnˈmætʃt/: lệch, không sánh bằng.",
+      "example": "She worked as a matchmaker. Matchmaking takes skill. He struck a matchstick. The desk was reduced to matchwood. The matchbook was empty. Her beauty is matchless. They wore matching outfits. His talent is unmatched.",
+      "count": 0
     },
     {
-    "word": "material",
-    "meaning": "materialise, /məˈtɪəriəlaɪz/: cụ thể hóa. materialism, /məˈtɪəriəlɪzəm/: chủ nghĩa duy vật. materialistic, /məˌtɪəriəˈlɪstɪk/: nặng về vật chất. immaterial, /ˌɪməˈtɪəriəl/: không quan trọng. materially, /məˈtɪəriəli/: một cách hữu hình.",
-    "example": "His ideas failed to materialise. He rejects materialism. She’s materialistic. That fact is immaterial. He was materially supported.",
-    "count": 0
+      "word": "material",
+      "meaning": "materialise, /məˈtɪəriəlaɪz/: cụ thể hóa. materialism, /məˈtɪəriəlɪzəm/: chủ nghĩa duy vật. materialistic, /məˌtɪəriəˈlɪstɪk/: nặng về vật chất. immaterial, /ˌɪməˈtɪəriəl/: không quan trọng. materially, /məˈtɪəriəli/: một cách hữu hình.",
+      "example": "His ideas failed to materialise. He rejects materialism. She’s materialistic. That fact is immaterial. He was materially supported.",
+      "count": 0
     },
     {
-    "word": "mature",
-    "meaning": "(im)maturity, /(ˌɪ)məˈtjʊərəti/: (sự) (thiếu) trưởng thành. maturation, /ˌmætʃuˈreɪʃn/: sự chín, trưởng thành. immature, /ˌɪməˈtjʊə(r)/: non nớt.",
-    "example": "He showed maturity beyond his years. The maturation process takes time. His behavior was immature.",
-    "count": 0
+      "word": "mature",
+      "meaning": "(im)maturity, /(ˌɪ)məˈtjʊərəti/: (sự) (thiếu) trưởng thành. maturation, /ˌmætʃuˈreɪʃn/: sự chín, trưởng thành. immature, /ˌɪməˈtjʊə(r)/: non nớt.",
+      "example": "He showed maturity beyond his years. The maturation process takes time. His behavior was immature.",
+      "count": 0
     },
     {
-    "word": "mean",
-    "meaning": "meaning, /ˈmiːnɪŋ/: ý nghĩa. meaningfulness, /ˈmiːnɪŋflnəs/: sự có ý nghĩa. meaningless, /ˈmiːnɪŋləs/: vô nghĩa. meaningful(ly), /ˈmiːnɪŋfl(i)/: (một cách) có ý nghĩa.",
-    "example": "The meaning is unclear. She questioned the meaningfulness of the ritual. The phrase is meaningless. He nodded meaningfully.",
-    "count": 0
+      "word": "mean",
+      "meaning": "meaning, /ˈmiːnɪŋ/: ý nghĩa. meaningfulness, /ˈmiːnɪŋflnəs/: sự có ý nghĩa. meaningless, /ˈmiːnɪŋləs/: vô nghĩa. meaningful(ly), /ˈmiːnɪŋfl(i)/: (một cách) có ý nghĩa.",
+      "example": "The meaning is unclear. She questioned the meaningfulness of the ritual. The phrase is meaningless. He nodded meaningfully.",
+      "count": 0
     },
     {
-    "word": "metal",
-    "meaning": "metallic, /məˈtælɪk/: (thuộc) kim loại. metallurgy, /məˈtælədʒi/: ngành luyện kim.",
-    "example": "The sculpture had a metallic finish. He studied metallurgy in college.",
-    "count": 0
+      "word": "metal",
+      "meaning": "metallic, /məˈtælɪk/: (thuộc) kim loại. metallurgy, /məˈtælədʒi/: ngành luyện kim.",
+      "example": "The sculpture had a metallic finish. He studied metallurgy in college.",
+      "count": 0
     },
     {
-    "word": "might",
-    "meaning": "mighty, /ˈmaɪti/: mạnh, hùng cường. mightily, /ˈmaɪtəli/: một cách đầy quyền lực.",
-    "example": "He gave a mighty roar. She tried mightily to finish on time.",
-    "count": 0
+      "word": "might",
+      "meaning": "mighty, /ˈmaɪti/: mạnh, hùng cường. mightily, /ˈmaɪtəli/: một cách đầy quyền lực.",
+      "example": "He gave a mighty roar. She tried mightily to finish on time.",
+      "count": 0
     },
     {
-    "word": "minor",
-    "meaning": "minority, /maɪˈnɒrəti/: thiểu số.",
-    "example": "The ethnic minority lives in the mountains.",
-    "count": 0
+      "word": "minor",
+      "meaning": "minority, /maɪˈnɒrəti/: thiểu số.",
+      "example": "The ethnic minority lives in the mountains.",
+      "count": 0
     },
     {
-    "word": "mobile",
-    "meaning": "(im)mobilise, /(ˌɪ)məʊbəlaɪz/: huy động, huy động. (im)mobility, /(ˌɪ)məʊˈbɪləti/: (sự) (không) chuyển động. mobilisation, /ˌməʊbəlaɪˈzeɪʃn/: sự huy động. immobile, /ɪˈməʊbaɪl/: bất động.",
-    "example": "The army was mobilised quickly. Economic mobility is important. Mobilisation began at dawn. He remained immobile during treatment.",
-    "count": 0
+      "word": "mobile",
+      "meaning": "(im)mobilise, /(ˌɪ)məʊbəlaɪz/: huy động, huy động. (im)mobility, /(ˌɪ)məʊˈbɪləti/: (sự) (không) chuyển động. mobilisation, /ˌməʊbəlaɪˈzeɪʃn/: sự huy động. immobile, /ɪˈməʊbaɪl/: bất động.",
+      "example": "The army was mobilised quickly. Economic mobility is important. Mobilisation began at dawn. He remained immobile during treatment.",
+      "count": 0
     },
     {
-    "word": "modern",
-    "meaning": "modernise, /ˈmɒdənaɪz/: hiện đại hóa. modernisation, /ˌmɒdənaɪˈzeɪʃn/: sự hiện đại hóa. modernism, /ˈmɒdənɪzəm/: chủ nghĩa hiện đại. modernist, /ˈmɒdənɪst/: người theo chủ nghĩa hiện đại.",
-    "example": "We plan to modernise the building. Modernisation takes time. Modernism influenced design. He’s a modernist architect.",
-    "count": 0
+      "word": "modern",
+      "meaning": "modernise, /ˈmɒdənaɪz/: hiện đại hóa. modernisation, /ˌmɒdənaɪˈzeɪʃn/: sự hiện đại hóa. modernism, /ˈmɒdənɪzəm/: chủ nghĩa hiện đại. modernist, /ˈmɒdənɪst/: người theo chủ nghĩa hiện đại.",
+      "example": "We plan to modernise the building. Modernisation takes time. Modernism influenced design. He’s a modernist architect.",
+      "count": 0
     },
     {
-    "word": "mode",
-    "meaning": "modality, /məʊˈdæləti/: trình hiện đại.",
-    "example": "Different learning modalities exist.",
-    "count": 0
+      "word": "mode",
+      "meaning": "modality, /məʊˈdæləti/: trình hiện đại.",
+      "example": "Different learning modalities exist.",
+      "count": 0
     },
     {
-    "word": "moment",
-    "meaning": "momentary, /ˈməʊməntri/: chốc lát. momentarily, /ˌməʊmənˈterəli/: ngay tức khắc.",
-    "example": "There was a momentary silence. She paused momentarily.",
-    "count": 0
+      "word": "moment",
+      "meaning": "momentary, /ˈməʊməntri/: chốc lát. momentarily, /ˌməʊmənˈterəli/: ngay tức khắc.",
+      "example": "There was a momentary silence. She paused momentarily.",
+      "count": 0
     },
     {
-    "word": "moral",
-    "meaning": "moralise, /ˈmɒrəlaɪz/: lên lớp dạy đời. demoralise, /dɪˈmɒrəlaɪz/: làm mất tinh thần. (im/a)morality, /(ɪ)məˈræləti/: (trái) đạo đức. moralist, /ˈmɒrəlɪst/: nhà đạo đức học. morale, /məˈrɑːl/: nhuệ khí. (im/a)moral(ly), /(ɪ)mˈɒrəli/: (không) phù hợp đạo đức.",
-    "example": "Stop trying to moralise everything. War can demoralise soldiers. Immorality is punished. He’s a moralist. Troop morale was low. It was morally wrong.",
-    "count": 0
+      "word": "moral",
+      "meaning": "moralise, /ˈmɒrəlaɪz/: lên lớp dạy đời. demoralise, /dɪˈmɒrəlaɪz/: làm mất tinh thần. (im/a)morality, /(ɪ)məˈræləti/: (trái) đạo đức. moralist, /ˈmɒrəlɪst/: nhà đạo đức học. morale, /məˈrɑːl/: nhuệ khí. (im/a)moral(ly), /(ɪ)mˈɒrəli/: (không) phù hợp đạo đức.",
+      "example": "Stop trying to moralise everything. War can demoralise soldiers. Immorality is punished. He’s a moralist. Troop morale was low. It was morally wrong.",
+      "count": 0
     },
     {
-    "word": "motion",
-    "meaning": "motionless, /ˈməʊʃnləs/: bất động.",
-    "example": "She stood motionless with fear.",
-    "count": 0
+      "word": "motion",
+      "meaning": "motionless, /ˈməʊʃnləs/: bất động.",
+      "example": "She stood motionless with fear.",
+      "count": 0
     },
     {
-    "word": "motive",
-    "meaning": "(de)motivate, /(ˌdiː)ˈməʊtɪveɪt/: (tước bỏ) thúc đẩy. motivator, /ˈməʊtɪveɪtə(r)/: yếu tố thúc đẩy. (de)motivation, /(ˌdiː)ˌməʊtɪˈveɪʃn/: (sự) (thiếu) động lực. (de)motivating, /(ˌdiː)ˈməʊtɪveɪtɪŋ/: (có tính) (tước bỏ) động lực. motivational, /ˌməʊtɪˈveɪʃənl/: có sức truyền cảm hứng.",
-    "example": "Praise can motivate students. Lack of pay demotivates workers. A good teacher is a motivator. Demotivation spread through the team. Her speech was motivational.",
-    "count": 0
+      "word": "motive",
+      "meaning": "(de)motivate, /(ˌdiː)ˈməʊtɪveɪt/: (tước bỏ) thúc đẩy. motivator, /ˈməʊtɪveɪtə(r)/: yếu tố thúc đẩy. (de)motivation, /(ˌdiː)ˌməʊtɪˈveɪʃn/: (sự) (thiếu) động lực. (de)motivating, /(ˌdiː)ˈməʊtɪveɪtɪŋ/: (có tính) (tước bỏ) động lực. motivational, /ˌməʊtɪˈveɪʃənl/: có sức truyền cảm hứng.",
+      "example": "Praise can motivate students. Lack of pay demotivates workers. A good teacher is a motivator. Demotivation spread through the team. Her speech was motivational.",
+      "count": 0
     },
     {
-    "word": "mount",
-    "meaning": "surmount, /səˈmaʊnt/: vượt qua. mountain, /ˈmaʊntən/: núi. mountaineering, /ˌmaʊntəˈnɪərɪŋ/: môn leo núi. (in)surmountable, /(ɪn)səˈmaʊntəbl/: (không) thể khắc phục được. mountainous, /ˈmaʊntənəs/: (thuộc) vùng núi.",
-    "example": "They tried to surmount the obstacles. We hiked up the mountain. Mountaineering requires training. The problem is insurmountable. It’s a mountainous region.",
-    "count": 0
+      "word": "mount",
+      "meaning": "surmount, /səˈmaʊnt/: vượt qua. mountain, /ˈmaʊntən/: núi. mountaineering, /ˌmaʊntəˈnɪərɪŋ/: môn leo núi. (in)surmountable, /(ɪn)səˈmaʊntəbl/: (không) thể khắc phục được. mountainous, /ˈmaʊntənəs/: (thuộc) vùng núi.",
+      "example": "They tried to surmount the obstacles. We hiked up the mountain. Mountaineering requires training. The problem is insurmountable. It’s a mountainous region.",
+      "count": 0
     },
     {
-    "word": "move",
-    "meaning": "mover, /ˈmuːvə(r)/: động cơ, lực. movement, /ˈmuːvmənt/: sự chuyển động. (im)movable, /(ˌɪ)ˈmuːvəbl/: (không) có thể di chuyển.",
-    "example": "He is a fast mover. The movement was quick. This box is immovable.",
-    "count": 0
+      "word": "move",
+      "meaning": "mover, /ˈmuːvə(r)/: động cơ, lực. movement, /ˈmuːvmənt/: sự chuyển động. (im)movable, /(ˌɪ)ˈmuːvəbl/: (không) có thể di chuyển.",
+      "example": "He is a fast mover. The movement was quick. This box is immovable.",
+      "count": 0
     },
     {
-    "word": "mystery",
-    "meaning": "mystify, /ˈmɪstɪfaɪ/: làm hoang mang. mystification, /ˌmɪstɪfɪˈkeɪʃn/: tình trạng bối rối. mysterious(ly), /mɪˈstɪəriəs(li)/: (một cách) bí ẩn.",
-    "example": "The instructions mystify me. His disappearance caused mystification. She smiled mysteriously.",
-    "count": 0
+      "word": "mystery",
+      "meaning": "mystify, /ˈmɪstɪfaɪ/: làm hoang mang. mystification, /ˌmɪstɪfɪˈkeɪʃn/: tình trạng bối rối. mysterious(ly), /mɪˈstɪəriəs(li)/: (một cách) bí ẩn.",
+      "example": "The instructions mystify me. His disappearance caused mystification. She smiled mysteriously.",
+      "count": 0
     },
     {
-    "word": "neglect",
-    "meaning": "negligence, /ˈneɡlɪdʒəns/: tính cẩu thả. negligible, /ˈneɡlɪdʒəbl/: không đáng kể. neglectful(ly), /nɪˈɡlektfl(i)/: (một cách) tắc trách.",
-    "example": "His negligence led to an accident. The effect is negligible. He behaved neglectfully.",
-    "count": 0
+      "word": "neglect",
+      "meaning": "negligence, /ˈneɡlɪdʒəns/: tính cẩu thả. negligible, /ˈneɡlɪdʒəbl/: không đáng kể. neglectful(ly), /nɪˈɡlektfl(i)/: (một cách) tắc trách.",
+      "example": "His negligence led to an accident. The effect is negligible. He behaved neglectfully.",
+      "count": 0
     },
     {
-    "word": "new",
-    "meaning": "renew, /rɪˈnjuː/: làm mới lại. renewal, /rɪˈnjuːəl/: sự làm mới lại. newness, /ˈnjuːnəs/: tính mới mẻ. renewable, /rɪˈnjuːəbl/: có thể đổi mới. anew, /əˈnjuː/: lại, một lần nữa.",
-    "example": "They renewed their vows. The building needs renewal. He enjoyed the newness of the place. It’s a renewable contract. Let’s try anew.",
-    "count": 0
+      "word": "new",
+      "meaning": "renew, /rɪˈnjuː/: làm mới lại. renewal, /rɪˈnjuːəl/: sự làm mới lại. newness, /ˈnjuːnəs/: tính mới mẻ. renewable, /rɪˈnjuːəbl/: có thể đổi mới. anew, /əˈnjuː/: lại, một lần nữa.",
+      "example": "They renewed their vows. The building needs renewal. He enjoyed the newness of the place. It’s a renewable contract. Let’s try anew.",
+      "count": 0
     },
     {
-    "word": "object",
-    "meaning": "objective, /əbˈdʒektɪv/: mục tiêu. objection, /əbˈdʒekʃn/: sự phản đối. objectivity, /ˌɒbdʒekˈtɪvəti/: tính khách quan. objector, /əbˈdʒektə(r)/: người phản đối. (un)objectionable, /ʌnəbˈdʒekʃənəbl/: (không) có thể chấp nhận.",
-    "example": "Our objective is clear. He raised an objection. She judged with objectivity. The objector interrupted the meeting. That remark is unobjectionable.",
-    "count": 0
+      "word": "object",
+      "meaning": "objective, /əbˈdʒektɪv/: mục tiêu. objection, /əbˈdʒekʃn/: sự phản đối. objectivity, /ˌɒbdʒekˈtɪvəti/: tính khách quan. objector, /əbˈdʒektə(r)/: người phản đối. (un)objectionable, /ʌnəbˈdʒekʃənəbl/: (không) có thể chấp nhận.",
+      "example": "Our objective is clear. He raised an objection. She judged with objectivity. The objector interrupted the meeting. That remark is unobjectionable.",
+      "count": 0
     },
     {
-    "word": "observe",
-    "meaning": "objectively, /əbˈdʒektɪvli/: một cách khách quan. observation, /ˌɒbzəˈveɪʃn/: sự quan sát. observance, /əbˈzɜːvəns/: sự tuân thủ. observer, /əbˈzɜːvə(r)/: người quan sát. observatory, /əbˈzɜːvətəri/: đài quan sát. observable, /əbˈzɜːvəbl/: dễ thấy. observant, /əbˈzɜːvənt/: tinh mắt. observably, /əbˈzɜːvəbli/: dễ thấy.",
-    "example": "She wrote objectively. Careful observation is needed. Observance of rules is required. An observer stood nearby. The observatory tracks stars. The change was observable. He is very observant. The effects were observably strong.",
-    "count": 0
+      "word": "observe",
+      "meaning": "objectively, /əbˈdʒektɪvli/: một cách khách quan. observation, /ˌɒbzəˈveɪʃn/: sự quan sát. observance, /əbˈzɜːvəns/: sự tuân thủ. observer, /əbˈzɜːvə(r)/: người quan sát. observatory, /əbˈzɜːvətəri/: đài quan sát. observable, /əbˈzɜːvəbl/: dễ thấy. observant, /əbˈzɜːvənt/: tinh mắt. observably, /əbˈzɜːvəbli/: dễ thấy.",
+      "example": "She wrote objectively. Careful observation is needed. Observance of rules is required. An observer stood nearby. The observatory tracks stars. The change was observable. He is very observant. The effects were observably strong.",
+      "count": 0
     },
     {
-    "word": "obsess",
-    "meaning": "obsession, /əbˈseʃn/: sự ám ảnh. obsessed, /əbˈsest/: bị ám ảnh. obsessive(ly), /əbˈsesɪv(li)/: (một cách) ám ảnh.",
-    "example": "Her obsession with details is extreme. He’s obsessed with fitness. She cleaned obsessively.",
-    "count": 0
+      "word": "obsess",
+      "meaning": "obsession, /əbˈseʃn/: sự ám ảnh. obsessed, /əbˈsest/: bị ám ảnh. obsessive(ly), /əbˈsesɪv(li)/: (một cách) ám ảnh.",
+      "example": "Her obsession with details is extreme. He’s obsessed with fitness. She cleaned obsessively.",
+      "count": 0
     },
     {
-    "word": "place",
-    "meaning": "replace, /rɪˈpleɪs/: thay thế. placement, /ˈpleɪsmənt/: sự sắp xếp. placing, /ˈpleɪsɪŋ/: sự sắp xếp. replacement, /rɪˈpleɪsmənt/: sự thay thế. (ir)replaceable, /(ˌɪr)rɪˈpleɪsəbl/: (không) thể thay thế.",
-    "example": "She had to replace the batteries. Placement was done randomly. The placing of furniture matters. He's a good replacement. That ring is irreplaceable.",
-    "count": 0
+      "word": "place",
+      "meaning": "replace, /rɪˈpleɪs/: thay thế. placement, /ˈpleɪsmənt/: sự sắp xếp. placing, /ˈpleɪsɪŋ/: sự sắp xếp. replacement, /rɪˈpleɪsmənt/: sự thay thế. (ir)replaceable, /(ˌɪr)rɪˈpleɪsəbl/: (không) thể thay thế.",
+      "example": "She had to replace the batteries. Placement was done randomly. The placing of furniture matters. He's a good replacement. That ring is irreplaceable.",
+      "count": 0
     },
     {
-    "word": "play",
-    "meaning": "replay, /ˈriːpleɪ/: chơi lại. overplay, /ˌəʊvəˈpleɪ/: cường điệu quá mức. downplay, /ˌdaʊnˈpleɪ/: làm giảm mức quan trọng. player, /ˈpleɪə(r)/: người chơi. playful(ly), /ˈpleɪfl(i)/: (một cách) đùa bỡn.",
-    "example": "They replayed the game. Don’t overplay your role. He tried to downplay the issue. He is a good player. She smiled playfully.",
-    "count": 0
+      "word": "play",
+      "meaning": "replay, /ˈriːpleɪ/: chơi lại. overplay, /ˌəʊvəˈpleɪ/: cường điệu quá mức. downplay, /ˌdaʊnˈpleɪ/: làm giảm mức quan trọng. player, /ˈpleɪə(r)/: người chơi. playful(ly), /ˈpleɪfl(i)/: (một cách) đùa bỡn.",
+      "example": "They replayed the game. Don’t overplay your role. He tried to downplay the issue. He is a good player. She smiled playfully.",
+      "count": 0
     },
     {
-    "word": "portion",
-    "meaning": "apportion, /əˈpɔːʃn/: phân chia.",
-    "example": "They apportioned the land among the heirs.",
-    "count": 0
+      "word": "portion",
+      "meaning": "apportion, /əˈpɔːʃn/: phân chia.",
+      "example": "They apportioned the land among the heirs.",
+      "count": 0
     },
     {
-    "word": "power",
-    "meaning": "empower, /ɪmˈpaʊə(r)/: trao quyền. overpower, /ˌəʊvəˈpaʊə(r)/: áp đảo. empowerment, /ɪmˈpaʊəmənt/: sự trao quyền. powerlessness, /ˈpaʊələsnəs/: sự bất lực. powerful(ly), /ˈpaʊəfl(i)/: (một cách) mạnh mẽ. powerless(ly), /ˈpaʊələsli/: (một cách) bất lực.",
-    "example": "The law empowers citizens. The enemy was overpowered. Empowerment is key. He felt powerlessness. She spoke powerfully. He watched powerlessly.",
-    "count": 0
+      "word": "power",
+      "meaning": "empower, /ɪmˈpaʊə(r)/: trao quyền. overpower, /ˌəʊvəˈpaʊə(r)/: áp đảo. empowerment, /ɪmˈpaʊəmənt/: sự trao quyền. powerlessness, /ˈpaʊələsnəs/: sự bất lực. powerful(ly), /ˈpaʊəfl(i)/: (một cách) mạnh mẽ. powerless(ly), /ˈpaʊələsli/: (một cách) bất lực.",
+      "example": "The law empowers citizens. The enemy was overpowered. Empowerment is key. He felt powerlessness. She spoke powerfully. He watched powerlessly.",
+      "count": 0
     },
     {
-    "word": "prefer",
-    "meaning": "preference, /ˈprefrəns/: sở thích. preferable, /ˈprefrəbl/: tốt hơn. preferred, /prɪˈfɜːd/: được ưa thích. preferential, /ˌprefəˈrenʃl/: ưu đãi. preferably, /ˈprefrəbli/: một cách tốt hơn.",
-    "example": "I have no preference. Tea is preferable to coffee. She chose her preferred seat. They offer preferential treatment. Preferably, bring ID.",
-    "count": 0
+      "word": "prefer",
+      "meaning": "preference, /ˈprefrəns/: sở thích. preferable, /ˈprefrəbl/: tốt hơn. preferred, /prɪˈfɜːd/: được ưa thích. preferential, /ˌprefəˈrenʃl/: ưu đãi. preferably, /ˈprefrəbli/: một cách tốt hơn.",
+      "example": "I have no preference. Tea is preferable to coffee. She chose her preferred seat. They offer preferential treatment. Preferably, bring ID.",
+      "count": 0
     },
     {
-    "word": "prejudice",
-    "meaning": "(un)prejudiced, /(ˌʌn)ˈpredʒədɪst/: (không) có thành kiến.",
-    "example": "He is prejudiced against foreigners. She remained unprejudiced.",
-    "count": 0
+      "word": "prejudice",
+      "meaning": "(un)prejudiced, /(ˌʌn)ˈpredʒədɪst/: (không) có thành kiến.",
+      "example": "He is prejudiced against foreigners. She remained unprejudiced.",
+      "count": 0
     },
     {
-    "word": "prevent",
-    "meaning": "prevention, /prɪˈvenʃn/: sự phòng ngừa. preventive, /prɪˈventɪv/: ngăn chặn. (un)preventable, /(ˌʌn)prɪˈventəbl/: (không) có thể ngăn chặn.",
-    "example": "Prevention is better than cure. Take preventive measures. The illness is preventable.",
-    "count": 0
+      "word": "prevent",
+      "meaning": "prevention, /prɪˈvenʃn/: sự phòng ngừa. preventive, /prɪˈventɪv/: ngăn chặn. (un)preventable, /(ˌʌn)prɪˈventəbl/: (không) có thể ngăn chặn.",
+      "example": "Prevention is better than cure. Take preventive measures. The illness is preventable.",
+      "count": 0
     },
     {
-    "word": "print",
-    "meaning": "reprint, /ˈriːprɪnt/: tái bản. printing, /ˈprɪntɪŋ/: sự in. printer, /ˈprɪntə(r)/: máy in. printout, /ˈprɪntaʊt/: bản in. imprint, /ˈɪmprɪnt/: in dấu, ấn dấu. printed, /ˈprɪntɪd/: được in ra. (un)printable, /(ʌn)ˈprɪntəbl/: (không) có thể in được.",
-    "example": "They will reprint the article. The printing was delayed. I need a new printer. I’ll check the printout. That left an imprint. It’s a printed copy. That word is unprintable.",
-    "count": 0
+      "word": "print",
+      "meaning": "reprint, /ˈriːprɪnt/: tái bản. printing, /ˈprɪntɪŋ/: sự in. printer, /ˈprɪntə(r)/: máy in. printout, /ˈprɪntaʊt/: bản in. imprint, /ˈɪmprɪnt/: in dấu, ấn dấu. printed, /ˈprɪntɪd/: được in ra. (un)printable, /(ʌn)ˈprɪntəbl/: (không) có thể in được.",
+      "example": "They will reprint the article. The printing was delayed. I need a new printer. I’ll check the printout. That left an imprint. It’s a printed copy. That word is unprintable.",
+      "count": 0
     },
     {
-    "word": "probable",
-    "meaning": "(im)probability, /(ɪm)ˌprɒbəˈbɪləti/: (không) có khả năng. improbable, /ɪmˈprɒbəbl/: không chắc xảy ra. (im)probably, /(ɪm)ˈprɒbəbli/: (một cách) (không) chắc.",
-    "example": "There is a high probability of rain. That’s improbable. It will probably rain. It probably won’t help.",
-    "count": 0
+      "word": "probable",
+      "meaning": "(im)probability, /(ɪm)ˌprɒbəˈbɪləti/: (không) có khả năng. improbable, /ɪmˈprɒbəbl/: không chắc xảy ra. (im)probably, /(ɪm)ˈprɒbəbli/: (một cách) (không) chắc.",
+      "example": "There is a high probability of rain. That’s improbable. It will probably rain. It probably won’t help.",
+      "count": 0
     },
     {
-    "word": "process",
-    "meaning": "processor, /ˈprəʊsesə(r)/: bộ xử lý. processing, /ˈprəʊsesɪŋ/: xử lý. processed, /ˈprəʊsest/: được chế biến.",
-    "example": "The processor is fast. Image processing takes time. Avoid processed foods.",
-    "count": 0
+      "word": "process",
+      "meaning": "processor, /ˈprəʊsesə(r)/: bộ xử lý. processing, /ˈprəʊsesɪŋ/: xử lý. processed, /ˈprəʊsest/: được chế biến.",
+      "example": "The processor is fast. Image processing takes time. Avoid processed foods.",
+      "count": 0
     },
     {
-    "word": "produce",
-    "meaning": "producer, /prəˈdjuːsə(r)/: nhà sản xuất. product, /ˈprɒdʌkt/: sản phẩm. productivity, /ˌprɒdʌkˈtɪvəti/: năng suất. production, /prəˈdʌkʃn/: sự sản xuất. counterproductive, /ˌkaʊntəprəˈdʌktɪv/: phản tác dụng. (un)productive(ly), /(ˌʌn)prəˈdʌktɪv(li)/: (một cách) (không) hiệu quả.",
-    "example": "The producer launched a new show. This is a useful product. Productivity increased last year. Production was delayed. That habit is counterproductive. She worked productively.",
-    "count": 0
+      "word": "produce",
+      "meaning": "producer, /prəˈdjuːsə(r)/: nhà sản xuất. product, /ˈprɒdʌkt/: sản phẩm. productivity, /ˌprɒdʌkˈtɪvəti/: năng suất. production, /prəˈdʌkʃn/: sự sản xuất. counterproductive, /ˌkaʊntəprəˈdʌktɪv/: phản tác dụng. (un)productive(ly), /(ˌʌn)prəˈdʌktɪv(li)/: (một cách) (không) hiệu quả.",
+      "example": "The producer launched a new show. This is a useful product. Productivity increased last year. Production was delayed. That habit is counterproductive. She worked productively.",
+      "count": 0
     },
     {
-    "word": "progress",
-    "meaning": "progression, /prəˈɡreʃn/: sự tiến bộ. progressive(ly), /prəˈɡresɪv(li)/: (một cách) tiến bộ.",
-    "example": "His progression in math is impressive. The symptoms worsened progressively.",
-    "count": 0
+      "word": "progress",
+      "meaning": "progression, /prəˈɡreʃn/: sự tiến bộ. progressive(ly), /prəˈɡresɪv(li)/: (một cách) tiến bộ.",
+      "example": "His progression in math is impressive. The symptoms worsened progressively.",
+      "count": 0
     },
     {
-    "word": "provoke",
-    "meaning": "provocation, /ˌprɒvəˈkeɪʃn/: sự khiêu khích. provocative(ly), /prəˈvɒkətɪv(li)/: (một cách) khiêu khích.",
-    "example": "They acted without provocation. She dressed provocatively.",
-    "count": 0
+      "word": "provoke",
+      "meaning": "provocation, /ˌprɒvəˈkeɪʃn/: sự khiêu khích. provocative(ly), /prəˈvɒkətɪv(li)/: (một cách) khiêu khích.",
+      "example": "They acted without provocation. She dressed provocatively.",
+      "count": 0
     },
     {
-    "word": "public",
-    "meaning": "publicise, /ˈpʌblɪsaɪz/: công bố. publicity, /pʌbˈlɪsəti/: sự chú ý của công chúng. publication, /ˌpʌblɪˈkeɪʃn/: sự xuất bản. publicist, /ˈpʌblɪsɪst/: chuyên gia truyền thông. publicised, /ˈpʌblɪsaɪzd/: đã công khai. (un)publicised, /ʌnˈpʌblɪsaɪzd/: (không) được công bố.",
-    "example": "The company publicised its new policy. The event gained a lot of publicity. His book is ready for publication. The publicist sent the release. That report was widely publicised. The issue remains unpublicised.",
-    "count": 0
+      "word": "public",
+      "meaning": "publicise, /ˈpʌblɪsaɪz/: công bố. publicity, /pʌbˈlɪsəti/: sự chú ý của công chúng. publication, /ˌpʌblɪˈkeɪʃn/: sự xuất bản. publicist, /ˈpʌblɪsɪst/: chuyên gia truyền thông. publicised, /ˈpʌblɪsaɪzd/: đã công khai. (un)publicised, /ʌnˈpʌblɪsaɪzd/: (không) được công bố.",
+      "example": "The company publicised its new policy. The event gained a lot of publicity. His book is ready for publication. The publicist sent the release. That report was widely publicised. The issue remains unpublicised.",
+      "count": 0
     },
     {
-    "word": "pursue",
-    "meaning": "pursuer, /pəˈsjuːə(r)/: người theo đuổi.",
-    "example": "The pursuer didn’t give up easily.",
-    "count": 0
+      "word": "pursue",
+      "meaning": "pursuer, /pəˈsjuːə(r)/: người theo đuổi.",
+      "example": "The pursuer didn’t give up easily.",
+      "count": 0
     },
     {
-    "word": "quality",
-    "meaning": "qualitative(ly), /ˈkwɒlɪtətɪv(li)/: (một cách) định tính.",
-    "example": "The results were qualitatively better.",
-    "count": 0
+      "word": "quality",
+      "meaning": "qualitative(ly), /ˈkwɒlɪtətɪv(li)/: (một cách) định tính.",
+      "example": "The results were qualitatively better.",
+      "count": 0
     },
     {
-    "word": "race",
-    "meaning": "racist, /ˈreɪsɪst/: người phân biệt chủng tộc. racial(ly), /ˈreɪʃl(i)/: (về) chủng tộc. interracial, /ˌɪntəˈreɪʃl/: giữa các chủng tộc.",
-    "example": "He was accused of being a racist. They debated racial issues. It was an interracial marriage.",
-    "count": 0
+      "word": "race",
+      "meaning": "racist, /ˈreɪsɪst/: người phân biệt chủng tộc. racial(ly), /ˈreɪʃl(i)/: (về) chủng tộc. interracial, /ˌɪntəˈreɪʃl/: giữa các chủng tộc.",
+      "example": "He was accused of being a racist. They debated racial issues. It was an interracial marriage.",
+      "count": 0
     },
     {
-    "word": "rapid",
-    "meaning": "rapidly, /ˈræpɪdli/: một cách nhanh chóng.",
-    "example": "Technology is evolving rapidly.",
-    "count": 0
+      "word": "rapid",
+      "meaning": "rapidly, /ˈræpɪdli/: một cách nhanh chóng.",
+      "example": "Technology is evolving rapidly.",
+      "count": 0
     },
     {
-    "word": "rational",
-    "meaning": "rationalise, /ˈræʃnəlaɪz/: hợp lý hóa. rationalisation, /ˌræʃnəlaɪˈzeɪʃn/: sự hợp lý hóa. rationalist, /ˈræʃnəlɪst/: người theo chủ nghĩa duy lý. rationalism, /ˈræʃnəlɪzəm/: chủ nghĩa duy lý. (ir)rationality, /(ɪ)ˌræʃnəˈlæti/: (không) hợp lý. (ir)rational(ly), /(ɪ)ˈræʃnəli/: (một cách) (không) hợp lý.",
-    "example": "We need to rationalise spending. The plan's rationalisation was approved. He's a rationalist. She believes in rationalism. His decision lacked rationality. You acted irrationally.",
-    "count": 0
+      "word": "rational",
+      "meaning": "rationalise, /ˈræʃnəlaɪz/: hợp lý hóa. rationalisation, /ˌræʃnəlaɪˈzeɪʃn/: sự hợp lý hóa. rationalist, /ˈræʃnəlɪst/: người theo chủ nghĩa duy lý. rationalism, /ˈræʃnəlɪzəm/: chủ nghĩa duy lý. (ir)rationality, /(ɪ)ˌræʃnəˈlæti/: (không) hợp lý. (ir)rational(ly), /(ɪ)ˈræʃnəli/: (một cách) (không) hợp lý.",
+      "example": "We need to rationalise spending. The plan's rationalisation was approved. He's a rationalist. She believes in rationalism. His decision lacked rationality. You acted irrationally.",
+      "count": 0
     },
     {
-    "word": "reason",
-    "meaning": "reasonableness, /ˈriːznəblnəs/: sự có lý. (un)reasonable, /ʌnˈriːznəbl/: (không) hợp lý. (un)reasonably, /ʌnˈriːznəbli/: (một cách) (không) hợp lý.",
-    "example": "He showed reasonableness in negotiation. That’s unreasonable! She reacted unreasonably.",
-    "count": 0
+      "word": "reason",
+      "meaning": "reasonableness, /ˈriːznəblnəs/: sự có lý. (un)reasonable, /ʌnˈriːznəbl/: (không) hợp lý. (un)reasonably, /ʌnˈriːznəbli/: (một cách) (không) hợp lý.",
+      "example": "He showed reasonableness in negotiation. That’s unreasonable! She reacted unreasonably.",
+      "count": 0
     },
     {
-    "word": "regret",
-    "meaning": "regrettable, /rɪˈɡretəbl/: đáng tiếc. regrettably, /rɪˈɡretəbli/: thật đáng tiếc là. regretful(ly), /rɪˈɡretfl(i)/: (một cách) hối tiếc.",
-    "example": "It was a regrettable mistake. Regrettably, we must cancel. She looked at him regretfully.",
-    "count": 0
+      "word": "regret",
+      "meaning": "regrettable, /rɪˈɡretəbl/: đáng tiếc. regrettably, /rɪˈɡretəbli/: thật đáng tiếc là. regretful(ly), /rɪˈɡretfl(i)/: (một cách) hối tiếc.",
+      "example": "It was a regrettable mistake. Regrettably, we must cancel. She looked at him regretfully.",
+      "count": 0
     },
     {
-    "word": "occur",
-    "meaning": "recur, /rɪˈkɜː(r)/: tái diễn. occurrence, /əˈkʌrəns/: sự xuất hiện. recurrence, /rɪˈkʌrəns/: sự tái diễn. recurring, /rɪˈkɜːrɪŋ/: lặp đi lặp lại.",
-    "example": "Headaches may recur frequently. The occurrence was unusual. We want to prevent recurrence. It's a recurring problem.",
-    "count": 0
+      "word": "occur",
+      "meaning": "recur, /rɪˈkɜː(r)/: tái diễn. occurrence, /əˈkʌrəns/: sự xuất hiện. recurrence, /rɪˈkʌrəns/: sự tái diễn. recurring, /rɪˈkɜːrɪŋ/: lặp đi lặp lại.",
+      "example": "Headaches may recur frequently. The occurrence was unusual. We want to prevent recurrence. It's a recurring problem.",
+      "count": 0
     },
     {
-    "word": "office",
-    "meaning": "officiate, /əˈfɪʃieɪt/: làm lễ, chủ trì. official(dom), /əˈfɪʃl/: làm nhiệm vụ, chính thức. officer, /ˈɒfɪsə(r)/: viên chức. officious, /əˈfɪʃəs/: lắm lời, không chính thức. (un)official(ly), /(ˌʌn)əˈfɪʃəli/: (không) chính thức.",
-    "example": "He officiated the ceremony. The official attended the meeting. The officer gave instructions. He was being officious. The decision is unofficial.",
-    "count": 0
+      "word": "office",
+      "meaning": "officiate, /əˈfɪʃieɪt/: làm lễ, chủ trì. official(dom), /əˈfɪʃl/: làm nhiệm vụ, chính thức. officer, /ˈɒfɪsə(r)/: viên chức. officious, /əˈfɪʃəs/: lắm lời, không chính thức. (un)official(ly), /(ˌʌn)əˈfɪʃəli/: (không) chính thức.",
+      "example": "He officiated the ceremony. The official attended the meeting. The officer gave instructions. He was being officious. The decision is unofficial.",
+      "count": 0
     },
     {
-    "word": "opinion",
-    "meaning": "opinionated, /əˈpɪnjəneɪtɪd/: cứng đầu, ngoan cố.",
-    "example": "She’s very opinionated and won’t listen.",
-    "count": 0
+      "word": "opinion",
+      "meaning": "opinionated, /əˈpɪnjəneɪtɪd/: cứng đầu, ngoan cố.",
+      "example": "She’s very opinionated and won’t listen.",
+      "count": 0
     },
     {
-    "word": "parent",
-    "meaning": "parenting, /ˈpeərəntɪŋ/: việc làm cha mẹ. parentage, /ˈpeərəntɪdʒ/: tư cách làm cha mẹ. parenthood, /ˈpeərəntʊd/: bậc cha mẹ. parental(ly), /pəˈrentl(i)/: (thuộc) cha mẹ.",
-    "example": "Good parenting is important. His parentage is unknown. Parenthood changes people. They acted parentally.",
-    "count": 0
+      "word": "parent",
+      "meaning": "parenting, /ˈpeərəntɪŋ/: việc làm cha mẹ. parentage, /ˈpeərəntɪdʒ/: tư cách làm cha mẹ. parenthood, /ˈpeərəntʊd/: bậc cha mẹ. parental(ly), /pəˈrentl(i)/: (thuộc) cha mẹ.",
+      "example": "Good parenting is important. His parentage is unknown. Parenthood changes people. They acted parentally.",
+      "count": 0
     },
     {
-    "word": "pass",
-    "meaning": "(im)passable, /(ˌɪm)ˈpɑːsəbl/: (không) thể đi qua. passing, /ˈpɑːsɪŋ/: sự qua đi. passable, /ˈpɑːsəbl/: có thể đi qua. impatient, /ɪmˈpeɪʃnt/: không kiên nhẫn. (im)patient(ly), /(ɪm)ˈpeɪʃntli/: (một cách) (không) kiên nhẫn.",
-    "example": "The road is impassable due to snow. His passing was sudden. The trail is passable now. She’s an impatient person. He waited patiently.",
-    "count": 0
+      "word": "pass",
+      "meaning": "(im)passable, /(ˌɪm)ˈpɑːsəbl/: (không) thể đi qua. passing, /ˈpɑːsɪŋ/: sự qua đi. passable, /ˈpɑːsəbl/: có thể đi qua. impatient, /ɪmˈpeɪʃnt/: không kiên nhẫn. (im)patient(ly), /(ɪm)ˈpeɪʃntli/: (một cách) (không) kiên nhẫn.",
+      "example": "The road is impassable due to snow. His passing was sudden. The trail is passable now. She’s an impatient person. He waited patiently.",
+      "count": 0
     },
     {
-    "word": "pay",
-    "meaning": "overpay, /ˌəʊvəˈpeɪ/: trả quá nhiều tiền. underpay, /ˌʌndəˈpeɪ/: trả lương quá thấp. repay, /rɪˈpeɪ/: trả lại. overpayment, /ˌəʊvəˈpeɪmənt/: trả vượt mức. underpayment, /ˌʌndəˈpeɪmənt/: trả lương thấp. repayment, /rɪˈpeɪmənt/: sự trả lại. payback, /ˈpeɪbæk/: lợi tức. payee, /ˌpeɪˈiː/: người nhận tiền. payer, /ˈpeɪə(r)/: người trả tiền. payload, /ˈpeɪləʊd/: tải trọng. payoff, /ˈpeɪɒf/: tiền bồi dưỡng. payable, /ˈpeɪəbl/: phải trả. payroll, /ˈpeɪrəʊl/: bảng lương. payslip, /ˈpeɪslɪp/: phiếu lương. overpaid, /ˌəʊvəˈpeɪd/: được trả quá cao. underpaid, /ˌʌndəˈpeɪd/: bị trả quá thấp.",
-    "example": "They overpay their employees. Many teachers are underpaid. I’ll repay the loan soon. His overpayment was refunded. The underpayment caused issues. The repayment is due tomorrow. She got her payback. The payee was verified. The payer is responsible. The payload is too heavy. He received a payoff. The invoice is payable next week. Check your payroll account. I lost my payslip. He’s definitely overpaid. Nurses are often underpaid.",
-    "count": 0
+      "word": "pay",
+      "meaning": "overpay: trả quá nhiều tiền. underpay: trả lương quá thấp. repay: trả lại. overpayment: trả vượt mức. underpayment: trả lương thấp. repayment: sự trả lại. payback: lợi tức. payee: người nhận tiền. payer: người trả tiền. payload: tải trọng. payoff: tiền bồi dưỡng. payable: phải trả. payroll: bảng lương. payslip: phiếu lương. overpaid: được trả quá cao. underpaid: bị trả quá thấp.",
+      "example": "They overpay their employees. Many teachers are underpaid. I’ll repay the loan soon. His overpayment was refunded. The underpayment caused issues. The repayment is due tomorrow. She got her payback. The payee was verified. The payer is responsible. The payload is too heavy. He received a payoff. The invoice is payable next week. Check your payroll account. I lost my payslip. He’s definitely overpaid. Nurses are often underpaid.",
+      "count": 0
     },
     {
-    "word": "perceive",
-    "meaning": "perception, /pəˈsepʃn/: sự nhận thức. perceptiveness, /pəˈseptɪvnəs/: khả năng nhận thức. (im)perceptible, /(ɪm)ˈpɜːsəptəbl/: (không) thể cảm nhận được. (im)perceptively, /(ɪm)ˈpɜːsəptɪvli/: (một cách) (không) nhạy bén.",
-    "example": "Her perception of reality is accurate. He showed great perceptiveness. The change was imperceptible. She nodded perceptively.",
-    "count": 0
+      "word": "perceive",
+      "meaning": "perception, /pəˈsepʃn/: sự nhận thức. perceptiveness, /pəˈseptɪvnəs/: khả năng nhận thức. (im)perceptible, /(ɪm)ˈpɜːsəptəbl/: (không) thể cảm nhận được. (im)perceptively, /(ɪm)ˈpɜːsəptɪvli/: (một cách) (không) nhạy bén.",
+      "example": "Her perception of reality is accurate. He showed great perceptiveness. The change was imperceptible. She nodded perceptively.",
+      "count": 0
     },
     {
-    "word": "perfect",
-    "meaning": "perfection, /pəˈfekʃn/: sự hoàn hảo. perfectionist, /pəˈfekʃənɪst/: người cầu toàn. perfectionism, /pəˈfekʃənɪzəm/: chủ nghĩa hoàn hảo. perfectible, /pəˈfektəbl/: có thể hoàn thiện. perfectly, /ˈpɜːfɪktli/: một cách hoàn hảo. imperfect(ly), /ɪmˈpɜːfɪkt(li)/: (một cách) không hoàn hảo.",
-    "example": "He strives for perfection. She’s a perfectionist. Perfectionism can be stressful. The plan is perfectible. You handled it perfectly. The copy is imperfect.",
-    "count": 0
+      "word": "perfect",
+      "meaning": "perfection, /pəˈfekʃn/: sự hoàn hảo. perfectionist, /pəˈfekʃənɪst/: người cầu toàn. perfectionism, /pəˈfekʃənɪzəm/: chủ nghĩa hoàn hảo. perfectible, /pəˈfektəbl/: có thể hoàn thiện. perfectly, /ˈpɜːfɪktli/: một cách hoàn hảo. imperfect(ly), /ɪmˈpɜːfɪkt(li)/: (một cách) không hoàn hảo.",
+      "example": "He strives for perfection. She’s a perfectionist. Perfectionism can be stressful. The plan is perfectible. You handled it perfectly. The copy is imperfect.",
+      "count": 0
     },
     {
-    "word": "period",
-    "meaning": "periodical, /ˌpɪəriˈɒdɪkl/: tạp chí định kỳ. periodically, /ˌpɪəriˈɒdɪkli/: một cách định kỳ.",
-    "example": "The data is published in a periodical. We meet periodically to discuss progress.",
-    "count": 0
+      "word": "period",
+      "meaning": "periodical, /ˌpɪəriˈɒdɪkl/: tạp chí định kỳ. periodically, /ˌpɪəriˈɒdɪkli/: một cách định kỳ.",
+      "example": "The data is published in a periodical. We meet periodically to discuss progress.",
+      "count": 0
     },
     {
-    "word": "permit",
-    "meaning": "permission, /pəˈmɪʃn/: sự cho phép. permissiveness, /pəˈmɪsɪvnəs/: tính dễ dãi. permissive, /pəˈmɪsɪv/: dễ dãi. permissible, /pəˈmɪsəbl/: có thể chấp nhận.",
-    "example": "Do you have permission to enter? The teacher’s permissiveness led to chaos. It’s a permissive culture. That behavior is not permissible.",
-    "count": 0
+      "word": "permit",
+      "meaning": "permission, /pəˈmɪʃn/: sự cho phép. permissiveness, /pəˈmɪsɪvnəs/: tính dễ dãi. permissive, /pəˈmɪsɪv/: dễ dãi. permissible, /pəˈmɪsəbl/: có thể chấp nhận.",
+      "example": "Do you have permission to enter? The teacher’s permissiveness led to chaos. It’s a permissive culture. That behavior is not permissible.",
+      "count": 0
     },
     {
-    "word": "persist",
-    "meaning": "persistence, /pəˈsɪstəns/: sự kiên trì. persistent(ly), /pəˈsɪstəntli/: (một cách) kiên trì.",
-    "example": "Her persistence paid off. He called persistently.",
-    "count": 0
+      "word": "persist",
+      "meaning": "persistence, /pəˈsɪstəns/: sự kiên trì. persistent(ly), /pəˈsɪstəntli/: (một cách) kiên trì.",
+      "example": "Her persistence paid off. He called persistently.",
+      "count": 0
     },
     {
-    "word": "person",
-    "meaning": "personalise, /ˈpɜːsənaɪz/: cá nhân hóa. impersonate, /ɪmˈpɜːsəneɪt/: giả danh. personality, /ˌpɜːsəˈnæləti/: tính cách. personnel, /ˌpɜːsəˈnel/: nhân sự. interpersonal, /ˌɪntəˈpɜːsənl/: giữa các cá nhân. (im)personal(ly), /(ˌɪm)ˈpɜːsənəli/: (một cách) (không) cụ thể, riêng tư.",
-    "example": "You can personalise your profile. He impersonated a police officer. She has a friendly personality. All personnel must report at 9. Interpersonal skills are crucial. Don't take it personally.",
-    "count": 0
+      "word": "person",
+      "meaning": "personalise, /ˈpɜːsənaɪz/: cá nhân hóa. impersonate, /ɪmˈpɜːsəneɪt/: giả danh. personality, /ˌpɜːsəˈnæləti/: tính cách. personnel, /ˌpɜːsəˈnel/: nhân sự. interpersonal, /ˌɪntəˈpɜːsənl/: giữa các cá nhân. (im)personal(ly), /(ˌɪm)ˈpɜːsənəli/: (một cách) (không) cụ thể, riêng tư.",
+      "example": "You can personalise your profile. He impersonated a police officer. She has a friendly personality. All personnel must report at 9. Interpersonal skills are crucial. Don't take it personally.",
+      "count": 0
     },
     {
-    "word": "persuade",
-    "meaning": "dissuade, /dɪˈsweɪd/: ngăn cản, thuyết phục từ bỏ. persuasion, /pəˈsweɪʒn/: sự thuyết phục. persuasive(ly), /pəˈsweɪsɪv(li)/: (một cách) thuyết phục.",
-    "example": "He tried to dissuade her. Her persuasion worked. She argued persuasively.",
-    "count": 0
+      "word": "persuade",
+      "meaning": "dissuade, /dɪˈsweɪd/: ngăn cản, thuyết phục từ bỏ. persuasion, /pəˈsweɪʒn/: sự thuyết phục. persuasive(ly), /pəˈsweɪsɪv(li)/: (một cách) thuyết phục.",
+      "example": "He tried to dissuade her. Her persuasion worked. She argued persuasively.",
+      "count": 0
     },
     {
-    "word": "phrase",
-    "meaning": "rephrase, /ˌriːˈfreɪz/: diễn đạt bằng cách khác. paraphrase, /ˈpærəfreɪz/: diễn giải, diễn đạt. phrasing, /ˈfreɪzɪŋ/: cách phân nhịp. phraseology, /ˌfreɪziˈɒlədʒi/: ngữ cú, cách nói viết.",
-    "example": "Let me rephrase that. Can you paraphrase this paragraph? The song has strange phrasing. His phraseology was too formal.",
-    "count": 0
-    },                        
-{
-    "word": "fold",
-    "meaning": "enfold, /ɪnˈfəʊld/: gấp nếp, bọc lại. unfold, /ʌnˈfəʊld/: mở ra, bày ra. folder, /ˈfəʊldə(r)/: thư mục. (un)folding, /(ʌn)ˈfəʊldɪŋ/: (không) gấp lại được. foldaway, /ˈfəʊldəweɪ/: gấp/kép lại được.",
-    "example": "She enfolded the letter gently. The truth began to unfold. Save the file in a folder. This chair is folding. The foldaway bed saves space.",
-    "count": 0
+      "word": "phrase",
+      "meaning": "rephrase, /ˌriːˈfreɪz/: diễn đạt bằng cách khác. paraphrase, /ˈpærəfreɪz/: diễn giải, diễn đạt. phrasing, /ˈfreɪzɪŋ/: cách phân nhịp. phraseology, /ˌfreɪziˈɒlədʒi/: ngữ cú, cách nói viết.",
+      "example": "Let me rephrase that. Can you paraphrase this paragraph? The song has strange phrasing. His phraseology was too formal.",
+      "count": 0
     },
     {
-    "word": "fortune",
-    "meaning": "misfortune, /ˌmɪsˈfɔːtʃuːn/: điều không may. (un)fortunate(ly), /(ʌn)ˈfɔːtʃənət(li)/: (một cách) (không) may mắn. fortuitous(ly), /fɔːˈtjuːɪtəs(li)/: tình cờ, ngẫu nhiên.",
-    "example": "They suffered great misfortune. Fortunately, no one was hurt. She chose her path fortuitously.",
-    "count": 0
+      "word": "fold",
+      "meaning": "enfold, /ɪnˈfəʊld/: gấp nếp, bọc lại. unfold, /ʌnˈfəʊld/: mở ra, bày ra. folder, /ˈfəʊldə(r)/: thư mục. (un)folding, /(ʌn)ˈfəʊldɪŋ/: (không) gấp lại được. foldaway, /ˈfəʊldəweɪ/: gấp/kép lại được.",
+      "example": "She enfolded the letter gently. The truth began to unfold. Save the file in a folder. This chair is folding. The foldaway bed saves space.",
+      "count": 0
     },
     {
-    "word": "fruit",
-    "meaning": "fruitfulness, /ˈfruːtflnəs/: sự sai quả, khả năng thành công. fruitlessness, /ˈfruːtləsnəs/: sự không ra quả. fruition, /fruːˈɪʃn/: sự kết trái, sự hưởng. fruitful(ly), /ˈfruːtfl(i)/: (một cách) thành công. fruitless(ly), /ˈfruːtləsli/: (một cách) vô ích.",
-    "example": "Her garden is known for fruitfulness. The effort ended in fruitlessness. The plan came to fruition. They discussed fruitfully. He searched fruitlessly.",
-    "count": 0
+      "word": "fortune",
+      "meaning": "misfortune, /ˌmɪsˈfɔːtʃuːn/: điều không may. (un)fortunate(ly), /(ʌn)ˈfɔːtʃənət(li)/: (một cách) (không) may mắn. fortuitous(ly), /fɔːˈtjuːɪtəs(li)/: tình cờ, ngẫu nhiên.",
+      "example": "They suffered great misfortune. Fortunately, no one was hurt. She chose her path fortuitously.",
+      "count": 0
     },
     {
-    "word": "future",
-    "meaning": "futurist, /ˈfjuːtʃərɪst/: người theo thuyết vị lai. futuristic(ally), /ˌfjuːtʃəˈrɪstɪk(ə)li/: (một cách) thuộc về tương lai.",
-    "example": "The futurist predicted AI domination. The building looks futuristically advanced.",
-    "count": 0
+      "word": "fruit",
+      "meaning": "fruitfulness, /ˈfruːtflnəs/: sự sai quả, khả năng thành công. fruitlessness, /ˈfruːtləsnəs/: sự không ra quả. fruition, /fruːˈɪʃn/: sự kết trái, sự hưởng. fruitful(ly), /ˈfruːtfl(i)/: (một cách) thành công. fruitless(ly), /ˈfruːtləsli/: (một cách) vô ích.",
+      "example": "Her garden is known for fruitfulness. The effort ended in fruitlessness. The plan came to fruition. They discussed fruitfully. He searched fruitlessly.",
+      "count": 0
     },
     {
-    "word": "go",
-    "meaning": "undergo, /ˌʌndəˈɡəʊ/: trải qua. went, /went/: quá khứ của go. for(e)go, /fəˈɡəʊ/: đi trước. for(e)went, /fəˈwent/: quá khứ của forego. for(e)gone, /fəˈɡɒn/: quá khứ phân từ của forego. ongoing, /ˈɒnɡəʊɪŋ/: đang diễn ra. outgoing, /ˈaʊtɡəʊɪŋ/: cởi mở.",
-    "example": "She had to undergo surgery. He went to the market. They chose to forego luxuries. It was a foregone conclusion. The discussion is ongoing. He is very outgoing.",
-    "count": 0
+      "word": "future",
+      "meaning": "futurist, /ˈfjuːtʃərɪst/: người theo thuyết vị lai. futuristic(ally), /ˌfjuːtʃəˈrɪstɪk(ə)li/: (một cách) thuộc về tương lai.",
+      "example": "The futurist predicted AI domination. The building looks futuristically advanced.",
+      "count": 0
     },
     {
-    "word": "good",
-    "meaning": "goods, /ɡʊdz/: hàng hóa. goodness, /ˈɡʊdnəs/: lòng tốt. goodwill, /ˌɡʊdˈwɪl/: thiện chí. goody/goodie, /ˈɡʊdi/: người tốt.",
-    "example": "They donated goods. Her kindness showed great goodness. We appreciate your goodwill. He's always the goodie in stories.",
-    "count": 0
+      "word": "go",
+      "meaning": "undergo, /ˌʌndəˈɡəʊ/: trải qua. went, /went/: quá khứ của go. for(e)go, /fəˈɡəʊ/: đi trước. for(e)went, /fəˈwent/: quá khứ của forego. for(e)gone, /fəˈɡɒn/: quá khứ phân từ của forego. ongoing, /ˈɒnɡəʊɪŋ/: đang diễn ra. outgoing, /ˈaʊtɡəʊɪŋ/: cởi mở.",
+      "example": "She had to undergo surgery. He went to the market. They chose to forego luxuries. It was a foregone conclusion. The discussion is ongoing. He is very outgoing.",
+      "count": 0
     },
     {
-    "word": "govern",
-    "meaning": "misgovern, /ˌmɪsˈɡʌvn/: cai trị sai. government, /ˈɡʌvənmənt/: chính phủ. governor, /ˈɡʌvənə(r)/: thống đốc. governess, /ˈɡʌvənəs/: cô giáo. governing, /ˈɡʌvnɪŋ/: có quyền cai trị. governmental, /ˌɡʌvənˈmentl/: thuộc chính phủ. ungovernable, /ʌnˈɡʌvənəbl/: không thể kiểm soát.",
-    "example": "They misgoverned the nation. The government introduced reforms. The governor visited. She worked as a governess. It’s a governing body. Governmental agencies responded. The region became ungovernable.",
-    "count": 0
+      "word": "good",
+      "meaning": "goods, /ɡʊdz/: hàng hóa. goodness, /ˈɡʊdnəs/: lòng tốt. goodwill, /ˌɡʊdˈwɪl/: thiện chí. goody/goodie, /ˈɡʊdi/: người tốt.",
+      "example": "They donated goods. Her kindness showed great goodness. We appreciate your goodwill. He's always the goodie in stories.",
+      "count": 0
     },
     {
-    "word": "hand",
-    "meaning": "handle, /ˈhændl/: xử lý. handler, /ˈhændlə(r)/: người điều khiển. handling, /ˈhændlɪŋ/: cách xử lý. handout, /ˈhændaʊt/: tài liệu phát ra. handover, /ˈhændəʊvə(r)/: sự bàn giao. handful, /ˈhændfʊl/: một nắm tay. handmade, /ˌhændˈmeɪd/: đồ do tay làm. underhand, /ˌʌndəˈhænd/: lén lút.",
-    "example": "She handled the problem well. The dog handler gave commands. Proper handling is important. Please take a handout. The manager completed the handover. He gave me a handful of nuts. These are handmade crafts. That was an underhand tactic.",
-    "count": 0
+      "word": "govern",
+      "meaning": "misgovern, /ˌmɪsˈɡʌvn/: cai trị sai. government, /ˈɡʌvənmənt/: chính phủ. governor, /ˈɡʌvənə(r)/: thống đốc. governess, /ˈɡʌvənəs/: cô giáo. governing, /ˈɡʌvnɪŋ/: có quyền cai trị. governmental, /ˌɡʌvənˈmentl/: thuộc chính phủ. ungovernable, /ʌnˈɡʌvənəbl/: không thể kiểm soát.",
+      "example": "They misgoverned the nation. The government introduced reforms. The governor visited. She worked as a governess. It’s a governing body. Governmental agencies responded. The region became ungovernable.",
+      "count": 0
     },
     {
-    "word": "hard",
-    "meaning": "handy, /ˈhændi/: có ích, tiện tay. hardship, /ˈhɑːdʃɪp/: sự gian khổ. hardness, /ˈhɑːdnəs/: độ cứng. hardy, /ˈhɑːdi/: chịu khó, bền.",
-    "example": "This tool is handy. They endured great hardship. The material’s hardness is tested. These plants are hardy.",
-    "count": 0
+      "word": "hand",
+      "meaning": "handle, /ˈhændl/: xử lý. handler, /ˈhændlə(r)/: người điều khiển. handling, /ˈhændlɪŋ/: cách xử lý. handout, /ˈhændaʊt/: tài liệu phát ra. handover, /ˈhændəʊvə(r)/: sự bàn giao. handful, /ˈhændfʊl/: một nắm tay. handmade, /ˌhændˈmeɪd/: đồ do tay làm. underhand, /ˌʌndəˈhænd/: lén lút.",
+      "example": "She handled the problem well. The dog handler gave commands. Proper handling is important. Please take a handout. The manager completed the handover. He gave me a handful of nuts. These are handmade crafts. That was an underhand tactic.",
+      "count": 0
     },
     {
-    "word": "hear",
-    "meaning": "overhear, /ˌəʊvəˈhɪə(r)/: nghe lỏm. hearing, /ˈhɪərɪŋ/: thính giác. hearsay, /ˈhɪəseɪ/: tin đồn.",
-    "example": "I overheard them arguing. Her hearing is excellent. Don’t trust hearsay.",
-    "count": 0
+      "word": "hard",
+      "meaning": "handy, /ˈhændi/: có ích, tiện tay. hardship, /ˈhɑːdʃɪp/: sự gian khổ. hardness, /ˈhɑːdnəs/: độ cứng. hardy, /ˈhɑːdi/: chịu khó, bền.",
+      "example": "This tool is handy. They endured great hardship. The material’s hardness is tested. These plants are hardy.",
+      "count": 0
     },
     {
-    "word": "high",
-    "meaning": "heighten, /ˈhaɪtn/: làm cao thêm. highbrow, /ˈhaɪbraʊ/: xa rời thực tế. highly, /ˈhaɪli/: ở mức độ cao. highlight, /ˈhaɪlaɪt/: làm nổi bật. height, /haɪt/: chiều cao. heights, /haɪts/: đỉnh cao.",
-    "example": "Tensions heightened overnight. It’s a highbrow film. She’s highly respected. The report highlights key points. What’s your height? He’s afraid of heights.",
-    "count": 0
+      "word": "hear",
+      "meaning": "overhear, /ˌəʊvəˈhɪə(r)/: nghe lỏm. hearing, /ˈhɪərɪŋ/: thính giác. hearsay, /ˈhɪəseɪ/: tin đồn.",
+      "example": "I overheard them arguing. Her hearing is excellent. Don’t trust hearsay.",
+      "count": 0
     },
     {
-    "word": "history",
-    "meaning": "historian, /hɪˈstɔːriən/: nhà sử học. historic, /hɪˈstɒrɪk/: mang tính lịch sử. historical(ly), /hɪˈstɒrɪkl(i)/: (một cách) thuộc lịch sử.",
-    "example": "The historian gave a lecture. It was a historic event. Historically, this site is significant.",
-    "count": 0
+      "word": "high",
+      "meaning": "heighten, /ˈhaɪtn/: làm cao thêm. highbrow, /ˈhaɪbraʊ/: xa rời thực tế. highly, /ˈhaɪli/: ở mức độ cao. highlight, /ˈhaɪlaɪt/: làm nổi bật. height, /haɪt/: chiều cao. heights, /haɪts/: đỉnh cao.",
+      "example": "Tensions heightened overnight. It’s a highbrow film. She’s highly respected. The report highlights key points. What’s your height? He’s afraid of heights.",
+      "count": 0
     },
     {
-    "word": "house",
-    "meaning": "housing, /ˈhaʊzɪŋ/: nhà ở. household(er), /ˈhaʊshəʊld(ə)/: hộ gia đình. houseful, /ˈhaʊsfʊl/: đầy một nhà.",
-    "example": "Affordable housing is a concern. The householder paid taxes. We had a houseful of guests.",
-    "count": 0
+      "word": "history",
+      "meaning": "historian, /hɪˈstɔːriən/: nhà sử học. historic, /hɪˈstɒrɪk/: mang tính lịch sử. historical(ly), /hɪˈstɒrɪkl(i)/: (một cách) thuộc lịch sử.",
+      "example": "The historian gave a lecture. It was a historic event. Historically, this site is significant.",
+      "count": 0
     },
     {
-    "word": "human",
-    "meaning": "humanise, /ˈhjuːmənaɪz/: nhân hóa. humanity, /hjuːˈmænəti/: nhân loại. humanism, /ˈhjuːmənɪzəm/: chủ nghĩa nhân đạo. humanist, /ˈhjuːmənɪst/: người theo chủ nghĩa nhân đạo. humanities, /hjuːˈmænətiz/: các môn nhân văn. humanitarian, /hjuːˌmænɪˈteəriən/: người theo chủ nghĩa nhân đạo. humane, /hjuːˈmeɪn/: nhân văn. humanly, /ˈhjuːmənli/: từ góc độ con người.",
-    "example": "They tried to humanise the system. We must protect humanity. She promotes humanism. He’s a humanist. She teaches the humanities. The humanitarian helped refugees. It’s the humane thing to do. Humanly speaking, it’s impossible.",
-    "count": 0
+      "word": "house",
+      "meaning": "housing, /ˈhaʊzɪŋ/: nhà ở. household(er), /ˈhaʊshəʊld(ə)/: hộ gia đình. houseful, /ˈhaʊsfʊl/: đầy một nhà.",
+      "example": "Affordable housing is a concern. The householder paid taxes. We had a houseful of guests.",
+      "count": 0
     },
     {
-    "word": "ideal",
-    "meaning": "idealise, /aɪˈdɪəlaɪz/: lý tưởng hóa. idealism, /ˈaɪdiəlɪzəm/: chủ nghĩa lý tưởng. idealisation, /ˌaɪdɪələˈzeɪʃn/: sự lý tưởng hóa. idealist, /ˈaɪdiəlɪst/: người theo chủ nghĩa lý tưởng. idealistic, /ˌaɪdiəˈlɪstɪk/: duy tâm. idealised, /ˈaɪdiəlaɪzd/: được lý tưởng hóa. ideally, /aɪˈdɪəli/: một cách lý tưởng.",
-    "example": "He tends to idealise relationships. She believes in idealism. Their idealisation of youth is common. He’s a romantic idealist. That view is idealistic. The story is idealised. Ideally, we should leave at noon.",
-    "count": 0
+      "word": "human",
+      "meaning": "humanise, /ˈhjuːmənaɪz/: nhân hóa. humanity, /hjuːˈmænəti/: nhân loại. humanism, /ˈhjuːmənɪzəm/: chủ nghĩa nhân đạo. humanist, /ˈhjuːmənɪst/: người theo chủ nghĩa nhân đạo. humanities, /hjuːˈmænətiz/: các môn nhân văn. humanitarian, /hjuːˌmænɪˈteəriən/: người theo chủ nghĩa nhân đạo. humane, /hjuːˈmeɪn/: nhân văn. humanly, /ˈhjuːmənli/: từ góc độ con người.",
+      "example": "They tried to humanise the system. We must protect humanity. She promotes humanism. He’s a humanist. She teaches the humanities. The humanitarian helped refugees. It’s the humane thing to do. Humanly speaking, it’s impossible.",
+      "count": 0
     },
     {
-    "word": "illusion",
-    "meaning": "disillusion, /ˌdɪsɪˈluːʒn/: sự vỡ mộng. disillusionment, /ˌdɪsɪˈluːʒnmənt/: sự làm vỡ mộng. disillusioned, /ˌdɪsɪˈluːʒnd/: bị vỡ mộng. illusory, /ɪˈluːsəri/: ảo tưởng, viển vông.",
-    "example": "He felt disillusioned by politics. Disillusionment followed quickly. She became disillusioned. Their hopes proved illusory.",
-    "count": 0
+      "word": "ideal",
+      "meaning": "idealise, /aɪˈdɪəlaɪz/: lý tưởng hóa. idealism, /ˈaɪdiəlɪzəm/: chủ nghĩa lý tưởng. idealisation, /ˌaɪdɪələˈzeɪʃn/: sự lý tưởng hóa. idealist, /ˈaɪdiəlɪst/: người theo chủ nghĩa lý tưởng. idealistic, /ˌaɪdiəˈlɪstɪk/: duy tâm. idealised, /ˈaɪdiəlaɪzd/: được lý tưởng hóa. ideally, /aɪˈdɪəli/: một cách lý tưởng.",
+      "example": "He tends to idealise relationships. She believes in idealism. Their idealisation of youth is common. He’s a romantic idealist. That view is idealistic. The story is idealised. Ideally, we should leave at noon.",
+      "count": 0
     },
     {
-    "word": "imagine",
-    "meaning": "imagination, /ɪˌmædʒɪˈneɪʃn/: trí tưởng tượng. imaginings, /ɪˈmædʒɪnɪŋz/: những hình dung. imaginative(ly), /ɪˈmædʒɪnətɪv(li)/: (một cách) giàu trí tưởng tượng. (un)imaginative(ly), /(ʌn)ɪˈmædʒɪnətɪv(li)/: (một cách) (không) giàu trí tưởng tượng.",
-    "example": "Children have great imagination. Her imaginings were vivid. He’s very imaginative. The design was unimaginatively done.",
-    "count": 0
+      "word": "illusion",
+      "meaning": "disillusion, /ˌdɪsɪˈluːʒn/: sự vỡ mộng. disillusionment, /ˌdɪsɪˈluːʒnmənt/: sự làm vỡ mộng. disillusioned, /ˌdɪsɪˈluːʒnd/: bị vỡ mộng. illusory, /ɪˈluːsəri/: ảo tưởng, viển vông.",
+      "example": "He felt disillusioned by politics. Disillusionment followed quickly. She became disillusioned. Their hopes proved illusory.",
+      "count": 0
     },
     {
-    "word": "imitate",
-    "meaning": "imitation, /ˌɪmɪˈteɪʃn/: sự bắt chước. imitator, /ˈɪmɪteɪtə(r)/: kẻ bắt chước. imitative, /ˈɪmɪtətɪv/: giả, có tính bắt chước. inimitable, /ɪˈnɪmɪtəbl/: không thể bắt chước được.",
-    "example": "That was only an imitation. He is a clever imitator. Her style is imitative. His performance is inimitable.",
-    "count": 0
+      "word": "imagine",
+      "meaning": "imagination, /ɪˌmædʒɪˈneɪʃn/: trí tưởng tượng. imaginings, /ɪˈmædʒɪnɪŋz/: những hình dung. imaginative(ly), /ɪˈmædʒɪnətɪv(li)/: (một cách) giàu trí tưởng tượng. (un)imaginative(ly), /(ʌn)ɪˈmædʒɪnətɪv(li)/: (một cách) (không) giàu trí tưởng tượng.",
+      "example": "Children have great imagination. Her imaginings were vivid. He’s very imaginative. The design was unimaginatively done.",
+      "count": 0
     },
     {
-    "word": "imply",
-    "meaning": "implicate, /ˈɪmplɪkeɪt/: lôi kéo, dính líu. implication, /ˌɪmplɪˈkeɪʃn/: sự liên can. implicit(ly), /ɪmˈplɪsɪt(li)/: (một cách) ngầm định.",
-    "example": "He was implicated in the crime. The implication is serious. She trusted him implicitly.",
-    "count": 0
+      "word": "imitate",
+      "meaning": "imitation, /ˌɪmɪˈteɪʃn/: sự bắt chước. imitator, /ˈɪmɪteɪtə(r)/: kẻ bắt chước. imitative, /ˈɪmɪtətɪv/: giả, có tính bắt chước. inimitable, /ɪˈnɪmɪtəbl/: không thể bắt chước được.",
+      "example": "That was only an imitation. He is a clever imitator. Her style is imitative. His performance is inimitable.",
+      "count": 0
     },
     {
-    "word": "impress",
-    "meaning": "impression, /ɪmˈpreʃn/: ấn tượng. (un)impressiveness, /(ʌn)ɪmˈpresɪvnəs/: sự (không) ấn tượng. impressionist, /ɪmˈpreʃənɪst/: người theo trường phái ấn tượng. impressionable, /ɪmˈpreʃənəbl/: dễ bị ảnh hưởng. impressionistic, /ˌɪmpreʃəˈnɪstɪk/: thuộc trường phái ấn tượng. (un)impressive(ly), /(ʌn)ɪmˈpresɪvli/: (một cách) (không) gây ấn tượng.",
-    "example": "He made a strong impression. The show lacked impressiveness. She is an impressionist painter. Teens are often impressionable. The painting was impressionistic. He performed impressively.",
-    "count": 0
+      "word": "imply",
+      "meaning": "implicate, /ˈɪmplɪkeɪt/: lôi kéo, dính líu. implication, /ˌɪmplɪˈkeɪʃn/: sự liên can. implicit(ly), /ɪmˈplɪsɪt(li)/: (một cách) ngầm định.",
+      "example": "He was implicated in the crime. The implication is serious. She trusted him implicitly.",
+      "count": 0
     },
     {
-    "word": "improve",
-    "meaning": "improvement, /ɪmˈpruːvmənt/: sự cải thiện. improvable, /ɪmˈpruːvəbl/: có thể cải thiện. improved, /ɪmˈpruːvd/: được cải thiện.",
-    "example": "There’s been great improvement. The system is improvable. His skills have improved.",
-    "count": 0
+      "word": "impress",
+      "meaning": "impression, /ɪmˈpreʃn/: ấn tượng. (un)impressiveness, /(ʌn)ɪmˈpresɪvnəs/: sự (không) ấn tượng. impressionist, /ɪmˈpreʃənɪst/: người theo trường phái ấn tượng. impressionable, /ɪmˈpreʃənəbl/: dễ bị ảnh hưởng. impressionistic, /ˌɪmpreʃəˈnɪstɪk/: thuộc trường phái ấn tượng. (un)impressive(ly), /(ʌn)ɪmˈpresɪvli/: (một cách) (không) gây ấn tượng.",
+      "example": "He made a strong impression. The show lacked impressiveness. She is an impressionist painter. Teens are often impressionable. The painting was impressionistic. He performed impressively.",
+      "count": 0
     },
     {
-    "word": "incident",
-    "meaning": "incidence, /ˈɪnsɪdəns/: tần suất, tỉ lệ mắc phải.",
-    "example": "The incidence of flu increases in winter.",
-    "count": 0
+      "word": "improve",
+      "meaning": "improvement, /ɪmˈpruːvmənt/: sự cải thiện. improvable, /ɪmˈpruːvəbl/: có thể cải thiện. improved, /ɪmˈpruːvd/: được cải thiện.",
+      "example": "There’s been great improvement. The system is improvable. His skills have improved.",
+      "count": 0
     },
     {
-    "word": "coincide",
-    "meaning": "coincidence, /kəʊˈɪnsɪdəns/: sự trùng hợp. coincidental(ly), /kəʊˌɪnsɪˈdentl(i)/: (một cách) ngẫu nhiên.",
-    "example": "It was pure coincidence. They met coincidentally at the airport.",
-    "count": 0
+      "word": "incident",
+      "meaning": "incidence, /ˈɪnsɪdəns/: tần suất, tỉ lệ mắc phải.",
+      "example": "The incidence of flu increases in winter.",
+      "count": 0
     },
     {
-    "word": "indicate",
-    "meaning": "indication, /ˌɪndɪˈkeɪʃn/: sự biểu thị. indicator, /ˈɪndɪkeɪtə(r)/: tín hiệu. indicative, /ɪnˈdɪkətɪv/: chỉ ra.",
-    "example": "There’s no clear indication of fraud. The fuel gauge is an indicator. The results are indicative of progress.",
-    "count": 0
+      "word": "coincide",
+      "meaning": "coincidence, /kəʊˈɪnsɪdəns/: sự trùng hợp. coincidental(ly), /kəʊˌɪnsɪˈdentl(i)/: (một cách) ngẫu nhiên.",
+      "example": "It was pure coincidence. They met coincidentally at the airport.",
+      "count": 0
     },
     {
-    "word": "individual",
-    "meaning": "individualise, /ˌɪndɪˈvɪdʒuəlaɪz/: cá nhân hóa. individualism, /ɪnˈdɪvɪdʒuəlɪzəm/: chủ nghĩa cá nhân. individuality, /ˌɪndɪˌvɪdʒuˈæləti/: cá tính. individualist, /ɪnˈdɪvɪdʒuəlɪst/: người theo chủ nghĩa cá nhân. individualistic, /ˌɪndɪˌvɪdʒuəˈlɪstɪk/: mang tính cá nhân.",
-    "example": "The teacher individualises lessons. She supports individualism. His individuality stood out. He is an individualist. She has an individualistic style.",
-    "count": 0
+      "word": "indicate",
+      "meaning": "indication, /ˌɪndɪˈkeɪʃn/: sự biểu thị. indicator, /ˈɪndɪkeɪtə(r)/: tín hiệu. indicative, /ɪnˈdɪkətɪv/: chỉ ra.",
+      "example": "There’s no clear indication of fraud. The fuel gauge is an indicator. The results are indicative of progress.",
+      "count": 0
     },
     {
-    "word": "influence",
-    "meaning": "influential, /ˌɪnfluˈenʃl/: có ảnh hưởng lớn.",
-    "example": "He is an influential speaker.",
-    "count": 0
+      "word": "individual",
+      "meaning": "individualise, /ˌɪndɪˈvɪdʒuəlaɪz/: cá nhân hóa. individualism, /ɪnˈdɪvɪdʒuəlɪzəm/: chủ nghĩa cá nhân. individuality, /ˌɪndɪˌvɪdʒuˈæləti/: cá tính. individualist, /ɪnˈdɪvɪdʒuəlɪst/: người theo chủ nghĩa cá nhân. individualistic, /ˌɪndɪˌvɪdʒuəˈlɪstɪk/: mang tính cá nhân.",
+      "example": "The teacher individualises lessons. She supports individualism. His individuality stood out. He is an individualist. She has an individualistic style.",
+      "count": 0
     },
     {
-    "word": "inhabit",
-    "meaning": "inhabitant, /ɪnˈhæbɪtənt/: cư dân. habitat, /ˈhæbɪtæt/: môi trường sống. habitation, /ˌhæbɪˈteɪʃn/: nơi ở. (un)inhabitable, /ʌnˈhæbɪtəbl/: (không) thể ở được.",
-    "example": "The city has millions of inhabitants. This area is a natural habitat. The building is uninhabitable.",
-    "count": 0
+      "word": "influence",
+      "meaning": "influential, /ˌɪnfluˈenʃl/: có ảnh hưởng lớn.",
+      "example": "He is an influential speaker.",
+      "count": 0
     },
     {
-    "word": "inherit",
-    "meaning": "inheritance, /ɪnˈherɪtəns/: sự thừa kế. heritage, /ˈherɪtɪdʒ/: di sản. hereditary, /həˈredɪtəri/: truyền từ đời này sang đời khác.",
-    "example": "She received a large inheritance. The temple is part of cultural heritage. It’s a hereditary disease.",
-    "count": 0
+      "word": "inhabit",
+      "meaning": "inhabitant, /ɪnˈhæbɪtənt/: cư dân. habitat, /ˈhæbɪtæt/: môi trường sống. habitation, /ˌhæbɪˈteɪʃn/: nơi ở. (un)inhabitable, /ʌnˈhæbɪtəbl/: (không) thể ở được.",
+      "example": "The city has millions of inhabitants. This area is a natural habitat. The building is uninhabitable.",
+      "count": 0
     },
     {
-    "word": "insist",
-    "meaning": "insistence, /ɪnˈsɪstəns/: sự khăng khăng. insistent, /ɪnˈsɪstənt/: khăng khăng.",
-    "example": "Her insistence on details was exhausting. He was very insistent.",
-    "count": 0
+      "word": "inherit",
+      "meaning": "inheritance, /ɪnˈherɪtəns/: sự thừa kế. heritage, /ˈherɪtɪdʒ/: di sản. hereditary, /həˈredɪtəri/: truyền từ đời này sang đời khác.",
+      "example": "She received a large inheritance. The temple is part of cultural heritage. It’s a hereditary disease.",
+      "count": 0
     },
     {
-    "word": "instinct",
-    "meaning": "instinctive(ly), /ɪnˈstɪŋktɪv(li)/: (một cách) theo bản năng.",
-    "example": "She responded instinctively to danger.",
-    "count": 0
+      "word": "insist",
+      "meaning": "insistence, /ɪnˈsɪstəns/: sự khăng khăng. insistent, /ɪnˈsɪstənt/: khăng khăng.",
+      "example": "Her insistence on details was exhausting. He was very insistent.",
+      "count": 0
     },
     {
-    "word": "institute",
-    "meaning": "institutionalise, /ˌɪnstɪˈtjuːʃənəlaɪz/: thể chế hóa. institution, /ˌɪnstɪˈtjuːʃn/: tổ chức. institutional, /ˌɪnstɪˈtjuːʃənl/: thuộc tổ chức. institutionalised, /ˌɪnstɪˈtjuːʃnəlaɪzd/: được thể chế hóa.",
-    "example": "They want to institutionalise the reform. She works at a large institution. It’s an institutional decision. That practice is now institutionalised.",
-    "count": 0
+      "word": "instinct",
+      "meaning": "instinctive(ly), /ɪnˈstɪŋktɪv(li)/: (một cách) theo bản năng.",
+      "example": "She responded instinctively to danger.",
+      "count": 0
     },
     {
-    "word": "intend",
-    "meaning": "intention, /ɪnˈtenʃn/: ý định. (un)intended, /(ʌn)ɪnˈtendɪd/: (không) cố ý. (un)intentional(ly), /(ʌn)ɪnˈtenʃən(ə)li/: (một cách) (không) có chủ đích.",
-    "example": "His intention was clear. It was an unintended consequence. She acted intentionally.",
-    "count": 0
+      "word": "institute",
+      "meaning": "institutionalise, /ˌɪnstɪˈtjuːʃənəlaɪz/: thể chế hóa. institution, /ˌɪnstɪˈtjuːʃn/: tổ chức. institutional, /ˌɪnstɪˈtjuːʃənl/: thuộc tổ chức. institutionalised, /ˌɪnstɪˈtjuːʃnəlaɪzd/: được thể chế hóa.",
+      "example": "They want to institutionalise the reform. She works at a large institution. It’s an institutional decision. That practice is now institutionalised.",
+      "count": 0
     },
     {
-    "word": "intimate",
-    "meaning": "intimacy, /ˈɪntɪməsi/: sự thân mật. intimately, /ˈɪntɪmətli/: một cách thân mật.",
-    "example": "There was an intimacy between them. They spoke intimately.",
-    "count": 0
+      "word": "intend",
+      "meaning": "intention, /ɪnˈtenʃn/: ý định. (un)intended, /(ʌn)ɪnˈtendɪd/: (không) cố ý. (un)intentional(ly), /(ʌn)ɪnˈtenʃən(ə)li/: (một cách) (không) có chủ đích.",
+      "example": "His intention was clear. It was an unintended consequence. She acted intentionally.",
+      "count": 0
     },
     {
-    "word": "job",
-    "meaning": "jobbing, /ˈdʒɒbɪŋ/: làm việc vặt. jobless, /ˈdʒɒbləs/: thất nghiệp.",
-    "example": "He found jobbing work easily. Many people are jobless this year.",
-    "count": 0
-    },            
-{
-    "word": "electric",
-    "meaning": "electrify, /ɪˈlektrɪfaɪ/: làm nhiễm điện. electrician, /ɪˌlekˈtrɪʃn/: thợ điện. electricity, /ɪˌlekˈtrɪsəti/: điện. electrified, /ɪˈlektrɪfaɪd/: đã nhiễm điện. electrifying, /ɪˈlektrɪfaɪɪŋ/: nhiễm điện. electrical(ly), /ɪˈlektrɪkl(i)/: (về) điện.",
-    "example": "The wires were electrified. Call an electrician for this job. Electricity went out. The crowd was electrified by the speech. It was an electrifying moment. That’s an electrical failure.",
-    "count": 0
+      "word": "intimate",
+      "meaning": "intimacy, /ˈɪntɪməsi/: sự thân mật. intimately, /ˈɪntɪmətli/: một cách thân mật.",
+      "example": "There was an intimacy between them. They spoke intimately.",
+      "count": 0
     },
     {
-    "word": "elude",
-    "meaning": "elusiveness, /ɪˈluːsɪvnəs/: tính lảng tránh. elusive(ly), /ɪˈluːsɪv(li)/: một cách khó nắm bắt.",
-    "example": "The criminal’s elusiveness frustrated the police. She smiled elusively.",
-    "count": 0
+      "word": "job",
+      "meaning": "jobbing, /ˈdʒɒbɪŋ/: làm việc vặt. jobless, /ˈdʒɒbləs/: thất nghiệp.",
+      "example": "He found jobbing work easily. Many people are jobless this year.",
+      "count": 0
     },
     {
-    "word": "employ",
-    "meaning": "(un)employment, /(ˌʌn)ɪmˈplɔɪmənt/: (tình trạng) thất nghiệp. underemployment, /ˌʌndərɪmˈplɔɪmənt/: tình trạng thiếu việc. employer, /ɪmˈplɔɪə(r)/: người sử dụng lao động. employee, /ˌemplɔɪˈiː/: người lao động. (un)employed, /(ʌn)ɪmˈplɔɪd/: (không) có việc. unemployed, /ˌʌnɪmˈplɔɪd/: thất nghiệp. (un)employable, /(ˌʌn)ɪmˈplɔɪəbl/: (không) có thể tuyển dụng.",
-    "example": "Unemployment rose last year. Many face underemployment. The employer posted a new job. The employee was promoted. He is currently unemployed. They are unemployable.",
-    "count": 0
+      "word": "electric",
+      "meaning": "electrify, /ɪˈlektrɪfaɪ/: làm nhiễm điện. electrician, /ɪˌlekˈtrɪʃn/: thợ điện. electricity, /ɪˌlekˈtrɪsəti/: điện. electrified, /ɪˈlektrɪfaɪd/: đã nhiễm điện. electrifying, /ɪˈlektrɪfaɪɪŋ/: nhiễm điện. electrical(ly), /ɪˈlektrɪkl(i)/: (về) điện.",
+      "example": "The wires were electrified. Call an electrician for this job. Electricity went out. The crowd was electrified by the speech. It was an electrifying moment. That’s an electrical failure.",
+      "count": 0
     },
     {
-    "word": "end",
-    "meaning": "endure, /ɪnˈdjʊə(r)/: chịu đựng. endurance, /ɪnˈdjʊərəns/: sức bền. (un)endurable, /(ʌn)ɪnˈdjʊərəbl/: (không) chịu đựng được. unending, /ʌnˈendɪŋ/: lâu dài. ending, /ˈendɪŋ/: sự kết thúc. endless(ly), /ˈendləs(li)/: (một cách) bất tận.",
-    "example": "She had to endure pain. His endurance is impressive. The noise was unendurable. They faced unending challenges. The ending was sad. The rain fell endlessly.",
-    "count": 0
+      "word": "elude",
+      "meaning": "elusiveness, /ɪˈluːsɪvnəs/: tính lảng tránh. elusive(ly), /ɪˈluːsɪv(li)/: một cách khó nắm bắt.",
+      "example": "The criminal’s elusiveness frustrated the police. She smiled elusively.",
+      "count": 0
     },
     {
-    "word": "envy",
-    "meaning": "(un)enviable, /(ʌn)ˈenviəbl/: (không) đáng ghen tị. (un)enviably, /(ʌn)ˈenviəbli/: (một cách) (không) đáng ghen tị. envious(ly), /ˈenviəs(li)/: (một cách) ghen tị.",
-    "example": "She has an enviable position. It’s enviably close to the beach. He looked at me enviously.",
-    "count": 0
+      "word": "employ",
+      "meaning": "(un)employment, /(ˌʌn)ɪmˈplɔɪmənt/: (tình trạng) thất nghiệp. underemployment, /ˌʌndərɪmˈplɔɪmənt/: tình trạng thiếu việc. employer, /ɪmˈplɔɪə(r)/: người sử dụng lao động. employee, /ˌemplɔɪˈiː/: người lao động. (un)employed, /(ʌn)ɪmˈplɔɪd/: (không) có việc. unemployed, /ˌʌnɪmˈplɔɪd/: thất nghiệp. (un)employable, /(ˌʌn)ɪmˈplɔɪəbl/: (không) có thể tuyển dụng.",
+      "example": "Unemployment rose last year. Many face underemployment. The employer posted a new job. The employee was promoted. He is currently unemployed. They are unemployable.",
+      "count": 0
     },
     {
-    "word": "erode",
-    "meaning": "erosion, /ɪˈrəʊʒn/: sự xói mòn.",
-    "example": "Soil erosion is a serious problem.",
-    "count": 0
+      "word": "end",
+      "meaning": "endure, /ɪnˈdjʊə(r)/: chịu đựng. endurance, /ɪnˈdjʊərəns/: sức bền. (un)endurable, /(ʌn)ɪnˈdjʊərəbl/: (không) chịu đựng được. unending, /ʌnˈendɪŋ/: lâu dài. ending, /ˈendɪŋ/: sự kết thúc. endless(ly), /ˈendləs(li)/: (một cách) bất tận.",
+      "example": "She had to endure pain. His endurance is impressive. The noise was unendurable. They faced unending challenges. The ending was sad. The rain fell endlessly.",
+      "count": 0
     },
     {
-    "word": "erupt",
-    "meaning": "eruption, /ɪˈrʌpʃn/: sự phun trào.",
-    "example": "The volcano's eruption was massive.",
-    "count": 0
+      "word": "envy",
+      "meaning": "(un)enviable, /(ʌn)ˈenviəbl/: (không) đáng ghen tị. (un)enviably, /(ʌn)ˈenviəbli/: (một cách) (không) đáng ghen tị. envious(ly), /ˈenviəs(li)/: (một cách) ghen tị.",
+      "example": "She has an enviable position. It’s enviably close to the beach. He looked at me enviously.",
+      "count": 0
     },
     {
-    "word": "event",
-    "meaning": "eventuality, /ɪˌventʃuˈæləti/: tình huống có thể xảy ra. (un)eventful, /(ʌn)ɪˈventfl/: (không) có nhiều sự kiện. eventual(ly), /ɪˈventʃuəli/: rốt cuộc.",
-    "example": "We prepared for every eventuality. It was an uneventful trip. Eventually, she succeeded.",
-    "count": 0
+      "word": "erode",
+      "meaning": "erosion, /ɪˈrəʊʒn/: sự xói mòn.",
+      "example": "Soil erosion is a serious problem.",
+      "count": 0
     },
     {
-    "word": "evolve",
-    "meaning": "evolution, /ˌiːvəˈluːʃn/: sự tiến hóa. evolutionary, /ˌiːvəˈluːʃənəri/: thuộc tiến hóa. evolving, /ɪˈvɒlvɪŋ/: đang tiến hóa.",
-    "example": "Evolution is a natural process. This is an evolutionary step. Language is constantly evolving.",
-    "count": 0
+      "word": "erupt",
+      "meaning": "eruption, /ɪˈrʌpʃn/: sự phun trào.",
+      "example": "The volcano's eruption was massive.",
+      "count": 0
     },
     {
-    "word": "example",
-    "meaning": "exemplify, /ɪɡˈzemplɪfaɪ/: minh họa. exemplification, /ɪɡˌzemplɪfɪˈkeɪʃn/: sự minh họa. exemplary, /ɪɡˈzempləri/: mẫu mực.",
-    "example": "She exemplifies dedication. His action is an exemplification. He received an award for exemplary conduct.",
-    "count": 0
+      "word": "event",
+      "meaning": "eventuality, /ɪˌventʃuˈæləti/: tình huống có thể xảy ra. (un)eventful, /(ʌn)ɪˈventfl/: (không) có nhiều sự kiện. eventual(ly), /ɪˈventʃuəli/: rốt cuộc.",
+      "example": "We prepared for every eventuality. It was an uneventful trip. Eventually, she succeeded.",
+      "count": 0
     },
     {
-    "word": "exclaim",
-    "meaning": "exclamation, /ˌekskləˈmeɪʃn/: câu cảm thán. exclamatory, /eksˈklæmətri/: có tính cảm thán.",
-    "example": "He let out an exclamation. She gave an exclamatory shout.",
-    "count": 0
+      "word": "evolve",
+      "meaning": "evolution, /ˌiːvəˈluːʃn/: sự tiến hóa. evolutionary, /ˌiːvəˈluːʃənəri/: thuộc tiến hóa. evolving, /ɪˈvɒlvɪŋ/: đang tiến hóa.",
+      "example": "Evolution is a natural process. This is an evolutionary step. Language is constantly evolving.",
+      "count": 0
     },
     {
-    "word": "expect",
-    "meaning": "expectation, /ˌekspekˈteɪʃn/: sự mong đợi. expectancy, /ɪkˈspektənsi/: (một cách) đầy mong đợi. expectant(ly), /ɪkˈspektənt(li)/: (một cách) mong chờ. (un)expected(ly), /(ʌn)ɪkˈspektɪd(li)/: (một cách) (không) ngờ tới.",
-    "example": "The results met our expectations. The atmosphere was full of expectancy. She looked at me expectantly. The call came unexpectedly.",
-    "count": 0
+      "word": "example",
+      "meaning": "exemplify, /ɪɡˈzemplɪfaɪ/: minh họa. exemplification, /ɪɡˌzemplɪfɪˈkeɪʃn/: sự minh họa. exemplary, /ɪɡˈzempləri/: mẫu mực.",
+      "example": "She exemplifies dedication. His action is an exemplification. He received an award for exemplary conduct.",
+      "count": 0
     },
     {
-    "word": "explain",
-    "meaning": "explanation, /ˌekspləˈneɪʃn/: sự giải thích. explanatory, /ɪkˈsplænətri/: mang tính giải thích. unexplained, /ˌʌnɪkˈspleɪnd/: không rõ nguyên nhân. (in)explicable, /(ɪn)ˈeksplɪkəbl/: (không) thể giải thích được. inexplicably, /ˌɪnɪkˈsplɪkəbli/: một cách không thể giải thích được.",
-    "example": "She gave a clear explanation. Read the explanatory notes. The illness remains unexplained. His reaction was inexplicable. She left inexplicably.",
-    "count": 0
+      "word": "exclaim",
+      "meaning": "exclamation, /ˌekskləˈmeɪʃn/: câu cảm thán. exclamatory, /eksˈklæmətri/: có tính cảm thán.",
+      "example": "He let out an exclamation. She gave an exclamatory shout.",
+      "count": 0
     },
     {
-    "word": "express",
-    "meaning": "expression, /ɪkˈspreʃn/: sự biểu lộ. expressiveness, /ɪkˈspreʃɪvnəs/: tính diễn cảm. expressionism, /ɪkˈspreʃənɪzəm/: chủ nghĩa biểu hiện. expressionist, /ɪkˈspreʃənɪst/: người theo chủ nghĩa biểu hiện. expressive(ly), /ɪkˈspresɪv(li)/: (một cách) biểu cảm. expressionless(ness), /ɪkˈspreʃnləs(nəs)/: (một cách) vô cảm.",
-    "example": "Her expression changed suddenly. His eyes were full of expressiveness. She studied expressionism. He’s an expressionist painter. He smiled expressively. His face remained expressionless.",
-    "count": 0
+      "word": "expect",
+      "meaning": "expectation, /ˌekspekˈteɪʃn/: sự mong đợi. expectancy, /ɪkˈspektənsi/: (một cách) đầy mong đợi. expectant(ly), /ɪkˈspektənt(li)/: (một cách) mong chờ. (un)expected(ly), /(ʌn)ɪkˈspektɪd(li)/: (một cách) (không) ngờ tới.",
+      "example": "The results met our expectations. The atmosphere was full of expectancy. She looked at me expectantly. The call came unexpectedly.",
+      "count": 0
     },
     {
-    "word": "extend",
-    "meaning": "extension, /ɪkˈstenʃn/: sự mở rộng. extent, /ɪkˈstent/: mức độ. (un)extended, /(ʌn)ɪkˈstendɪd/: (không) được mở rộng. (in)extensible, /(ɪn)ɪkˈstensəbl/: (không) có thể bao quát.",
-    "example": "They built an extension to the house. To a large extent, I agree. It’s an extended warranty. The rope is inextensible.",
-    "count": 0
+      "word": "explain",
+      "meaning": "explanation, /ˌekspləˈneɪʃn/: sự giải thích. explanatory, /ɪkˈsplænətri/: mang tính giải thích. unexplained, /ˌʌnɪkˈspleɪnd/: không rõ nguyên nhân. (in)explicable, /(ɪn)ˈeksplɪkəbl/: (không) thể giải thích được. inexplicably, /ˌɪnɪkˈsplɪkəbli/: một cách không thể giải thích được.",
+      "example": "She gave a clear explanation. Read the explanatory notes. The illness remains unexplained. His reaction was inexplicable. She left inexplicably.",
+      "count": 0
     },
     {
-    "word": "extinct",
-    "meaning": "extinction, /ɪkˈstɪŋkʃn/: sự tuyệt chủng.",
-    "example": "Many species face extinction.",
-    "count": 0
+      "word": "express",
+      "meaning": "expression, /ɪkˈspreʃn/: sự biểu lộ. expressiveness, /ɪkˈspreʃɪvnəs/: tính diễn cảm. expressionism, /ɪkˈspreʃənɪzəm/: chủ nghĩa biểu hiện. expressionist, /ɪkˈspreʃənɪst/: người theo chủ nghĩa biểu hiện. expressive(ly), /ɪkˈspresɪv(li)/: (một cách) biểu cảm. expressionless(ness), /ɪkˈspreʃnləs(nəs)/: (một cách) vô cảm.",
+      "example": "Her expression changed suddenly. His eyes were full of expressiveness. She studied expressionism. He’s an expressionist painter. He smiled expressively. His face remained expressionless.",
+      "count": 0
     },
     {
-    "word": "familiar",
-    "meaning": "familiarise, /fəˈmɪliəraɪz/: làm cho quen thuộc. (un)familiarity, /(ʌn)fəˌmɪliˈærəti/: (sự) (không) quen thuộc. unfamiliar, /ˌʌnfəˈmɪliə(r)/: không quen thuộc. familiarly, /fəˈmɪliəli/: một cách thân thuộc.",
-    "example": "You should familiarise yourself with the rules. His unfamiliarity was obvious. This is unfamiliar territory. She spoke familiarly.",
-    "count": 0
+      "word": "extend",
+      "meaning": "extension, /ɪkˈstenʃn/: sự mở rộng. extent, /ɪkˈstent/: mức độ. (un)extended, /(ʌn)ɪkˈstendɪd/: (không) được mở rộng. (in)extensible, /(ɪn)ɪkˈstensəbl/: (không) có thể bao quát.",
+      "example": "They built an extension to the house. To a large extent, I agree. It’s an extended warranty. The rope is inextensible.",
+      "count": 0
     },
     {
-    "word": "favour",
-    "meaning": "favouritism, /ˈfeɪvərɪtɪzəm/: sự thiên vị. favourite, /ˈfeɪvərɪt/: yêu thích. (un)favourable, /(ʌn)ˈfeɪvərəbl/: (không) có thiện chí. (un)favourably, /(ʌn)ˈfeɪvərəbli/: (một cách) (không) thuận lợi.",
-    "example": "He was accused of favouritism. She is my favourite teacher. The outcome was favourable. They were unfavourably compared.",
-    "count": 0
+      "word": "extinct",
+      "meaning": "extinction, /ɪkˈstɪŋkʃn/: sự tuyệt chủng.",
+      "example": "Many species face extinction.",
+      "count": 0
     },
     {
-    "word": "finite",
-    "meaning": "infinity, /ɪnˈfɪnəti/: vô cực. infinitive, /ɪnˈfɪnətɪv/: nguyên thể. infinite(ly), /ˈɪnfɪnət(li)/: (một cách) vô hạn. infinitesimal(ly), /ˌɪnfɪnɪˈtesɪml(i)/: (một cách) vi phân.",
-    "example": "The universe is not infinite. Infinity is a complex idea. Use the infinitive form. Infinitely more efficient. The difference was infinitesimal.",
-    "count": 0
+      "word": "familiar",
+      "meaning": "familiarise, /fəˈmɪliəraɪz/: làm cho quen thuộc. (un)familiarity, /(ʌn)fəˌmɪliˈærəti/: (sự) (không) quen thuộc. unfamiliar, /ˌʌnfəˈmɪliə(r)/: không quen thuộc. familiarly, /fəˈmɪliəli/: một cách thân thuộc.",
+      "example": "You should familiarise yourself with the rules. His unfamiliarity was obvious. This is unfamiliar territory. She spoke familiarly.",
+      "count": 0
     },
     {
-    "word": "flexible",
-    "meaning": "(in)flexibility, /(ɪn)ˌfleksəˈbɪləti/: (tính) (không) linh hoạt. inflexible, /ɪnˈfleksəbl/: cứng nhắc.",
-    "example": "Flexibility is key in this job. The plan was inflexible.",
-    "count": 0
-    },      
-{
-    "word": "character",
-    "meaning": "characterise, /ˈkærəktəraɪz/: mô tả như là. characterisation, /ˌkærəktəraɪˈzeɪʃn/: sự mô tả như là. (un)characteristic, /(ʌn)ˌkærəktəˈrɪstɪk/: (không) đặc trưng. characterless, /ˈkærəktələs/: không có bản sắc.",
-    "example": "The author characterises him as a hero. Her characterisation was accurate. That behavior is uncharacteristic. The new building feels characterless.",
-    "count": 0
+      "word": "favour",
+      "meaning": "favouritism, /ˈfeɪvərɪtɪzəm/: sự thiên vị. favourite, /ˈfeɪvərɪt/: yêu thích. (un)favourable, /(ʌn)ˈfeɪvərəbl/: (không) có thiện chí. (un)favourably, /(ʌn)ˈfeɪvərəbli/: (một cách) (không) thuận lợi.",
+      "example": "He was accused of favouritism. She is my favourite teacher. The outcome was favourable. They were unfavourably compared.",
+      "count": 0
     },
     {
-    "word": "charity",
-    "meaning": "charitableness, /ˈtʃærətəblnəs/: lòng nhân ái. (un)charitable(ly), /(ʌn)ˈtʃærətəbl(i)/: (không) khoan dung.",
-    "example": "Her charitableness touched many lives. He spoke uncharitably in anger.",
-    "count": 0
+      "word": "finite",
+      "meaning": "infinity, /ɪnˈfɪnəti/: vô cực. infinitive, /ɪnˈfɪnətɪv/: nguyên thể. infinite(ly), /ˈɪnfɪnət(li)/: (một cách) vô hạn. infinitesimal(ly), /ˌɪnfɪnɪˈtesɪml(i)/: (một cách) vi phân.",
+      "example": "The universe is not infinite. Infinity is a complex idea. Use the infinitive form. Infinitely more efficient. The difference was infinitesimal.",
+      "count": 0
     },
     {
-    "word": "choose",
-    "meaning": "chose, /tʃəʊz/: quá khứ choose. chosen, /ˈtʃəʊzn/: được chọn. choice, /tʃɔɪs/: sự lựa chọn. choosy, /ˈtʃuːzi/: kén chọn.",
-    "example": "He chose wisely. She is the chosen candidate. You have a choice. She’s very choosy about clothes.",
-    "count": 0
+      "word": "flexible",
+      "meaning": "(in)flexibility, /(ɪn)ˌfleksəˈbɪləti/: (tính) (không) linh hoạt. inflexible, /ɪnˈfleksəbl/: cứng nhắc.",
+      "example": "Flexibility is key in this job. The plan was inflexible.",
+      "count": 0
     },
     {
-    "word": "class",
-    "meaning": "outclass, /ˌaʊtˈklɑːs/: vượt trội. (de)classify, /ˈklæsɪfaɪ/: phân loại. classics, /ˈklæsɪks/: văn học Hy Lạp cổ. classifieds, /ˈklæsɪfaɪdz/: mục rao vặt. classification, /ˌklæsɪfɪˈkeɪʃn/: sự phân loại. classlessness, /ˈklɑːsləsnəs/: không giai cấp. classmate, /ˈklɑːsmeɪt/: bạn cùng lớp. classroom, /ˈklɑːsruːm/: phòng học. classwork, /ˈklɑːswɜːk/: bài học trên lớp. classy, /ˈklɑːsi/: ưu tú.",
-    "example": "She outclassed all the runners. They classified the documents. I love reading the classics. He searched the classifieds. We studied animal classification. The movement promoted classlessness. My classmate is helpful. The classroom was quiet. His classwork is excellent. That's a classy dress.",
-    "count": 0
+      "word": "character",
+      "meaning": "characterise, /ˈkærəktəraɪz/: mô tả như là. characterisation, /ˌkærəktəraɪˈzeɪʃn/: sự mô tả như là. (un)characteristic, /(ʌn)ˌkærəktəˈrɪstɪk/: (không) đặc trưng. characterless, /ˈkærəktələs/: không có bản sắc.",
+      "example": "The author characterises him as a hero. Her characterisation was accurate. That behavior is uncharacteristic. The new building feels characterless.",
+      "count": 0
     },
     {
-    "word": "collect",
-    "meaning": "collect(v), /kəˈlekt/: thu thập. collector, /kəˈlektə(r)/: người sưu tầm. collection, /kəˈlekʃn/: bộ sưu tập. collectable, /kəˈlektəbl/: có thể thu thập được. collected, /kəˈlektɪd/: được thu thập. collective(ly), /kəˈlektɪv(li)/: (một cách) tập thể.",
-    "example": "He collects stamps. The art collector visited. This is a rare collection. These items are collectable. All data was collected. We acted collectively.",
-    "count": 0
+      "word": "charity",
+      "meaning": "charitableness, /ˈtʃærətəblnəs/: lòng nhân ái. (un)charitable(ly), /(ʌn)ˈtʃærətəbl(i)/: (không) khoan dung.",
+      "example": "Her charitableness touched many lives. He spoke uncharitably in anger.",
+      "count": 0
     },
     {
-    "word": "come",
-    "meaning": "overcome, /ˌəʊvəˈkʌm/: vượt qua. comeback, /ˈkʌmbæk/: sự trở lại. newcomer, /ˈnjuːˌkʌmə(r)/: người mới. outcome, /ˈaʊtkʌm/: kết quả. income, /ˈɪnkʌm/: thu nhập. coming, /ˈkʌmɪŋ/: sắp tới. oncoming, /ˈɒnkʌmɪŋ/: đang đến gần. incoming, /ˈɪnkʌmɪŋ/: mới đến.",
-    "example": "He overcame great odds. The singer made a comeback. The newcomer was nervous. The outcome was expected. My income has increased. The coming days are busy. An oncoming car appeared. The incoming mail was sorted.",
-    "count": 0
+      "word": "choose",
+      "meaning": "chose, /tʃəʊz/: quá khứ choose. chosen, /ˈtʃəʊzn/: được chọn. choice, /tʃɔɪs/: sự lựa chọn. choosy, /ˈtʃuːzi/: kén chọn.",
+      "example": "He chose wisely. She is the chosen candidate. You have a choice. She’s very choosy about clothes.",
+      "count": 0
     },
     {
-    "word": "compete",
-    "meaning": "competition, /ˌkɒmpəˈtɪʃn/: cuộc thi. competitor, /kəmˈpetɪtə(r)/: đối thủ. competitiveness, /kəmˈpetətɪvnəs/: tính cạnh tranh. (un)competitive(ly), /(ʌn)kəmˈpetətɪv(li)/: (một cách) (không) cạnh tranh.",
-    "example": "The competition was fierce. He’s a strong competitor. They promote competitiveness. She priced it competitively. It’s uncompetitively expensive.",
-    "count": 0
+      "word": "class",
+      "meaning": "outclass, /ˌaʊtˈklɑːs/: vượt trội. (de)classify, /ˈklæsɪfaɪ/: phân loại. classics, /ˈklæsɪks/: văn học Hy Lạp cổ. classifieds, /ˈklæsɪfaɪdz/: mục rao vặt. classification, /ˌklæsɪfɪˈkeɪʃn/: sự phân loại. classlessness, /ˈklɑːsləsnəs/: không giai cấp. classmate, /ˈklɑːsmeɪt/: bạn cùng lớp. classroom, /ˈklɑːsruːm/: phòng học. classwork, /ˈklɑːswɜːk/: bài học trên lớp. classy, /ˈklɑːsi/: ưu tú.",
+      "example": "She outclassed all the runners. They classified the documents. I love reading the classics. He searched the classifieds. We studied animal classification. The movement promoted classlessness. My classmate is helpful. The classroom was quiet. His classwork is excellent. That's a classy dress.",
+      "count": 0
     },
     {
-    "word": "concept",
-    "meaning": "conceptualise, /kənˈseptʃuəlaɪz/: khái niệm hóa. concept, /ˈkɒnsept/: khái niệm. conception, /kənˈsepʃn/: quan niệm. (in)conceivable, /(ɪn)kənˈsiːvəbl/: (không) có thể tưởng tượng. (in)conceivably, /(ɪn)kənˈsiːvəbli/: (một cách) (không) tưởng tượng được.",
-    "example": "He struggled to conceptualise freedom. It’s a difficult concept. Her conception differs. It’s inconceivable! They may conceivably win.",
-    "count": 0
+      "word": "collect",
+      "meaning": "collect(v), /kəˈlekt/: thu thập. collector, /kəˈlektə(r)/: người sưu tầm. collection, /kəˈlekʃn/: bộ sưu tập. collectable, /kəˈlektəbl/: có thể thu thập được. collected, /kəˈlektɪd/: được thu thập. collective(ly), /kəˈlektɪv(li)/: (một cách) tập thể.",
+      "example": "He collects stamps. The art collector visited. This is a rare collection. These items are collectable. All data was collected. We acted collectively.",
+      "count": 0
     },
     {
-    "word": "confuse",
-    "meaning": "confusion, /kənˈfjuːʒn/: sự nhầm lẫn. confused, /kənˈfjuːzd/: bối rối. confusing(ly), /kənˈfjuːzɪŋ(li)/: (một cách) gây nhầm lẫn.",
-    "example": "There was a lot of confusion. She looked confused. The instructions were confusingly worded.",
-    "count": 0
+      "word": "come",
+      "meaning": "overcome, /ˌəʊvəˈkʌm/: vượt qua. comeback, /ˈkʌmbæk/: sự trở lại. newcomer, /ˈnjuːˌkʌmə(r)/: người mới. outcome, /ˈaʊtkʌm/: kết quả. income, /ˈɪnkʌm/: thu nhập. coming, /ˈkʌmɪŋ/: sắp tới. oncoming, /ˈɒnkʌmɪŋ/: đang đến gần. incoming, /ˈɪnkʌmɪŋ/: mới đến.",
+      "example": "He overcame great odds. The singer made a comeback. The newcomer was nervous. The outcome was expected. My income has increased. The coming days are busy. An oncoming car appeared. The incoming mail was sorted.",
+      "count": 0
     },
     {
-    "word": "connect",
-    "meaning": "disconnect, /ˌdɪskəˈnekt/: ngắt kết nối. reconnect, /ˌriːkəˈnekt/: kết nối lại. interconnect, /ˌɪntəkəˈnekt/: kết nối lẫn nhau. interconnection, /ˌɪntəkəˈnekʃn/: sự liên kết. (dis/re)connection, /ˌdɪskəˈnekʃn/: (ngắt/tái) kết nối. (inter)connector, /ˌɪntəˈnek.tə(r)/: đầu nối.",
-    "example": "He disconnected the cable. We need to reconnect. The systems are interconnected. Their interconnection was solid. Reboot after disconnection. Use the connector carefully.",
-    "count": 0
+      "word": "compete",
+      "meaning": "competition, /ˌkɒmpəˈtɪʃn/: cuộc thi. competitor, /kəmˈpetɪtə(r)/: đối thủ. competitiveness, /kəmˈpetətɪvnəs/: tính cạnh tranh. (un)competitive(ly), /(ʌn)kəmˈpetətɪv(li)/: (một cách) (không) cạnh tranh.",
+      "example": "The competition was fierce. He’s a strong competitor. They promote competitiveness. She priced it competitively. It’s uncompetitively expensive.",
+      "count": 0
     },
     {
-    "word": "conserve",
-    "meaning": "conservation, /ˌkɒnsəˈveɪʃn/: sự bảo tồn. conservationist, /ˌkɒnsəˈveɪʃənɪst/: nhà bảo tồn. conservative(ly), /kənˈsɜːvətɪv(li)/: (một cách) bảo thủ.",
-    "example": "We support wildlife conservation. The conservationist gave a talk. He dressed conservatively.",
-    "count": 0
+      "word": "concept",
+      "meaning": "conceptualise, /kənˈseptʃuəlaɪz/: khái niệm hóa. concept, /ˈkɒnsept/: khái niệm. conception, /kənˈsepʃn/: quan niệm. (in)conceivable, /(ɪn)kənˈsiːvəbl/: (không) có thể tưởng tượng. (in)conceivably, /(ɪn)kənˈsiːvəbli/: (một cách) (không) tưởng tượng được.",
+      "example": "He struggled to conceptualise freedom. It’s a difficult concept. Her conception differs. It’s inconceivable! They may conceivably win.",
+      "count": 0
     },
     {
-    "word": "consider",
-    "meaning": "consideration, /kənˌsɪdəˈreɪʃn/: sự cân nhắc. considered, /kənˈsɪdəd/: được xem là. considering, /kənˈsɪdərɪŋ/: đang xem xét. (in)considerable, /(ɪn)kənˈsɪdərəbl/: (không) đáng kể. considerably, /kənˈsɪdərəbli/: (một cách) đáng kể.",
-    "example": "We appreciate your consideration. She is a considered expert. Considering the weather, we stayed in. The loss was considerable. Prices dropped considerably.",
-    "count": 0
+      "word": "confuse",
+      "meaning": "confusion, /kənˈfjuːʒn/: sự nhầm lẫn. confused, /kənˈfjuːzd/: bối rối. confusing(ly), /kənˈfjuːzɪŋ(li)/: (một cách) gây nhầm lẫn.",
+      "example": "There was a lot of confusion. She looked confused. The instructions were confusingly worded.",
+      "count": 0
     },
     {
-    "word": "content",
-    "meaning": "(dis)content, /ˈkɒntent/: (không) thỏa mãn. (dis)contented, /ˌdɪskənˈtentɪd/: (không) hài lòng.",
-    "example": "He seemed content. Many workers felt discontent. She was discontented with her job.",
-    "count": 0
+      "word": "connect",
+      "meaning": "disconnect, /ˌdɪskəˈnekt/: ngắt kết nối. reconnect, /ˌriːkəˈnekt/: kết nối lại. interconnect, /ˌɪntəkəˈnekt/: kết nối lẫn nhau. interconnection, /ˌɪntəkəˈnekʃn/: sự liên kết. (dis/re)connection, /ˌdɪskəˈnekʃn/: (ngắt/tái) kết nối. (inter)connector, /ˌɪntəˈnek.tə(r)/: đầu nối.",
+      "example": "He disconnected the cable. We need to reconnect. The systems are interconnected. Their interconnection was solid. Reboot after disconnection. Use the connector carefully.",
+      "count": 0
     },
     {
-    "word": "continue",
-    "meaning": "discontinue, /ˌdɪskənˈtɪnjuː/: ngừng lại. continuation, /kənˌtɪnjuˈeɪʃn/: sự tiếp tục. continuity, /ˌkɒntɪˈnjuːəti/: tính liên tục. continual(ly), /kənˈtɪnjuəl(i)/: (một cách) liên tiếp. continuous(ly), /kənˈtɪnjuəs(li)/: (một cách) liên tục.",
-    "example": "They will discontinue the service. The continuation of talks is vital. We need continuity in leadership. He faced continual interruptions. It rained continuously.",
-    "count": 0
+      "word": "conserve",
+      "meaning": "conservation, /ˌkɒnsəˈveɪʃn/: sự bảo tồn. conservationist, /ˌkɒnsəˈveɪʃənɪst/: nhà bảo tồn. conservative(ly), /kənˈsɜːvətɪv(li)/: (một cách) bảo thủ.",
+      "example": "We support wildlife conservation. The conservationist gave a talk. He dressed conservatively.",
+      "count": 0
     },
     {
-    "word": "convert",
-    "meaning": "conversion, /kənˈvɜːʃn/: sự thay đổi. convertible, /kənˈvɜːtəbl/: có thể chuyển đổi.",
-    "example": "Their conversion to solar energy was fast. This sofa is convertible to a bed.",
-    "count": 0
+      "word": "consider",
+      "meaning": "consideration, /kənˌsɪdəˈreɪʃn/: sự cân nhắc. considered, /kənˈsɪdəd/: được xem là. considering, /kənˈsɪdərɪŋ/: đang xem xét. (in)considerable, /(ɪn)kənˈsɪdərəbl/: (không) đáng kể. considerably, /kənˈsɪdərəbli/: (một cách) đáng kể.",
+      "example": "We appreciate your consideration. She is a considered expert. Considering the weather, we stayed in. The loss was considerable. Prices dropped considerably.",
+      "count": 0
     },
     {
-    "word": "convince",
-    "meaning": "conviction, /kənˈvɪkʃn/: sức thuyết phục. (un)convinced, /(ʌn)kənˈvɪnst/: (không) bị thuyết phục. (un)convincing(ly), /(ʌn)kənˈvɪnsɪŋ(li)/: (một cách) (không) thuyết phục.",
-    "example": "She spoke with conviction. I'm not convinced. He argued unconvincingly.",
-    "count": 0
-    },      
-{
-    "word": "crime",
-    "meaning": "(de)criminalise, /ˈkrɪmɪnəlaɪz/: (không) hình sự hóa. criminal, /ˈkrɪmɪnl/: kẻ tội phạm. criminality, /ˌkrɪmɪˈnæləti/: sự phạm tội. criminally, /ˈkrɪmɪnəli/: một cách sai trái.",
-    "example": "Some countries have decriminalised certain drugs. The criminal was caught. Criminality is on the rise. He acted criminally.",
-    "count": 0
+      "word": "content",
+      "meaning": "(dis)content, /ˈkɒntent/: (không) thỏa mãn. (dis)contented, /ˌdɪskənˈtentɪd/: (không) hài lòng.",
+      "example": "He seemed content. Many workers felt discontent. She was discontented with her job.",
+      "count": 0
     },
     {
-    "word": "decide",
-    "meaning": "decision, /dɪˈsɪʒn/: quyết định. decider, /dɪˈsaɪdə(r)/: vòng quyết đấu. decisiveness, /dɪˈsaɪsɪvnəs/: sự quyết đoán. (in)decisive(ly), /(ɪn)dɪˈsaɪsɪv(li)/: (không) quyết đoán.",
-    "example": "She made a quick decision. The final match was a decider. Decisiveness is key in business. He spoke decisively.",
-    "count": 0
+      "word": "continue",
+      "meaning": "discontinue, /ˌdɪskənˈtɪnjuː/: ngừng lại. continuation, /kənˌtɪnjuˈeɪʃn/: sự tiếp tục. continuity, /ˌkɒntɪˈnjuːəti/: tính liên tục. continual(ly), /kənˈtɪnjuəl(i)/: (một cách) liên tiếp. continuous(ly), /kənˈtɪnjuəs(li)/: (một cách) liên tục.",
+      "example": "They will discontinue the service. The continuation of talks is vital. We need continuity in leadership. He faced continual interruptions. It rained continuously.",
+      "count": 0
     },
     {
-    "word": "declare",
-    "meaning": "declaration, /ˌdekləˈreɪʃn/: lời tuyên bố. (un)declared, /(ʌn)dɪˈkleəd/: (không) công khai.",
-    "example": "They issued a declaration of independence. It was an undeclared war.",
-    "count": 0
+      "word": "convert",
+      "meaning": "conversion, /kənˈvɜːʃn/: sự thay đổi. convertible, /kənˈvɜːtəbl/: có thể chuyển đổi.",
+      "example": "Their conversion to solar energy was fast. This sofa is convertible to a bed.",
+      "count": 0
     },
     {
-    "word": "deep",
-    "meaning": "deepen, /ˈdiːpən/: đào sâu. depth, /depθ/: độ sâu. deeply, /ˈdiːpli/: sâu sắc.",
-    "example": "This course will deepen your knowledge. The lake has great depth. She was deeply moved.",
-    "count": 0
+      "word": "convince",
+      "meaning": "conviction, /kənˈvɪkʃn/: sức thuyết phục. (un)convinced, /(ʌn)kənˈvɪnst/: (không) bị thuyết phục. (un)convincing(ly), /(ʌn)kənˈvɪnsɪŋ(li)/: (một cách) (không) thuyết phục.",
+      "example": "She spoke with conviction. I'm not convinced. He argued unconvincingly.",
+      "count": 0
     },
     {
-    "word": "define",
-    "meaning": "definition, /ˌdefɪˈnɪʃn/: định nghĩa. defined, /dɪˈfaɪnd/: được xác định. definitive(ly), /dɪˈfɪnətɪv(li)/: (một cách) chắc chắn. (in)definite(ly), /(ɪn)ˈdefɪnət(li)/: (không) rõ ràng.",
-    "example": "Give a clear definition. The borders are clearly defined. That’s the definitive answer. We postponed it indefinitely.",
-    "count": 0
+      "word": "crime",
+      "meaning": "(de)criminalise, /ˈkrɪmɪnəlaɪz/: (không) hình sự hóa. criminal, /ˈkrɪmɪnl/: kẻ tội phạm. criminality, /ˌkrɪmɪˈnæləti/: sự phạm tội. criminally, /ˈkrɪmɪnəli/: một cách sai trái.",
+      "example": "Some countries have decriminalised certain drugs. The criminal was caught. Criminality is on the rise. He acted criminally.",
+      "count": 0
     },
     {
-    "word": "dense",
-    "meaning": "density, /ˈdensəti/: mật độ. (in)dependence, /(ɪn)dɪˈpendəns/: (không) phụ thuộc. (in)dependent(ly), /(ɪn)dɪˈpendənt(li)/: (một cách) (không) phụ thuộc.",
-    "example": "The fog’s density was high. They value independence. Children become independent. He lives independently.",
-    "count": 0
+      "word": "decide",
+      "meaning": "decision, /dɪˈsɪʒn/: quyết định. decider, /dɪˈsaɪdə(r)/: vòng quyết đấu. decisiveness, /dɪˈsaɪsɪvnəs/: sự quyết đoán. (in)decisive(ly), /(ɪn)dɪˈsaɪsɪv(li)/: (không) quyết đoán.",
+      "example": "She made a quick decision. The final match was a decider. Decisiveness is key in business. He spoke decisively.",
+      "count": 0
     },
     {
-    "word": "derive",
-    "meaning": "derivation, /ˌderɪˈveɪʃn/: nguồn gốc. derivative, /dɪˈrɪvətɪv/: bắt nguồn từ.",
-    "example": "The word is of Latin derivation. This idea is a derivative of his work.",
-    "count": 0
+      "word": "declare",
+      "meaning": "declaration, /ˌdekləˈreɪʃn/: lời tuyên bố. (un)declared, /(ʌn)dɪˈkleəd/: (không) công khai.",
+      "example": "They issued a declaration of independence. It was an undeclared war.",
+      "count": 0
     },
     {
-    "word": "desire",
-    "meaning": "(un)desirable, /(ʌn)dɪˈzaɪərəbl/: (không) đáng ao ước. desire, /dɪˈzaɪə(r)/: ham muốn. desired, /dɪˈzaɪəd/: mong muốn. (un)desirably, /(ʌn)dɪˈzaɪərəbli/: (một cách) (không) đáng ao ước.",
-    "example": "This is a desirable area. She expressed her desire. The desired effect was achieved. It is undesirably hot.",
-    "count": 0
+      "word": "deep",
+      "meaning": "deepen, /ˈdiːpən/: đào sâu. depth, /depθ/: độ sâu. deeply, /ˈdiːpli/: sâu sắc.",
+      "example": "This course will deepen your knowledge. The lake has great depth. She was deeply moved.",
+      "count": 0
     },
     {
-    "word": "destroy",
-    "meaning": "destroyer, /dɪˈstrɔɪə(r)/: kẻ phá hoại. destruction, /dɪˈstrʌkʃn/: sự tàn phá. indestructible, /ˌɪndɪˈstrʌktəbl/: không thể phá hủy. destructive(ly), /dɪˈstrʌktɪv(li)/: (một cách) hủy diệt.",
-    "example": "The destroyer arrived at dawn. War causes destruction. The box is indestructible. He shouted destructively.",
-    "count": 0
+      "word": "define",
+      "meaning": "definition, /ˌdefɪˈnɪʃn/: định nghĩa. defined, /dɪˈfaɪnd/: được xác định. definitive(ly), /dɪˈfɪnətɪv(li)/: (một cách) chắc chắn. (in)definite(ly), /(ɪn)ˈdefɪnət(li)/: (không) rõ ràng.",
+      "example": "Give a clear definition. The borders are clearly defined. That’s the definitive answer. We postponed it indefinitely.",
+      "count": 0
     },
     {
-    "word": "distant",
-    "meaning": "(equi)distant(ly), /ˈdɪstənt(li)/: (cách đều) nhau. equidistant, /ˌekwɪˈdɪstənt/: cách đều nhau. distantly, /ˈdɪstəntli/: xa.",
-    "example": "The houses are equidistant. He stood distantly from the group.",
-    "count": 0
+      "word": "dense",
+      "meaning": "density, /ˈdensəti/: mật độ. (in)dependence, /(ɪn)dɪˈpendəns/: (không) phụ thuộc. (in)dependent(ly), /(ɪn)dɪˈpendənt(li)/: (một cách) (không) phụ thuộc.",
+      "example": "The fog’s density was high. They value independence. Children become independent. He lives independently.",
+      "count": 0
     },
     {
-    "word": "do",
-    "meaning": "overdo, /ˌəʊvəˈduː/: làm quá sức. outdo, /ˌaʊtˈduː/: làm giỏi hơn. redo, /ˌriːˈduː/: làm lại. undo, /ʌnˈduː/: hoàn tác. (over/out/re/un)did, /dɪd/: (quá khứ) làm. (over/out/re/un)done, /dʌn/: (quá khứ phân từ) làm xong. doing, /ˈduːɪŋ/: hành động. doings, /ˈduːɪŋz/: hành vi.",
-    "example": "Don’t overdo the spices. She outdid everyone. You need to redo the form. He tried to undo the mistake. It’s already done. Strange doings occurred.",
-    "count": 0
+      "word": "derive",
+      "meaning": "derivation, /ˌderɪˈveɪʃn/: nguồn gốc. derivative, /dɪˈrɪvətɪv/: bắt nguồn từ.",
+      "example": "The word is of Latin derivation. This idea is a derivative of his work.",
+      "count": 0
     },
     {
-    "word": "dominate",
-    "meaning": "domineer, /ˌdɒmɪˈnɪə(r)/: độc đoán. domination, /ˌdɒmɪˈneɪʃn/: sự thống trị. (pre)dominance, /ˈpridɒmɪnəns/: sự trội hơn. dominant, /ˈdɒmɪnənt/: vượt trội. dominating, /ˈdɒmɪneɪtɪŋ/: thống trị. predominantly, /prɪˈdɒmɪnəntli/: chủ yếu.",
-    "example": "He tends to domineer over others. Their domination of the market is clear. English has global dominance. She has a dominant personality. A dominating figure. The team was predominantly local.",
-    "count": 0
+      "word": "desire",
+      "meaning": "(un)desirable, /(ʌn)dɪˈzaɪərəbl/: (không) đáng ao ước. desire, /dɪˈzaɪə(r)/: ham muốn. desired, /dɪˈzaɪəd/: mong muốn. (un)desirably, /(ʌn)dɪˈzaɪərəbli/: (một cách) (không) đáng ao ước.",
+      "example": "This is a desirable area. She expressed her desire. The desired effect was achieved. It is undesirably hot.",
+      "count": 0
     },
     {
-    "word": "doubt",
-    "meaning": "doubter, /ˈdaʊtə(r)/: người hay nghi ngờ. doubtful(ly), /ˈdaʊtfl(i)/: (một cách) nghi ngờ. undoubted(ly), /ʌnˈdaʊtɪd(li)/: (một cách) chắc chắn.",
-    "example": "He’s a doubter of all theories. That’s doubtfully useful. She is undoubtedly talented.",
-    "count": 0
+      "word": "destroy",
+      "meaning": "destroyer, /dɪˈstrɔɪə(r)/: kẻ phá hoại. destruction, /dɪˈstrʌkʃn/: sự tàn phá. indestructible, /ˌɪndɪˈstrʌktəbl/: không thể phá hủy. destructive(ly), /dɪˈstrʌktɪv(li)/: (một cách) hủy diệt.",
+      "example": "The destroyer arrived at dawn. War causes destruction. The box is indestructible. He shouted destructively.",
+      "count": 0
     },
     {
-    "word": "draw",
-    "meaning": "withdraw, /wɪðˈdrɔː/: rút lui. withdrew, /wɪðˈdruː/: rút (quá khứ). drawn, /drɔːn/: rút (phân từ). withdrawal, /wɪðˈdrɔːəl/: sự rút lui. drawing, /ˈdrɔːɪŋ/: bản vẽ. overdraft, /ˈəʊvədrɑːft/: thấu chi. overdrawn, /ˌəʊvəˈdrɔːn/: quá hạn. withdrawable, /wɪðˈdrɔːəbl/: có thể rút.",
-    "example": "He decided to withdraw. She withdrew from the race. All money was drawn. The withdrawal was quiet. That’s a great drawing. I have an overdraft. His account is overdrawn. This deposit is withdrawable.",
-    "count": 0
+      "word": "distant",
+      "meaning": "(equi)distant(ly), /ˈdɪstənt(li)/: (cách đều) nhau. equidistant, /ˌekwɪˈdɪstənt/: cách đều nhau. distantly, /ˈdɪstəntli/: xa.",
+      "example": "The houses are equidistant. He stood distantly from the group.",
+      "count": 0
     },
     {
-    "word": "duty",
-    "meaning": "dutiful(ly), /ˈdjuːtɪfl(i)/: (một cách) vâng lời.",
-    "example": "She served dutifully.",
-    "count": 0
+      "word": "do",
+      "meaning": "overdo, /ˌəʊvəˈduː/: làm quá sức. outdo, /ˌaʊtˈduː/: làm giỏi hơn. redo, /ˌriːˈduː/: làm lại. undo, /ʌnˈduː/: hoàn tác. (over/out/re/un)did, /dɪd/: (quá khứ) làm. (over/out/re/un)done, /dʌn/: (quá khứ phân từ) làm xong. doing, /ˈduːɪŋ/: hành động. doings, /ˈduːɪŋz/: hành vi.",
+      "example": "Don’t overdo the spices. She outdid everyone. You need to redo the form. He tried to undo the mistake. It’s already done. Strange doings occurred.",
+      "count": 0
     },
     {
-    "word": "ecology",
-    "meaning": "ecologist, /ɪˈkɒlədʒɪst/: nhà sinh thái học. ecological(ly), /ˌiːkəˈlɒdʒɪkl(i)/: (thuộc) sinh thái.",
-    "example": "The ecologist gave a lecture. We must consider ecological impacts.",
-    "count": 0
+      "word": "dominate",
+      "meaning": "domineer, /ˌdɒmɪˈnɪə(r)/: độc đoán. domination, /ˌdɒmɪˈneɪʃn/: sự thống trị. (pre)dominance, /ˈpridɒmɪnəns/: sự trội hơn. dominant, /ˈdɒmɪnənt/: vượt trội. dominating, /ˈdɒmɪneɪtɪŋ/: thống trị. predominantly, /prɪˈdɒmɪnəntli/: chủ yếu.",
+      "example": "He tends to domineer over others. Their domination of the market is clear. English has global dominance. She has a dominant personality. A dominating figure. The team was predominantly local.",
+      "count": 0
     },
     {
-    "word": "edit",
-    "meaning": "edition, /ɪˈdɪʃn/: ấn bản. editor, /ˈedɪtə(r)/: biên tập viên. editorship, /ˈedɪtəʃɪp/: công tác biên tập. (un)edited, /(ʌn)ˈedɪtɪd/: (không) được biên tập. editorial(ly), /ˌedɪˈtɔːriəli/: (một cách) biên tập.",
-    "example": "I read the latest edition. She is the editor. He took over the editorship. The footage is unedited. It was editorially approved.",
-    "count": 0
+      "word": "doubt",
+      "meaning": "doubter, /ˈdaʊtə(r)/: người hay nghi ngờ. doubtful(ly), /ˈdaʊtfl(i)/: (một cách) nghi ngờ. undoubted(ly), /ʌnˈdaʊtɪd(li)/: (một cách) chắc chắn.",
+      "example": "He’s a doubter of all theories. That’s doubtfully useful. She is undoubtedly talented.",
+      "count": 0
     },
     {
-    "word": "effect",
-    "meaning": "(in)effectiveness, /(ɪn)ɪˈfektɪvnəs/: (sự) (không) hiệu quả. (in)effectual(ly), /(ɪn)ɪˈfektʃuəl(li)/: (một cách) (không) hiệu lực. (in)effective(ly), /(ɪn)ɪˈfektɪv(li)/: (một cách) (không) hiệu quả.",
-    "example": "The treatment’s effectiveness is clear. His efforts were ineffectual. She works effectively.",
-    "count": 0
-    },      
+      "word": "draw",
+      "meaning": "withdraw, /wɪðˈdrɔː/: rút lui. withdrew, /wɪðˈdruː/: rút (quá khứ). drawn, /drɔːn/: rút (phân từ). withdrawal, /wɪðˈdrɔːəl/: sự rút lui. drawing, /ˈdrɔːɪŋ/: bản vẽ. overdraft, /ˈəʊvədrɑːft/: thấu chi. overdrawn, /ˌəʊvəˈdrɔːn/: quá hạn. withdrawable, /wɪðˈdrɔːəbl/: có thể rút.",
+      "example": "He decided to withdraw. She withdrew from the race. All money was drawn. The withdrawal was quiet. That’s a great drawing. I have an overdraft. His account is overdrawn. This deposit is withdrawable.",
+      "count": 0
+    },
+    {
+      "word": "duty",
+      "meaning": "dutiful(ly), /ˈdjuːtɪfl(i)/: (một cách) vâng lời.",
+      "example": "She served dutifully.",
+      "count": 0
+    },
+    {
+      "word": "ecology",
+      "meaning": "ecologist, /ɪˈkɒlədʒɪst/: nhà sinh thái học. ecological(ly), /ˌiːkəˈlɒdʒɪkl(i)/: (thuộc) sinh thái.",
+      "example": "The ecologist gave a lecture. We must consider ecological impacts.",
+      "count": 0
+    },
+    {
+      "word": "edit",
+      "meaning": "edition, /ɪˈdɪʃn/: ấn bản. editor, /ˈedɪtə(r)/: biên tập viên. editorship, /ˈedɪtəʃɪp/: công tác biên tập. (un)edited, /(ʌn)ˈedɪtɪd/: (không) được biên tập. editorial(ly), /ˌedɪˈtɔːriəli/: (một cách) biên tập.",
+      "example": "I read the latest edition. She is the editor. He took over the editorship. The footage is unedited. It was editorially approved.",
+      "count": 0
+    },
+    {
+      "word": "effect",
+      "meaning": "(in)effectiveness, /(ɪn)ɪˈfektɪvnəs/: (sự) (không) hiệu quả. (in)effectual(ly), /(ɪn)ɪˈfektʃuəl(li)/: (một cách) (không) hiệu lực. (in)effective(ly), /(ɪn)ɪˈfektɪv(li)/: (một cách) (không) hiệu quả.",
+      "example": "The treatment’s effectiveness is clear. His efforts were ineffectual. She works effectively.",
+      "count": 0
+    },
+    {
+      "word": "relate",
+      "meaning": "relation, /rɪˈleɪʃn/: mối tương quan. relationship, /rɪˈleɪʃnʃɪp/: mối quan hệ. (un)related, /(ʌn)ˈreɪtɪd/: (không) có liên quan. relative(ly), /ˈrelətɪv(li)/: (một cách) tương đối.",
+      "example": "They have a close relationship. Those events are unrelated. The change is relatively minor.",
+      "count": 0
+    },
+    {
+      "word": "relax",
+      "meaning": "relaxation, /ˌriːlækˈseɪʃn/: sự thư giãn. relaxing, /rɪˈlæksɪŋ/: có tính thư giãn.",
+      "example": "Take time for relaxation. The music is very relaxing.",
+      "count": 0
+    },
     {
-    "word": "relate",
-    "meaning": "relation, /rɪˈleɪʃn/: mối tương quan. relationship, /rɪˈleɪʃnʃɪp/: mối quan hệ. (un)related, /(ʌn)ˈreɪtɪd/: (không) có liên quan. relative(ly), /ˈrelətɪv(li)/: (một cách) tương đối.",
-    "example": "They have a close relationship. Those events are unrelated. The change is relatively minor.",
-    "count": 0
+      "word": "repair",
+      "meaning": "repairman/men, /rɪˈpeəmən/: thợ sửa máy móc. repairer, /rɪˈpeərə/: người sửa chữa. reparation, /ˌrepəˈreɪʃn/: sự sửa chữa. repair, /rɪˈpeə/: việc sửa chữa. irreparable, /ɪˈrepərəbl/: không thể sửa chữa. irreparably, /ɪˈrepərəbli/: một cách không thể sửa.",
+      "example": "The repairman fixed the leak. She is a skilled repairer. The damages required reparation. This repair was costly. The loss is irreparable. The damage was irreparably done.",
+      "count": 0
     },
     {
-    "word": "relax",
-    "meaning": "relaxation, /ˌriːlækˈseɪʃn/: sự thư giãn. relaxing, /rɪˈlæksɪŋ/: có tính thư giãn.",
-    "example": "Take time for relaxation. The music is very relaxing.",
-    "count": 0
+      "word": "reside",
+      "meaning": "residence, /ˈrezɪdns/: nhà ở. resident, /ˈrezɪdənt/: cư dân. residing, /rɪˈzaɪdɪŋ/: cư trú. residential(ly), /ˌrezɪˈdenʃl(i)/: thuộc về, ở tại.",
+      "example": "His residence is near the park. The residents complained. He is currently residing in Tokyo. It's a residential area.",
+      "count": 0
     },
     {
-    "word": "repair",
-    "meaning": "repairman/men, /rɪˈpeəmən/: thợ sửa máy móc. repairer, /rɪˈpeərə/: người sửa chữa. reparation, /ˌrepəˈreɪʃn/: sự sửa chữa. repair, /rɪˈpeə/: việc sửa chữa. irreparable, /ɪˈrepərəbl/: không thể sửa chữa. irreparably, /ɪˈrepərəbli/: một cách không thể sửa.",
-    "example": "The repairman fixed the leak. She is a skilled repairer. The damages required reparation. This repair was costly. The loss is irreparable. The damage was irreparably done.",
-    "count": 0
+      "word": "resolve",
+      "meaning": "(ir)resolution, /(ˌɪr)ˌrezəˈluːʃn/: (sự) (thiếu) kiên quyết. (un)resolved, /(ˌʌn)rɪˈzɒlvd/: (chưa) được giải quyết. (ir)resolute(ly), /(ˌɪr)ˈrezəluːt(li)/: (một cách) (thiếu) kiên quyết.",
+      "example": "The resolution was unanimous. The conflict remains unresolved. She spoke resolutely.",
+      "count": 0
     },
     {
-    "word": "reside",
-    "meaning": "residence, /ˈrezɪdns/: nhà ở. resident, /ˈrezɪdənt/: cư dân. residing, /rɪˈzaɪdɪŋ/: cư trú. residential(ly), /ˌrezɪˈdenʃl(i)/: thuộc về, ở tại.",
-    "example": "His residence is near the park. The residents complained. He is currently residing in Tokyo. It's a residential area.",
-    "count": 0
+      "word": "respond",
+      "meaning": "response, /rɪˈspɒns/: phản hồi. respondent, /rɪˈspɒndənt/: người trả lời. (un)responsive(ly), /(ˌʌn)rɪˈspɒnsɪv(li)/: (thiếu) nhiệt tình, phản hồi.",
+      "example": "His response was quick. The respondent answered all questions. The system is unresponsive. She responded responsively.",
+      "count": 0
     },
     {
-    "word": "resolve",
-    "meaning": "(ir)resolution, /(ˌɪr)ˌrezəˈluːʃn/: (sự) (thiếu) kiên quyết. (un)resolved, /(ˌʌn)rɪˈzɒlvd/: (chưa) được giải quyết. (ir)resolute(ly), /(ˌɪr)ˈrezəluːt(li)/: (một cách) (thiếu) kiên quyết.",
-    "example": "The resolution was unanimous. The conflict remains unresolved. She spoke resolutely.",
-    "count": 0
+      "word": "rest",
+      "meaning": "restlessness, /ˈrestləsnəs/: sự bồn chồn. unrest, /ʌnˈrest/: tình trạng không yên. restive, /ˈrestɪv/: bồn chồn, ngang bướng. restful(ly), /ˈrestfl(i)/: (một cách) yên tĩnh. restless(ly), /ˈrestləsli/: (một cách) không yên.",
+      "example": "He felt restlessness before the exam. Political unrest spread. The child was restive. The lake was restful. She slept restlessly.",
+      "count": 0
     },
     {
-    "word": "respond",
-    "meaning": "response, /rɪˈspɒns/: phản hồi. respondent, /rɪˈspɒndənt/: người trả lời. (un)responsive(ly), /(ˌʌn)rɪˈspɒnsɪv(li)/: (thiếu) nhiệt tình, phản hồi.",
-    "example": "His response was quick. The respondent answered all questions. The system is unresponsive. She responded responsively.",
-    "count": 0
+      "word": "result",
+      "meaning": "resultant, /rɪˈzʌltənt/: như kết quả. resulting, /rɪˈzʌltɪŋ/: như kết quả của cái gì.",
+      "example": "The resultant damage was severe. The traffic jam was resulting from the accident.",
+      "count": 0
     },
     {
-    "word": "rest",
-    "meaning": "restlessness, /ˈrestləsnəs/: sự bồn chồn. unrest, /ʌnˈrest/: tình trạng không yên. restive, /ˈrestɪv/: bồn chồn, ngang bướng. restful(ly), /ˈrestfl(i)/: (một cách) yên tĩnh. restless(ly), /ˈrestləsli/: (một cách) không yên.",
-    "example": "He felt restlessness before the exam. Political unrest spread. The child was restive. The lake was restful. She slept restlessly.",
-    "count": 0
+      "word": "revolt",
+      "meaning": "revolutionise, /ˌrevəˈluːʃənaɪz/: cách mạng hóa. revolution, /ˌrevəˈluːʃn/: cuộc cách mạng. revolutionary, /ˌrevəˈluːʃənəri/: có tính cách mạng. revolting, /rɪˈvəʊltɪŋ/: gây phản cảm.",
+      "example": "Technology revolutionised our lives. The revolution changed history. He’s a revolutionary leader. The dish looked revolting.",
+      "count": 0
     },
     {
-    "word": "result",
-    "meaning": "resultant, /rɪˈzʌltənt/: như kết quả. resulting, /rɪˈzʌltɪŋ/: như kết quả của cái gì.",
-    "example": "The resultant damage was severe. The traffic jam was resulting from the accident.",
-    "count": 0
+      "word": "rhythm",
+      "meaning": "rhythmic(al)(ly), /ˈrɪðmɪk(ə)li/: nhịp nhàng, một cách nhịp nhàng.",
+      "example": "The song has a rhythmic beat. She danced rhythmically.",
+      "count": 0
     },
     {
-    "word": "revolt",
-    "meaning": "revolutionise, /ˌrevəˈluːʃənaɪz/: cách mạng hóa. revolution, /ˌrevəˈluːʃn/: cuộc cách mạng. revolutionary, /ˌrevəˈluːʃənəri/: có tính cách mạng. revolting, /rɪˈvəʊltɪŋ/: gây phản cảm.",
-    "example": "Technology revolutionised our lives. The revolution changed history. He’s a revolutionary leader. The dish looked revolting.",
-    "count": 0
+      "word": "rigid",
+      "meaning": "rigidity, /rɪˈdʒɪdəti/: sự cứng, sự khắt khe. rigidly, /ˈrɪdʒɪdli/: một cách cứng nhắc.",
+      "example": "The rigidity of the structure is impressive. He rigidly followed the rules.",
+      "count": 0
     },
     {
-    "word": "rhythm",
-    "meaning": "rhythmic(al)(ly), /ˈrɪðmɪk(ə)li/: nhịp nhàng, một cách nhịp nhàng.",
-    "example": "The song has a rhythmic beat. She danced rhythmically.",
-    "count": 0
+      "word": "risk",
+      "meaning": "risky, /ˈrɪski/: mạo hiểm.",
+      "example": "That's a risky investment.",
+      "count": 0
     },
     {
-    "word": "rigid",
-    "meaning": "rigidity, /rɪˈdʒɪdəti/: sự cứng, sự khắt khe. rigidly, /ˈrɪdʒɪdli/: một cách cứng nhắc.",
-    "example": "The rigidity of the structure is impressive. He rigidly followed the rules.",
-    "count": 0
+      "word": "surround",
+      "meaning": "surroundings, /səˈraʊndɪŋz/: vùng xung quanh. roundabout, /ˈraʊndəbaʊt/: vòng tròn. surrounding, /səˈraʊndɪŋ/: bao quanh. roundly, /ˈraʊndli/: thẳng thắn, tròn trịa.",
+      "example": "She was unfamiliar with her surroundings. Take the next roundabout. The mountain was surrounded by fog. He was roundly criticized.",
+      "count": 0
     },
     {
-    "word": "risk",
-    "meaning": "risky, /ˈrɪski/: mạo hiểm.",
-    "example": "That's a risky investment.",
-    "count": 0
+      "word": "sane",
+      "meaning": "(in)sanity, /(ɪn)ˈsænəti/: (mất) trạng thái tỉnh táo. insane(ly), /ɪnˈseɪn(li)/: (một cách) điên rồ.",
+      "example": "He questioned her sanity. The idea is insanely expensive.",
+      "count": 0
     },
     {
-    "word": "surround",
-    "meaning": "surroundings, /səˈraʊndɪŋz/: vùng xung quanh. roundabout, /ˈraʊndəbaʊt/: vòng tròn. surrounding, /səˈraʊndɪŋ/: bao quanh. roundly, /ˈraʊndli/: thẳng thắn, tròn trịa.",
-    "example": "She was unfamiliar with her surroundings. Take the next roundabout. The mountain was surrounded by fog. He was roundly criticized.",
-    "count": 0
+      "word": "satisfy",
+      "meaning": "(un)satisfactory, /(ʌn)ˌsætɪsˈfæktəri/: (không) hài lòng. (dis)satisfied, /(ˌdɪs)ˈsætɪsfaɪd/: (không) hài lòng. (un)satisfying(ly), /(ʌn)ˈsætɪsfaɪɪŋli/: (một cách) (không) thỏa mãn. satisfaction, /ˌsætɪsˈfækʃn/: sự hài lòng.",
+      "example": "The result was unsatisfactory. She felt dissatisfied with the service. He smiled satisfyingly. Her satisfaction was evident.",
+      "count": 0
     },
     {
-    "word": "sane",
-    "meaning": "(in)sanity, /(ɪn)ˈsænəti/: (mất) trạng thái tỉnh táo. insane(ly), /ɪnˈseɪn(li)/: (một cách) điên rồ.",
-    "example": "He questioned her sanity. The idea is insanely expensive.",
-    "count": 0
+      "word": "say",
+      "meaning": "gainsay, /ˌɡeɪnˈseɪ/: chối cãi. saying, /ˈseɪɪŋ/: ngạn ngữ. unsaid, /ʌnˈsed/: không nói ra.",
+      "example": "No one dared to gainsay him. That’s a wise saying. Some things are better left unsaid.",
+      "count": 0
     },
     {
-    "word": "satisfy",
-    "meaning": "(un)satisfactory, /(ʌn)ˌsætɪsˈfæktəri/: (không) hài lòng. (dis)satisfied, /(ˌdɪs)ˈsætɪsfaɪd/: (không) hài lòng. (un)satisfying(ly), /(ʌn)ˈsætɪsfaɪɪŋli/: (một cách) (không) thỏa mãn. satisfaction, /ˌsætɪsˈfækʃn/: sự hài lòng.",
-    "example": "The result was unsatisfactory. She felt dissatisfied with the service. He smiled satisfyingly. Her satisfaction was evident.",
-    "count": 0
+      "word": "seem",
+      "meaning": "seeming(ly), /ˈsiːmɪŋ(li)/: (có vẻ) như, có vẻ.",
+      "example": "She was seemingly unaware of the danger.",
+      "count": 0
     },
     {
-    "word": "say",
-    "meaning": "gainsay, /ˌɡeɪnˈseɪ/: chối cãi. saying, /ˈseɪɪŋ/: ngạn ngữ. unsaid, /ʌnˈsed/: không nói ra.",
-    "example": "No one dared to gainsay him. That’s a wise saying. Some things are better left unsaid.",
-    "count": 0
+      "word": "select",
+      "meaning": "deselect, /ˌdiːsɪˈlekt/: bỏ chọn. selection, /sɪˈlekʃn/: sự lựa chọn. selective(ly), /sɪˈlektɪv(li)/: (một cách) chọn lọc.",
+      "example": "You can deselect the item. The selection process was rigorous. She listened selectively.",
+      "count": 0
     },
     {
-    "word": "seem",
-    "meaning": "seeming(ly), /ˈsiːmɪŋ(li)/: (có vẻ) như, có vẻ.",
-    "example": "She was seemingly unaware of the danger.",
-    "count": 0
+      "word": "self",
+      "meaning": "(un)selfishness, /ʌnˈselfɪʃnəs/: (sự) (không) ích kỷ. (un)selfishly, /ʌnˈselfɪʃli/: (một cách) (không) ích kỷ. selfless(ly), /ˈselfləsli/: (một cách) vị tha.",
+      "example": "Her unselfishness was inspiring. He acted unselfishly. They worked selflessly.",
+      "count": 0
     },
     {
-    "word": "select",
-    "meaning": "deselect, /ˌdiːsɪˈlekt/: bỏ chọn. selection, /sɪˈlekʃn/: sự lựa chọn. selective(ly), /sɪˈlektɪv(li)/: (một cách) chọn lọc.",
-    "example": "You can deselect the item. The selection process was rigorous. She listened selectively.",
-    "count": 0
+      "word": "sense (2)",
+      "meaning": "desensitise: làm mất nhạy cảm. sensitivity: sự nhạy cảm. hypersensitivity: sự quá nhạy cảm. sensibility: trí giác. senselessness: vô nghĩa. sensuality: ham muốn nhục dục. sensuousness: ham muốn nhục dục. sensor: cảm biến. hypersensitive: quá nhạy cảm. oversensitive: quá nhạy cảm. nonsense: vô nghĩa. sensory: thuộc cảm giác.",
+      "example": "The drug desensitised his pain. Her insensitivity upset him. He suffers from hypersensitivity. Her sensibility makes her a great artist. The joke was senseless. His sensuality was obvious. The poem had deep sensuousness. The sensor detected movement. She’s hypersensitive to criticism. Don’t be oversensitive. That’s complete nonsense. The painting evoked a strong sensory response.",
+      "count": 0
     },
     {
-    "word": "self",
-    "meaning": "(un)selfishness, /ʌnˈselfɪʃnəs/: (sự) (không) ích kỷ. (un)selfishly, /ʌnˈselfɪʃli/: (một cách) (không) ích kỷ. selfless(ly), /ˈselfləsli/: (một cách) vị tha.",
-    "example": "Her unselfishness was inspiring. He acted unselfishly. They worked selflessly.",
-    "count": 0
+      "word": "sense",
+      "meaning": "sensible, /ˈsensəbl/: nhạy bén, khôn ngoan. nonsensical(ly), /ˌnɒnˈsensɪkl(i)/: vô lý. sensibly, /ˈsensəbli/: một cách hợp lý. (in)sensitive(ly), /(ɪn)ˈsensətɪv(li)/: (một cách) (không) nhạy cảm. (in)sensational(ly), /(ɪn)senˈseɪʃənl(i)/: (một cách) (không) gây xúc động. sensual(ly), /ˈsenʃuəl(i)/: (một cách) nhục dục. sensuous(ly), /ˈsenʃuəsli/: (một cách) đầy kích thích giác quan.",
+      "example": "She made a sensible decision. That idea is nonsensical. He acted sensibly. He responded insensitively. The news was sensationally exaggerated. The perfume was described sensually. The music played sensuously.",
+      "count": 0
     },
     {
-    "word": "sense (2)",
-    "meaning": "(de)sensitise, /ˈdesəntaɪz/: làm (mất) nhạy cảm. (in)sensitivity, /ˌɪnsensəˈtɪvəti/: (thiếu) nhạy cảm. hypersensitivity, /ˌhaɪpəsensəˈtɪvəti/: sự quá nhạy cảm. sensibility, /ˌsensəˈbɪləti/: trí giác, sự nhạy cảm. sense(less)(ness), /ˈsensləs(nəs)/: (sự) bất tỉnh, vô nghĩa. sensuality, /ˌsenʃuˈæləti/: ham muốn nhục dục. sensuousness, /ˈsenʃuəsnəs/: ham muốn nhục dục. sensor, /ˈsensər/: cảm biến. hypersensitive, /ˌhaɪpəˈsensətɪv/: quá nhạy cảm. oversensitive, /ˌəʊvəsensətɪv/: quá nhạy cảm. nonsense, /ˈnɒnsens/: vô nghĩa. sensory, /ˈsensəri/: (thuộc) cảm giác, xúc giác.",
-    "example": "The drug desensitised his pain. Her insensitivity upset him. He suffers from hypersensitivity. Her sensibility makes her a great artist. The joke was senseless. His sensuality was obvious. The poem had deep sensuousness. The sensor detected movement. She’s hypersensitive to criticism. Don’t be oversensitive. That’s complete nonsense. The painting evoked a strong sensory response.",
-    "count": 0
+      "word": "separate",
+      "meaning": "separation, /ˌsepəˈreɪʃn/: sự ngăn cách, chia cắt. (in)separable, /(ɪn)ˈseprəbl/: (không) thể tách rời. separated, /ˈsepəreɪtɪd/: ly thân. separately, /ˈseprətli/: một cách tách biệt.",
+      "example": "The separation lasted months. The twins are inseparable. They are now separated. The items were packed separately.",
+      "count": 0
     },
     {
-    "word": "sense",
-    "meaning": "sensible, /ˈsensəbl/: nhạy bén, khôn ngoan. nonsensical(ly), /ˌnɒnˈsensɪkl(i)/: vô lý. sensibly, /ˈsensəbli/: một cách hợp lý. (in)sensitive(ly), /(ɪn)ˈsensətɪv(li)/: (một cách) (không) nhạy cảm. (in)sensational(ly), /(ɪn)senˈseɪʃənl(i)/: (một cách) (không) gây xúc động. sensual(ly), /ˈsenʃuəl(i)/: (một cách) nhục dục. sensuous(ly), /ˈsenʃuəsli/: (một cách) đầy kích thích giác quan.",
-    "example": "She made a sensible decision. That idea is nonsensical. He acted sensibly. He responded insensitively. The news was sensationally exaggerated. The perfume was described sensually. The music played sensuously.",
-    "count": 0
+      "word": "shelf",
+      "meaning": "shelve, /ʃelv/: xếp vào ngăn. shelves, /ʃelvz/: giá sách. shelving, /ˈʃelvɪŋ/: vật liệu làm kệ.",
+      "example": "Please shelve the books alphabetically. The shelves were full. We need new shelving for the pantry.",
+      "count": 0
     },
     {
-    "word": "separate",
-    "meaning": "separation, /ˌsepəˈreɪʃn/: sự ngăn cách, chia cắt. (in)separable, /(ɪn)ˈseprəbl/: (không) thể tách rời. separated, /ˈsepəreɪtɪd/: ly thân. separately, /ˈseprətli/: một cách tách biệt.",
-    "example": "The separation lasted months. The twins are inseparable. They are now separated. The items were packed separately.",
-    "count": 0
+      "word": "signify",
+      "meaning": "(in)significance, /(ɪn)ˌsɪɡnɪˈfɪkəns/: (sự) (không) quan trọng. (in)significantly, /(ɪn)sɪɡˈnɪfɪkəntli/: (một cách) (không) đáng kể.",
+      "example": "The discovery has great significance. The price increased significantly. His role is insignificant in the project. That error didn’t significantly affect results.",
+      "count": 0
     },
     {
-    "word": "shelf",
-    "meaning": "shelve, /ʃelv/: xếp vào ngăn. shelves, /ʃelvz/: giá sách. shelving, /ˈʃelvɪŋ/: vật liệu làm kệ.",
-    "example": "Please shelve the books alphabetically. The shelves were full. We need new shelving for the pantry.",
-    "count": 0
+      "word": "slip",
+      "meaning": "slippage, /ˈslɪpɪdʒ/: sự trượt giá. slippery, /ˈslɪpəri/: trơn trượt.",
+      "example": "There was a slippage in profits. The road is slippery when wet.",
+      "count": 0
     },
     {
-    "word": "signify",
-    "meaning": "(in)significance, /(ɪn)ˌsɪɡnɪˈfɪkəns/: (sự) (không) quan trọng. (in)significantly, /(ɪn)sɪɡˈnɪfɪkəntli/: (một cách) (không) đáng kể.",
-    "example": "The discovery has great significance. The price increased significantly. His role is insignificant in the project. That error didn’t significantly affect results.",
-    "count": 0
+      "word": "soft",
+      "meaning": "soften, /ˈsɒfn/: làm dịu. softener, /ˈsɒfənər/: chất làm mềm. softly, /ˈsɒftli/: một cách dịu dàng.",
+      "example": "Let the butter soften. Add fabric softener. She spoke softly.",
+      "count": 0
     },
     {
-    "word": "slip",
-    "meaning": "slippage, /ˈslɪpɪdʒ/: sự trượt giá. slippery, /ˈslɪpəri/: trơn trượt.",
-    "example": "There was a slippage in profits. The road is slippery when wet.",
-    "count": 0
+      "word": "solid",
+      "meaning": "solidify, /səˈlɪdɪfaɪ/: làm cứng. solidity, /səˈlɪdəti/: sự vững chắc.",
+      "example": "Let the mixture solidify overnight. The wall has great solidity.",
+      "count": 0
     },
     {
-    "word": "soft",
-    "meaning": "soften, /ˈsɒfn/: làm dịu. softener, /ˈsɒfənər/: chất làm mềm. softly, /ˈsɒftli/: một cách dịu dàng.",
-    "example": "Let the butter soften. Add fabric softener. She spoke softly.",
-    "count": 0
+      "word": "space",
+      "meaning": "spacing, /ˈspeɪsɪŋ/: sự giãn cách. spaciousness, /ˈspeɪʃəsnəs/: tính rộng rãi. spacious(ly), /ˈspeɪʃəsli/: (một cách) rộng rãi.",
+      "example": "Check the line spacing. I admire the spaciousness of the house. The room is spaciously designed.",
+      "count": 0
     },
     {
-    "word": "solid",
-    "meaning": "solidify, /səˈlɪdɪfaɪ/: làm cứng. solidity, /səˈlɪdəti/: sự vững chắc.",
-    "example": "Let the mixture solidify overnight. The wall has great solidity.",
-    "count": 0
+      "word": "speak",
+      "meaning": "spoke, /spəʊk/: nói (quá khứ). speech, /spiːtʃ/: bài diễn văn. speaker, /ˈspiːkər/: người nói. spokesmen, /ˈspəʊksmən/: phát ngôn viên (nam). spokeswoman, /ˈspəʊkswʊmən/: phát ngôn viên (nữ). spokeswomen, /ˈspəʊkswɪmɪn/: phát ngôn viên (nữ, số nhiều). spokesperson, /ˈspəʊkspɜːsn/: người phát ngôn.",
+      "example": "He spoke at the event. Her speech was inspiring. The speaker took questions. The company’s spokesman issued a statement. The spokeswoman denied the claims. Two spokeswomen were present. The spokesperson addressed the press.",
+      "count": 0
     },
     {
-    "word": "space",
-    "meaning": "spacing, /ˈspeɪsɪŋ/: sự giãn cách. spaciousness, /ˈspeɪʃəsnəs/: tính rộng rãi. spacious(ly), /ˈspeɪʃəsli/: (một cách) rộng rãi.",
-    "example": "Check the line spacing. I admire the spaciousness of the house. The room is spaciously designed.",
-    "count": 0
+      "word": "speak (2)",
+      "meaning": "spokespeople, /ˈspəʊksˌpiːpl/: những phát ngôn viên. outspokenness, /ˌaʊtˈspəʊkənnəs/: thẳng thắn. (un)spoken, /ˌʌnˈspəʊkən/: (không) được nói ra. speechless, /ˈspiːtʃləs/: cạn lời. unspeakable, /ʌnˈspiːkəbl/: không thể diễn tả. unspeakably, /ʌnˈspiːkəbli/: cực kỳ. outspoken(ly), /ˌaʊtˈspəʊkən(li)/: (một cách) thẳng thắn.",
+      "example": "The spokespeople met the press. His outspokenness was admirable. The pain was unspoken. She was speechless with joy. That crime was unspeakable. He was unspeakably rude. She criticized them outspokenly.",
+      "count": 0
     },
     {
-    "word": "speak",
-    "meaning": "spoke, /spəʊk/: nói (quá khứ). speech, /spiːtʃ/: bài diễn văn. speaker, /ˈspiːkər/: người nói. spokesmen, /ˈspəʊksmən/: phát ngôn viên (nam). spokeswoman, /ˈspəʊkswʊmən/: phát ngôn viên (nữ). spokeswomen, /ˈspəʊkswɪmɪn/: phát ngôn viên (nữ, số nhiều). spokesperson, /ˈspəʊkspɜːsn/: người phát ngôn.",
-    "example": "He spoke at the event. Her speech was inspiring. The speaker took questions. The company’s spokesman issued a statement. The spokeswoman denied the claims. Two spokeswomen were present. The spokesperson addressed the press.",
-    "count": 0
+      "word": "speed",
+      "meaning": "sped, /sped/: sự chạy tốc độ. speeding, /ˈspiːdɪŋ/: lái xe quá tốc độ. speedy, /ˈspiːdi/: nhanh chóng. speedily, /ˈspiːdɪli/: một cách nhanh chóng.",
+      "example": "He sped down the highway. She was fined for speeding. We need a speedy solution. The issue was resolved speedily.",
+      "count": 0
     },
     {
-    "word": "speak (2)",
-    "meaning": "spokespeople, /ˈspəʊksˌpiːpl/: những phát ngôn viên. outspokenness, /ˌaʊtˈspəʊkənnəs/: thẳng thắn. (un)spoken, /ˌʌnˈspəʊkən/: (không) được nói ra. speechless, /ˈspiːtʃləs/: cạn lời. unspeakable, /ʌnˈspiːkəbl/: không thể diễn tả. unspeakably, /ʌnˈspiːkəbli/: cực kỳ. outspoken(ly), /ˌaʊtˈspəʊkən(li)/: (một cách) thẳng thắn.",
-    "example": "The spokespeople met the press. His outspokenness was admirable. The pain was unspoken. She was speechless with joy. That crime was unspeakable. He was unspeakably rude. She criticized them outspokenly.",
-    "count": 0
+      "word": "sport",
+      "meaning": "sportsman, /ˈspɔːtsmən/: vận động viên (nam). sportswoman, /ˈspɔːtsˌwʊmən/: vận động viên (nữ). sportsperson, /ˈspɔːtspɜːsn/: vận động viên. sportsmanship, /ˈspɔːtsmənʃɪp/: tinh thần thể thao. sports, /spɔːts/: các môn thể thao. sporting, /ˈspɔːtɪŋ/: (có) tính thể thao. sporty, /ˈspɔːti/: thích thể thao.",
+      "example": "He is a talented sportsman. She’s a famous sportswoman. That sportsperson won gold. They showed great sportsmanship. I enjoy watching sports. He took a sporting chance. She wears sporty outfits.",
+      "count": 0
     },
     {
-    "word": "speed",
-    "meaning": "sped, /sped/: sự chạy tốc độ. speeding, /ˈspiːdɪŋ/: lái xe quá tốc độ. speedy, /ˈspiːdi/: nhanh chóng. speedily, /ˈspiːdɪli/: một cách nhanh chóng.",
-    "example": "He sped down the highway. She was fined for speeding. We need a speedy solution. The issue was resolved speedily.",
-    "count": 0
+      "word": "stable",
+      "meaning": "(de)stabilise, /ˈsteɪbəlaɪz/: làm (mất) ổn định. (in)stability, /(ɪn)stəˈbɪləti/: (không) ổn định. stabiliser, /ˈsteɪbəlaɪzə(r)/: thiết bị ổn định. (de)stabilising, /ˈsteɪbəlaɪzɪŋ/: có tính (mất) ổn định.",
+      "example": "The government aims to stabilise prices. There’s political instability in the region. The stabiliser kept the ship balanced. Those events were destabilising.",
+      "count": 0
     },
     {
-    "word": "sport",
-    "meaning": "sportsman, /ˈspɔːtsmən/: vận động viên (nam). sportswoman, /ˈspɔːtsˌwʊmən/: vận động viên (nữ). sportsperson, /ˈspɔːtspɜːsn/: vận động viên. sportsmanship, /ˈspɔːtsmənʃɪp/: tinh thần thể thao. sports, /spɔːts/: các môn thể thao. sporting, /ˈspɔːtɪŋ/: (có) tính thể thao. sporty, /ˈspɔːti/: thích thể thao.",
-    "example": "He is a talented sportsman. She’s a famous sportswoman. That sportsperson won gold. They showed great sportsmanship. I enjoy watching sports. He took a sporting chance. She wears sporty outfits.",
-    "count": 0
+      "word": "stand",
+      "meaning": "withstand, /wɪðˈstænd/: chịu đựng. withstood, /wɪðˈstʊd/: đã chịu đựng. standing, /ˈstændɪŋ/: tư thế đứng, địa vị. upstanding, /ʌpˈstændɪŋ/: thẳng thắn, đáng kính. outstanding, /aʊtˈstændɪŋ/: nổi bật. notwithstanding, /ˌnɒtwɪðˈstændɪŋ/: tuy nhiên.",
+      "example": "These materials can withstand heat. She withstood all criticism. He has long-standing respect. He is an upstanding citizen. Her work is outstanding. Notwithstanding the delay, the work continued.",
+      "count": 0
     },
     {
-    "word": "stable",
-    "meaning": "(de)stabilise, /ˈsteɪbəlaɪz/: làm (mất) ổn định. (in)stability, /(ɪn)stəˈbɪləti/: (không) ổn định. stabiliser, /ˈsteɪbəlaɪzə(r)/: thiết bị ổn định. (de)stabilising, /ˈsteɪbəlaɪzɪŋ/: có tính (mất) ổn định.",
-    "example": "The government aims to stabilise prices. There’s political instability in the region. The stabiliser kept the ship balanced. Those events were destabilising.",
-    "count": 0
+      "word": "state",
+      "meaning": "restate, /ˌriːˈsteɪt/: nhấn mạnh lại. overstate, /ˌəʊvəˈsteɪt/: phóng đại. understate, /ˌʌndəˈsteɪt/: nói giảm. statement, /ˈsteɪtmənt/: bản tuyên bố. understatement, /ˌʌndəˈsteɪtmənt/: nói nhẹ. overstated, /ˌəʊvəˈsteɪtɪd/: bị phóng đại. understated, /ˌʌndəˈsteɪtɪd/: bị giảm bớt.",
+      "example": "She restated her position clearly. He overstated the facts. She tends to understate problems. The statement was official. Saying it's cold is an understatement. The importance was overstated. The issue was understated in the report.",
+      "count": 0
     },
     {
-    "word": "stand",
-    "meaning": "withstand, /wɪðˈstænd/: chịu đựng. withstood, /wɪðˈstʊd/: đã chịu đựng. standing, /ˈstændɪŋ/: tư thế đứng, địa vị. upstanding, /ʌpˈstændɪŋ/: thẳng thắn, đáng kính. outstanding, /aʊtˈstændɪŋ/: nổi bật. notwithstanding, /ˌnɒtwɪðˈstændɪŋ/: tuy nhiên.",
-    "example": "These materials can withstand heat. She withstood all criticism. He has long-standing respect. He is an upstanding citizen. Her work is outstanding. Notwithstanding the delay, the work continued.",
-    "count": 0
+      "word": "steady",
+      "meaning": "unsteady, /ʌnˈstedi/: không ổn định, bất ổn. (un)steadily, /(ʌn)ˈstedəli/: một cách (không) ổn định, đều đặn.",
+      "example": "The ladder is unsteady. He walked unsteadily after the fall.",
+      "count": 0
     },
     {
-    "word": "state",
-    "meaning": "restate, /ˌriːˈsteɪt/: nhấn mạnh lại. overstate, /ˌəʊvəˈsteɪt/: phóng đại. understate, /ˌʌndəˈsteɪt/: nói giảm. statement, /ˈsteɪtmənt/: bản tuyên bố. understatement, /ˌʌndəˈsteɪtmənt/: nói nhẹ. overstated, /ˌəʊvəˈsteɪtɪd/: bị phóng đại. understated, /ˌʌndəˈsteɪtɪd/: bị giảm bớt.",
-    "example": "She restated her position clearly. He overstated the facts. She tends to understate problems. The statement was official. Saying it's cold is an understatement. The importance was overstated. The issue was understated in the report.",
-    "count": 0
-    },            
+      "word": "stimulate",
+      "meaning": "stimulation, /ˌstɪmjʊˈleɪʃn/: sự kích thích. stimulant, /ˈstɪmjələnt/: chất kích thích. stimulus, /ˈstɪmjələs/: sự kích thích. stimuli, /ˈstɪmjʊlaɪ/: các tác nhân kích thích. stimulating, /ˈstɪmjəleɪtɪŋ/: kích thích, thú vị. stimulated, /ˈstɪmjəleɪtɪd/: bị kích thích.",
+      "example": "Mental stimulation helps keep your brain sharp. Coffee is a common stimulant. Music acts as a stimulus. These lights are visual stimuli. The lecture was very stimulating. Her curiosity was stimulated by the mystery.",
+      "count": 0
+    },
     {
-    "word": "steady",
-    "meaning": "unsteady, /ʌnˈstedi/: không ổn định, bất ổn. (un)steadily, /(ʌn)ˈstedəli/: một cách (không) ổn định, đều đặn.",
-    "example": "The ladder is unsteady. He walked unsteadily after the fall.",
-    "count": 0
+      "word": "strong",
+      "meaning": "strengthen, /ˈstreŋθn/: gia cố, làm mạnh lên. strength, /streŋθ/: sức mạnh. stronghold, /ˈstrɒŋhəʊld/: thành trì. strongly, /ˈstrɒŋli/: một cách mạnh mẽ.",
+      "example": "They aim to strengthen the economy. She showed great strength. The castle was a stronghold of the rebels. I strongly disagree with that view.",
+      "count": 0
     },
     {
-    "word": "stimulate",
-    "meaning": "stimulation, /ˌstɪmjʊˈleɪʃn/: sự kích thích. stimulant, /ˈstɪmjələnt/: chất kích thích. stimulus, /ˈstɪmjələs/: sự kích thích. stimuli, /ˈstɪmjʊlaɪ/: các tác nhân kích thích. stimulating, /ˈstɪmjəleɪtɪŋ/: kích thích, thú vị. stimulated, /ˈstɪmjəleɪtɪd/: bị kích thích.",
-    "example": "Mental stimulation helps keep your brain sharp. Coffee is a common stimulant. Music acts as a stimulus. These lights are visual stimuli. The lecture was very stimulating. Her curiosity was stimulated by the mystery.",
-    "count": 0
+      "word": "structure",
+      "meaning": "infrastructure, /ˈɪnfrəstrʌktʃə/: cơ sở hạ tầng. structural(ly), /ˈstrʌktʃər(ə)li/: (về) cấu trúc. (un)structured, /(ˌʌn)ˈstrʌktʃərd/: (không) có bố cục, cấu trúc rõ.",
+      "example": "The country needs better infrastructure. The problem is structural. The meeting was unstructured and confusing.",
+      "count": 0
     },
     {
-    "word": "strong",
-    "meaning": "strengthen, /ˈstreŋθn/: gia cố, làm mạnh lên. strength, /streŋθ/: sức mạnh. stronghold, /ˈstrɒŋhəʊld/: thành trì. strongly, /ˈstrɒŋli/: một cách mạnh mẽ.",
-    "example": "They aim to strengthen the economy. She showed great strength. The castle was a stronghold of the rebels. I strongly disagree with that view.",
-    "count": 0
+      "word": "substance",
+      "meaning": "substantiation, /səbˌstænʃiˈeɪʃn/: sự chứng minh. substantiate, /səbˈstænʃieɪt/: chứng minh. (in)substantial(ly), /(ˌɪn)səbˈstænʃl(i)/: (một cách) (không) đáng kể.",
+      "example": "The theory lacked substantiation. Can you substantiate your claim? The cost is insubstantial.",
+      "count": 0
     },
     {
-    "word": "structure",
-    "meaning": "infrastructure, /ˈɪnfrəstrʌktʃə/: cơ sở hạ tầng. structural(ly), /ˈstrʌktʃər(ə)li/: (về) cấu trúc. (un)structured, /(ˌʌn)ˈstrʌktʃərd/: (không) có bố cục, cấu trúc rõ.",
-    "example": "The country needs better infrastructure. The problem is structural. The meeting was unstructured and confusing.",
-    "count": 0
+      "word": "suggest",
+      "meaning": "suggestion, /səˈdʒestʃn/: sự đề nghị. suggested, /səˈdʒestɪd/: được đề xuất. suggestive(ly), /səˈdʒestɪv(li)/: (một cách) mang tính đề nghị. suggestible, /səˈdʒestəbl/: dễ bị ảnh hưởng.",
+      "example": "She made a helpful suggestion. The solution suggested by the teacher was effective. He nodded suggestively. Children are highly suggestible.",
+      "count": 0
     },
     {
-    "word": "substance",
-    "meaning": "substantiation, /səbˌstænʃiˈeɪʃn/: sự chứng minh. substantiate, /səbˈstænʃieɪt/: chứng minh. (in)substantial(ly), /(ˌɪn)səbˈstænʃl(i)/: (một cách) (không) đáng kể.",
-    "example": "The theory lacked substantiation. Can you substantiate your claim? The cost is insubstantial.",
-    "count": 0
+      "word": "sympathy",
+      "meaning": "sympathise, /ˈsɪmpəθaɪz/: thông cảm. sympathiser, /ˈsɪmpəθaɪzər/: người ủng hộ. (un)sympathetic, /ˌʌnsɪmpəˈθetɪk/: (không) đồng cảm. (un)sympathetically, /(ʌn)sɪmpəˈθetɪkli/: một cách (không) cảm thông.",
+      "example": "I sympathise with your loss. She’s a known political sympathiser. The teacher was unsympathetic. He listened sympathetically.",
+      "count": 0
     },
     {
-    "word": "suggest",
-    "meaning": "suggestion, /səˈdʒestʃn/: sự đề nghị. suggested, /səˈdʒestɪd/: được đề xuất. suggestive(ly), /səˈdʒestɪv(li)/: (một cách) mang tính đề nghị. suggestible, /səˈdʒestəbl/: dễ bị ảnh hưởng.",
-    "example": "She made a helpful suggestion. The solution suggested by the teacher was effective. He nodded suggestively. Children are highly suggestible.",
-    "count": 0
+      "word": "talk",
+      "meaning": "talker, /ˈtɔːkər/: người nói. talkie, /ˈtɔːki/: phim nói. talkback, /ˈtɔːkbæk/: ý kiến đóng góp. talkative, /ˈtɔːkətɪv/: nói nhiều.",
+      "example": "He’s a good talker. They watched an old black-and-white talkie. The show features a talkback segment. She’s very talkative.",
+      "count": 0
     },
     {
-    "word": "sympathy",
-    "meaning": "sympathise, /ˈsɪmpəθaɪz/: thông cảm. sympathiser, /ˈsɪmpəθaɪzər/: người ủng hộ. (un)sympathetic, /ˌʌnsɪmpəˈθetɪk/: (không) đồng cảm. (un)sympathetically, /(ʌn)sɪmpəˈθetɪkli/: một cách (không) cảm thông.",
-    "example": "I sympathise with your loss. She’s a known political sympathiser. The teacher was unsympathetic. He listened sympathetically.",
-    "count": 0
+      "word": "tend",
+      "meaning": "tendency, /ˈtendənsi/: xu hướng.",
+      "example": "There’s a growing tendency to work from home.",
+      "count": 0
     },
     {
-    "word": "talk",
-    "meaning": "talker, /ˈtɔːkər/: người nói. talkie, /ˈtɔːki/: phim nói. talkback, /ˈtɔːkbæk/: ý kiến đóng góp. talkative, /ˈtɔːkətɪv/: nói nhiều.",
-    "example": "He’s a good talker. They watched an old black-and-white talkie. The show features a talkback segment. She’s very talkative.",
-    "count": 0
+      "word": "terror",
+      "meaning": "terrorise, /ˈterəraɪz/: khủng bố. terrify, /ˈterəfaɪ/: làm kinh hãi. terrorist, /ˈterərɪst/: kẻ khủng bố. terrorism, /ˈterərɪzəm/: chủ nghĩa khủng bố. terror, /ˈterər/: kinh hoàng. terrible, /ˈterəbl/: kinh khủng. terrific, /təˈrɪfɪk/: xuất sắc. terrifying, /ˈterəfaɪɪŋ/: kinh hoàng. terrified, /ˈterəfaɪd/: sợ hãi. terribly, /ˈterəbli/: rất, cực kỳ.",
+      "example": "They tried to terrorise the public. The loud noise terrified the child. The terrorist was caught. The country faces terrorism threats. She felt pure terror. That movie was terrible. His performance was terrific. It was a terrifying experience. I’m terrified of spiders. He was terribly late.",
+      "count": 0
     },
     {
-    "word": "tend",
-    "meaning": "tendency, /ˈtendənsi/: xu hướng.",
-    "example": "There’s a growing tendency to work from home.",
-    "count": 0
+      "word": "think",
+      "meaning": "thought, /θɔːt/: suy nghĩ, tư duy. thinker, /ˈθɪŋkər/: nhà tư tưởng. thinking, /ˈθɪŋkɪŋ/: tư duy. thoughtfulness, /ˈθɔːtfəlnəs/: sự chu đáo. thoughtlessness, /ˈθɔːtləsnəs/: sự vô tâm. (un)thinkable, /ʌnˈθɪŋkəbl/: (không) thể tưởng tượng. thoughtful(ly), /ˈθɔːtfl(i)/: (một cách) chu đáo. thoughtless(ly), /ˈθɔːtləsli/: (một cách) vô tâm.",
+      "example": "He paused in thought. She’s a deep thinker. Creative thinking is valuable. Her thoughtfulness was appreciated. His thoughtlessness hurt her. That’s unthinkable! She acted thoughtfully. He spoke thoughtlessly.",
+      "count": 0
     },
     {
-    "word": "terror",
-    "meaning": "terrorise, /ˈterəraɪz/: khủng bố. terrify, /ˈterəfaɪ/: làm kinh hãi. terrorist, /ˈterərɪst/: kẻ khủng bố. terrorism, /ˈterərɪzəm/: chủ nghĩa khủng bố. terror, /ˈterər/: kinh hoàng. terrible, /ˈterəbl/: kinh khủng. terrific, /təˈrɪfɪk/: xuất sắc. terrifying, /ˈterəfaɪɪŋ/: kinh hoàng. terrified, /ˈterəfaɪd/: sợ hãi. terribly, /ˈterəbli/: rất, cực kỳ.",
-    "example": "They tried to terrorise the public. The loud noise terrified the child. The terrorist was caught. The country faces terrorism threats. She felt pure terror. That movie was terrible. His performance was terrific. It was a terrifying experience. I’m terrified of spiders. He was terribly late.",
-    "count": 0
+      "word": "threat",
+      "meaning": "threaten, /ˈθretn/: đe dọa. threatened, /ˈθretənd/: bị đe dọa. threatening(ly), /ˈθretnɪŋli/: (một cách) đe dọa.",
+      "example": "He threatened to leave. The animals are threatened by extinction. She glared at him threateningly.",
+      "count": 0
     },
     {
-    "word": "think",
-    "meaning": "thought, /θɔːt/: suy nghĩ, tư duy. thinker, /ˈθɪŋkər/: nhà tư tưởng. thinking, /ˈθɪŋkɪŋ/: tư duy. thoughtfulness, /ˈθɔːtfəlnəs/: sự chu đáo. thoughtlessness, /ˈθɔːtləsnəs/: sự vô tâm. (un)thinkable, /ʌnˈθɪŋkəbl/: (không) thể tưởng tượng. thoughtful(ly), /ˈθɔːtfl(i)/: (một cách) chu đáo. thoughtless(ly), /ˈθɔːtləsli/: (một cách) vô tâm.",
-    "example": "He paused in thought. She’s a deep thinker. Creative thinking is valuable. Her thoughtfulness was appreciated. His thoughtlessness hurt her. That’s unthinkable! She acted thoughtfully. He spoke thoughtlessly.",
-    "count": 0
+      "word": "time",
+      "meaning": "mistime, /ˌmɪsˈtaɪm/: định thời gian không đúng lúc. timer, /ˈtaɪmər/: bộ hẹn giờ. timing, /ˈtaɪmɪŋ/: sự tính toán thời gian. overtime, /ˈəʊvətaɪm/: làm thêm giờ. timetable, /ˈtaɪmteɪbl/: thời gian biểu. timeless(ness), /ˈtaɪmləs(nəs)/: (sự) vượt thời gian. (un)timely, /ˈtaɪmli/: (không) đúng lúc. timeless(ly), /ˈtaɪmləsli/: một cách vượt thời gian.",
+      "example": "He mistimed the pass. Set the timer for 10 minutes. Her timing was perfect. I worked overtime last week. Check the class timetable. Her beauty is timeless. The rescue was timely. The book is timelessly relevant.",
+      "count": 0
     },
     {
-    "word": "threat",
-    "meaning": "threaten, /ˈθretn/: đe dọa. threatened, /ˈθretənd/: bị đe dọa. threatening(ly), /ˈθretnɪŋli/: (một cách) đe dọa.",
-    "example": "He threatened to leave. The animals are threatened by extinction. She glared at him threateningly.",
-    "count": 0
+      "word": "transit",
+      "meaning": "transition, /trænˈzɪʃn/: sự chuyển đổi. transitory, /ˈtrænzətri/: tạm thời. transitional, /trænˈzɪʃənl/: mang tính chuyển tiếp. transitionally, /trænˈzɪʃnəli/: quá độ, chuyển tiếp.",
+      "example": "The country is in a political transition. These feelings are transitory. A transitional period is expected. Things changed transitionally over time.",
+      "count": 0
     },
     {
-    "word": "time",
-    "meaning": "mistime, /ˌmɪsˈtaɪm/: định thời gian không đúng lúc. timer, /ˈtaɪmər/: bộ hẹn giờ. timing, /ˈtaɪmɪŋ/: sự tính toán thời gian. overtime, /ˈəʊvətaɪm/: làm thêm giờ. timetable, /ˈtaɪmteɪbl/: thời gian biểu. timeless(ness), /ˈtaɪmləs(nəs)/: (sự) vượt thời gian. (un)timely, /ˈtaɪmli/: (không) đúng lúc. timeless(ly), /ˈtaɪmləsli/: một cách vượt thời gian.",
-    "example": "He mistimed the pass. Set the timer for 10 minutes. Her timing was perfect. I worked overtime last week. Check the class timetable. Her beauty is timeless. The rescue was timely. The book is timelessly relevant.",
-    "count": 0
+      "word": "type",
+      "meaning": "typeset, /ˈtaɪpset/: sắp chữ. typecast, /ˈtaɪpkɑːst/: đóng khung. typify, /ˈtɪpɪfaɪ/: điển hình. typist, /ˈtaɪpɪst/: người đánh máy. typewriter, /ˈtaɪpraɪtər/: máy đánh chữ. typeface, /ˈtaɪpfeɪs/: kiểu chữ. typesetting, /ˈtaɪpsetɪŋ/: sự sắp chữ. typesetter, /ˈtaɪpsetər/: thợ xếp chữ. typewritten, /ˈtaɪprɪtn/: được đánh máy. typical(ly), /ˈtɪpɪkl(i)/: (một cách) điển hình.",
+      "example": "He learned to typeset pages. She was typecast as the villain. That style typifies the 80s. The typist finished quickly. I used a typewriter in school. This font uses a modern typeface. Typesetting takes skill. The typesetter adjusted the layout. The document was typewritten. She answered typically sarcastically.",
+      "count": 0
     },
     {
-    "word": "transit",
-    "meaning": "transition, /trænˈzɪʃn/: sự chuyển đổi. transitory, /ˈtrænzətri/: tạm thời. transitional, /trænˈzɪʃənl/: mang tính chuyển tiếp. transitionally, /trænˈzɪʃnəli/: quá độ, chuyển tiếp.",
-    "example": "The country is in a political transition. These feelings are transitory. A transitional period is expected. Things changed transitionally over time.",
-    "count": 0
+      "word": "up",
+      "meaning": "uppermost, /ˈʌpəməʊst/: cao nhất. upright, /ˈʌpraɪt/: thẳng đứng, ngay ngắn. upward(s), /ˈʌpwəd(z)/: hướng lên trên. upwardly, /ˈʌpwədli/: hướng lên trên.",
+      "example": "That was the uppermost shelf. Stand upright for posture. Look upward. Prices moved upwardly this quarter.",
+      "count": 0
     },
     {
-    "word": "type",
-    "meaning": "typeset, /ˈtaɪpset/: sắp chữ. typecast, /ˈtaɪpkɑːst/: đóng khung. typify, /ˈtɪpɪfaɪ/: điển hình. typist, /ˈtaɪpɪst/: người đánh máy. typewriter, /ˈtaɪpraɪtər/: máy đánh chữ. typeface, /ˈtaɪpfeɪs/: kiểu chữ. typesetting, /ˈtaɪpsetɪŋ/: sự sắp chữ. typesetter, /ˈtaɪpsetər/: thợ xếp chữ. typewritten, /ˈtaɪprɪtn/: được đánh máy. typical(ly), /ˈtɪpɪkl(i)/: (một cách) điển hình.",
-    "example": "He learned to typeset pages. She was typecast as the villain. That style typifies the 80s. The typist finished quickly. I used a typewriter in school. This font uses a modern typeface. Typesetting takes skill. The typesetter adjusted the layout. The document was typewritten. She answered typically sarcastically.",
-    "count": 0
+      "word": "use",
+      "meaning": "abuse: lạm dụng. misuse: sử dụng sai. reuse: tái sử dụng. overuse: sử dụng quá mức. user: người sử dụng. usefulness: tính hữu dụng. usage: cách sử dụng. uselessness: sự vô dụng. unused: chưa sử dụng. usable: có thể sử dụng. reusable: có thể tái sử dụng. abused: bị lạm dụng. abusive: lạm dụng. usefully: một cách hữu dụng.",
+      "example": "He abused the system for personal gain. Misuse of funds led to legal action. We should reuse old containers. The overuse of antibiotics is dangerous. The app tracks each user’s time. This knife is known for its usefulness. Usage instructions are included. The tool’s uselessness made it obsolete. This coupon is unused. The material is unusable. These bags are reusable. The child was abused. He spoke abusively. She reacted usefully in the situation.",
+      "count": 0
     },
     {
-    "word": "up",
-    "meaning": "uppermost, /ˈʌpəməʊst/: cao nhất. upright, /ˈʌpraɪt/: thẳng đứng, ngay ngắn. upward(s), /ˈʌpwəd(z)/: hướng lên trên. upwardly, /ˈʌpwədli/: hướng lên trên.",
-    "example": "That was the uppermost shelf. Stand upright for posture. Look upward. Prices moved upwardly this quarter.",
-    "count": 0
+      "word": "value",
+      "meaning": "revalue, /ˌriːˈvæljuː/: đánh giá lại, nâng giá. overvalue, /ˌəʊvəˈvæljuː/: đánh giá quá cao. evaluate, /ɪˈvæljueɪt/: đánh giá. (re)evaluation, /ˌ(riː)ɪˌvæljuˈeɪʃn/: sự (tái) đánh giá. evaluation, /ˌɪvæljuˈeɪʃn/: sự đánh giá. overvaluation, /ˌəʊvərˌvæljuˈeɪʃn/: sự định giá quá cao. valuer, /ˈvæljuər/: người định giá. valuables, /ˈvæljəblz/: vật quý giá. (in)valuable, /ˌɪnˈvæljuəbl/: (vô) giá trị. valueless, /ˈvæljuləs/: không có tác dụng.",
+      "example": "The currency was revalued. He tends to overvalue his input. They evaluate the project yearly. A reevaluation is needed. The evaluation took two days. That’s an overvaluation of the house. The valuer arrived late. Keep your valuables in a safe. Her advice was invaluable. That item is valueless now.",
+      "count": 0
     },
     {
-    "word": "use",
-    "meaning": "abuse, /əˈbjuːz/: lạm dụng. misuse, /ˌmɪsˈjuːz/: sử dụng sai, lạm dụng. reuse, /ˌriːˈjuːz/: tái sử dụng. overuse, /ˌəʊvəˈjuːz/: sử dụng quá mức. (ab)user, /ə(b)ˈjuːzər/: (người) sử dụng. usefulness, /ˈjuːsfəlnəs/: tính hữu dụng. usage, /ˈjuːsɪdʒ/: cách sử dụng. uselessness, /ˈjuːsləsnəs/: sự vô dụng. (un)used, /ˌʌnˈjuːzd/: (chưa) được sử dụng. (un)usable, /ˈjuːzəbl/: (không) thể sử dụng. reusable, /ˌriːˈjuːzəbl/: có thể tái sử dụng. abused, /əˈbjuːzd/: bị lạm dụng. abusive(ly), /əˈbjuːsɪv(li)/: (một cách) lạm dụng. usefully, /ˈjuːsfəli/: một cách hữu dụng.",
-    "example": "He abused the system for personal gain. Misuse of funds led to legal action. We should reuse old containers. The overuse of antibiotics is dangerous. The app tracks each user’s time. This knife is known for its usefulness. Usage instructions are included. The tool’s uselessness made it obsolete. This coupon is unused. The material is unusable. These bags are reusable. The child was abused. He spoke abusively. She reacted usefully in the situation.",
-    "count": 0
+      "word": "weigh",
+      "meaning": "weight, /weɪt/: cân nặng. weightlifter, /ˈweɪtlɪftər/: vận động viên cử tạ. weightlifting, /ˈweɪtlɪftɪŋ/: môn cử tạ. weightiness, /ˈweɪtinəs/: tính quan trọng. overweight, /ˌəʊvəˈweɪt/: béo phì. underweight, /ˌʌndəˈweɪt/: nhẹ cân. (un)weighted, /ˈweɪtɪd/: (không) được cân. weightless(ness), /ˈweɪtləs(nəs)/: (sự) không trọng lượng. weighty, /ˈweɪti/: nặng, nghiêm trọng.",
+      "example": "He gained a lot of weight. The weightlifter won gold. Weightlifting is his passion. Her words had great weightiness. He became overweight after the holidays. She is slightly underweight. The dice are weighted. The astronaut floated in weightlessness. That’s a weighty matter.",
+      "count": 0
     },
     {
-    "word": "value",
-    "meaning": "revalue, /ˌriːˈvæljuː/: đánh giá lại, nâng giá. overvalue, /ˌəʊvəˈvæljuː/: đánh giá quá cao. evaluate, /ɪˈvæljueɪt/: đánh giá. (re)evaluation, /ˌ(riː)ɪˌvæljuˈeɪʃn/: sự (tái) đánh giá. evaluation, /ˌɪvæljuˈeɪʃn/: sự đánh giá. overvaluation, /ˌəʊvərˌvæljuˈeɪʃn/: sự định giá quá cao. valuer, /ˈvæljuər/: người định giá. valuables, /ˈvæljəblz/: vật quý giá. (in)valuable, /ˌɪnˈvæljuəbl/: (vô) giá trị. valueless, /ˈvæljuləs/: không có tác dụng.",
-    "example": "The currency was revalued. He tends to overvalue his input. They evaluate the project yearly. A reevaluation is needed. The evaluation took two days. That’s an overvaluation of the house. The valuer arrived late. Keep your valuables in a safe. Her advice was invaluable. That item is valueless now.",
-    "count": 0
+      "word": "wild",
+      "meaning": "wilderness, /ˈwɪldənəs/: vùng hoang dã. wildlife, /ˈwaɪldlaɪf/: động vật hoang dã. wildness, /ˈwaɪldnəs/: tính chất hoang dã. wildly, /ˈwaɪldli/: điên dại, hoang dã.",
+      "example": "They explored the wilderness. The park protects wildlife. The wildness of the storm was shocking. He danced wildly.",
+      "count": 0
     },
     {
-    "word": "weigh",
-    "meaning": "weight, /weɪt/: cân nặng. weightlifter, /ˈweɪtlɪftər/: vận động viên cử tạ. weightlifting, /ˈweɪtlɪftɪŋ/: môn cử tạ. weightiness, /ˈweɪtinəs/: tính quan trọng. overweight, /ˌəʊvəˈweɪt/: béo phì. underweight, /ˌʌndəˈweɪt/: nhẹ cân. (un)weighted, /ˈweɪtɪd/: (không) được cân. weightless(ness), /ˈweɪtləs(nəs)/: (sự) không trọng lượng. weighty, /ˈweɪti/: nặng, nghiêm trọng.",
-    "example": "He gained a lot of weight. The weightlifter won gold. Weightlifting is his passion. Her words had great weightiness. He became overweight after the holidays. She is slightly underweight. The dice are weighted. The astronaut floated in weightlessness. That’s a weighty matter.",
-    "count": 0
+      "word": "wise",
+      "meaning": "wisdom, /ˈwɪzdəm/: trí khôn, sự thông thái. (un)wise(ly), /ˈ(wɪz)(li)/: (một cách) (không) khôn ngoan.",
+      "example": "He is full of wisdom. She acted unwisely in that situation.",
+      "count": 0
     },
     {
-    "word": "wild",
-    "meaning": "wilderness, /ˈwɪldənəs/: vùng hoang dã. wildlife, /ˈwaɪldlaɪf/: động vật hoang dã. wildness, /ˈwaɪldnəs/: tính chất hoang dã. wildly, /ˈwaɪldli/: điên dại, hoang dã.",
-    "example": "They explored the wilderness. The park protects wildlife. The wildness of the storm was shocking. He danced wildly.",
-    "count": 0
+      "word": "reword",
+      "meaning": "reword, /ˌriːˈwɜːd/: diễn đạt lại, soạn lại. (re)wording, /ˌriːˈwɜːdɪŋ/: cách dùng từ (soạn lại từ). wordplay, /ˈwɜːdpleɪ/: chơi chữ. wordy, /ˈwɜːdi/: dài dòng. (re)worded, /ˌriːˈwɜːdɪd/: được diễn đạt (lại). wordless(ly), /ˈwɜːdləs(li)/: (một cách) không thể diễn tả bằng lời.",
+      "example": "She reworded the sentence for clarity. The legal document needs careful rewording. The comedian is known for clever wordplay. His explanation was too wordy. The statement was reworded formally. He stared wordlessly at the scene.",
+      "count": 0
     },
     {
-    "word": "wise",
-    "meaning": "wisdom, /ˈwɪzdəm/: trí khôn, sự thông thái. (un)wise(ly), /ˈ(wɪz)(li)/: (một cách) (không) khôn ngoan.",
-    "example": "He is full of wisdom. She acted unwisely in that situation.",
-    "count": 0
+      "word": "work",
+      "meaning": "rework, /ˌriːˈwɜːk/: làm lại. overwork, /ˌəʊvəˈwɜːk/: làm việc quá sức. worker, /ˈwɜːkər/: công nhân. works, /wɜːks/: tác phẩm. workplace, /ˈwɜːkpleɪs/: nơi làm việc. working, /ˈwɜːkɪŋ/: (thuộc) công việc. (un)workable, /ʌnˈwɜːkəbl/: (không) thể thực hiện.",
+      "example": "We need to rework the design. She often overworks herself. The workers went on strike. His collected works are famous. Safety is important in the workplace. They discussed the working hours. That plan is unworkable.",
+      "count": 0
     },
     {
-    "word": "reword",
-    "meaning": "reword, /ˌriːˈwɜːd/: diễn đạt lại, soạn lại. (re)wording, /ˌriːˈwɜːdɪŋ/: cách dùng từ (soạn lại từ). wordplay, /ˈwɜːdpleɪ/: chơi chữ. wordy, /ˈwɜːdi/: dài dòng. (re)worded, /ˌriːˈwɜːdɪd/: được diễn đạt (lại). wordless(ly), /ˈwɜːdləs(li)/: (một cách) không thể diễn tả bằng lời.",
-    "example": "She reworded the sentence for clarity. The legal document needs careful rewording. The comedian is known for clever wordplay. His explanation was too wordy. The statement was reworded formally. He stared wordlessly at the scene.",
-    "count": 0
+      "word": "worth",
+      "meaning": "worthlessness, /ˈwɜːθləsnəs/: sự vô dụng. worthy, /ˈwɜːði/: xứng đáng. worthless, /ˈwɜːθləs/: vô giá trị. worthwhile, /ˌwɜːθˈwaɪl/: đáng giá.",
+      "example": "She felt a deep sense of worthlessness. He is a worthy opponent. That item is worthless now. Helping others is always worthwhile.",
+      "count": 0
     },
     {
-    "word": "work",
-    "meaning": "rework, /ˌriːˈwɜːk/: làm lại. overwork, /ˌəʊvəˈwɜːk/: làm việc quá sức. worker, /ˈwɜːkər/: công nhân. works, /wɜːks/: tác phẩm. workplace, /ˈwɜːkpleɪs/: nơi làm việc. working, /ˈwɜːkɪŋ/: (thuộc) công việc. (un)workable, /ʌnˈwɜːkəbl/: (không) thể thực hiện.",
-    "example": "We need to rework the design. She often overworks herself. The workers went on strike. His collected works are famous. Safety is important in the workplace. They discussed the working hours. That plan is unworkable.",
-    "count": 0
+      "word": "write",
+      "meaning": "rewrite, /ˌriːˈraɪt/: viết lại. (re)wrote, /ˌ(riː)ˈrəʊt/: (đã) viết lại. (re)written, /ˌ(riː)ˈrɪtn/: (đã) được viết lại. writing(s), /ˈraɪtɪŋ(z)/: sự viết/bài viết. writer, /ˈraɪtər/: tác giả, nhà văn. unwritten, /ʌnˈrɪtn/: bất thành văn.",
+      "example": "He had to rewrite the essay. She rewrote the ending. The script was rewritten for clarity. His writings are inspiring. She is a well-known writer. It’s an unwritten rule.",
+      "count": 0
     },
     {
-    "word": "worth",
-    "meaning": "worthlessness, /ˈwɜːθləsnəs/: sự vô dụng. worthy, /ˈwɜːði/: xứng đáng. worthless, /ˈwɜːθləs/: vô giá trị. worthwhile, /ˌwɜːθˈwaɪl/: đáng giá.",
-    "example": "She felt a deep sense of worthlessness. He is a worthy opponent. That item is worthless now. Helping others is always worthwhile.",
-    "count": 0
+      "word": "young",
+      "meaning": "youngster, /ˈjʌŋstər/: đứa con, người trẻ. youth, /juːθ/: thanh xuân, tuổi trẻ. youthful, /ˈjuːθfl/: trẻ trung.",
+      "example": "The youngster was eager to learn. She remembered her youth fondly. He has a youthful spirit.",
+      "count": 0
     },
     {
-    "word": "write",
-    "meaning": "rewrite, /ˌriːˈraɪt/: viết lại. (re)wrote, /ˌ(riː)ˈrəʊt/: (đã) viết lại. (re)written, /ˌ(riː)ˈrɪtn/: (đã) được viết lại. writing(s), /ˈraɪtɪŋ(z)/: sự viết/bài viết. writer, /ˈraɪtər/: tác giả, nhà văn. unwritten, /ʌnˈrɪtn/: bất thành văn.",
-    "example": "He had to rewrite the essay. She rewrote the ending. The script was rewritten for clarity. His writings are inspiring. She is a well-known writer. It’s an unwritten rule.",
-    "count": 0
+      "word": "zeal",
+      "meaning": "zealot, /ˈzelət/: người cuồng tín, người quá khích. zealous(ly), /ˈzeləs(li)/: (một cách) sốt sắng, đầy nhiệt huyết.",
+      "example": "The zealot refused to compromise. She supported the cause zealously.",
+      "count": 0
     },
     {
-    "word": "young",
-    "meaning": "youngster, /ˈjʌŋstər/: đứa con, người trẻ. youth, /juːθ/: thanh xuân, tuổi trẻ. youthful, /ˈjuːθfl/: trẻ trung.",
-    "example": "The youngster was eager to learn. She remembered her youth fondly. He has a youthful spirit.",
-    "count": 0
+      "word": "avoid",
+      "meaning": "avoidance, /əˈvɔɪdəns/: sự tránh. (un)avoidable, /əˈvɔɪdəbl/: (không thể) tránh khỏi. (un)avoidably, /ˌʌnəˈvɔɪdəbli/: (một cách không thể) tránh khỏi.",
+      "example": "His avoidance of the issue was clear. The damage was unavoidable. The crash was unavoidably caused by the fog.",
+      "count": 0
     },
     {
-    "word": "zeal",
-    "meaning": "zealot, /ˈzelət/: người cuồng tín, người quá khích. zealous(ly), /ˈzeləs(li)/: (một cách) sốt sắng, đầy nhiệt huyết.",
-    "example": "The zealot refused to compromise. She supported the cause zealously.",
-    "count": 0
-    },            
+      "word": "awe",
+      "meaning": "awfulness, /ˈɔːflnəs/: sự khủng khiếp. awesomeness, /ˈɔːsəmnəs/: sự tuyệt vời. awestruck, /ˈɔːstrʌk/: kinh ngạc. awfully(ly), /ˈɔːf(ə)li/: (một cách) kinh khủng. awesome(ly), /ˈɔːs(ə)mli/: (một cách) tuyệt vời.",
+      "example": "The awfulness of the event shocked everyone. Her awesomeness was undeniable. He was awestruck by the view. It was awfully noisy. She danced awesomely.",
+      "count": 0
+    },
     {
-    "word": "avoid",
-    "meaning": "avoidance, /əˈvɔɪdəns/: sự tránh. (un)avoidable, /əˈvɔɪdəbl/: (không thể) tránh khỏi. (un)avoidably, /ˌʌnəˈvɔɪdəbli/: (một cách không thể) tránh khỏi.",
-    "example": "His avoidance of the issue was clear. The damage was unavoidable. The crash was unavoidably caused by the fog.",
-    "count": 0
+      "word": "believe",
+      "meaning": "disbelieve, /ˌdɪsbɪˈliːv/: không tin. belief, /bɪˈliːf/: niềm tin. believer, /bɪˈliːvər/: người tin tưởng. (un)believable, /ˌʌnbɪˈliːvəbl/: (không) thể tin được. disbelieving(ly), /ˌdɪsbɪˈliːvɪŋ(li)/: (một cách) không tin.",
+      "example": "I disbelieve that rumor. He has a strong belief in honesty. She’s a true believer. That’s unbelievable! He looked at me disbelievingly.",
+      "count": 0
     },
     {
-    "word": "awe",
-    "meaning": "awfulness, /ˈɔːflnəs/: sự khủng khiếp. awesomeness, /ˈɔːsəmnəs/: sự tuyệt vời. awestruck, /ˈɔːstrʌk/: kinh ngạc. awfully(ly), /ˈɔːf(ə)li/: (một cách) kinh khủng. awesome(ly), /ˈɔːs(ə)mli/: (một cách) tuyệt vời.",
-    "example": "The awfulness of the event shocked everyone. Her awesomeness was undeniable. He was awestruck by the view. It was awfully noisy. She danced awesomely.",
-    "count": 0
+      "word": "benefit",
+      "meaning": "beneficiary, /ˌbenɪˈfɪʃəri/: người hưởng lợi. beneficial(ly), /ˌbenɪˈfɪʃəl(li)/: (một cách) có lợi.",
+      "example": "She’s the main beneficiary of the will. The program worked beneficially for all.",
+      "count": 0
     },
     {
-    "word": "believe",
-    "meaning": "disbelieve, /ˌdɪsbɪˈliːv/: không tin. belief, /bɪˈliːf/: niềm tin. believer, /bɪˈliːvər/: người tin tưởng. (un)believable, /ˌʌnbɪˈliːvəbl/: (không) thể tin được. disbelieving(ly), /ˌdɪsbɪˈliːvɪŋ(li)/: (một cách) không tin.",
-    "example": "I disbelieve that rumor. He has a strong belief in honesty. She’s a true believer. That’s unbelievable! He looked at me disbelievingly.",
-    "count": 0
+      "word": "brief",
+      "meaning": "(de)briefing, /ˈbriːfɪŋ/: cuộc phỏng vấn, thẩm vấn. brevity, /ˈbrevəti/: sự ngắn gọn. briefs, /briːfs/: quần lót nam. briefly, /ˈbriːfli/: một cách vắn tắt.",
+      "example": "The debriefing took an hour. The letter was praised for its brevity. He packed several briefs. She explained briefly.",
+      "count": 0
     },
     {
-    "word": "benefit",
-    "meaning": "beneficiary, /ˌbenɪˈfɪʃəri/: người hưởng lợi. beneficial(ly), /ˌbenɪˈfɪʃəl(li)/: (một cách) có lợi.",
-    "example": "She’s the main beneficiary of the will. The program worked beneficially for all.",
-    "count": 0
+      "word": "brilliant",
+      "meaning": "brilliance, /ˈbrɪljəns/: sự tài giỏi. brilliantly, /ˈbrɪljəntli/: một cách giỏi giang.",
+      "example": "Her brilliance impressed everyone. He played brilliantly.",
+      "count": 0
     },
     {
-    "word": "brief",
-    "meaning": "(de)briefing, /ˈbriːfɪŋ/: cuộc phỏng vấn, thẩm vấn. brevity, /ˈbrevəti/: sự ngắn gọn. briefs, /briːfs/: quần lót nam. briefly, /ˈbriːfli/: một cách vắn tắt.",
-    "example": "The debriefing took an hour. The letter was praised for its brevity. He packed several briefs. She explained briefly.",
-    "count": 0
+      "word": "broad",
+      "meaning": "broaden, /ˈbrɔːdn/: mở rộng. breadth, /bredθ/: chiều rộng. broadly, /ˈbrɔːdli/: một cách rộng rãi.",
+      "example": "Travel broadens the mind. The table has a great breadth. He smiled broadly.",
+      "count": 0
     },
     {
-    "word": "brilliant",
-    "meaning": "brilliance, /ˈbrɪljəns/: sự tài giỏi. brilliantly, /ˈbrɪljəntli/: một cách giỏi giang.",
-    "example": "Her brilliance impressed everyone. He played brilliantly.",
-    "count": 0
+      "word": "capable",
+      "meaning": "capability, /ˌkeɪpəˈbɪləti/: khả năng. incapable, /ɪnˈkeɪpəbl/: không có khả năng.",
+      "example": "She has great capability. He is incapable of lying.",
+      "count": 0
     },
     {
-    "word": "broad",
-    "meaning": "broaden, /ˈbrɔːdn/: mở rộng. breadth, /bredθ/: chiều rộng. broadly, /ˈbrɔːdli/: một cách rộng rãi.",
-    "example": "Travel broadens the mind. The table has a great breadth. He smiled broadly.",
-    "count": 0
+      "word": "cause",
+      "meaning": "causation, /kɔːˈzeɪʃn/: nguyên nhân. causal, /ˈkɔːzl/: thuộc quan hệ nhân quả. causative, /ˈkɔːzətɪv/: là nguyên nhân gây ra.",
+      "example": "The causation of the accident is unclear. There is a causal link between stress and illness. Smoking is a causative factor of cancer.",
+      "count": 0
     },
     {
-    "word": "capable",
-    "meaning": "capability, /ˌkeɪpəˈbɪləti/: khả năng. incapable, /ɪnˈkeɪpəbl/: không có khả năng.",
-    "example": "She has great capability. He is incapable of lying.",
-    "count": 0
+      "word": "change",
+      "meaning": "exchange, /ɪksˈtʃeɪndʒ/: trao đổi. changeover, /ˈtʃeɪndʒəʊvə(r)/: chuyển biến. (un)changing, /ˌʌnˈtʃeɪndʒɪŋ/: (không) thay đổi. (un)changeable, /ˌʌnˈtʃeɪndʒəbl/: (không) dễ thay đổi. interchangeable, /ˌɪntəˈtʃeɪndʒəbl/: có tính thay thế lẫn nhau.",
+      "example": "They discussed a cultural exchange. The changeover was seamless. His mood is unchanging. The weather is changeable. These parts are interchangeable.",
+      "count": 0
     },
     {
-    "word": "cause",
-    "meaning": "causation, /kɔːˈzeɪʃn/: nguyên nhân. causal, /ˈkɔːzl/: thuộc quan hệ nhân quả. causative, /ˈkɔːzətɪv/: là nguyên nhân gây ra.",
-    "example": "The causation of the accident is unclear. There is a causal link between stress and illness. Smoking is a causative factor of cancer.",
-    "count": 0
+      "word": "approve",
+      "meaning": "disapprove, /ˌdɪsəˈpruːv/: không ủng hộ, không thông qua. (dis)approval, /ˌdɪsəˈpruːvəl/: sự (không) ủng hộ, thông qua. (dis)approved, /ˌdɪsəˈpruːvd/: (không) được thông qua. (dis)approving(ly), /ˌdɪsəˈpruːvɪŋ(li)/: (một cách) (không) tán thành.",
+      "example": "She disapproved of his decision. The plan received official approval. The application was disapproved. He looked at them disapprovingly.",
+      "count": 0
     },
     {
-    "word": "change",
-    "meaning": "exchange, /ɪksˈtʃeɪndʒ/: trao đổi. changeover, /ˈtʃeɪndʒəʊvə(r)/: chuyển biến. (un)changing, /ˌʌnˈtʃeɪndʒɪŋ/: (không) thay đổi. (un)changeable, /ˌʌnˈtʃeɪndʒəbl/: (không) dễ thay đổi. interchangeable, /ˌɪntəˈtʃeɪndʒəbl/: có tính thay thế lẫn nhau.",
-    "example": "They discussed a cultural exchange. The changeover was seamless. His mood is unchanging. The weather is changeable. These parts are interchangeable.",
-    "count": 0
-    },      
+      "word": "architect",
+      "meaning": "architecture, /ˈɑːkɪtektʃə(r)/: kiến trúc. architectural(ly), /ˌɑːkɪˈtek.tʃər(ə)li/: (thuộc) kiến trúc.",
+      "example": "The building is famous for its modern architecture. The city is architecturally diverse.",
+      "count": 0
+    },
     {
-    "word": "approve",
-    "meaning": "disapprove, /ˌdɪsəˈpruːv/: không ủng hộ, không thông qua. (dis)approval, /ˌdɪsəˈpruːvəl/: sự (không) ủng hộ, thông qua. (dis)approved, /ˌdɪsəˈpruːvd/: (không) được thông qua. (dis)approving(ly), /ˌdɪsəˈpruːvɪŋ(li)/: (một cách) (không) tán thành.",
-    "example": "She disapproved of his decision. The plan received official approval. The application was disapproved. He looked at them disapprovingly.",
-    "count": 0
+      "word": "argue",
+      "meaning": "argument, /ˈɑːɡjumənt/: lập luận, lý lẽ. argumentative(ly), /ˌɑːɡjumənˈtetɪv(li)/: (một cách) thích tranh luận. (un)arguable, /ˈɑːɡjuəbl/: (không thể) bàn cãi. arguably, /ˈɑːɡjuəbli/: có thể cho là.",
+      "example": "They had a strong argument. He answered argumentatively. That’s an unarguable fact. Arguably, she’s the best in the team.",
+      "count": 0
     },
     {
-    "word": "architect",
-    "meaning": "architecture, /ˈɑːkɪtektʃə(r)/: kiến trúc. architectural(ly), /ˌɑːkɪˈtek.tʃər(ə)li/: (thuộc) kiến trúc.",
-    "example": "The building is famous for its modern architecture. The city is architecturally diverse.",
-    "count": 0
+      "word": "arrange",
+      "meaning": "rearrange, /ˌriːəˈreɪndʒ/: sắp xếp lại. (re)arrangement, /ˌ(riː)əˈreɪndʒmənt/: sự sắp xếp (lại). arranged, /əˈreɪndʒd/: được sắp xếp.",
+      "example": "Let’s rearrange the meeting. The rearrangement was necessary. Everything was neatly arranged.",
+      "count": 0
     },
     {
-    "word": "argue",
-    "meaning": "argument, /ˈɑːɡjumənt/: lập luận, lý lẽ. argumentative(ly), /ˌɑːɡjumənˈtetɪv(li)/: (một cách) thích tranh luận. (un)arguable, /ˈɑːɡjuəbl/: (không thể) bàn cãi. arguably, /ˈɑːɡjuəbli/: có thể cho là.",
-    "example": "They had a strong argument. He answered argumentatively. That’s an unarguable fact. Arguably, she’s the best in the team.",
-    "count": 0
+      "word": "art",
+      "meaning": "arts, /ɑːts/: nghệ thuật. artfulness, /ˈɑːtfəlnəs/: sự tinh ranh, khéo léo. artificiality, /ˌɑːtɪˌfɪʃiˈæləti/: tính nhân tạo, giả tạo. artist, /ˈɑːtɪst/: nghệ sĩ. artistic(ally), /ɑːˈtɪstɪk(li)/: (một cách) nghệ thuật. artificial(ly), /ˌɑːtɪˈfɪʃl(i)/: (một cách) giả tạo. artful(ly), /ˈɑːtfəl(i)/: (một cách) tinh vi. artless(ly), /ˈɑːtləs(li)/: (một cách) chân thật.",
+      "example": "She studied the arts. His artfulness was impressive. The flower looked artificial. The artist displayed new work. She decorated the room artistically. It was artificially sweetened. He answered artfully. She sang artlessly.",
+      "count": 0
     },
     {
-    "word": "arrange",
-    "meaning": "rearrange, /ˌriːəˈreɪndʒ/: sắp xếp lại. (re)arrangement, /ˌ(riː)əˈreɪndʒmənt/: sự sắp xếp (lại). arranged, /əˈreɪndʒd/: được sắp xếp.",
-    "example": "Let’s rearrange the meeting. The rearrangement was necessary. Everything was neatly arranged.",
-    "count": 0
+      "word": "assess",
+      "meaning": "reassess, /ˌriːəˈses/: đánh giá lại. (re)assessment, /ˌ(riː)əˈsesmənt/: đánh giá (lại). assessor, /əˈsesər/: người đánh giá. assessed, /əˈsest/: bị đánh thuế.",
+      "example": "We need to reassess our priorities. The assessment was thorough. The assessor arrived on time. Property was assessed last year.",
+      "count": 0
     },
     {
-    "word": "art",
-    "meaning": "arts, /ɑːts/: nghệ thuật. artfulness, /ˈɑːtfəlnəs/: sự tinh ranh, khéo léo. artificiality, /ˌɑːtɪˌfɪʃiˈæləti/: tính nhân tạo, giả tạo. artist, /ˈɑːtɪst/: nghệ sĩ. artistic(ally), /ɑːˈtɪstɪk(li)/: (một cách) nghệ thuật. artificial(ly), /ˌɑːtɪˈfɪʃl(i)/: (một cách) giả tạo. artful(ly), /ˈɑːtfəl(i)/: (một cách) tinh vi. artless(ly), /ˈɑːtləs(li)/: (một cách) chân thật.",
-    "example": "She studied the arts. His artfulness was impressive. The flower looked artificial. The artist displayed new work. She decorated the room artistically. It was artificially sweetened. He answered artfully. She sang artlessly.",
-    "count": 0
+      "word": "associate",
+      "meaning": "dissociate, /dɪˈsəʊʃieɪt/: phân tách. association, /əˌsəʊsiˈeɪʃn/: sự liên kết. associate, /əˈsəʊʃiət/: người cộng tác. associated, /əˈsəʊsieɪtɪd/: có liên hệ.",
+      "example": "He tried to dissociate himself from the scandal. The event is organized by a student association. She’s a business associate. The risks are associated with smoking.",
+      "count": 0
     },
     {
-    "word": "assess",
-    "meaning": "reassess, /ˌriːəˈses/: đánh giá lại. (re)assessment, /ˌ(riː)əˈsesmənt/: đánh giá (lại). assessor, /əˈsesər/: người đánh giá. assessed, /əˈsest/: bị đánh thuế.",
-    "example": "We need to reassess our priorities. The assessment was thorough. The assessor arrived on time. Property was assessed last year.",
-    "count": 0
+      "word": "assume",
+      "meaning": "assumption, /əˈsʌmpʃn/: giả định. assuming, /əˈsjuːmɪŋ/: giả sử. unassuming, /ˌʌnəˈsjuːmɪŋ/: khiêm tốn. assumed, /əˈsjuːmd/: giả, sai sự thật.",
+      "example": "That’s a risky assumption. Assuming he’s right, we’ll win. He is very unassuming. She used an assumed name.",
+      "count": 0
     },
     {
-    "word": "associate",
-    "meaning": "dissociate, /dɪˈsəʊʃieɪt/: phân tách. association, /əˌsəʊsiˈeɪʃn/: sự liên kết. associate, /əˈsəʊʃiət/: người cộng tác. associated, /əˈsəʊsieɪtɪd/: có liên hệ.",
-    "example": "He tried to dissociate himself from the scandal. The event is organized by a student association. She’s a business associate. The risks are associated with smoking.",
-    "count": 0
+      "word": "attach",
+      "meaning": "reattach, /ˌriːəˈtætʃ/: đính kèm lại. attachment, /əˈtætʃmənt/: sự đính kèm. (un)attached, /ʌnəˈtætʃt/: (không) đính kèm.",
+      "example": "Please reattach the document. The email had an attachment. He arrived unattached.",
+      "count": 0
     },
     {
-    "word": "assume",
-    "meaning": "assumption, /əˈsʌmpʃn/: giả định. assuming, /əˈsjuːmɪŋ/: giả sử. unassuming, /ˌʌnəˈsjuːmɪŋ/: khiêm tốn. assumed, /əˈsjuːmd/: giả, sai sự thật.",
-    "example": "That’s a risky assumption. Assuming he’s right, we’ll win. He is very unassuming. She used an assumed name.",
-    "count": 0
+      "word": "available",
+      "meaning": "(un)availability, /əˌveɪləˈbɪləti/: sự (không) sẵn sàng.",
+      "example": "Check the availability of the room. Internet unavailability affected our work.",
+      "count": 0
     },
     {
-    "word": "attach",
-    "meaning": "reattach, /ˌriːəˈtætʃ/: đính kèm lại. attachment, /əˈtætʃmənt/: sự đính kèm. (un)attached, /ʌnəˈtætʃt/: (không) đính kèm.",
-    "example": "Please reattach the document. The email had an attachment. He arrived unattached.",
-    "count": 0
+      "word": "access",
+      "meaning": "accessibility, /ˌæk.ses.əˈbɪl.ə.ti/: khả năng tiếp cận. (in)accessible, /ˌɪn.əkˈses.ə.bəl/: (không) có thể tiếp cận được.",
+      "example": "The accessibility of this website is excellent for visually impaired users. This island is inaccessible during the monsoon season.",
+      "count": 0
     },
     {
-    "word": "available",
-    "meaning": "(un)availability, /əˌveɪləˈbɪləti/: sự (không) sẵn sàng.",
-    "example": "Check the availability of the room. Internet unavailability affected our work.",
-    "count": 0
-    },      
-    {      
-    "word": "access",
-    "meaning": "accessibility, /ˌæk.ses.əˈbɪl.ə.ti/: khả năng tiếp cận. (in)accessible, /ˌɪn.əkˈses.ə.bəl/: (không) có thể tiếp cận được.",
-    "example": "The accessibility of this website is excellent for visually impaired users. This island is inaccessible during the monsoon season.",
-    "count": 0
+      "word": "act (1)",
+      "meaning": "enact: ban hành. react: phản ứng. counteract: chống lại. interact: tương tác. transact: giao dịch. overact: diễn quá mức. overreact: phản ứng quá mức. activate: kích hoạt. deactivate: ngừng kích hoạt. acting: tạm thời. actor: diễn viên. actress: nữ diễn viên. action: hành động. activity: hoạt động. inactivity: sự thiếu hoạt động. radioactivity: phóng xạ. transaction: sự giao dịch.",
+      "example": "They enacted new environmental laws. She reacted quickly to the danger. This drug counteracts allergic reactions. Children interact well through games. We transact business via online banking. He tends to overact in every scene. Please don’t overreact to criticism. The alarm was deactivated remotely. The acting director approved the plan. The actor received a standing ovation. The actress accepted the award. Take action before it's too late. Inactivity leads to poor health. We measured radioactivity in the soil. The transaction went smoothly. She’s a human rights activist. Youth activism is growing globally. Their interaction was respectful. His overreaction was unnecessary. He was overacting again. The bill was blocked by reactionary forces. The reactor was shut down. The report is highly transactional. Stay active to stay healthy. That child is hyperactive. This is a radioactive zone. His glands are overactive. She actively supported the cause.",
+      "count": 0
     },
     {
-    "word": "act",
-    "meaning": "enact, /ɪˈnækt/: ban hành, đóng vai. react, /riˈækt/: phản ứng. counteract, /ˌkaʊntərˈækt/: chống lại. interact, /ˌɪntərˈækt/: tương tác. transact, /trænˈzækt/: giao dịch. overact, /ˌəʊvərˈækt/: diễn quá cường điệu. overreact, /ˌəʊvəriˈækt/: phản ứng quá mức. (de/re)activate, /(ˌdiː/ˌriː)ˈæktɪveɪt/: (ngừng) kích hoạt. acting, /ˈæktɪŋ/: quyền, tạm thời. actor, /ˈæktər/: diễn viên. actress, /ˈæktrəs/: nữ diễn viên. action, /ˈækʃən/: hành động. (in)activity, /ˌɪn.ækˈtɪv.ə.ti/: sự (thiếu) hoạt động. radioactivity, /ˌreɪ.di.əʊ.ækˈtɪv.ə.ti/: phóng xạ. transaction, /trænˈzækʃən/: sự giao dịch. activist, /ˈæktɪvɪst/: nhà hoạt động. activism, /ˈæktɪvɪzəm/: chủ nghĩa tích cực. interaction, /ˌɪntərˈækʃən/: sự tương tác. (over)reaction, /ˌəʊvəriˈækʃən/: sự phản ứng (quá). overacting, /ˌəʊvərˈæktɪŋ/: diễn cường điệu. reactionary, /riˈækʃənəri/: phản động. reactor, /riˈæktər/: lò phản ứng hạt nhân. transactional, /trænˈzækʃənl/: liên quan tới giao dịch. active, /ˈæktɪv/: chủ động, tích cực. hyperactive, /ˌhaɪ.pərˈæk.tɪv/: hiếu động thái quá. radioactive, /ˌreɪ.di.əʊˈæk.tɪv/: phóng xạ. overactive, /ˌəʊvərˈæktɪv/: hoạt động quá mức. (in)active(ly), /(ˌɪn)ˈæk.tɪv(li)/: một cách (không) tích cực.",
-    "example": "They enacted new environmental laws. She reacted quickly to the danger. This drug counteracts allergic reactions. Children interact well through games. We transact business via online banking. He tends to overact in every scene. Please don’t overreact to criticism. The alarm was deactivated remotely. The acting director approved the plan. The actor received a standing ovation. The actress accepted the award. Take action before it's too late. Inactivity leads to poor health. We measured radioactivity in the soil. The transaction went smoothly. She’s a human rights activist. Youth activism is growing globally. Their interaction was respectful. His overreaction was unnecessary. He was overacting again. The bill was blocked by reactionary forces. The reactor was shut down. The report is highly transactional. Stay active to stay healthy. That child is hyperactive. This is a radioactive zone. His glands are overactive. She actively supported the cause.",
-    "count": 0
+      "word": "act (2)",
+      "meaning": "activist: nhà hoạt động. activism: chủ nghĩa tích cực. interaction: sự tương tác. reaction: sự phản ứng. overacting: diễn cường điệu. reactionary: phản động. reactor: lò phản ứng. transactional: liên quan tới giao dịch. active: chủ động. hyperactive: hiếu động thái quá. radioactive: phóng xạ. overactive: hoạt động quá mức. active(ly): một cách tích cực. inactive(ly): một cách không tích cực.",
+      "example": "They enacted new environmental laws. She reacted quickly to the danger. This drug counteracts allergic reactions. Children interact well through games. We transact business via online banking. He tends to overact in every scene. Please don’t overreact to criticism. The alarm was deactivated remotely. The acting director approved the plan. The actor received a standing ovation. The actress accepted the award. Take action before it's too late. Inactivity leads to poor health. We measured radioactivity in the soil. The transaction went smoothly. She’s a human rights activist. Youth activism is growing globally. Their interaction was respectful. His overreaction was unnecessary. He was overacting again. The bill was blocked by reactionary forces. The reactor was shut down. The report is highly transactional. Stay active to stay healthy. That child is hyperactive. This is a radioactive zone. His glands are overactive. She actively supported the cause.",
+      "count": 0
     },
     {
-    "word": "adapt",
-    "meaning": "adaptation, /ˌædæpˈteɪʃən/: sự thích nghi. adaptor, /əˈdæptər/: bộ chuyển đổi. adaptable, /əˈdæptəbl/: có thể thích nghi.",
-    "example": "The adaptation of the novel was successful. You’ll need an adaptor for your charger. She's very adaptable to change.",
-    "count": 0
+      "word": "adapt",
+      "meaning": "adaptation, /ˌædæpˈteɪʃən/: sự thích nghi. adaptor, /əˈdæptər/: bộ chuyển đổi. adaptable, /əˈdæptəbl/: có thể thích nghi.",
+      "example": "The adaptation of the novel was successful. You’ll need an adaptor for your charger. She's very adaptable to change.",
+      "count": 0
     },
     {
-    "word": "add",
-    "meaning": "addendum, /əˈdendəm/: phụ lục. addenda, /əˈdendə/: phụ lục (số nhiều). additive, /ˈædətɪv/: chất phụ gia. additional(ly), /əˈdɪʃənl/: thêm vào, ngoài ra.",
-    "example": "An addendum was added to the report. Please check the two addenda. This product contains no additives. Additionally, we provide free support.",
-    "count": 0
+      "word": "add",
+      "meaning": "addendum, /əˈdendəm/: phụ lục. addenda, /əˈdendə/: phụ lục (số nhiều). additive, /ˈædətɪv/: chất phụ gia. additional(ly), /əˈdɪʃənl/: thêm vào, ngoài ra.",
+      "example": "An addendum was added to the report. Please check the two addenda. This product contains no additives. Additionally, we provide free support.",
+      "count": 0
     },
     {
-    "word": "adequate",
-    "meaning": "(in)adequacy, /ˌɪnˈædɪkwəsi/: sự (không) thỏa đáng. inadequate, /ɪnˈædɪkwət/: không thỏa đáng. (in)adequately, /(ˌɪn)ˈædɪkwətli/: (không) đầy đủ.",
-    "example": "There’s a question of the adequacy of funds. The facilities are inadequate. The job was inadequately done.",
-    "count": 0
+      "word": "adequate",
+      "meaning": "(in)adequacy, /ˌɪnˈædɪkwəsi/: sự (không) thỏa đáng. inadequate, /ɪnˈædɪkwət/: không thỏa đáng. (in)adequately, /(ˌɪn)ˈædɪkwətli/: (không) đầy đủ.",
+      "example": "There’s a question of the adequacy of funds. The facilities are inadequate. The job was inadequately done.",
+      "count": 0
     },
     {
-    "word": "adjust",
-    "meaning": "readjust, /ˌriː.əˈdʒʌst/: điều chỉnh lại. adjustment, /əˈdʒʌstmənt/: sự điều chỉnh. adjustable, /əˈdʒʌstəbl/: có thể điều chỉnh.",
-    "example": "He had to readjust to a new routine. The adjustment took weeks. This chair is fully adjustable.",
-    "count": 0
+      "word": "adjust",
+      "meaning": "readjust, /ˌriː.əˈdʒʌst/: điều chỉnh lại. adjustment, /əˈdʒʌstmənt/: sự điều chỉnh. adjustable, /əˈdʒʌstəbl/: có thể điều chỉnh.",
+      "example": "He had to readjust to a new routine. The adjustment took weeks. This chair is fully adjustable.",
+      "count": 0
     },
     {
-    "word": "admire",
-    "meaning": "admiration, /ˌædməˈreɪʃən/: sự ngưỡng mộ. admirer, /ədˈmaɪərər/: người ngưỡng mộ. admirable, /ˈædmərəbl/: đáng ngưỡng mộ. admirably, /ˈædmərəbli/: một cách đáng ngưỡng mộ. admiring(ly), /ədˈmaɪərɪŋ(li)/: (một cách) ngưỡng mộ.",
-    "example": "His bravery won admiration. She has a secret admirer. That was an admirable act. She admirably handled the crisis. He looked at her admiringly.",
-    "count": 0
+      "word": "admire",
+      "meaning": "admiration, /ˌædməˈreɪʃən/: sự ngưỡng mộ. admirer, /ədˈmaɪərər/: người ngưỡng mộ. admirable, /ˈædmərəbl/: đáng ngưỡng mộ. admirably, /ˈædmərəbli/: một cách đáng ngưỡng mộ. admiring(ly), /ədˈmaɪərɪŋ(li)/: (một cách) ngưỡng mộ.",
+      "example": "His bravery won admiration. She has a secret admirer. That was an admirable act. She admirably handled the crisis. He looked at her admiringly.",
+      "count": 0
     },
     {
-    "word": "aggression",
-    "meaning": "aggressiveness, /əˈɡresɪvnəs/: tính hung hăng. aggressor, /əˈɡresər/: kẻ tấn công. aggressive(ly), /əˈɡresɪv(li)/: (một cách) hung hăng.",
-    "example": "His aggressiveness caused conflict. The aggressor started the war. He spoke aggressively to the team.",
-    "count": 0
+      "word": "aggression",
+      "meaning": "aggressiveness, /əˈɡresɪvnəs/: tính hung hăng. aggressor, /əˈɡresər/: kẻ tấn công. aggressive(ly), /əˈɡresɪv(li)/: (một cách) hung hăng.",
+      "example": "His aggressiveness caused conflict. The aggressor started the war. He spoke aggressively to the team.",
+      "count": 0
     },
     {
-    "word": "alter",
-    "meaning": "alteration, /ˌɔːltəˈreɪʃən/: sự thay đổi. alterable, /ˈɔːltərəbl/: có thể thay đổi. unaltered, /ʌnˈɔːltəd/: không thay đổi. alternate, /ˈɔːltərnət/: luân phiên. alternative, /ɔːlˈtɜːnətɪv/: thay thế.",
-    "example": "We made a slight alteration. The plan is alterable. His view remained unaltered. We take alternate routes. There's no alternative choice.",
-    "count": 0
+      "word": "alter",
+      "meaning": "alteration, /ˌɔːltəˈreɪʃən/: sự thay đổi. alterable, /ˈɔːltərəbl/: có thể thay đổi. unaltered, /ʌnˈɔːltəd/: không thay đổi. alternate, /ˈɔːltərnət/: luân phiên. alternative, /ɔːlˈtɜːnətɪv/: thay thế.",
+      "example": "We made a slight alteration. The plan is alterable. His view remained unaltered. We take alternate routes. There's no alternative choice.",
+      "count": 0
     },
     {
-    "word": "analyse",
-    "meaning": "analysis, /əˈnæləsɪs/: sự phân tích. analyst, /ˈænəlɪst/: nhà phân tích. analytical(ly), /ˌænəˈlɪtɪkl/: (một cách) phân tích.",
-    "example": "We conducted a data analysis. The analyst predicted a downturn. She approached the issue analytically.",
-    "count": 0
+      "word": "analyse",
+      "meaning": "analysis, /əˈnæləsɪs/: sự phân tích. analyst, /ˈænəlɪst/: nhà phân tích. analytical(ly), /ˌænəˈlɪtɪkl/: (một cách) phân tích.",
+      "example": "We conducted a data analysis. The analyst predicted a downturn. She approached the issue analytically.",
+      "count": 0
     },
     {
-    "word": "antique",
-    "meaning": "antiquity, /ænˈtɪkwəti/: thời cổ đại. antiquated, /ˈæntɪkweɪtɪd/: lỗi thời.",
-    "example": "The museum houses items from antiquity. That method is antiquated.",
-    "count": 0
+      "word": "antique",
+      "meaning": "antiquity, /ænˈtɪkwəti/: thời cổ đại. antiquated, /ˈæntɪkweɪtɪd/: lỗi thời.",
+      "example": "The museum houses items from antiquity. That method is antiquated.",
+      "count": 0
     },
     {
-    "word": "appear",
-    "meaning": "disappear, /ˌdɪsəˈpɪər/: biến mất. reappear, /ˌriːəˈpɪə(r)/: xuất hiện lại. (dis/re)appearance, /ˌdɪs/ˌriːəˈpɪərəns/: sự (biến/hiện) ra. apparition, /ˌæpəˈrɪʃn/: ma quỷ hiện ra. apparent(ly), /əˈpærənt(li)/: rõ ràng.",
-    "example": "The bird suddenly disappeared. He may reappear later. Her disappearance is suspicious. They claimed to see an apparition. Apparently, it’s going to rain.",
-    "count": 0
+      "word": "appear",
+      "meaning": "disappear, /ˌdɪsəˈpɪər/: biến mất. reappear, /ˌriːəˈpɪə(r)/: xuất hiện lại. (dis/re)appearance, /ˌdɪs/ˌriːəˈpɪərəns/: sự (biến/hiện) ra. apparition, /ˌæpəˈrɪʃn/: ma quỷ hiện ra. apparent(ly), /əˈpærənt(li)/: rõ ràng.",
+      "example": "The bird suddenly disappeared. He may reappear later. Her disappearance is suspicious. They claimed to see an apparition. Apparently, it’s going to rain.",
+      "count": 0
     },
     {
-    "word": "apply",
-    "meaning": "reapply, /ˌriːəˈplaɪ/: nộp lại. misapply, /ˌmɪsəˈplaɪ/: áp dụng sai. applicant, /ˈæplɪkənt/: người nộp đơn. application, /ˌæplɪˈkeɪʃn/: đơn xin. (in)applicability, /ˌɪnˌæplɪkəˈbɪləti/: (không) thể áp dụng. (in)applicable, /ˌɪnˈæplɪkəbl/: (không) thể áp dụng. (mis)applied, /ˌmɪsəˈplaɪd/: (áp dụng sai).",
-    "example": "You can reapply next year. They misapplied the method. The applicant was successful. Your application is under review. That rule has limited applicability. It’s not applicable in this case. He misapplied the principle.",
-    "count": 0
+      "word": "apply",
+      "meaning": "reapply, /ˌriːəˈplaɪ/: nộp lại. misapply, /ˌmɪsəˈplaɪ/: áp dụng sai. applicant, /ˈæplɪkənt/: người nộp đơn. application, /ˌæplɪˈkeɪʃn/: đơn xin. (in)applicability, /ˌɪnˌæplɪkəˈbɪləti/: (không) thể áp dụng. (in)applicable, /ˌɪnˈæplɪkəbl/: (không) thể áp dụng. (mis)applied, /ˌmɪsəˈplaɪd/: (áp dụng sai).",
+      "example": "You can reapply next year. They misapplied the method. The applicant was successful. Your application is under review. That rule has limited applicability. It’s not applicable in this case. He misapplied the principle.",
+      "count": 0
     },
     {
-    "word": "appreciate",
-    "meaning": "appreciation, /əˌpriːʃiˈeɪʃn/: sự cảm kích. appreciable, /əˈpriːʃəbl/: đáng kể. appreciably, /əˈpriːʃəbli/: một cách đáng kể. (un)appreciative(ly), /ʌnəˈpriːʃətɪv(li)/: (một cách không) biết ơn.",
-    "example": "He showed deep appreciation. The cost is appreciable. Profits increased appreciably. She nodded appreciatively.",
-    "count": 0
-    }             
+      "word": "appreciate",
+      "meaning": "appreciation, /əˌpriːʃiˈeɪʃn/: sự cảm kích. appreciable, /əˈpriːʃəbl/: đáng kể. appreciably, /əˈpriːʃəbli/: một cách đáng kể. (un)appreciative(ly), /ʌnəˈpriːʃətɪv(li)/: (một cách không) biết ơn.",
+      "example": "He showed deep appreciation. The cost is appreciable. Profits increased appreciably. She nodded appreciatively.",
+      "count": 0
+    }
   ]
 }

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validateVocabularyWord, validateMeaning, validateExample } from '../src/utils/security/validation';
+import { VALIDATION_LIMITS } from '../src/services/vocabulary/storage/constants';
 
 // Representative tests for vocabulary validation utilities
 
@@ -35,6 +36,12 @@ describe('validateMeaning', () => {
     const result = validateMeaning('SELECT * FROM users');
     expect(result.isValid).toBe(true);
     expect(result.sanitizedValue).toBe('users');
+  });
+
+  it('rejects meanings that exceed the configured length', () => {
+    const longMeaning = 'x'.repeat(VALIDATION_LIMITS.MAX_MEANING_LENGTH + 1);
+    const result = validateMeaning(longMeaning);
+    expect(result.isValid).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- document meaning length limit in README
- trim long meaning strings in the default vocabulary
- split the `act` entry into two shorter parts
- test meaning length validation

## Testing
- `npm test` *(fails: Unable to find an accessible element with the role "button" and name "US")*
- `npm run lint` *(fails: 41 errors, 32 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6851389687a4832fb6d85825a3fccdfb