### PR TITLE
Switch unifiedSpeechController to direct speech service

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -9,7 +9,7 @@ import { useUnifiedVocabularyController } from '@/hooks/vocabulary-controller/us
 import { useEnhancedUserInteraction } from '@/hooks/vocabulary-app/useEnhancedUserInteraction';
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { vocabularyService } from '@/services/vocabularyService';
-import { simpleSpeechController } from '@/utils/speech/controller/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 const VocabularyAppContainerNew: React.FC = () => {
   console.log('[VOCAB-CONTAINER-NEW] === Component Render ===');
@@ -58,7 +58,7 @@ const VocabularyAppContainerNew: React.FC = () => {
 
   // Enhanced auto-play with proper state monitoring
   useEffect(() => {
-    const speechState = simpleSpeechController.getState();
+    const speechState = unifiedSpeechController.getState();
     
     const autoPlayConditions = {
       hasData,

--- a/src/hooks/speech/useSimpleSpeech.ts
+++ b/src/hooks/speech/useSimpleSpeech.ts
@@ -1,7 +1,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
-import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Simplified speech hook with minimal complexity and maximum reliability
@@ -30,7 +30,7 @@ export const useSimpleSpeech = () => {
     // Stop any current speech
     if (isSpeaking) {
       console.log(`[SIMPLE-SPEECH-${speechId}] Stopping current speech before starting new one`);
-      simpleSpeechController.stop();
+      unifiedSpeechController.stop();
       setIsSpeaking(false);
       await new Promise(r => setTimeout(r, 100));
     }
@@ -48,7 +48,7 @@ export const useSimpleSpeech = () => {
       };
 
       // Use the correct signature with only word and region
-      const success = await simpleSpeechController.speak(wordObject, 'US');
+      const success = await unifiedSpeechController.speak(wordObject, 'US');
 
       if (success) {
         console.log(`[SIMPLE-SPEECH-${speechId}] Speech started successfully`);
@@ -83,7 +83,7 @@ export const useSimpleSpeech = () => {
 
   const stop = useCallback(() => {
     console.log('[SIMPLE-SPEECH] Stopping speech');
-    simpleSpeechController.stop();
+    unifiedSpeechController.stop();
     setIsSpeaking(false);
     currentSpeechRef.current = null;
   }, []);

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
@@ -2,7 +2,7 @@
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
-import { simpleSpeechController } from '@/utils/speech/controller/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Silent speech controller hook
@@ -32,8 +32,8 @@ export const useSpeechController = (
         return false;
       }
 
-      // Use the silent speech controller
-      const success = await simpleSpeechController.speak(currentWord, selectedVoice.region);
+      // Use the unified speech controller
+      const success = await unifiedSpeechController.speak(currentWord, selectedVoice.region);
 
       if (success) {
         onStart();

--- a/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
@@ -2,7 +2,7 @@
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '../../useVoiceSelection';
-import { simpleSpeechController } from '@/utils/speech/controller/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Silent speech execution hook
@@ -32,7 +32,7 @@ export const useSpeechExecution = (
     }
     
     try {
-      const success = await simpleSpeechController.speak(wordToPlay, selectedVoice.region);
+      const success = await unifiedSpeechController.speak(wordToPlay, selectedVoice.region);
       
       if (success) {
         setIsSpeaking(true);

--- a/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
@@ -4,7 +4,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { useVoiceSelection } from './useVoiceSelection';
 import { useSimpleWordNavigation } from './useSimpleWordNavigation';
 import { useSimpleWordPlayback } from './useSimpleWordPlayback';
-import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Simplified vocabulary playback with immediate pause response
@@ -62,12 +62,12 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
     
     if (paused) {
       console.log('[SIMPLE-VOCABULARY] ✓ Pausing speech controller immediately');
-      simpleSpeechController.pause();
+      unifiedSpeechController.pause();
     } else if (!muted) {
       console.log('[SIMPLE-VOCABULARY] ✓ Resuming from pause');
       
       // Resume the controller
-      simpleSpeechController.resume();
+      unifiedSpeechController.resume();
       
       // Play current word immediately after resume
       if (currentWord) {

--- a/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from './useVoiceSelection';
 import { useSimpleSpeech } from '@/hooks/speech/useSimpleSpeech';
-import { simpleSpeechController } from '@/utils/speech/simpleSpeechController';
+import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 /**
  * Simplified word playback with improved coordination and pause handling
@@ -23,7 +23,7 @@ export const useSimpleWordPlayback = (
     console.log(`[WORD-PLAYBACK-${playbackId}] Playing word: ${word.word}`);
 
     // Check if speech controller is paused - this is the critical check
-    if (simpleSpeechController.isPaused()) {
+    if (unifiedSpeechController.isPaused()) {
       console.log(`[WORD-PLAYBACK-${playbackId}] Speech controller is paused, skipping playback`);
       return;
     }
@@ -68,18 +68,18 @@ export const useSimpleWordPlayback = (
           playingRef.current = false;
           
           // Check all conditions before auto-advancing
-          if (!paused && !muted && !simpleSpeechController.isPaused()) {
+          if (!paused && !muted && !unifiedSpeechController.isPaused()) {
             console.log(`[WORD-PLAYBACK-${playbackId}] Auto-advancing to next word`);
             setTimeout(() => {
               // Double-check state before advancing
-              if (!paused && !muted && !simpleSpeechController.isPaused()) {
+              if (!paused && !muted && !unifiedSpeechController.isPaused()) {
                 goToNextWord();
               } else {
                 console.log(`[WORD-PLAYBACK-${playbackId}] State changed during delay, skipping auto-advance`);
               }
             }, 1500);
           } else {
-            console.log(`[WORD-PLAYBACK-${playbackId}] Not auto-advancing - paused: ${paused}, muted: ${muted}, controllerPaused: ${simpleSpeechController.isPaused()}`);
+            console.log(`[WORD-PLAYBACK-${playbackId}] Not auto-advancing - paused: ${paused}, muted: ${muted}, controllerPaused: ${unifiedSpeechController.isPaused()}`);
           }
         },
         onError: () => {
@@ -87,7 +87,7 @@ export const useSimpleWordPlayback = (
           playingRef.current = false;
           
           // Still advance on error to prevent getting stuck
-          if (!paused && !muted && !simpleSpeechController.isPaused()) {
+          if (!paused && !muted && !unifiedSpeechController.isPaused()) {
             setTimeout(() => goToNextWord(), 2000);
           }
         }
@@ -96,7 +96,7 @@ export const useSimpleWordPlayback = (
       if (!success) {
         console.log(`[WORD-PLAYBACK-${playbackId}] Speech failed to start, advancing`);
         playingRef.current = false;
-        if (!paused && !muted && !simpleSpeechController.isPaused()) {
+        if (!paused && !muted && !unifiedSpeechController.isPaused()) {
           setTimeout(() => goToNextWord(), 2000);
         }
       }
@@ -106,7 +106,7 @@ export const useSimpleWordPlayback = (
       playingRef.current = false;
       
       // Always advance on exception
-      if (!paused && !muted && !simpleSpeechController.isPaused()) {
+      if (!paused && !muted && !unifiedSpeechController.isPaused()) {
         setTimeout(() => goToNextWord(), 2000);
       }
     }


### PR DESCRIPTION
## Summary
- wire unifiedSpeechController to directSpeechService
- swap simpleSpeechController references in various hooks and components
- pass VocabularyWord data to directSpeechService
- ensure callbacks trigger when speech ends

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68522ec54814832fb8f758ae7d43e916