### PR TITLE
Enhance auto play and fix button label

### DIFF
--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -120,6 +120,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         onClick={handleCycleVoice}
         className="h-8 w-8 p-0 text-blue-700 border-blue-300 bg-blue-50"
         title={`Change to ${nextVoiceLabel}`}
+        aria-label={nextVoiceLabel}
       >
         <Speaker size={16} />
       </Button>

--- a/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
+++ b/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
@@ -111,6 +111,15 @@ export const useEnhancedUserInteraction = ({
     checkAudioStatus();
   }, [checkAudioStatus]);
 
+  // Auto-play when audio becomes unlocked for the first time
+  const hasPlayedRef = useRef(false);
+  useEffect(() => {
+    if (!hasPlayedRef.current && hasInitialized && isAudioUnlocked && currentWord && playCurrentWord) {
+      hasPlayedRef.current = true;
+      playCurrentWord();
+    }
+  }, [isAudioUnlocked, hasInitialized, currentWord, playCurrentWord]);
+
   return {
     hasInitialized,
     interactionCount,


### PR DESCRIPTION
## Summary
- fix accessible label for voice toggle button
- auto-play the current word after audio unlock

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: 42 errors, 32 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68524190d548832f8cf77df2e47b90ec