### PR TITLE
Update category change toast

### DIFF
--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -7,7 +7,7 @@ import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
-import { getCategoryLabel } from '@/utils/categoryLabels';
+import { getCategoryLabel, getCategoryMessageLabel } from '@/utils/categoryLabels';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -40,6 +40,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 }) => {
   const safeNextCategory = nextCategory || 'Next';
   const nextCategoryLabel = getCategoryLabel(safeNextCategory);
+  const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
 
   const handleToggleMute = () => {
     onToggleMute();
@@ -58,7 +59,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 
   const handleSwitchCategory = () => {
     onSwitchCategory();
-    toast(`Switched to ${nextCategoryLabel}`);
+    toast(`Switched to ${nextCategoryMessageLabel}`);
   };
 
   const handleCycleVoice = () => {

--- a/src/utils/categoryLabels.ts
+++ b/src/utils/categoryLabels.ts
@@ -4,7 +4,17 @@ export const CATEGORY_LABELS: Record<string, string> = {
   'phrasal verbs': 'Phrasal V',
 };
 
+export const CATEGORY_MESSAGE_LABELS: Record<string, string> = {
+  'phrases, collocations': 'Phrases, Collocations',
+  'topic vocab': 'Topic Vocabulary',
+  'phrasal verbs': 'Phrasal Verbs',
+};
+
 export function getCategoryLabel(category: string): string {
   return CATEGORY_LABELS[category] ||
     category.charAt(0).toUpperCase() + category.slice(1);
+}
+
+export function getCategoryMessageLabel(category: string): string {
+  return CATEGORY_MESSAGE_LABELS[category] || getCategoryLabel(category);
 }


### PR DESCRIPTION
## Summary
- add user-friendly category message labels
- show full category name in category change toast

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68527cbcedec832fb07cdedecba77917