### PR TITLE
Remove custom SpeechSynthesisVoice type

### DIFF
--- a/src/hooks/speech/useSequentialSpeech.tsx
+++ b/src/hooks/speech/useSequentialSpeech.tsx
@@ -1,7 +1,6 @@
 
 import { useCallback } from 'react';
 import { speak } from '@/utils/speech';
-import { SpeechSynthesisVoice } from '@/types/speech';
 
 export const useSequentialSpeech = () => {
   const speakChunksSequentially = useCallback(

--- a/src/types/speech.ts
+++ b/src/types/speech.ts
@@ -1,13 +1,4 @@
 
-// Define the built-in SpeechSynthesisVoice interface type
-export interface SpeechSynthesisVoice {
-  default: boolean;
-  lang: string;
-  localService: boolean;
-  name: string;
-  voiceURI: string;
-}
-
 // Speech settings configuration
 export interface SpeechSettings {
   rate: number;

--- a/src/types/vocabulary.ts
+++ b/src/types/vocabulary.ts
@@ -1,5 +1,4 @@
 
-import { SpeechSynthesisVoice } from './speech';
 
 export interface VocabularyWord {
   word: string;
@@ -21,6 +20,3 @@ export interface EditableWord {
 export interface SheetData {
   [key: string]: VocabularyWord[];
 }
-
-// Re-export the SpeechSynthesisVoice type
-export type { SpeechSynthesisVoice };

--- a/src/utils/speech/core/chunkSequencer.ts
+++ b/src/utils/speech/core/chunkSequencer.ts
@@ -1,5 +1,4 @@
 
-import { SpeechSynthesisVoice } from '@/types/speech';
 import { getSpeechRate, getSpeechPitch, getSpeechVolume } from './speechSettings';
 
 type ChunkResult = { success: boolean, error?: string };

--- a/src/utils/speech/core/engineManager.ts
+++ b/src/utils/speech/core/engineManager.ts
@@ -1,5 +1,4 @@
 
-import { SpeechSynthesisVoice } from '@/types/speech';
 import { getVoiceByRegion } from '../voiceUtils';
 import { getSpeechRate, getSpeechPitch, getSpeechVolume } from './speechSettings';
 

--- a/src/utils/speech/core/modules/speechVoiceLoader.ts
+++ b/src/utils/speech/core/modules/speechVoiceLoader.ts
@@ -1,5 +1,4 @@
 
-import { SpeechSynthesisVoice } from '@/types/speech';
 
 // Enhanced voice loading with comprehensive monitoring
 export const loadVoicesAndWait = async (): Promise<SpeechSynthesisVoice[]> => {

--- a/src/utils/speech/synthesisUtils.ts
+++ b/src/utils/speech/synthesisUtils.ts
@@ -1,5 +1,4 @@
 
-import { SpeechSynthesisVoice } from '@/types/speech';
 
 export const synthesizeAudio = (text: string, voice: SpeechSynthesisVoice | null): Promise<string> => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- drop custom `SpeechSynthesisVoice` interface
- switch all references to use the built‑in browser type

## Testing
- `npx vitest run`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6852bff5162c832f8248b4196cf43748