### PR TITLE
Refactor button state key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ The app strips IPA notation and Vietnamese diacritics from speech output by defa
 If you prefer to keep them, set a `preserveSpecial` flag in local storage:
 
 ```js
-localStorage.setItem('buttonStates', JSON.stringify({ preserveSpecial: true }));
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+
+localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify({ preserveSpecial: true }));
 ```
 
 When `preserveSpecial` is `true`, `extractSpeechableContent` will leave those

--- a/src/hooks/audio/useAudioMuteEffect.tsx
+++ b/src/hooks/audio/useAudioMuteEffect.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from 'react';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export const useAudioMuteEffect = (
   mute: boolean,
@@ -10,9 +11,9 @@ export const useAudioMuteEffect = (
   useEffect(() => {
     // Store mute state in localStorage
     try {
-      const buttonStates = JSON.parse(localStorage.getItem('buttonStates') || '{}');
+      const buttonStates = JSON.parse(localStorage.getItem(BUTTON_STATES_KEY) || '{}');
       buttonStates.isMuted = mute;
-      localStorage.setItem('buttonStates', JSON.stringify(buttonStates));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(buttonStates));
     } catch (e) {
       // Ignore localStorage errors
     }

--- a/src/hooks/speech/useSpeechPlayback.tsx
+++ b/src/hooks/speech/useSpeechPlayback.tsx
@@ -1,6 +1,7 @@
 
 import { useCallback } from 'react';
 import { speak } from '@/utils/speech';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 import { useVoiceManager } from '@/hooks/useVoiceManager';
 import { useVoiceSettings } from './useVoiceSettings';
 import { useSpeechState } from './useSpeechState';
@@ -74,8 +75,8 @@ export const useSpeechPlayback = () => {
         
         // Make sure UI gets updated with new text before speaking
         setTimeout(() => {
-          const voiceRegion = localStorage.getItem('buttonStates') ? 
-            JSON.parse(localStorage.getItem('buttonStates') || '{}').voiceRegion || 'US' : 
+          const voiceRegion = localStorage.getItem(BUTTON_STATES_KEY) ?
+            JSON.parse(localStorage.getItem(BUTTON_STATES_KEY) || '{}').voiceRegion || 'US' :
             'US';
 
           // Fix the Promise type issue by explicitly handling the return value from speak()

--- a/src/hooks/speech/useVoiceSettings.tsx
+++ b/src/hooks/speech/useVoiceSettings.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from 'react';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 interface VoiceSettings {
   isMuted: boolean;
@@ -9,7 +10,7 @@ interface VoiceSettings {
 export const useVoiceSettings = () => {
   const getInitialStates = (): VoiceSettings => {
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       if (storedStates) {
         const parsedStates = JSON.parse(storedStates);
         
@@ -39,10 +40,10 @@ export const useVoiceSettings = () => {
   // Update mute state in localStorage when it changes
   useEffect(() => {
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const parsedStates = storedStates ? JSON.parse(storedStates) : {};
       parsedStates.isMuted = isMuted;
-      localStorage.setItem('buttonStates', JSON.stringify(parsedStates));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(parsedStates));
     } catch (error) {
       console.error('Error saving mute state to localStorage:', error);
     }

--- a/src/hooks/useMuteToggle.tsx
+++ b/src/hooks/useMuteToggle.tsx
@@ -1,6 +1,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export const useMuteToggle = (
   isMuted: boolean,
@@ -26,9 +27,9 @@ export const useMuteToggle = (
     
     // Don't restart speech, just update the muted state in localStorage
     try {
-      const buttonStates = JSON.parse(localStorage.getItem('buttonStates') || '{}');
+      const buttonStates = JSON.parse(localStorage.getItem(BUTTON_STATES_KEY) || '{}');
       buttonStates.isMuted = !mute;
-      localStorage.setItem('buttonStates', JSON.stringify(buttonStates));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(buttonStates));
     } catch (error) {
       console.error('Error updating mute state in localStorage:', error);
     }

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -2,6 +2,7 @@
 import { useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 /**
  * Data loading and persistence
@@ -16,10 +17,10 @@ export const useVocabularyDataLoader = (
   // Persist voice region whenever it changes
   useEffect(() => {
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const states = storedStates ? JSON.parse(storedStates) : {};
       states.voiceRegion = voiceRegion;
-      localStorage.setItem('buttonStates', JSON.stringify(states));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(states));
     } catch (error) {
       console.error('Error saving voice region to localStorage:', error);
     }

--- a/src/hooks/vocabulary/useCategoryActions.tsx
+++ b/src/hooks/vocabulary/useCategoryActions.tsx
@@ -2,6 +2,7 @@
 import { useCallback } from "react";
 import { vocabularyService } from "@/services/vocabularyService";
 import { stopSpeaking } from "@/utils/speech";
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export const useCategoryActions = (
   setCurrentWord: React.Dispatch<React.SetStateAction<any>>,
@@ -45,9 +46,9 @@ export const useCategoryActions = (
       
       // Store the current category in localStorage for persistence
       try {
-        const buttonStates = JSON.parse(localStorage.getItem('buttonStates') || '{}');
+        const buttonStates = JSON.parse(localStorage.getItem(BUTTON_STATES_KEY) || '{}');
         buttonStates.currentCategory = nextCategory;
-        localStorage.setItem('buttonStates', JSON.stringify(buttonStates));
+        localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(buttonStates));
       } catch (e) {
         // Ignore localStorage errors
       }

--- a/src/hooks/vocabulary/usePauseState.tsx
+++ b/src/hooks/vocabulary/usePauseState.tsx
@@ -1,10 +1,11 @@
 
 import { useState, useEffect } from 'react';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export const usePauseState = () => {
   const getInitialPausedState = () => {
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       if (storedStates) {
         const parsedStates = JSON.parse(storedStates);
         return parsedStates.isPaused === true;
@@ -19,10 +20,10 @@ export const usePauseState = () => {
 
   useEffect(() => {
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const parsedStates = storedStates ? JSON.parse(storedStates) : {};
       parsedStates.isPaused = isPaused;
-      localStorage.setItem('buttonStates', JSON.stringify(parsedStates));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(parsedStates));
     } catch (error) {
       console.error('Error saving pause state to localStorage:', error);
     }

--- a/src/services/vocabulary/VocabularySheetOperations.ts
+++ b/src/services/vocabulary/VocabularySheetOperations.ts
@@ -1,6 +1,7 @@
 
 import { WordNavigation } from "./WordNavigation";
 import { VocabularyDataManager } from "./VocabularyDataManager";
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export class VocabularySheetOperations {
   private wordNavigation: WordNavigation;
@@ -17,7 +18,7 @@ export class VocabularySheetOperations {
     
     // Get initial sheet name from localStorage if available
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       if (storedStates) {
         const parsedStates = JSON.parse(storedStates);
         if (parsedStates.currentCategory && this.sheetOptions.includes(parsedStates.currentCategory)) {

--- a/src/services/vocabulary/WordNavigation.ts
+++ b/src/services/vocabulary/WordNavigation.ts
@@ -1,4 +1,5 @@
 import { VocabularyWord, SheetData } from "@/types/vocabulary";
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 export class WordNavigation {
   private data: SheetData;
@@ -69,10 +70,10 @@ export class WordNavigation {
     
     // Store current category in localStorage for persistence
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const states = storedStates ? JSON.parse(storedStates) : {};
       states.currentCategory = sheetName;
-      localStorage.setItem('buttonStates', JSON.stringify(states));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(states));
     } catch (error) {
       console.error("Error saving current category to localStorage:", error);
     }
@@ -95,10 +96,10 @@ export class WordNavigation {
     
     // Store current category
     try {
-      const storedStates = localStorage.getItem('buttonStates');
+      const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const states = storedStates ? JSON.parse(storedStates) : {};
       states.currentCategory = nextSheetName;
-      localStorage.setItem('buttonStates', JSON.stringify(states));
+      localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(states));
     } catch (error) {
       console.error("Error saving current category to localStorage:", error);
     }

--- a/src/utils/speech/core/speechPlayerUtils.ts
+++ b/src/utils/speech/core/speechPlayerUtils.ts
@@ -1,5 +1,6 @@
 
 import { getVoiceByRegion } from '../voiceUtils';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
 
 // Store the current text being spoken for sync checking
 export function setCurrentTextBeingSpoken(processedText: string) {
@@ -12,7 +13,7 @@ export function setCurrentTextBeingSpoken(processedText: string) {
 
 export function isMutedFromLocalStorage(): boolean {
   try {
-    const storedStates = localStorage.getItem('buttonStates');
+    const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
     if (storedStates) {
       const parsedStates = JSON.parse(storedStates);
       return parsedStates.isMuted === true;

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,7 +1,9 @@
 
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+
 export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
   try {
-    const storedStates = localStorage.getItem('buttonStates');
+    const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       if (storedStates) {
         const parsedStates = JSON.parse(storedStates);
         if (parsedStates.voiceRegion === 'UK' || parsedStates.voiceRegion === 'AU') {
@@ -17,7 +19,7 @@ export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
 
 export const saveVoiceRegionToStorage = (region: 'US' | 'UK' | 'AU'): void => {
   try {
-    const existingStates = localStorage.getItem('buttonStates');
+    const existingStates = localStorage.getItem(BUTTON_STATES_KEY);
     let buttonStates = {};
     
     if (existingStates) {
@@ -29,7 +31,7 @@ export const saveVoiceRegionToStorage = (region: 'US' | 'UK' | 'AU'): void => {
       voiceRegion: region
     };
     
-    localStorage.setItem('buttonStates', JSON.stringify(updatedStates));
+    localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(updatedStates));
     console.log(`Voice region saved to storage: ${region}`);
   } catch (error) {
     console.error('Error saving voice region to localStorage:', error);

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,0 +1,1 @@
+export const BUTTON_STATES_KEY = 'buttonStates';

--- a/src/utils/text/contentFilters.ts
+++ b/src/utils/text/contentFilters.ts
@@ -1,3 +1,5 @@
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+
 /**
  * Enhanced content filtering for speech synthesis
  * Improved to preserve more speechable content while filtering out problematic elements
@@ -28,7 +30,7 @@ const BYPASS_PATTERNS = [
 export const getPreserveSpecialFromStorage = (): boolean => {
   try {
     if (typeof localStorage === 'undefined') return false;
-    const stored = localStorage.getItem('buttonStates');
+    const stored = localStorage.getItem(BUTTON_STATES_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
       return parsed.preserveSpecial === true;


### PR DESCRIPTION
## Summary
- add `BUTTON_STATES_KEY` constant
- use the constant for localStorage access
- update README example

## Testing
- `npm test` *(fails: vitest watch mode required interactive exit)*

------
https://chatgpt.com/codex/tasks/task_e_6852bff16f84832f9707e1aa09ba045a