### PR TITLE
Centralize speech voice names

### DIFF
--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -2,11 +2,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { VoiceSelection } from '../useVoiceSelection';
 import { toast } from 'sonner';
-
-// Hard-coded voice names from previously working version
-const US_VOICE_NAME = "en-US-Standard-G";
-const UK_VOICE_NAME = "Google UK English Female";
-const AU_VOICE_NAME = "en-AU-Standard-C";
+import {
+  US_VOICE_NAME,
+  UK_VOICE_NAME,
+  AU_VOICE_NAME
+} from '@/utils/speech/voiceNames';
 
 /**
  * Hook for managing voice selection and finding appropriate voices

--- a/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
@@ -1,9 +1,8 @@
 
 import { VoiceSelection } from '../useVoiceSelection';
+import { US_VOICE_NAME, UK_VOICE_NAME } from '@/utils/speech/voiceNames';
 
 // Hard-coded voice names based on previously working version
-const US_VOICE_NAME = "en-US-Standard-G"; // For US voice
-const UK_VOICE_NAME = "Google UK English Female"; // For UK voice
 
 // Backup voice names in case primary ones aren't found
 const BACKUP_US_VOICES = ["Google US English", "Microsoft David", "Alex"];

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -1,11 +1,14 @@
 
 import { useState, useEffect } from 'react';
+import {
+  US_VOICE_NAME,
+  UK_VOICE_NAME,
+  AU_VOICE_NAME
+} from '@/utils/speech/voiceNames';
 
-// Hard-coded voice names from previously working version
-const US_VOICE_NAME = "en-US-Standard-G";
-const UK_VOICE_NAME = "Google UK English Female";
+// Additional AU voice options beyond the primary one
 const AU_VOICE_NAMES = [
-  "en-AU-Standard-C",
+  AU_VOICE_NAME,
   "Google AU English Male",
   "Google AU English Female",
   "Karen",

--- a/src/utils/speech/index.ts
+++ b/src/utils/speech/index.ts
@@ -29,6 +29,7 @@ import { splitTextIntoChunks } from './core/textChunker';
 import { speakChunksInSequence } from './core/chunkSequencer';
 import { createSpeechMonitor, clearSpeechMonitor } from './core/speechMonitor';
 import { synthesizeAudio } from './synthesisUtils';
+import { US_VOICE_NAME, UK_VOICE_NAME, AU_VOICE_NAME } from './voiceNames';
 
 export {
   speak,
@@ -56,5 +57,8 @@ export {
   speakChunksInSequence,
   createSpeechMonitor,
   clearSpeechMonitor,
-  synthesizeAudio
+  synthesizeAudio,
+  US_VOICE_NAME,
+  UK_VOICE_NAME,
+  AU_VOICE_NAME
 };

--- a/src/utils/speech/voiceNames.ts
+++ b/src/utils/speech/voiceNames.ts
@@ -1,0 +1,3 @@
+export const US_VOICE_NAME = "en-US-Standard-G";
+export const UK_VOICE_NAME = "Google UK English Female";
+export const AU_VOICE_NAME = "en-AU-Standard-C";

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -1,16 +1,20 @@
 import { VoiceSelection } from "@/hooks/vocabulary-playback/useVoiceSelection";
+import {
+  US_VOICE_NAME,
+  UK_VOICE_NAME,
+  AU_VOICE_NAME
+} from "@/utils/speech/voiceNames";
 
 // Updated voice names with better UK and AU options
-const US_VOICE_NAME = "en-US-Standard-G"; // For US voice
 const UK_VOICE_NAMES = [
-  "Google UK English Female", // Primary option
+  UK_VOICE_NAME, // Primary option
   "Daniel", // Backup UK voice
   "Kate", // Another backup
   "Susan", // Microsoft UK voice
   "Hazel" // Additional UK option
 ];
 const AU_VOICE_NAMES = [
-  "en-AU-Standard-C", // Energetic AU voice
+  AU_VOICE_NAME, // Energetic AU voice
   "Google AU English Male", // Younger male AU option
   "Google AU English Female", // Original female option
   "Karen", // macOS AU voice


### PR DESCRIPTION
## Summary
- create `voiceNames` constants for US, UK and AU voices
- import those voice names in hooks and utilities
- export voice constants from the speech index

## Testing
- `npm install --ignore-scripts`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6852c0061428832f8bf04e4076991fb8