### PR TITLE
Remove blocking text validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ npm test       # execute unit tests with vitest
 npm run lint   # check code style with ESLint
 ```
 
-## Vocabulary limits
-
-Meanings longer than 500 characters will be rejected during validation. The limit
-is defined as `MAX_MEANING_LENGTH` in
-`src/services/vocabulary/storage/constants.ts`. If you import custom lists,
-shorten or split very long definitions so they stay under this threshold.
 
 ## Enabling speech playback
 

--- a/src/utils/security/validation/exampleValidation.ts
+++ b/src/utils/security/validation/exampleValidation.ts
@@ -1,73 +1,33 @@
 
-import { ValidationResult, VOCABULARY_CHAR_CLASS } from '../validationTypes';
+import { ValidationResult } from '../validationTypes';
 import { sanitizeInput } from '../sanitization';
-import { shouldBypassValidation } from '../../text/contentFilters';
 
 /**
  * Validates example input with content filtering support
  */
 export const validateExample = (example: string): ValidationResult => {
   const errors: string[] = [];
-  
+
   console.log('[EXAMPLE-VALIDATION] Starting validation for example:', example);
-  
+
   if (!example || typeof example !== 'string') {
     errors.push('Example is required');
     return { isValid: false, errors };
   }
-  
-  // Check if content should bypass validation
-  if (shouldBypassValidation(example)) {
-    console.log('[EXAMPLE-VALIDATION] Content contains IPA/Vietnamese, bypassing character validation');
-    
-    const sanitized = sanitizeInput(example);
-    
-    if (sanitized.length === 0) {
-      errors.push('Example cannot be empty after sanitization');
-    }
-    
-    if (sanitized.length > 1000) {
-      errors.push('Example must be less than 1000 characters');
-    }
-    
-    const result = {
-      isValid: errors.length === 0,
-      sanitizedValue: sanitized,
-      errors
-    };
-    
-    console.log('[EXAMPLE-VALIDATION] Bypass validation result:', result);
-    return result;
-  }
-  
-  // Standard validation path
+
   const sanitized = sanitizeInput(example);
   console.log('[EXAMPLE-VALIDATION] After sanitization:', sanitized);
-  
+
   if (sanitized.length === 0) {
     errors.push('Example cannot be empty after sanitization');
   }
-  
-  if (sanitized.length > 1000) {
-    errors.push('Example must be less than 1000 characters');
-  }
-  
-  // Most permissive for examples - use the same comprehensive character class
-  const examplePattern = new RegExp(`^${VOCABULARY_CHAR_CLASS}+$`);
-  
-  if (!examplePattern.test(sanitized)) {
-    const invalidChars = sanitized.split('').filter(char => !examplePattern.test(char));
-    console.log('[EXAMPLE-VALIDATION] Character validation failed for:', sanitized);
-    console.log('[EXAMPLE-VALIDATION] Invalid characters found:', invalidChars);
-    errors.push(`Example contains unsupported characters: ${invalidChars.join(', ')}`);
-  }
-  
+
   const result = {
     isValid: errors.length === 0,
     sanitizedValue: sanitized,
     errors
   };
-  
+
   console.log('[EXAMPLE-VALIDATION] Validation result:', result);
   return result;
 };

--- a/src/utils/security/validation/meaningValidation.ts
+++ b/src/utils/security/validation/meaningValidation.ts
@@ -1,73 +1,33 @@
 
-import { ValidationResult, VOCABULARY_CHAR_CLASS } from '../validationTypes';
+import { ValidationResult } from '../validationTypes';
 import { sanitizeInput } from '../sanitization';
-import { shouldBypassValidation } from '../../text/contentFilters';
 
 /**
  * Validates meaning/definition input with content filtering support
  */
 export const validateMeaning = (meaning: string): ValidationResult => {
   const errors: string[] = [];
-  
+
   console.log('[MEANING-VALIDATION] Starting validation for meaning:', meaning);
-  
+
   if (!meaning || typeof meaning !== 'string') {
     errors.push('Meaning is required');
     return { isValid: false, errors };
   }
-  
-  // Check if content should bypass validation
-  if (shouldBypassValidation(meaning)) {
-    console.log('[MEANING-VALIDATION] Content contains IPA/Vietnamese, bypassing character validation');
-    
-    const sanitized = sanitizeInput(meaning);
-    
-    if (sanitized.length === 0) {
-      errors.push('Meaning cannot be empty after sanitization');
-    }
-    
-    if (sanitized.length > 500) {
-      errors.push('Meaning must be less than 500 characters');
-    }
-    
-    const result = {
-      isValid: errors.length === 0,
-      sanitizedValue: sanitized,
-      errors
-    };
-    
-    console.log('[MEANING-VALIDATION] Bypass validation result:', result);
-    return result;
-  }
-  
-  // Standard validation path
+
   const sanitized = sanitizeInput(meaning);
   console.log('[MEANING-VALIDATION] After sanitization:', sanitized);
-  
+
   if (sanitized.length === 0) {
     errors.push('Meaning cannot be empty after sanitization');
   }
-  
-  if (sanitized.length > 500) {
-    errors.push('Meaning must be less than 500 characters');
-  }
-  
-  // Use the comprehensive character class for meanings as well
-  const meaningPattern = new RegExp(`^${VOCABULARY_CHAR_CLASS}+$`);
-  
-  if (!meaningPattern.test(sanitized)) {
-    const invalidChars = sanitized.split('').filter(char => !meaningPattern.test(char));
-    console.log('[MEANING-VALIDATION] Character validation failed for:', sanitized);
-    console.log('[MEANING-VALIDATION] Invalid characters found:', invalidChars);
-    errors.push(`Meaning contains unsupported characters: ${invalidChars.join(', ')}`);
-  }
-  
+
   const result = {
     isValid: errors.length === 0,
     sanitizedValue: sanitized,
     errors
   };
-  
+
   console.log('[MEANING-VALIDATION] Validation result:', result);
   return result;
 };

--- a/src/utils/security/validation/wordValidation.ts
+++ b/src/utils/security/validation/wordValidation.ts
@@ -1,81 +1,33 @@
 
-import { ValidationResult, VOCABULARY_CHAR_CLASS } from '../validationTypes';
+import { ValidationResult } from '../validationTypes';
 import { sanitizeInput } from '../sanitization';
-import { shouldBypassValidation, hasValidSpeechableContent } from '../../text/contentFilters';
 
 /**
  * Validates vocabulary word input with content filtering support
  */
 export const validateVocabularyWord = (word: string): ValidationResult => {
   const errors: string[] = [];
-  
+
   console.log('[WORD-VALIDATION] Starting validation for word:', word);
-  
+
   if (!word || typeof word !== 'string') {
     errors.push('Word is required');
     return { isValid: false, errors };
   }
-  
-  // Check if content should bypass validation
-  if (shouldBypassValidation(word)) {
-    console.log('[WORD-VALIDATION] Content contains IPA/Vietnamese, bypassing character validation');
-    
-    // Still apply basic sanitization but skip character validation
-    const sanitized = sanitizeInput(word);
-    
-    if (sanitized.length === 0) {
-      errors.push('Word cannot be empty after sanitization');
-    }
-    
-    if (sanitized.length > 100) {
-      errors.push('Word must be less than 100 characters');
-    }
-    
-    // Check if there's any speechable content remaining
-    if (!hasValidSpeechableContent(sanitized)) {
-      console.log('[WORD-VALIDATION] Warning: No speechable content after filtering');
-      // This is just a warning, not an error - allow the word to pass
-    }
-    
-    const result = {
-      isValid: errors.length === 0,
-      sanitizedValue: sanitized,
-      errors
-    };
-    
-    console.log('[WORD-VALIDATION] Bypass validation result:', result);
-    return result;
-  }
-  
-  // Standard validation path for regular content
+
   const sanitized = sanitizeInput(word);
   console.log('[WORD-VALIDATION] After sanitization:', sanitized);
-  
+
   if (sanitized.length === 0) {
     errors.push('Word cannot be empty after sanitization');
   }
-  
-  if (sanitized.length > 100) {
-    errors.push('Word must be less than 100 characters');
-  }
-  
-  // Use the comprehensive character class that includes Unicode ranges
-  const wordPattern = new RegExp(`^${VOCABULARY_CHAR_CLASS}+$`);
-  
-  if (!wordPattern.test(sanitized)) {
-    // Get the invalid characters for debugging
-    const invalidChars = sanitized.split('').filter(char => !wordPattern.test(char));
-    console.log('[WORD-VALIDATION] Character validation failed for:', sanitized);
-    console.log('[WORD-VALIDATION] Invalid characters found:', invalidChars);
-    errors.push(`Word contains unsupported characters: ${invalidChars.join(', ')}`);
-  }
-  
+
   const result = {
     isValid: errors.length === 0,
     sanitizedValue: sanitized,
     errors
   };
-  
+
   console.log('[WORD-VALIDATION] Validation result:', result);
   return result;
 };

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { validateVocabularyWord, validateMeaning, validateExample } from '../src/utils/security/validation';
-import { VALIDATION_LIMITS } from '../src/services/vocabulary/storage/constants';
 
 // Representative tests for vocabulary validation utilities
 
@@ -38,10 +37,10 @@ describe('validateMeaning', () => {
     expect(result.sanitizedValue).toBe('users');
   });
 
-  it('rejects meanings that exceed the configured length', () => {
-    const longMeaning = 'x'.repeat(VALIDATION_LIMITS.MAX_MEANING_LENGTH + 1);
+  it('allows meanings of any length', () => {
+    const longMeaning = 'x'.repeat(600);
     const result = validateMeaning(longMeaning);
-    expect(result.isValid).toBe(false);
+    expect(result.isValid).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- relax vocabulary validation logic so all lengths pass
- update unit tests accordingly
- remove note about max meaning length from README

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 42 errors, 32 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6852c67796c8832fae2dd63fde464a30