### PR TITLE
Add mobile speech note

### DIFF
--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -67,6 +67,11 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
         voiceRegion={voiceRegion}
         nextVoiceLabel={nextVoiceLabel}
         />
+        <div className="mt-2 text-xs italic text-gray-500 text-center">
+          <p>On Mobile:</p>
+          <p>- Tap any button (e.g., Next) to enable speech</p>
+          <p>- Only Australian voice may be available</p>
+        </div>
       </div>
       
       {/* Controls column - positioned on the right side */}


### PR DESCRIPTION
## Summary
- add note about mobile speech below the card

## Testing
- `npm run build:dev` *(fails: Cannot find module '@vitejs/plugin-react-swc')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a06cd6564832fba6bf9c207432607