### PR TITLE
Move mobile speech note

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -74,10 +74,17 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         onOpenAddModal={handleOpenAddWordModal}
         onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       />
-      
-      
+
+
+      {/* Mobile speech note fixed above debug panel */}
+      <div className="fixed inset-x-0 bottom-24 text-xs italic text-gray-500 text-center pointer-events-none">
+        <p>On Mobile:</p>
+        <p>- Tap any button (e.g., Next) to enable speech</p>
+        <p>- Only Australian voice may be available</p>
+      </div>
+
       {/* Debug Panel */}
-      <DebugPanel 
+      <DebugPanel
         isMuted={muted}
         voiceRegion={voiceRegion}
         isPaused={paused}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -67,11 +67,6 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
         voiceRegion={voiceRegion}
         nextVoiceLabel={nextVoiceLabel}
         />
-        <div className="mt-2 text-xs italic text-gray-500 text-center">
-          <p>On Mobile:</p>
-          <p>- Tap any button (e.g., Next) to enable speech</p>
-          <p>- Only Australian voice may be available</p>
-        </div>
       </div>
       
       {/* Controls column - positioned on the right side */}


### PR DESCRIPTION
## Summary
- move mobile speech hint from inside `VocabularyMainNew` to a fixed block above the debug session

## Testing
- `npx vitest run` *(fails: Error: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685a084c5588832fa59747b626f524bb