### PR TITLE
Reduce default CardContent padding

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -33,7 +33,7 @@ const FileUpload: React.FC<FileUploadProps> = ({
 
   return (
     <Card className="w-full max-w-xl mx-auto">
-      <CardContent className="p-6">
+      <CardContent className="p-2">
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">

--- a/src/components/NotificationManager.tsx
+++ b/src/components/NotificationManager.tsx
@@ -142,7 +142,7 @@ const NotificationManager: React.FC<NotificationManagerProps> = ({
   
   return (
     <Card className="w-full max-w-xl mx-auto">
-      <CardContent className="p-6">
+      <CardContent className="p-2">
         <div className="space-y-4">
           <h2 className="text-xl font-semibold">Notifications</h2>
           

--- a/src/components/VocabularyCard.tsx
+++ b/src/components/VocabularyCard.tsx
@@ -75,7 +75,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
       )}
       style={{ backgroundColor }}
     >
-      <CardContent className="p-3">
+      <CardContent className="p-2">
         <div className="space-y-2">
           <div className="flex justify-between items-start">
             <div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-2 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -60,7 +60,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
       )}
       style={{ backgroundColor }}
     >
-      <CardContent className="p-6 sm:p-8">
+      <CardContent className="p-2">
         <div className="space-y-2">
           {/* Category and Word Count */}
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- tighten `CardContent` padding defaults
- adjust all components that override `CardContent` padding

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca9f98bc8832f9c3544eed4c9b61f