### PR TITLE
Add ChangeVariantIcon for voice variants

### DIFF
--- a/src/components/ChangeVariantIcon.tsx
+++ b/src/components/ChangeVariantIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Shuffle } from 'lucide-react';
+import { useVoiceContext } from '@/hooks/context/useVoiceContext';
+
+const ChangeVariantIcon: React.FC = () => {
+  const { variant, cycleVariant } = useVoiceContext();
+
+  const handleClick = () => {
+    cycleVariant();
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={handleClick}
+      aria-label={`Variant ${variant}`}
+      title={`Variant ${variant}`}
+      className="text-blue-700 border-blue-300 bg-blue-50"
+    >
+      <Shuffle size={16} />
+    </Button>
+  );
+};
+
+export default ChangeVariantIcon;

--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -10,6 +10,7 @@ import { useVocabularyAppState } from "./hooks/useVocabularyAppState";
 import { useDisplayWord } from "./hooks/useDisplayWord";
 import { useVoiceLabels } from "./hooks/useVoiceLabels";
 import VocabularyAppContent from "./components/VocabularyAppContent";
+import { VoiceProvider } from "@/hooks/context/useVoiceContext";
 
 const VocabularyAppContainer: React.FC = () => {
   console.log('[VOCAB-CONTAINER] === Component Render ===');
@@ -139,8 +140,9 @@ const VocabularyAppContainer: React.FC = () => {
   const displaySelectedVoice = typeof selectedVoice === 'string' ? selectedVoice : selectedVoice?.region || 'UK';
 
   return (
-    <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
-      <VocabularyAppContent
+    <VoiceProvider playCurrentWord={playCurrentWord}>
+      <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
+        <VocabularyAppContent
         hasData={hasData}
         hasAnyData={hasAnyData}
         displayWord={displayWord}
@@ -167,7 +169,8 @@ const VocabularyAppContainer: React.FC = () => {
         handleOpenAddWordModal={handleOpenAddWordModal}
         handleOpenEditWordModal={handleOpenEditWordModal}
       />
-    </VocabularyLayout>
+      </VocabularyLayout>
+    </VoiceProvider>
   );
 };
 

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker } from 'lucide-react';
+import ChangeVariantIcon from '../ChangeVariantIcon';
 import { toast } from 'sonner';
 import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
@@ -124,6 +125,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       >
         <Speaker size={16} />
       </Button>
+
+      <ChangeVariantIcon />
 
       <EditWordButton onClick={onOpenEditModal} disabled={!currentWord} />
       <AddWordButton onClick={onOpenAddModal} />

--- a/src/hooks/context/useVoiceContext.tsx
+++ b/src/hooks/context/useVoiceContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+interface VoiceContextValue {
+  variant: string;
+  cycleVariant: () => void;
+  playCurrentWord: () => void;
+}
+
+const VoiceContext = createContext<VoiceContextValue | undefined>(undefined);
+
+export const useVoiceContext = () => {
+  const ctx = useContext(VoiceContext);
+  if (!ctx) {
+    throw new Error('useVoiceContext must be used within VoiceProvider');
+  }
+  return ctx;
+};
+
+interface VoiceProviderProps {
+  playCurrentWord: () => void;
+  children: React.ReactNode;
+}
+
+const VARIANTS = ['A', 'B', 'C'];
+
+export const VoiceProvider: React.FC<VoiceProviderProps> = ({ playCurrentWord, children }) => {
+  const [index, setIndex] = useState(0);
+
+  const cycleVariant = useCallback(() => {
+    setIndex(i => (i + 1) % VARIANTS.length);
+    // restart playback after variant change
+    playCurrentWord();
+  }, [playCurrentWord]);
+
+  const value = {
+    variant: VARIANTS[index],
+    cycleVariant,
+    playCurrentWord,
+  };
+
+  return <VoiceContext.Provider value={value}>{children}</VoiceContext.Provider>;
+};


### PR DESCRIPTION
## Summary
- add `VoiceProvider` and `useVoiceContext` for variant cycling
- create `ChangeVariantIcon` small button
- show variant code with aria-label and tooltip
- restart playback after variant change
- expose provider in `VocabularyAppContainer`
- add icon next to voice controls in `VocabularyControlsColumn`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685cf50bd534832fbabd453a6563c85f