### PR TITLE
Add voice variant support

### DIFF
--- a/src/hooks/speech/useSimpleSpeech.ts
+++ b/src/hooks/speech/useSimpleSpeech.ts
@@ -48,7 +48,11 @@ export const useSimpleSpeech = () => {
       };
 
       // Use the correct signature with only word and region
-      const success = await unifiedSpeechController.speak(wordObject, 'US');
+      const success = await unifiedSpeechController.speak(
+        wordObject,
+        'US',
+        options.voice?.name
+      );
 
       if (success) {
         console.log(`[SIMPLE-SPEECH-${speechId}] Speech started successfully`);

--- a/src/hooks/useVoiceContext.tsx
+++ b/src/hooks/useVoiceContext.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { VOICE_SETTINGS_KEY } from '@/utils/storageKeys';
+import { VOICE_VARIANTS } from '@/utils/speech/voiceVariants';
+import type { VoiceVariant } from '@/utils/speech/voiceVariants';
+
+export type VoiceRegion = 'US' | 'UK' | 'AU';
+
+interface VoiceContext {
+  voiceRegion: VoiceRegion;
+  voiceVariant: VoiceVariant;
+  setVoiceRegion: (region: VoiceRegion) => void;
+  setVoiceVariant: (variant: VoiceVariant) => void;
+}
+
+export const useVoiceContext = (): VoiceContext => {
+  const loadSettings = () => {
+    try {
+      const raw = localStorage.getItem(VOICE_SETTINGS_KEY);
+      if (raw) {
+        return JSON.parse(raw) as { voiceRegion?: VoiceRegion; voiceVariant?: VoiceVariant };
+      }
+    } catch (err) {
+      console.error('Failed to load voice settings', err);
+    }
+    return {};
+  };
+
+  const saved = loadSettings();
+  const defaultRegion: VoiceRegion = saved.voiceRegion || 'UK';
+  const defaultVariant: VoiceVariant =
+    saved.voiceVariant || VOICE_VARIANTS[defaultRegion][0];
+
+  const [voiceRegion, setVoiceRegionState] = useState<VoiceRegion>(defaultRegion);
+  const [voiceVariant, setVoiceVariantState] = useState<VoiceVariant>(defaultVariant);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        VOICE_SETTINGS_KEY,
+        JSON.stringify({ voiceRegion, voiceVariant })
+      );
+    } catch (err) {
+      console.error('Failed to save voice settings', err);
+    }
+  }, [voiceRegion, voiceVariant]);
+
+  const setVoiceRegion = (region: VoiceRegion) => {
+    setVoiceRegionState(region);
+    // Reset variant if region changes and variant is not in list
+    if (!VOICE_VARIANTS[region].includes(voiceVariant)) {
+      setVoiceVariantState(VOICE_VARIANTS[region][0]);
+    }
+  };
+
+  const setVoiceVariant = (variant: VoiceVariant) => {
+    setVoiceVariantState(variant);
+  };
+
+  return { voiceRegion, voiceVariant, setVoiceRegion, setVoiceVariant };
+};

--- a/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
+++ b/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
@@ -8,6 +8,7 @@ import { unifiedSpeechController } from '@/services/speech/unifiedSpeechControll
 interface SpeechIntegrationProps {
   currentWord: VocabularyWord | null;
   voiceRegion: VoiceRegion;
+  voiceVariant: string;
   isPaused: boolean;
   isMuted: boolean;
   isTransitioningRef: React.MutableRefObject<boolean>;
@@ -16,6 +17,7 @@ interface SpeechIntegrationProps {
 export const useSpeechIntegration = (
   currentWord: VocabularyWord | null,
   voiceRegion: VoiceRegion,
+  voiceVariant: string,
   isPaused: boolean,
   isMuted: boolean,
   isTransitioningRef: React.MutableRefObject<boolean>
@@ -41,13 +43,13 @@ export const useSpeechIntegration = (
     setSpeechState(prev => ({ ...prev, isActive: true, phase: 'speaking' }));
     
     try {
-      await unifiedSpeechController.speak(currentWord, voiceRegion);
+      await unifiedSpeechController.speak(currentWord, voiceRegion, voiceVariant);
     } catch (error) {
       console.error('[SPEECH-INTEGRATION] Error playing word:', error);
     } finally {
       setSpeechState(prev => ({ ...prev, isActive: false, phase: 'idle' }));
     }
-  }, [currentWord, voiceRegion, isPaused, isMuted, isTransitioningRef]);
+  }, [currentWord, voiceRegion, voiceVariant, isPaused, isMuted, isTransitioningRef]);
 
   // Effect to trigger speech when dependencies change
   useEffect(() => {
@@ -64,7 +66,7 @@ export const useSpeechIntegration = (
     console.log('[SPEECH-INTEGRATION] Dependencies changed, attempting to speak:', currentWord.word);
     playCurrentWord();
 
-  }, [currentWord, isMuted, isPaused, voiceRegion, playCurrentWord]);
+  }, [currentWord, isMuted, isPaused, voiceRegion, voiceVariant, playCurrentWord]);
 
   return {
     speechState,

--- a/src/hooks/vocabulary-controller/core/useVocabularyState.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyState.ts
@@ -1,7 +1,7 @@
 
 import { useState, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
-import { getVoiceRegionFromStorage } from '@/utils/speech/core/speechSettings';
+import { useVoiceContext } from '@/hooks/useVoiceContext';
 
 /**
  * Core vocabulary state management
@@ -15,8 +15,12 @@ export const useVocabularyState = () => {
   // Control state
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
-  const initialRegion = getVoiceRegionFromStorage();
-  const [voiceRegion, setVoiceRegion] = useState<'US' | 'UK' | 'AU'>(initialRegion);
+  const {
+    voiceRegion,
+    setVoiceRegion,
+    voiceVariant,
+    setVoiceVariant
+  } = useVoiceContext();
 
   // Derived state - calculate currentWord safely
   const currentWord = wordList[currentIndex] ?? null;
@@ -39,6 +43,8 @@ export const useVocabularyState = () => {
     setIsMuted,
     voiceRegion,
     setVoiceRegion,
+    voiceVariant,
+    setVoiceVariant,
     currentWord,
     
     // Refs

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -29,6 +29,8 @@ export const useUnifiedVocabularyController = () => {
     setIsMuted,
     voiceRegion,
     setVoiceRegion,
+    voiceVariant,
+    setVoiceVariant,
     currentWord,
     isTransitioningRef,
     lastWordChangeRef
@@ -44,7 +46,7 @@ export const useUnifiedVocabularyController = () => {
   const {
     speechState,
     playCurrentWord
-  } = useSpeechIntegration(currentWord, voiceRegion, isPaused, isMuted, isTransitioningRef);
+  } = useSpeechIntegration(currentWord, voiceRegion, voiceVariant, isPaused, isMuted, isTransitioningRef);
 
   // Word navigation with proper state management
   const {
@@ -134,6 +136,7 @@ export const useUnifiedVocabularyController = () => {
     isPaused,
     isMuted,
     voiceRegion,
+    voiceVariant,
     isSpeaking: speechState.isActive,
     
     // Actions

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechController.ts
@@ -10,6 +10,7 @@ import { unifiedSpeechController } from '@/services/speech/unifiedSpeechControll
 export const useSpeechController = (
   findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
+  voiceVariant: string,
   scheduleAutoAdvance: (delay: number) => void
 ) => {
   const executeSpeechSynthesis = useCallback(async (
@@ -33,7 +34,11 @@ export const useSpeechController = (
       }
 
       // Use the unified speech controller
-      const success = await unifiedSpeechController.speak(currentWord, selectedVoice.region);
+      const success = await unifiedSpeechController.speak(
+        currentWord,
+        selectedVoice.region,
+        voiceVariant
+      );
 
       if (success) {
         onStart();
@@ -57,7 +62,7 @@ export const useSpeechController = (
       }
       return false;
     }
-  }, [selectedVoice, scheduleAutoAdvance]);
+  }, [selectedVoice, voiceVariant, scheduleAutoAdvance]);
 
   return {
     executeSpeechSynthesis

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
@@ -34,6 +34,7 @@ export const usePlaybackExecution = (
   const { executeSpeech } = useSpeechExecution(
     findVoice,
     selectedVoice,
+    selectedVoice.label,
     setIsSpeaking,
     speakingRef,
     resetRetryAttempts,

--- a/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
@@ -15,7 +15,8 @@ export const useSpeechExecution = (
   isPlayingRef: React.MutableRefObject<boolean>,
   advanceToNext: () => void,
   muted: boolean,
-  paused: boolean
+  paused: boolean,
+  voiceVariant: string
 ) => {
   const executeSpeech = useCallback(async (
     wordToPlay: VocabularyWord,
@@ -33,7 +34,11 @@ export const useSpeechExecution = (
     }
     
     try {
-      const success = await unifiedSpeechController.speak(wordToPlay, selectedVoice.region);
+      const success = await unifiedSpeechController.speak(
+        wordToPlay,
+        selectedVoice.region,
+        voiceVariant
+      );
       
       if (success) {
         setIsSpeaking(true);
@@ -77,7 +82,7 @@ export const useSpeechExecution = (
       
       return false;
     }
-  }, [selectedVoice, setIsSpeaking, isPlayingRef, advanceToNext, muted, paused]);
+  }, [selectedVoice, voiceVariant, setIsSpeaking, isPlayingRef, advanceToNext, muted, paused]);
 
   return {
     executeSpeech

--- a/src/hooks/vocabulary-playback/speech-playback/useSpeechPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/useSpeechPlaybackCore.ts
@@ -28,7 +28,8 @@ export const useSpeechPlaybackCore = (
     isPlayingRef,
     advanceToNext,
     muted,
-    paused
+    paused,
+    selectedVoice.label
   );
 
   const playWord = useCallback(async (wordToPlay: VocabularyWord | null) => {

--- a/src/hooks/vocabulary-playback/speech-playbook/core/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/speech-playbook/core/useSpeechExecution.ts
@@ -15,7 +15,8 @@ export const useSpeechExecution = (
   isPlayingRef: React.MutableRefObject<boolean>,
   advanceToNext: () => void,
   muted: boolean,
-  paused: boolean
+  paused: boolean,
+  voiceVariant: string
 ) => {
   const executeSpeech = useCallback(async (
     wordToPlay: VocabularyWord,
@@ -33,7 +34,11 @@ export const useSpeechExecution = (
     }
     
     try {
-      const success = await unifiedSpeechController.speak(wordToPlay, selectedVoice.region);
+      const success = await unifiedSpeechController.speak(
+        wordToPlay,
+        selectedVoice.region,
+        voiceVariant
+      );
       
       if (success) {
         setIsSpeaking(true);
@@ -77,7 +82,7 @@ export const useSpeechExecution = (
       
       return false;
     }
-  }, [selectedVoice, setIsSpeaking, isPlayingRef, advanceToNext, muted, paused]);
+  }, [selectedVoice, voiceVariant, setIsSpeaking, isPlayingRef, advanceToNext, muted, paused]);
 
   return {
     executeSpeech

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -3,6 +3,7 @@ import { realSpeechService } from './realSpeechService';
 
 interface SpeechOptions {
   voiceRegion: 'US' | 'UK' | 'AU';
+  voiceVariant?: string;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
 }

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -3,6 +3,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 
 interface SpeechOptions {
   voiceRegion: 'US' | 'UK' | 'AU';
+  voiceVariant?: string;
   onStart?: () => void;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
@@ -29,8 +30,9 @@ class RealSpeechService {
     return new Promise((resolve) => {
       const utterance = new SpeechSynthesisUtterance(text);
       
-      // Set voice based on region
-      const voice = this.findVoiceByRegion(options.voiceRegion);
+      // Set voice based on variant or region
+      const voice = this.findVoiceByVariant(options.voiceVariant) ||
+                    this.findVoiceByRegion(options.voiceRegion);
       if (voice) {
         utterance.voice = voice;
         console.log('Using voice:', voice.name, 'for region:', options.voiceRegion);
@@ -138,6 +140,12 @@ class RealSpeechService {
 
   getCurrentUtterance(): SpeechSynthesisUtterance | null {
     return this.currentUtterance;
+  }
+
+  private findVoiceByVariant(name?: string): SpeechSynthesisVoice | null {
+    if (!name) return null;
+    const voices = window.speechSynthesis.getVoices();
+    return voices.find(v => v.name === name || v.name.includes(name)) || null;
   }
 
   private findVoiceByRegion(region: 'US' | 'UK' | 'AU'): SpeechSynthesisVoice | null {

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -14,7 +14,8 @@ class UnifiedSpeechController {
 
   async speak(
     word: VocabularyWord,
-    region: 'US' | 'UK' | 'AU' = 'US'
+    region: 'US' | 'UK' | 'AU' = 'US',
+    variant?: string
   ): Promise<boolean> {
     if (this.isMutedState) {
       console.log('Speech is muted, scheduling auto-advance instead');
@@ -27,10 +28,11 @@ class UnifiedSpeechController {
       .map(part => part.trim());
     const text = parts.join('. ');
 
-    console.log('UnifiedSpeechController: Speaking word:', word.word, 'in region:', region);
+    console.log('UnifiedSpeechController: Speaking word:', word.word, 'in region:', region, 'variant:', variant);
 
     return realSpeechService.speak(text, {
       voiceRegion: region,
+      voiceVariant: variant,
       onStart: () => {
         console.log('Word speech started:', word.word);
       },

--- a/src/types/speech.ts
+++ b/src/types/speech.ts
@@ -8,3 +8,5 @@ export interface SpeechSettings {
 
 // Voice region type
 export type VoiceRegion = 'US' | 'UK' | 'AU';
+
+export type VoiceVariant = string;

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,5 +1,5 @@
 
-import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+import { BUTTON_STATES_KEY, VOICE_SETTINGS_KEY } from '@/utils/storageKeys';
 
 export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
   try {
@@ -35,6 +35,32 @@ export const saveVoiceRegionToStorage = (region: 'US' | 'UK' | 'AU'): void => {
     console.log(`Voice region saved to storage: ${region}`);
   } catch (error) {
     console.error('Error saving voice region to localStorage:', error);
+  }
+};
+
+export const getVoiceVariantFromStorage = (): string => {
+  try {
+    const stored = localStorage.getItem(VOICE_SETTINGS_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (typeof parsed.voiceVariant === 'string') {
+        return parsed.voiceVariant;
+      }
+    }
+  } catch (error) {
+    console.error('Error reading voice variant from localStorage:', error);
+  }
+  return '';
+};
+
+export const saveVoiceVariantToStorage = (variant: string): void => {
+  try {
+    const existing = localStorage.getItem(VOICE_SETTINGS_KEY);
+    const data = existing ? JSON.parse(existing) : {};
+    data.voiceVariant = variant;
+    localStorage.setItem(VOICE_SETTINGS_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('Error saving voice variant to localStorage:', error);
   }
 };
 

--- a/src/utils/speech/voiceVariants.ts
+++ b/src/utils/speech/voiceVariants.ts
@@ -1,0 +1,9 @@
+import { US_VOICE_NAME, UK_VOICE_NAMES, AU_VOICE_NAMES } from './voiceNames';
+
+export const VOICE_VARIANTS = {
+  US: [US_VOICE_NAME],
+  UK: UK_VOICE_NAMES,
+  AU: AU_VOICE_NAMES
+} as const;
+
+export type VoiceVariant = typeof VOICE_VARIANTS[keyof typeof VOICE_VARIANTS][number];

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,1 +1,2 @@
 export const BUTTON_STATES_KEY = 'buttonStates';
+export const VOICE_SETTINGS_KEY = 'voiceSettings';


### PR DESCRIPTION
## Summary
- add `VOICE_VARIANTS` mapping of available voice names
- create `useVoiceContext` hook to store region and variant
- persist voice settings in `VOICE_SETTINGS_KEY`
- extend speech services/controllers to accept voice variant
- propagate variant through vocabulary controllers and playback

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cf50aa118832f8ddfb62251a0b9c7