### PR TITLE
Wrap content with VoiceProvider

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -11,6 +11,7 @@ import { useStableVocabularyState } from "@/hooks/vocabulary-app/useStableVocabu
 import { useOptimizedAutoPlay } from "@/hooks/vocabulary-app/useOptimizedAutoPlay";
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { vocabularyService } from '@/services/vocabularyService';
+import { VoiceProvider } from "@/hooks/context/useVoiceContext";
 
 const VocabularyAppContainerNew: React.FC = () => {
   // Use stable state management
@@ -78,9 +79,10 @@ const VocabularyAppContainerNew: React.FC = () => {
       : null;
   }, [currentWord?.word, currentWord?.category, currentCategory]);
 
-  // Render different states based on data availability
+  let content: React.ReactNode;
+
   if (!hasData && !vocabularyService.hasData()) {
-    return (
+    content = (
       <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -88,7 +90,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
           />
-          <AudioStatusIndicator 
+          <AudioStatusIndicator
             isAudioUnlocked={userInteractionState.isAudioUnlocked}
             hasInitialized={userInteractionState.hasInitialized}
             interactionCount={userInteractionState.interactionCount}
@@ -115,10 +117,8 @@ const VocabularyAppContainerNew: React.FC = () => {
         </div>
       </VocabularyLayout>
     );
-  }
-
-  if (!hasData) {
-    return (
+  } else if (!hasData) {
+    content = (
       <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -126,7 +126,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
           />
-          <AudioStatusIndicator 
+          <AudioStatusIndicator
             isAudioUnlocked={userInteractionState.isAudioUnlocked}
             hasInitialized={userInteractionState.hasInitialized}
             interactionCount={userInteractionState.interactionCount}
@@ -153,10 +153,8 @@ const VocabularyAppContainerNew: React.FC = () => {
         </div>
       </VocabularyLayout>
     );
-  }
-
-  if (!currentWord) {
-    return (
+  } else if (!currentWord) {
+    content = (
       <VocabularyLayout showWordCard={true} hasData={true} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -164,7 +162,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
           />
-          <AudioStatusIndicator 
+          <AudioStatusIndicator
             isAudioUnlocked={userInteractionState.isAudioUnlocked}
             hasInitialized={userInteractionState.hasInitialized}
             interactionCount={userInteractionState.interactionCount}
@@ -191,52 +189,54 @@ const VocabularyAppContainerNew: React.FC = () => {
         </div>
       </VocabularyLayout>
     );
+  } else {
+    content = (
+      <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
+        <div className="space-y-4">
+          <UserInteractionManager
+            currentWord={currentWord}
+            playCurrentWord={playCurrentWord}
+            onInteractionUpdate={handleInteractionUpdate}
+          />
+
+          <AudioStatusIndicator
+            isAudioUnlocked={userInteractionState.isAudioUnlocked}
+            hasInitialized={userInteractionState.hasInitialized}
+            interactionCount={userInteractionState.interactionCount}
+          />
+
+          <ErrorDisplay jsonLoadError={false} />
+
+          <ContentWithDataNew
+            displayWord={currentWord}
+            muted={isMuted}
+            paused={isPaused}
+            toggleMute={toggleMute}
+            handleTogglePause={togglePause}
+            handleCycleVoice={toggleVoice}
+            nextVoiceLabel={nextVoiceLabel}
+            handleSwitchCategory={switchCategory}
+            currentCategory={currentCategory}
+            nextCategory={nextCategory}
+            isSpeaking={isSpeaking}
+            handleManualNext={goToNext}
+            displayTime={5000}
+            voiceRegion={voiceRegion}
+            debugPanelData={debugData}
+            isAddWordModalOpen={isAddWordModalOpen}
+            handleCloseModal={handleCloseModal}
+            handleSaveWord={handleSaveWord}
+            isEditMode={isEditMode}
+            wordToEdit={wordToEdit}
+            handleOpenAddWordModal={handleOpenAddWordModal}
+            handleOpenEditWordModal={handleOpenEditWordModal}
+          />
+        </div>
+      </VocabularyLayout>
+    );
   }
 
-  return (
-    <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
-      <div className="space-y-4">
-        <UserInteractionManager
-          currentWord={currentWord}
-          playCurrentWord={playCurrentWord}
-          onInteractionUpdate={handleInteractionUpdate}
-        />
-        
-        <AudioStatusIndicator 
-          isAudioUnlocked={userInteractionState.isAudioUnlocked}
-          hasInitialized={userInteractionState.hasInitialized}
-          interactionCount={userInteractionState.interactionCount}
-        />
-        
-        <ErrorDisplay jsonLoadError={false} />
-        
-        <ContentWithDataNew
-          displayWord={currentWord}
-          muted={isMuted}
-          paused={isPaused}
-          toggleMute={toggleMute}
-          handleTogglePause={togglePause}
-          handleCycleVoice={toggleVoice}
-          nextVoiceLabel={nextVoiceLabel}
-          handleSwitchCategory={switchCategory}
-          currentCategory={currentCategory}
-          nextCategory={nextCategory}
-          isSpeaking={isSpeaking}
-          handleManualNext={goToNext}
-          displayTime={5000}
-          voiceRegion={voiceRegion}
-          debugPanelData={debugData}
-          isAddWordModalOpen={isAddWordModalOpen}
-          handleCloseModal={handleCloseModal}
-          handleSaveWord={handleSaveWord}
-          isEditMode={isEditMode}
-          wordToEdit={wordToEdit}
-          handleOpenAddWordModal={handleOpenAddWordModal}
-          handleOpenEditWordModal={handleOpenEditWordModal}
-        />
-      </div>
-    </VocabularyLayout>
-  );
+  return <VoiceProvider playCurrentWord={playCurrentWord}>{content}</VoiceProvider>;
 };
 
 export default VocabularyAppContainerNew;


### PR DESCRIPTION
## Summary
- bring VoiceProvider into `VocabularyAppContainerNew`
- render all vocabulary layouts through VoiceProvider

## Testing
- `npx --yes jest` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685d0b427d30832fb93684f06bf52ed9