### PR TITLE
Fix speech playback cancellation

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechValidation.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/speech-execution/useSpeechValidation.ts
@@ -28,12 +28,10 @@ export const useSpeechValidation = () => {
   const validateSpeechContent = (
     sessionId: string,
     speechableText: string,
-    setPlayInProgress: (inProgress: boolean) => void,
-    goToNextWord: () => void
+    setPlayInProgress: (inProgress: boolean) => void
   ) => {
     if (!speechableText || speechableText.trim().length === 0) {
       setPlayInProgress(false);
-      setTimeout(() => goToNextWord(), 1500);
       return false;
     }
     return true;

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useOrchestratorCore.ts
@@ -64,12 +64,9 @@ export const useOrchestratorCore = (
   
   // Use playback execution logic
   const { executePlayback } = usePlaybackExecution(
-    findVoice,
     selectedVoice,
     setIsSpeaking,
     speakingRef,
-    resetRetryAttempts,
-    incrementRetryAttempts,
     goToNextWord,
     scheduleAutoAdvance,
     lastManualActionTimeRef,

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/usePlaybackExecution.ts
@@ -11,12 +11,9 @@ import { toast } from 'sonner';
  * Hook for executing the playback process
  */
 export const usePlaybackExecution = (
-  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   selectedVoice: VoiceSelection,
   setIsSpeaking: (isSpeaking: boolean) => void,
   speakingRef: React.MutableRefObject<boolean>,
-  resetRetryAttempts: () => void,
-  incrementRetryAttempts: () => boolean,
   goToNextWord: (fromUser?: boolean) => void,
   scheduleAutoAdvance: (delay: number) => void,
   lastManualActionTimeRef: React.MutableRefObject<number>,
@@ -32,18 +29,12 @@ export const usePlaybackExecution = (
   const { checkAll } = useUnifiedValidation();
   
   const { executeSpeech } = useSpeechExecution(
-    findVoice,
     selectedVoice,
-    selectedVoice.label,
     setIsSpeaking,
     speakingRef,
-    resetRetryAttempts,
-    incrementRetryAttempts,
     paused,
     muted,
-    wordTransitionRef,
-    goToNextWord,
-    scheduleAutoAdvance
+    wordTransitionRef
   );
 
   const executePlayback = useCallback(async (

--- a/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useSpeechExecution.ts
@@ -10,7 +10,6 @@ import { unifiedSpeechController } from '@/services/speech/unifiedSpeechControll
  */
 export const useSpeechExecution = (
   selectedVoice: VoiceSelection,
-  findVoice: (region: 'US' | 'UK' | 'AU') => SpeechSynthesisVoice | null,
   setIsSpeaking: (isSpeaking: boolean) => void,
   isPlayingRef: React.MutableRefObject<boolean>,
   advanceToNext: () => void,
@@ -39,35 +38,9 @@ export const useSpeechExecution = (
         selectedVoice.region,
         voiceVariant
       );
-      
-      if (success) {
-        setIsSpeaking(true);
-        
-        // Schedule completion callback with dynamic duration
-        const estimatedDuration = Math.max(2000, speechText.length * 40);
-        setTimeout(() => {
-          setIsSpeaking(false);
-          isPlayingRef.current = false;
-          
-          // Auto-advance with validation
-          if (!paused && !muted) {
-            setTimeout(() => {
-              // Double-check state before advancing
-              if (!paused && !muted) {
-                advanceToNext();
-              }
-            }, 1000);
-          }
-        }, estimatedDuration);
-      } else {
-        setIsSpeaking(false);
-        isPlayingRef.current = false;
-        
-        // Auto-advance on failure
-        if (!paused && !muted) {
-          setTimeout(() => advanceToNext(), 2000);
-        }
-      }
+
+      setIsSpeaking(false);
+      isPlayingRef.current = false;
 
       return success;
       

--- a/src/hooks/vocabulary-playback/speech-playback/useSpeechPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/useSpeechPlaybackCore.ts
@@ -3,11 +3,10 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '../useVoiceSelection';
-import { 
-  useSpeechState, 
-  useVoiceManager, 
-  useContentProcessor, 
-  useSpeechExecution 
+import {
+  useSpeechState,
+  useContentProcessor,
+  useSpeechExecution
 } from './core';
 
 export const useSpeechPlaybackCore = (
@@ -19,11 +18,9 @@ export const useSpeechPlaybackCore = (
 ) => {
   // Use our refactored hooks
   const { isSpeaking, setIsSpeaking, isPlayingRef } = useSpeechState();
-  const { findVoice } = useVoiceManager(selectedVoice);
   const { createSpeechText } = useContentProcessor();
   const { executeSpeech } = useSpeechExecution(
     selectedVoice,
-    findVoice,
     setIsSpeaking,
     isPlayingRef,
     advanceToNext,


### PR DESCRIPTION
## Summary
- remove automatic timer-based auto-advance
- rely on UnifiedSpeechController completion events
- simplify speech execution hooks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ad0dcb0832f900f2a27788bbf36