### PR TITLE
Add annotation parser for vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ Available variants are grouped by region:
 - **UK:** `Google UK English Female`, `Daniel`, `Kate`, `Susan`, `Hazel`
 - **AU:** `en-AU-Standard-C`, `Google AU English Male`, `Google AU English Female`, `Karen`, `Catherine`
 
+
 Your last selection is stored in `localStorage` under the `vocabularySettings` key so the chosen voice persists between sessions.
+
+## Word display
+
+Any tags inside square brackets or pronunciations written between slashes/parentheses are shown next to the word in a smaller gray font. The main word text no longer includes these annotations.
 
 ## What technologies are used for this project?
 

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward } from 'lucide-react';
 import { getCategoryLabel } from '@/utils/categoryLabels';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
+import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
 
 interface VocabularyCardProps {
   word: string;
@@ -62,6 +63,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   const mainWord = wordParts[0].trim();
   const wordType = wordParts.length > 1 ? `(${wordParts[1]})` : '';
   const phoneticPart = wordParts.length > 2 ? wordParts.slice(2).join(' ').trim() : '';
+  const { main, annotations } = parseWordAnnotations(word);
 
   return (
     <Card 
@@ -77,7 +79,10 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             className="text-left font-semibold text-[0.8rem] text-gray-800 leading-tight mb-2"
             style={{ marginTop: 0 }}
           >
-            {mainWord}
+            {main}
+            {annotations.map((t, i) => (
+              <span key={i} className="ml-1 text-xs text-gray-500">{t}</span>
+            ))}
           </h2>
           {/* Meaning */}
           <div

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -5,6 +5,7 @@ import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker } from '
 import { cn } from '@/lib/utils';
 import { getCategoryLabel } from '@/utils/categoryLabels';
 import WordCountDisplay from './WordCountDisplay';
+import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
 
 interface VocabularyCardNewProps {
   word: string;
@@ -51,6 +52,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   const nextCategoryLabel = getCategoryLabel(nextCategory);
 
   const currentWordObj = { word, meaning, example, category };
+  const { main, annotations } = parseWordAnnotations(word);
 
   return (
     <Card 
@@ -76,7 +78,10 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
           {/* Word */}
           <div className="text-left">
             <h1 className="font-bold" style={{ color: '#1F305E', fontSize: '1.25rem', textAlign: 'left' }}>
-              {word}
+              {main}
+              {annotations.map((t, i) => (
+                <span key={i} className="ml-1 text-xs text-gray-500">{t}</span>
+              ))}
             </h1>
           </div>
 

--- a/src/utils/text/parseWordAnnotations.ts
+++ b/src/utils/text/parseWordAnnotations.ts
@@ -1,0 +1,19 @@
+export interface ParsedWord {
+  main: string;
+  annotations: string[];
+}
+
+export function parseWordAnnotations(word: string): ParsedWord {
+  const annotations: string[] = [];
+  const regex = /\[[^\]]+\]|\([^\)]*\)|\/[^\/]+\/(?=\s|$)/g;
+  let main = word.replace(regex, (match) => {
+    annotations.push(match.trim());
+    return ' ';
+  });
+
+  main = main.replace(/\s+/g, ' ').trim();
+
+  return { main, annotations };
+}
+
+export default parseWordAnnotations;

--- a/tests/parseWordAnnotations.test.ts
+++ b/tests/parseWordAnnotations.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import parseWordAnnotations from '../src/utils/text/parseWordAnnotations';
+
+describe('parseWordAnnotations', () => {
+  it('extracts bracketed tags', () => {
+    const { main, annotations } = parseWordAnnotations('count on [transitive]');
+    expect(main).toBe('count on');
+    expect(annotations).toEqual(['[transitive]']);
+  });
+
+  it('extracts phonetics in parentheses', () => {
+    const { main, annotations } = parseWordAnnotations('add up (/æd ʌp tə/)');
+    expect(main).toBe('add up');
+    expect(annotations).toEqual(['(/æd ʌp tə/)']);
+  });
+});


### PR DESCRIPTION
## Summary
- parse annotations from square brackets, parenthetical notes and slash notation
- display these annotations next to the word in both vocabulary card components
- document annotation display in README
- add unit tests for parsing helper

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d1e453de8832f9223c659b4b4145d