### PR TITLE
Update category labels

### DIFF
--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -16,11 +16,12 @@ interface WordFormFieldsProps {
 
 // Updated category options without "All words"
 const CATEGORY_OPTIONS = [
-  { value: "phrasal verbs", label: "Phrasal V" },
-  { value: "idioms", label: "Idioms" },
-  { value: "topic vocab", label: "Topic" },
+  { value: "phrasal verbs", label: "Phrasal Verb" },
+  { value: "idioms", label: "Idiom" },
+  { value: "topic vocab", label: "Topic vocabulary" },
   { value: "grammar", label: "Grammar" },
-  { value: "phrases, collocations", label: "Phrasals" }
+  { value: "phrases, collocations", label: "Phrase - Collocation" },
+  { value: "word formation", label: "Word formation" }
 ];
 
 const WordFormFields: React.FC<WordFormFieldsProps> = ({

--- a/src/services/sheet/SheetManager.ts
+++ b/src/services/sheet/SheetManager.ts
@@ -10,7 +10,8 @@ export class SheetManager {
     "idioms",
     "topic vocab",
     "grammar",
-    "phrases, collocations"
+    "phrases, collocations",
+    "word formation"
   ];
   private sheetProcessor: SheetProcessor;
   private sheetNormalizer: SheetNormalizer;

--- a/src/services/sheet/SheetNormalizer.ts
+++ b/src/services/sheet/SheetNormalizer.ts
@@ -14,6 +14,7 @@ export class SheetNormalizer {
     if (normalized.includes("idiom")) return "idioms";
     if (normalized.includes("advanced")) return "topic vocab";
     if (normalized.includes("grammar")) return "grammar";
+    if (normalized.includes("formation")) return "word formation";
     if (normalized.includes("phrase") || normalized.includes("collocation")) return "phrases, collocations";
     
     // Default to "phrasal verbs" if no match (instead of original name)

--- a/src/services/vocabulary/VocabularyService.ts
+++ b/src/services/vocabulary/VocabularyService.ts
@@ -21,7 +21,8 @@ export class VocabularyService {
       "idioms",
       "topic vocab",
       "grammar",
-      "phrases, collocations"
+      "phrases, collocations",
+      "word formation"
     ];
     
     // Initialize the components

--- a/src/utils/categoryLabels.ts
+++ b/src/utils/categoryLabels.ts
@@ -1,13 +1,19 @@
 export const CATEGORY_LABELS: Record<string, string> = {
-  'phrases, collocations': 'Phrasals',
-  'topic vocab': 'Topic',
-  'phrasal verbs': 'Phrasal V',
+  'phrasal verbs': 'Phrasal Verb',
+  'idioms': 'Idiom',
+  'topic vocab': 'Topic vocabulary',
+  'grammar': 'Grammar',
+  'phrases, collocations': 'Phrase - Collocation',
+  'word formation': 'Word formation',
 };
 
 export const CATEGORY_MESSAGE_LABELS: Record<string, string> = {
-  'phrases, collocations': 'Phrases, Collocations',
-  'topic vocab': 'Topic Vocabulary',
-  'phrasal verbs': 'Phrasal Verbs',
+  'phrasal verbs': 'Phrasal Verb',
+  'idioms': 'Idiom',
+  'topic vocab': 'Topic vocabulary',
+  'grammar': 'Grammar',
+  'phrases, collocations': 'Phrase - Collocation',
+  'word formation': 'Word formation',
 };
 
 export function getCategoryLabel(category: string): string {


### PR DESCRIPTION
## Summary
- update category names
- sync category selection labels to match
- normalize sheet names to word formation
- add Grammar category back

## Testing
- `npx vitest --run` *(fails: Needs package installation)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_685d1f67b5e0832f93331423c490bf8b