### PR TITLE
Fix RealSpeechService stop cleanup

### DIFF
--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -114,6 +114,10 @@ class RealSpeechService {
 
   stop(): void {
     if (window.speechSynthesis) {
+      if (this.currentUtterance) {
+        this.currentUtterance.onend = null;
+        this.currentUtterance.onerror = null;
+      }
       window.speechSynthesis.cancel();
     }
     this.isActive = false;


### PR DESCRIPTION
## Summary
- make sure RealSpeechService clears onend/onerror handlers before cancelling speech synthesis

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685d23ed5a28832fa7eddefda7647af5