### PR TITLE
Add speech fallback timer

### DIFF
--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -11,6 +11,15 @@ class UnifiedSpeechController {
   private wordCompleteCallback: (() => void) | null = null;
   private isMutedState = false;
   private autoAdvanceTimer: number | null = null;
+  private fallbackTimer: number | null = null;
+
+  private clearFallbackTimer() {
+    if (this.fallbackTimer) {
+      console.log('Clearing speech fallback timer');
+      clearTimeout(this.fallbackTimer);
+      this.fallbackTimer = null;
+    }
+  }
 
   async speak(
     word: VocabularyWord,
@@ -33,13 +42,22 @@ class UnifiedSpeechController {
       voiceRegion: region,
       onStart: () => {
         console.log('Word speech started:', word.word);
+        this.clearFallbackTimer();
+        this.fallbackTimer = window.setTimeout(() => {
+          console.warn('Speech fallback timer expired for', word.word);
+          realSpeechService.stop();
+          this.scheduleAutoAdvance();
+        }, 5000);
+        console.log('Started speech fallback timer for', word.word);
       },
       onEnd: () => {
         console.log('Word speech completed:', word.word);
+        this.clearFallbackTimer();
         this.scheduleAutoAdvance();
       },
       onError: (error) => {
         console.error('Word speech error:', error);
+        this.clearFallbackTimer();
         this.scheduleAutoAdvance();
       }
     });
@@ -60,6 +78,7 @@ class UnifiedSpeechController {
 
   stop(): void {
     realSpeechService.stop();
+    this.clearFallbackTimer();
     if (this.autoAdvanceTimer) {
       clearTimeout(this.autoAdvanceTimer);
       this.autoAdvanceTimer = null;

--- a/tests/unifiedSpeechFallback.test.ts
+++ b/tests/unifiedSpeechFallback.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { unifiedSpeechController } from '../src/services/speech/unifiedSpeechController';
+
+vi.mock('../src/services/speech/realSpeechService', () => ({
+  realSpeechService: {
+    speak: vi.fn().mockImplementation((_text: string, options: any) => {
+      options.onStart?.();
+      // never call onEnd or onError to simulate missing events
+      return Promise.resolve(true);
+    }),
+    stop: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    isCurrentlyActive: vi.fn(() => false),
+    getCurrentUtterance: vi.fn(() => null)
+  }
+}));
+
+const word = { word: 'hello', meaning: '', example: '', count: 0 };
+
+describe('unifiedSpeechController fallback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('auto advances when speech end event is missing', async () => {
+    const cb = vi.fn();
+    unifiedSpeechController.setWordCompleteCallback(cb);
+    await unifiedSpeechController.speak(word);
+    vi.advanceTimersByTime(7000); // 5s fallback + 2s auto advance
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure unified speech controller stops early when speech events are missing
- add fallback auto-advance test

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685d4fe9c318832f8f0d1264f2e3703d