### PR TITLE
Update speech note text

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -76,10 +76,10 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       />
 
       {/* Mobile speech note statically above debug panel */}
-      <div className="mobile-note text-xs italic text-gray-500 text-center my-2">
+      <div className="mobile-note text-xs italic text-gray-500 text-left my-2">
         <p>On Mobile:</p>
-        <p>- Tap any button (e.g., Next) to enable speech</p>
-        <p>- Only Australian voice may be available</p>
+        <p>- Tap any button (e.g., Next) to enable speech.</p>
+        <p>- On Mobile, only one voice may be available.</p>
       </div>
 
       {/* Debug Panel */}

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -100,7 +100,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           </div>
           {/* Mobile note below example */}
           <div className="mobile-note text-left italic mt-2" style={{ color: '#6b7280', fontSize: '0.8rem' }}>
-            On Mobile: Tap any button to enable speech. Only Australian voice may be available.
+            Tap any button (e.g., Next) to enable speech. On Mobile, only one voice may be available.
           </div>
         </div>
         {/* Control buttons wrapper - optimized spacing */}


### PR DESCRIPTION
## Summary
- update wording of mobile speech notes
- align note container text to the left

## Testing
- `npm test` *(fails: Missing script)*
- `npx vitest run` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685d519f15c4832f9d0a2085eea57496