### PR TITLE
Update UK voice defaults

### DIFF
--- a/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/findVoice.ts
@@ -5,7 +5,16 @@ import { US_VOICE_NAME, UK_VOICE_NAME } from '@/utils/speech/voiceNames';
 
 // Backup voice names in case primary ones aren't found
 const BACKUP_US_VOICES = ["Google US English", "Microsoft David", "Alex"];
-const BACKUP_UK_VOICES = ["Microsoft Susan", "Daniel", "Kate"];
+const BACKUP_UK_VOICES = [
+  UK_VOICE_NAME,
+  "en-GB-Standard-B",
+  "en-GB-Standard-C",
+  "Google UK English Male",
+  "Google UK English Female",
+  "Microsoft Susan",
+  "Daniel",
+  "Kate"
+];
 
 // Simplified voice finding function using hardcoded voice names and better fallbacks
 export const findVoice = (voices: SpeechSynthesisVoice[], voiceSelection: VoiceSelection): SpeechSynthesisVoice | null => {

--- a/src/utils/speech/voiceNames.ts
+++ b/src/utils/speech/voiceNames.ts
@@ -1,8 +1,14 @@
 // Default US voice
 export const US_VOICE_NAME = "en-US-Standard-B";
-export const UK_VOICE_NAME = "Google UK English Female";
+// Default UK voice now uses a Google standard ID
+export const UK_VOICE_NAME = "en-GB-Standard-A";
 export const UK_VOICE_NAMES = [
   UK_VOICE_NAME,
+  "en-GB-Standard-B",
+  "en-GB-Standard-C",
+  // keep old Google voice labels for backward compatibility
+  "Google UK English Male",
+  "Google UK English Female",
   "Daniel",
   "Kate",
   "Susan",

--- a/tests/voiceUtils.test.ts
+++ b/tests/voiceUtils.test.ts
@@ -24,7 +24,7 @@ describe('hasAvailableVoices', () => {
 
   it('returns true when voices are available', () => {
     (window as MockWindow).speechSynthesis.getVoices = () => [
-      { lang: 'en-GB', name: 'Google UK English Female' }
+      { lang: 'en-GB', name: 'en-GB-Standard-A' }
     ];
     expect(hasAvailableVoices()).toBe(true);
   });


### PR DESCRIPTION
## Summary
- use `en-GB-Standard-A` as default UK voice
- broaden UK voice fallbacks with additional standard IDs
- update backup arrays to reference the new UK voices
- adjust tests for new default voice

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d5406ed34832f96724b41bcff95fb