### PR TITLE
Add speech text formatter with SSML pauses

### DIFF
--- a/src/components/NotificationManager.tsx
+++ b/src/components/NotificationManager.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Bell, BellOff } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { VocabularyWord } from '@/types/vocabulary';
-import { speak } from '@/utils/speech';
+import { speak, formatSpeechText } from '@/utils/speech';
 
 const requestNotificationPermission = async () => {
   if (!('Notification' in window)) {
@@ -121,7 +121,7 @@ const NotificationManager: React.FC<NotificationManagerProps> = ({
     
     notification.onclick = async () => {
       notification.close();
-      const fullText = `${word}. ${meaning}. ${example}`;
+      const fullText = formatSpeechText({ word, meaning, example });
       await speak(fullText);
     };
     

--- a/src/hooks/audio/useAudioEffect.tsx
+++ b/src/hooks/audio/useAudioEffect.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
-import { speak, stopSpeaking } from '@/utils/speech';
+import { speak, stopSpeaking, formatSpeechText } from '@/utils/speech';
 
 export const useAudioEffect = (
   currentWord: VocabularyWord | null,
@@ -81,8 +81,12 @@ export const useAudioEffect = (
           
           console.log('[APP] ⚡ Speaking word:', currentWord.word);
           
-          // Create the text to speak with periods to create natural pauses
-          const fullText = `${currentWord.word}. ${currentWord.meaning}. ${currentWord.example}.`;
+          // Create the text to speak with explicit pauses
+          const fullText = formatSpeechText({
+            word: currentWord.word,
+            meaning: currentWord.meaning,
+            example: currentWord.example
+          });
           
           try {
             // Speak the text and wait for completion

--- a/src/hooks/useWordSpeechSync.tsx
+++ b/src/hooks/useWordSpeechSync.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
-import { stopSpeaking } from '@/utils/speech';
+import { stopSpeaking, formatSpeechText } from '@/utils/speech';
 import { useTimeoutManager } from './speech/useTimeoutManager';
 import { useWordStateManager } from './speech/useWordStateManager';
 import { useSpeechSync } from './speech/useSpeechSync';
@@ -98,7 +98,11 @@ export const useWordSpeechSync = (
       try {
         localStorage.setItem('currentDisplayedWord', wordToSpeak.word);
       } catch {}
-      const fullText = `${wordToSpeak.word}. ${wordToSpeak.meaning}. ${wordToSpeak.example}`;
+      const fullText = formatSpeechText({
+        word: wordToSpeak.word,
+        meaning: wordToSpeak.meaning,
+        example: wordToSpeak.example
+      });
       if ((isPaused && !forceSpeak) || isMuted) {
         console.log("App was paused/muted while preparing, aborting");
         isSpeakingRef.current = false;

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useContentValidation.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useContentValidation.ts
@@ -1,6 +1,6 @@
 
 import { VocabularyWord } from '@/types/vocabulary';
-import { prepareTextForSpeech } from '@/utils/speech';
+import { prepareTextForSpeech, formatSpeechText } from '@/utils/speech';
 import { hasValidSpeechableContent, getPreserveSpecialFromStorage } from '@/utils/text/contentFilters';
 import { toast } from '@/components/ui/use-toast';
 
@@ -13,13 +13,11 @@ export const useContentValidation = () => {
     const preserveSpecial = getPreserveSpecialFromStorage();
     
     // Construct text to speak
-    let rawTextToSpeak = currentWord.word;
-    if (currentWord.meaning) {
-      rawTextToSpeak += `. ${currentWord.meaning}`;
-    }
-    if (currentWord.example) {
-      rawTextToSpeak += `. ${currentWord.example}`;
-    }
+    let rawTextToSpeak = formatSpeechText({
+      word: currentWord.word,
+      meaning: currentWord.meaning,
+      example: currentWord.example
+    });
 
     // Prepare text for speech (whitespace cleanup only)
     const speechableText = prepareTextForSpeech(rawTextToSpeak);

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
@@ -2,6 +2,7 @@
 import { useCallback, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
+import { formatSpeechText } from '@/utils/speech';
 
 /**
  * Hook for managing utterance setup and reference
@@ -30,7 +31,7 @@ export const useUtteranceManager = () => {
     const utterance = new SpeechSynthesisUtterance();
     
     // Set up text
-    utterance.text = `${word.word}. ${word.meaning}. ${word.example}`;
+    utterance.text = formatSpeechText({ word: word.word, meaning: word.meaning, example: word.example });
     
     // Set up voice
     const voice = findVoice(selectedVoice.region);

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -1,5 +1,6 @@
 
 import { toast } from 'sonner';
+import { formatSpeechText } from '@/utils/speech';
 
 /**
  * Sets up and plays a speech utterance for the current word
@@ -34,8 +35,8 @@ export const useUtteranceSetup = ({
       const wordText = currentWord.word;
       const meaningText = currentWord.meaning || '';
       const exampleText = currentWord.example || '';
-      
-      utterance.text = `${wordText}. ${meaningText}. ${exampleText}`.trim();
+
+      utterance.text = formatSpeechText({ word: wordText, meaning: meaningText, example: exampleText });
       
       // Set language based on selected voice
       utterance.lang = selectedVoice.region === 'UK' ? 'en-GB' : 'en-US';

--- a/src/hooks/vocabulary-playback/speech-playback/core/useContentProcessor.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useContentProcessor.ts
@@ -2,6 +2,7 @@
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
+import { formatSpeechText } from '@/utils/speech';
 
 /**
  * Hook for processing vocabulary word content into speechable text
@@ -12,18 +13,8 @@ export const useContentProcessor = () => {
     const sanitizedWord = sanitizeForDisplay(word.word || '');
     const sanitizedMeaning = sanitizeForDisplay(word.meaning || '');
     const sanitizedExample = sanitizeForDisplay(word.example || '');
-    
-    let textToSpeak = sanitizedWord;
-    
-    if (sanitizedMeaning && sanitizedMeaning.trim().length > 0) {
-      textToSpeak += `. ${sanitizedMeaning}`;
-    }
-    
-    if (sanitizedExample && sanitizedExample.trim().length > 0) {
-      textToSpeak += `. ${sanitizedExample}`;
-    }
-    
-    return textToSpeak;
+
+    return formatSpeechText({ word: sanitizedWord, meaning: sanitizedMeaning, example: sanitizedExample });
   }, []);
 
   return {

--- a/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
@@ -3,6 +3,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '../useVoiceSelection';
 import { findVoice } from './findVoice';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
+import { formatSpeechText } from '@/utils/speech';
 
 // Function to create and configure a speech utterance
 export const createUtterance = (
@@ -23,15 +24,11 @@ export const createUtterance = (
     const sanitizedExample = sanitizeForDisplay(word.example || '');
     
     // Construct the text to speak with pauses
-    let textToSpeak = sanitizedWord;
-    
-    if (sanitizedMeaning && sanitizedMeaning.trim().length > 0) {
-      textToSpeak += `. ${sanitizedMeaning}`;
-    }
-    
-    if (sanitizedExample && sanitizedExample.trim().length > 0) {
-      textToSpeak += `. ${sanitizedExample}`;
-    }
+    let textToSpeak = formatSpeechText({
+      word: sanitizedWord,
+      meaning: sanitizedMeaning,
+      example: sanitizedExample
+    });
     
     // Additional sanitization for speech synthesis
     // Remove any remaining HTML entities and control characters

--- a/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
@@ -4,6 +4,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from './useVoiceSelection';
 import { useSimpleSpeech } from '@/hooks/speech/useSimpleSpeech';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
+import { formatSpeechText } from '@/utils/speech';
 
 /**
  * Simplified word playback with improved coordination and pause handling
@@ -47,8 +48,12 @@ export const useSimpleWordPlayback = (
       const voice = findVoice(selectedVoice.region);
       console.log(`[WORD-PLAYBACK-${playbackId}] Using voice: ${voice?.name || 'default'}`);
 
-      // Create speech text
-      const speechText = `${word.word}. ${word.meaning || ''}. ${word.example || ''}`.trim();
+      // Create speech text with consistent pauses
+      const speechText = formatSpeechText({
+        word: word.word,
+        meaning: word.meaning || '',
+        example: word.example || ''
+      });
       
       if (!speechText || speechText.length === 0) {
         console.log(`[WORD-PLAYBACK-${playbackId}] No content to speak`);

--- a/src/services/speech/core/VoiceManager.ts
+++ b/src/services/speech/core/VoiceManager.ts
@@ -2,16 +2,18 @@
 /**
  * Manages voice selection and text formatting for speech
  */
+import { formatSpeechText } from '@/utils/speech';
+
 export class VoiceManager {
-  // Create formatted speech text
+  // Create formatted speech text with SSML pauses
   createSpeechText(word: { word: string; meaning: string; example: string }): string {
     const cleanText = (text: string) => text.trim().replace(/\s+/g, ' ');
-    
+
     const wordText = cleanText(word.word);
     const meaningText = cleanText(word.meaning);
     const exampleText = cleanText(word.example);
-    
-    return `${wordText}. ${meaningText}. ${exampleText}`;
+
+    return formatSpeechText({ word: wordText, meaning: meaningText, example: exampleText });
   }
 
   // Find voice by region

--- a/src/utils/speech/formatSpeechText.ts
+++ b/src/utils/speech/formatSpeechText.ts
@@ -1,0 +1,20 @@
+export interface SpeechWord {
+  word: string;
+  meaning?: string;
+  example?: string;
+}
+
+/**
+ * Format vocabulary word fields into SSML text with 300ms pauses between
+ * segments. This ensures consistent pauses across platforms.
+ */
+export const formatSpeechText = ({ word, meaning = '', example = '' }: SpeechWord): string => {
+  const parts = [word.trim()];
+  if (meaning && meaning.trim().length > 0) {
+    parts.push(meaning.trim());
+  }
+  if (example && example.trim().length > 0) {
+    parts.push(example.trim());
+  }
+  return parts.filter(Boolean).join('<break time="300ms"/>');
+};

--- a/src/utils/speech/index.ts
+++ b/src/utils/speech/index.ts
@@ -30,6 +30,7 @@ import { speakChunksInSequence } from './core/chunkSequencer';
 import { createSpeechMonitor, clearSpeechMonitor } from './core/speechMonitor';
 import { synthesizeAudio } from './synthesisUtils';
 import { US_VOICE_NAME, UK_VOICE_NAME, AU_VOICE_NAME } from './voiceNames';
+import { formatSpeechText } from './formatSpeechText';
 
 export {
   speak,
@@ -60,5 +61,6 @@ export {
   synthesizeAudio,
   US_VOICE_NAME,
   UK_VOICE_NAME,
-  AU_VOICE_NAME
+  AU_VOICE_NAME,
+  formatSpeechText
 };

--- a/tests/useContentValidation.test.ts
+++ b/tests/useContentValidation.test.ts
@@ -14,7 +14,7 @@ describe('useContentValidation', () => {
     };
 
     const { speechableText } = validateAndPrepareContent(word);
-    expect(speechableText).toBe('quick. (adj) [kwiːk]');
+    expect(speechableText).toBe('quick<break time="300ms"/>(adj) [kwiːk]');
   });
 
   it('returns full text even if it contains IPA', () => {


### PR DESCRIPTION
## Summary
- centralize speech text building with `formatSpeechText`
- refactor speech utilities and hooks to use new helper
- update tests for new SSML output

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx vitest run` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d539b2f1c832f87d27f3a4c17dc0a