### PR TITLE
Introduce shared DEFAULT_SPEECH_RATE

### DIFF
--- a/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
+++ b/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 /**
  * Hook to handle Safari and iOS-specific initialization
@@ -25,7 +26,7 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
           // Create a minimal utterance - just a space
           const utterance = new SpeechSynthesisUtterance(' ');
           utterance.volume = 0.01;
-          utterance.rate = 1;
+          utterance.rate = DEFAULT_SPEECH_RATE;
           utterance.pitch = 1;
           
           // Try to speak it

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
@@ -2,6 +2,7 @@
 import { useCallback, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 /**
  * Hook for managing utterance setup and reference
@@ -44,7 +45,7 @@ export const useUtteranceManager = () => {
     }
     
     // Configure properties
-    utterance.rate = 0.9; // Slightly slower for better comprehension
+    utterance.rate = DEFAULT_SPEECH_RATE;
     utterance.pitch = 1;
     utterance.volume = 1.0;
     

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -1,5 +1,6 @@
 
 import { toast } from 'sonner';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 /**
  * Sets up and plays a speech utterance for the current word
@@ -51,7 +52,7 @@ export const useUtteranceSetup = ({
       let fallbackTimer: number | null = null;
 
       // Set speech parameters for better clarity
-      utterance.rate = 0.95; // Slightly slower for better comprehension
+      utterance.rate = DEFAULT_SPEECH_RATE;
       utterance.pitch = 1.0;
       utterance.volume = 1.0;
 

--- a/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
@@ -3,6 +3,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '../useVoiceSelection';
 import { findVoice } from './findVoice';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 // Function to create and configure a speech utterance
 export const createUtterance = (
@@ -63,8 +64,8 @@ export const createUtterance = (
       console.log(`No voice found, using default with language: ${utterance.lang}`);
     }
     
-    // Configure speech properties for much slower, clearer speech
-    utterance.rate = 0.6;   // Much slower rate for better comprehension
+    // Configure speech properties
+    utterance.rate = DEFAULT_SPEECH_RATE;
     utterance.pitch = 1.0;  // Default pitch
     utterance.volume = 1.0; // Full volume
     

--- a/src/services/speech/core/SpeechPlatformManager.ts
+++ b/src/services/speech/core/SpeechPlatformManager.ts
@@ -5,6 +5,7 @@ import { VoiceManager } from './VoiceManager';
 import { SpeechEventHandler } from './SpeechEventHandler';
 import { isMobileDevice } from '@/utils/device';
 import { directSpeechService } from '../directSpeechService';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 /**
  * Manages platform-specific speech execution (mobile vs desktop)
@@ -81,7 +82,7 @@ export class SpeechPlatformManager {
     
     const voice = this.voiceManager.findVoice(voiceRegion);
     if (voice) utterance.voice = voice;
-    utterance.rate = 0.8;
+    utterance.rate = DEFAULT_SPEECH_RATE;
     utterance.pitch = 1.0;
     utterance.volume = 1.0;
 

--- a/src/services/speech/core/constants.ts
+++ b/src/services/speech/core/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Shared constants for speech services
+ */
+export const DEFAULT_SPEECH_RATE = 1;

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -1,5 +1,6 @@
 
 import { VocabularyWord } from '@/types/vocabulary';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 interface SpeechOptions {
   voiceRegion: 'US' | 'UK' | 'AU';
@@ -39,7 +40,7 @@ class RealSpeechService {
       }
 
       // Configure speech settings
-      utterance.rate = 0.8;
+      utterance.rate = DEFAULT_SPEECH_RATE;
       utterance.pitch = 1.0;
       utterance.volume = 1.0;
 

--- a/src/utils/speech/controller/speechExecutor.ts
+++ b/src/utils/speech/controller/speechExecutor.ts
@@ -6,6 +6,7 @@ import {
 } from '../core/speechEngine';
 import { SpeechStateManager } from './speechStateManager';
 import { SpeechOptions } from './types';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 /**
  * Handles speech execution with comprehensive pause state checking
@@ -67,7 +68,7 @@ export class SpeechExecutor {
           utterance.voice = options.voice;
           console.log(`[SPEECH-EXECUTOR-${speechId}] Using voice:`, options.voice.name);
         }
-        utterance.rate = options.rate || 0.8;
+        utterance.rate = options.rate || DEFAULT_SPEECH_RATE;
         utterance.pitch = options.pitch || 1.0;
         utterance.volume = options.volume || 1.0;
         

--- a/src/utils/speech/core/engineManager.ts
+++ b/src/utils/speech/core/engineManager.ts
@@ -1,6 +1,7 @@
 
 import { getVoiceByRegion } from '../voiceUtils';
-import { getSpeechRate, getSpeechPitch, getSpeechVolume } from './speechSettings';
+import { getSpeechPitch, getSpeechVolume } from './speechSettings';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 'US' | 'UK' | 'AU'): void => {
   const langCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
@@ -15,7 +16,7 @@ export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 
     utterance.lang = langCode;
   }
   
-  utterance.rate = getSpeechRate();
+  utterance.rate = DEFAULT_SPEECH_RATE;
   utterance.pitch = getSpeechPitch();
   utterance.volume = getSpeechVolume();
   

--- a/src/utils/speech/core/speechController.ts
+++ b/src/utils/speech/core/speechController.ts
@@ -1,4 +1,6 @@
 
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+
 /**
  * Centralized Speech Controller - Single source of truth for all speech operations
  * Fixed version with improved state management and throttling
@@ -244,7 +246,7 @@ class SpeechController {
         
         // Configure utterance
         if (options.voice) utterance.voice = options.voice;
-        utterance.rate = options.rate || 0.8;
+        utterance.rate = options.rate || DEFAULT_SPEECH_RATE;
         utterance.pitch = options.pitch || 1.0;
         utterance.volume = options.volume || 1.0;
 

--- a/src/utils/speech/synthesisUtils.ts
+++ b/src/utils/speech/synthesisUtils.ts
@@ -1,4 +1,4 @@
-
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 export const synthesizeAudio = (text: string, voice: SpeechSynthesisVoice | null): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -22,7 +22,7 @@ export const synthesizeAudio = (text: string, voice: SpeechSynthesisVoice | null
     }
     
     // Set reasonable speech parameters
-    utterance.rate = 0.9;  // Slightly slower than default for better clarity
+    utterance.rate = DEFAULT_SPEECH_RATE;
     utterance.pitch = 1.0; // Normal pitch
     utterance.volume = 1.0; // Full volume
     


### PR DESCRIPTION
## Summary
- add `DEFAULT_SPEECH_RATE` constant
- use the constant when configuring `utterance.rate`
- keep tests passing
- set default speech rate to `1`

## Testing
- `npm i`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685d53993de0832facd892882d8bed7c