### PR TITLE
Improve canceled speech logging

### DIFF
--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -23,7 +23,8 @@ export const useUtteranceSetup = ({
   autoAdvanceTimerRef,
   muted,
   paused,
-  incrementRetryAttempts
+  incrementRetryAttempts,
+  userInteractionRef
 }) => {
   // Add a small delay before playing to ensure cancellation has completed
   setTimeout(() => {
@@ -85,6 +86,11 @@ export const useUtteranceSetup = ({
       
       utterance.onerror = (event) => {
         console.error(`Speech synthesis error:`, event);
+        if (event.error === 'canceled') {
+          console.log(
+            `Canceled context - muted: ${muted}, paused: ${paused}, userInteracted: ${userInteractionRef.current}`
+          );
+        }
         
         // Check if we're already in a word transition - if so, don't retry
         if (wordTransitionRef.current) {
@@ -111,7 +117,9 @@ export const useUtteranceSetup = ({
         
         // If error is "canceled" but it was intentional (during muting/pausing), don't retry
         if (event.error === 'canceled' && (muted || paused)) {
-          console.log('Speech canceled due to muting or pausing, not retrying');
+          console.log(
+            `Speech canceled due to muting or pausing, not retrying (muted: ${muted}, paused: ${paused}, userInteracted: ${userInteractionRef.current})`
+          );
           // Still auto-advance after a short delay
           scheduleAutoAdvance(2000);
           return;
@@ -143,7 +151,8 @@ export const useUtteranceSetup = ({
                 autoAdvanceTimerRef,
                 muted,
                 paused,
-                incrementRetryAttempts
+                incrementRetryAttempts,
+                userInteractionRef
               });
             }
           }, 500);
@@ -194,7 +203,8 @@ export const useUtteranceSetup = ({
                 autoAdvanceTimerRef,
                 muted,
                 paused,
-                incrementRetryAttempts
+                incrementRetryAttempts,
+                userInteractionRef
               });
             } else {
               // If we've tried enough times, move on

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -5,6 +5,9 @@ interface SpeechOptions {
   voiceRegion: 'US' | 'UK' | 'AU';
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
+  muted?: boolean;
+  paused?: boolean;
+  userInteracted?: boolean;
 }
 
 class DirectSpeechService {

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -7,6 +7,9 @@ interface SpeechOptions {
   onStart?: () => void;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
+  muted?: boolean;
+  paused?: boolean;
+  userInteracted?: boolean;
 }
 
 class RealSpeechService {
@@ -66,6 +69,11 @@ class RealSpeechService {
 
       utterance.onerror = (event) => {
         console.error('Speech error:', event.error, event);
+        if (event.error === 'canceled') {
+          console.log(
+            `Canceled context - muted: ${options.muted}, paused: ${options.paused}, userInteracted: ${options.userInteracted}`
+          );
+        }
         this.isActive = false;
         this.currentUtterance = null;
         if (options.onError) {


### PR DESCRIPTION
## Summary
- log user interaction and playback state when speech is canceled in `useUtteranceSetup`
- capture the same info inside `realSpeechService.speak`
- extend speech option interfaces to carry context

## Testing
- `npx vitest run`
- `npx eslint .` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_685d587e4804832fbbee6746adc9c70a