### PR TITLE
Fix speech cancellation state handling

### DIFF
--- a/src/hooks/speech/useSpeechState.tsx
+++ b/src/hooks/speech/useSpeechState.tsx
@@ -1,5 +1,5 @@
 
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 
 export const useSpeechState = () => {
   // For keeping track of speaking state
@@ -37,6 +37,18 @@ export const useSpeechState = () => {
     pauseRequestedRef.current = false;
     // The next word will be spoken when the regular flow continues
   }, []);
+
+  // Reset local flags if a speech cancellation error occurs
+  useEffect(() => {
+    const handleCanceled = () => {
+      console.log('[SpeechState] Resetting flags after cancellation');
+      stopSpeakingLocal();
+    };
+    document.addEventListener('speech-canceled', handleCanceled);
+    return () => {
+      document.removeEventListener('speech-canceled', handleCanceled);
+    };
+  }, [stopSpeakingLocal]);
 
   return {
     isSpeakingRef,

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -5,6 +5,7 @@ interface SpeechOptions {
   voiceRegion: 'US' | 'UK' | 'AU';
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
+  onCancel?: () => void;
   muted?: boolean;
   paused?: boolean;
   userInteracted?: boolean;

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -7,6 +7,7 @@ interface SpeechOptions {
   onStart?: () => void;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
+  onCancel?: () => void;
   muted?: boolean;
   paused?: boolean;
   userInteracted?: boolean;
@@ -73,6 +74,10 @@ class RealSpeechService {
           console.log(
             `Canceled context - muted: ${options.muted}, paused: ${options.paused}, userInteracted: ${options.userInteracted}`
           );
+          document.dispatchEvent(new Event('speech-canceled'));
+          if (options.onCancel) {
+            options.onCancel();
+          }
         }
         this.isActive = false;
         this.currentUtterance = null;

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -59,6 +59,10 @@ class UnifiedSpeechController {
         console.error('Word speech error:', error);
         this.clearFallbackTimer();
         this.scheduleAutoAdvance();
+      },
+      onCancel: () => {
+        console.log('Word speech canceled, resetting state');
+        this.clearFallbackTimer();
       }
     });
   }


### PR DESCRIPTION
## Summary
- reset speech state when cancellation errors happen
- dispatch a `speech-canceled` event from `realSpeechService`
- handle canceled events in `useSpeechState`
- plumb cancel callbacks through `directSpeechService` and `unifiedSpeechController`

## Testing
- `npx vitest run` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_685d5e47433c832fa52abae2b6fba0d3