### PR TITLE
Adjust speech fallback timing

### DIFF
--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -1,6 +1,7 @@
 
 import { VocabularyWord } from '@/types/vocabulary';
 import { realSpeechService } from './realSpeechService';
+import { calculateSpeechDuration } from '@/utils/speech/durationUtils';
 
 interface SpeechGuardResult {
   canPlay: boolean;
@@ -35,6 +36,7 @@ class UnifiedSpeechController {
       .filter(Boolean)
       .map(part => part.trim());
     const text = parts.join('. ');
+    const est = calculateSpeechDuration(text);
 
     console.log('UnifiedSpeechController: Speaking word:', word.word, 'in region:', region);
 
@@ -47,7 +49,7 @@ class UnifiedSpeechController {
           console.warn('Speech fallback timer expired for', word.word);
           realSpeechService.stop();
           this.scheduleAutoAdvance();
-        }, 5000);
+        }, Math.max(est * 1.2, 7000));
         console.log('Started speech fallback timer for', word.word);
       },
       onEnd: () => {

--- a/tests/unifiedSpeechFallback.test.ts
+++ b/tests/unifiedSpeechFallback.test.ts
@@ -34,7 +34,7 @@ describe('unifiedSpeechController fallback', () => {
     const cb = vi.fn();
     unifiedSpeechController.setWordCompleteCallback(cb);
     await unifiedSpeechController.speak(word);
-    vi.advanceTimersByTime(7000); // 5s fallback + 2s auto advance
+    vi.advanceTimersByTime(9000); // fallback (min 7s) + 2s auto advance
     expect(cb).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- estimate speech duration in unified controller
- scale fallback timer based on calculated duration
- update fallback timer test expectation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npx -y vitest run` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_685d60f2dd54832f95cfc589712a3c60