### PR TITLE
Add resume-last-word feature

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -3,6 +3,8 @@ import { useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+import { getLastWord } from '@/utils/lastWordStorage';
+import { findFuzzyIndex } from '@/utils/text/findFuzzyIndex';
 
 /**
  * Data loading and persistence
@@ -34,12 +36,21 @@ export const useVocabularyDataLoader = (
       try {
         const words = vocabularyService.getWordList();
         console.log(`[DATA-LOADER] Loaded ${words.length} words`);
-        
+
         setWordList(words);
         setHasData(words.length > 0);
-        
+
         if (words.length > 0) {
-          setCurrentIndex(0);
+          const category = vocabularyService.getCurrentSheetName();
+          const savedWord = getLastWord(category);
+          let startIndex = 0;
+          if (savedWord) {
+            const idx = findFuzzyIndex(words.map(w => w.word), savedWord);
+            if (idx >= 0) {
+              startIndex = idx;
+            }
+          }
+          setCurrentIndex(startIndex);
         }
       } catch (error) {
         console.error('[DATA-LOADER] Error loading vocabulary data:', error);

--- a/src/hooks/vocabulary-controller/core/useWordNavigation.ts
+++ b/src/hooks/vocabulary-controller/core/useWordNavigation.ts
@@ -3,6 +3,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
+import { saveLastWord } from '@/utils/lastWordStorage';
 
 /**
  * Word navigation logic
@@ -51,6 +52,10 @@ export const useWordNavigation = (
       const nextIndex = (currentIndex + 1) % wordList.length;
       console.log('[WORD-NAVIGATION] Moving from word', currentIndex, 'to', nextIndex);
       setCurrentIndex(nextIndex);
+      const nextWord = wordList[nextIndex];
+      if (nextWord) {
+        saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
+      }
 
     } catch (error) {
       console.error('[WORD-NAVIGATION] Error navigating to next word:', error);

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -8,6 +8,7 @@ import { useSpeechIntegration } from './core/useSpeechIntegration';
 import { useWordNavigation } from './core/useWordNavigation';
 import { useVocabularyControls } from './core/useVocabularyControls';
 import { useVocabularyDataLoader } from './core/useVocabularyDataLoader';
+import { saveLastWord } from '@/utils/lastWordStorage';
 
 /**
  * Unified Vocabulary Controller - Single source of truth for vocabulary state
@@ -115,6 +116,13 @@ export const useUnifiedVocabularyController = () => {
     console.log(`[UNIFIED-CONTROLLER] Setting muted: ${isMuted}`);
     unifiedSpeechController.setMuted(isMuted);
   }, [isMuted]);
+
+  // Persist last viewed word for the current category
+  useEffect(() => {
+    if (currentWord) {
+      saveLastWord(vocabularyService.getCurrentSheetName(), currentWord.word);
+    }
+  }, [currentWord?.word]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/utils/lastWordStorage.ts
+++ b/src/utils/lastWordStorage.ts
@@ -1,0 +1,35 @@
+export const LAST_WORD_KEY = 'lazyVoca.lastWordByCategory';
+
+export const getLastWords = (): Record<string, string> => {
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    const stored = localStorage.getItem(LAST_WORD_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, string>;
+    }
+  } catch (error) {
+    console.error('Error reading last words from localStorage:', error);
+  }
+  try {
+    localStorage.removeItem(LAST_WORD_KEY);
+  } catch {}
+  return {};
+};
+
+export const getLastWord = (category: string): string | undefined => {
+  const map = getLastWords();
+  return map[category];
+};
+
+export const saveLastWord = (category: string, word: string): void => {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    const map = getLastWords();
+    map[category] = word;
+    localStorage.setItem(LAST_WORD_KEY, JSON.stringify(map));
+  } catch (error) {
+    console.error('Error saving last word to localStorage:', error);
+  }
+};

--- a/src/utils/text/findFuzzyIndex.ts
+++ b/src/utils/text/findFuzzyIndex.ts
@@ -1,0 +1,5 @@
+export const findFuzzyIndex = (list: string[], target: string): number => {
+  if (!target) return -1;
+  const lower = target.toLowerCase();
+  return list.findIndex(w => w.toLowerCase().startsWith(lower));
+};


### PR DESCRIPTION
## Summary
- persist per-category last word in `localStorage`
- restore saved position on load or after switching category
- update navigation to save last word on advance
- expose utility helpers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df9b71664832f896ee11d184218de