### PR TITLE
Add quick word search modal

### DIFF
--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -1,10 +1,11 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker } from 'lucide-react';
+import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker, Search } from 'lucide-react';
 import { toast } from 'sonner';
 import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
+import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { getCategoryLabel, getCategoryMessageLabel } from '@/utils/categoryLabels';
@@ -65,6 +66,10 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
     onCycleVoice();
     toast(`Voice changed to ${nextVoiceLabel}`);
   };
+
+  const [isSearchOpen, setIsSearchOpen] = React.useState(false);
+  const openSearch = () => setIsSearchOpen(true);
+  const closeSearch = () => setIsSearchOpen(false);
 
   return (
     <div className="flex flex-col gap-2 items-end">
@@ -128,6 +133,16 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 
       <EditWordButton onClick={onOpenEditModal} disabled={!currentWord} />
       <AddWordButton onClick={onOpenAddModal} />
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={openSearch}
+        className="h-8 w-8 p-0"
+        title="Quick Search"
+      >
+        <Search size={16} />
+      </Button>
+      <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
     </div>
   );
 };

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Search, Volume2 } from 'lucide-react';
+import { vocabularyService } from '@/services/vocabularyService';
+import { VocabularyWord } from '@/types/vocabulary';
+import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
+
+interface WordSearchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) => {
+  const wordList = vocabularyService.getWordList();
+  const [query, setQuery] = useState('');
+  const [selectedWord, setSelectedWord] = useState<VocabularyWord | null>(null);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [] as VocabularyWord[];
+    return wordList.filter(w => w.word.toLowerCase().includes(q));
+  }, [query, wordList]);
+
+  const handlePlay = () => {
+    if (!selectedWord) return;
+    const text = [selectedWord.word, selectedWord.meaning, selectedWord.example]
+      .filter(Boolean)
+      .join('. ');
+    const utterance = new SpeechSynthesisUtterance(text);
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const handleClose = () => {
+    setQuery('');
+    setSelectedWord(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md max-h-[90vh]">
+        <DialogHeader>
+          <DialogTitle>Quick Search</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex gap-2 items-center">
+          <Input
+            placeholder="Search word..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') e.preventDefault();
+            }}
+          />
+          <Button size="icon" variant="outline">
+            <Search className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <ScrollArea className="h-40 mt-3 border rounded-md">
+          {results.map((word) => (
+            <div
+              key={word.word}
+              className="px-2 py-1 cursor-pointer hover:bg-accent"
+              onClick={() => setSelectedWord(word)}
+            >
+              {word.word}
+            </div>
+          ))}
+          {results.length === 0 && query.trim() && (
+            <p className="p-2 text-sm text-muted-foreground">No results</p>
+          )}
+        </ScrollArea>
+
+        {selectedWord && (
+          <div className="mt-4 space-y-2">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="font-semibold text-lg">
+                  {parseWordAnnotations(selectedWord.word).main}
+                </h3>
+                <p className="text-sm text-gray-500">
+                  {parseWordAnnotations(selectedWord.word).annotations.join(' ')}
+                </p>
+              </div>
+              <Button size="icon" variant="ghost" onClick={handlePlay} title="Play">
+                <Volume2 className="h-4 w-4" />
+              </Button>
+            </div>
+            <p className="text-green-700 italic text-sm">{selectedWord.meaning}</p>
+            <p className="text-red-700 italic text-sm">{selectedWord.example}</p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default WordSearchModal;


### PR DESCRIPTION
## Summary
- add `WordSearchModal` component to search words in current category
- add search button in `VocabularyControlsColumn`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e034cb4e8832f82231fcc2d0fc4dd