### PR TITLE
Improve search modal result selection

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -8,6 +8,8 @@ import { Loader, Search, Volume2 } from 'lucide-react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { Badge } from '@/components/ui/badge';
 import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
+import VocabularyCard from './VocabularyCard';
+import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 
 interface WordSearchModalProps {
   isOpen: boolean;
@@ -22,6 +24,12 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [results, setResults] = useState<Fuse.FuseResult<VocabularyWord>[]>([]);
   const [selectedWord, setSelectedWord] = useState<VocabularyWord | null>(null);
+  const previewVoice: VoiceSelection = {
+    label: 'US',
+    region: 'US',
+    gender: 'female',
+    index: 0
+  };
 
   useEffect(() => {
     if (isOpen && !fuseRef.current && !loading) {
@@ -64,6 +72,12 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
   useEffect(() => {
     const id = setTimeout(() => setDebouncedQuery(query), 200);
     return () => clearTimeout(id);
+  }, [query]);
+
+  useEffect(() => {
+    if (selectedWord) {
+      setSelectedWord(null);
+    }
   }, [query]);
 
   useEffect(() => {
@@ -110,51 +124,71 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
           </Button>
         </div>
 
-        <ScrollArea className="h-40 mt-3 border rounded-md">
-          {loading && !fuseRef.current && (
-            <div className="flex justify-center py-4" aria-label="loading">
-              <Loader className="h-4 w-4 animate-spin" />
-            </div>
-          )}
-          {loadError && <p className="p-2 text-sm text-destructive">{loadError}</p>}
-          {results.map(({ item, matches }) => (
-            <div
-              key={`${item.word}-${item.category}`}
-              className="px-2 py-1 cursor-pointer hover:bg-accent flex justify-between"
-              onClick={() => setSelectedWord(item)}
-            >
-              <span className="mr-2 flex-1">
-                {highlightMatch(item.word, matches?.find(m => m.key === 'word'))}
-              </span>
-              {item.category && (
-                <Badge variant="secondary" className="shrink-0">
-                  {item.category}
-                </Badge>
-              )}
-            </div>
-          ))}
-          {results.length === 0 && debouncedQuery.trim() && !loading && !loadError && (
-            <p className="p-2 text-sm text-muted-foreground">No results</p>
-          )}
-        </ScrollArea>
-
-        {selectedWord && (
-          <div className="mt-4 space-y-2">
-            <div className="flex items-start justify-between">
-              <div>
-                <h3 className="font-semibold text-lg">
-                  {parseWordAnnotations(selectedWord.word).main}
-                </h3>
-                <p className="text-sm text-gray-500">
-                  {parseWordAnnotations(selectedWord.word).annotations.join(' ')}
-                </p>
+        {!selectedWord ? (
+          <ScrollArea className="h-40 mt-3 border rounded-md">
+            {loading && !fuseRef.current && (
+              <div className="flex justify-center py-4" aria-label="loading">
+                <Loader className="h-4 w-4 animate-spin" />
               </div>
-              <Button size="icon" variant="ghost" onClick={handlePlay} title="Play">
+            )}
+            {loadError && (
+              <p className="p-2 text-sm text-destructive">{loadError}</p>
+            )}
+            {results.map(({ item, matches }) => (
+              <div
+                key={`${item.word}-${item.category}`}
+                className="px-2 py-1 cursor-pointer hover:bg-accent flex justify-between"
+                onClick={() => setSelectedWord(item)}
+              >
+                <span className="mr-2 flex-1">
+                  {highlightMatch(
+                    item.word,
+                    matches?.find(m => m.key === 'word')
+                  )}
+                </span>
+                {item.category && (
+                  <Badge variant="secondary" className="shrink-0">
+                    {item.category}
+                  </Badge>
+                )}
+              </div>
+            ))}
+            {results.length === 0 &&
+              debouncedQuery.trim() &&
+              !loading &&
+              !loadError && (
+                <p className="p-2 text-sm text-muted-foreground">No results</p>
+              )}
+          </ScrollArea>
+        ) : (
+          <div className="mt-3 space-y-2">
+            <VocabularyCard
+              word={selectedWord.word}
+              meaning={selectedWord.meaning}
+              example={selectedWord.example}
+              backgroundColor="#ffffff"
+              isMuted={false}
+              isPaused={false}
+              onToggleMute={() => {}}
+              onTogglePause={() => {}}
+              onCycleVoice={() => {}}
+              onSwitchCategory={() => {}}
+              onNextWord={() => {}}
+              currentCategory={selectedWord.category || ''}
+              nextCategory=""
+              selectedVoice={previewVoice}
+              nextVoiceLabel=""
+            />
+            <div className="flex justify-end">
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handlePlay}
+                title="Play"
+              >
                 <Volume2 className="h-4 w-4" />
               </Button>
             </div>
-            <p className="text-green-700 italic text-sm">{selectedWord.meaning}</p>
-            <p className="text-red-700 italic text-sm">{selectedWord.example}</p>
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
## Summary
- refine `WordSearchModal` to toggle between result list and word preview
- hide results when a word is selected
- reopen results when the user edits the search

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f929730832f861afdad1d51f788