### PR TITLE
Improve mobile modal offset

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -121,7 +121,9 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md max-h-[90vh]">
+      <DialogContent
+        className="sm:max-w-md max-h-[90vh] top-[5%] sm:top-[10%] md:top-1/2 translate-y-0 md:translate-y-[-50%]"
+      >
         <DialogHeader>
           <DialogTitle>Quick Search</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- tweak dialog positioning so Quick Search modal sits higher on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e11817878832fa0cf0b00ca80f18a