### PR TITLE
Fix search modal debounced query

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -21,6 +21,7 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState('');
   const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
   const [results, setResults] = useState<Fuse.FuseResult<VocabularyWord>[]>([]);
   const [selectedWord, setSelectedWord] = useState<VocabularyWord | null>(null);
   const previewVoice: VoiceSelection = {


### PR DESCRIPTION
## Summary
- fix ReferenceError in WordSearchModal by adding missing state for `debouncedQuery`

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 54 errors, 38 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685e15365778832fba34ebc11083fd59