### PR TITLE
Remove controls on search preview

### DIFF
--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -26,6 +26,7 @@ interface VocabularyCardProps {
   category?: string;
   selectedVoice: VoiceSelection;
   nextVoiceLabel: string;
+  searchPreview?: boolean;
 }
 
 const VocabularyCard: React.FC<VocabularyCardProps> = ({
@@ -45,7 +46,8 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   isSpeaking = false,
   category,
   selectedVoice,
-  nextVoiceLabel
+  nextVoiceLabel,
+  searchPreview = false
 }) => {
   // Store current word in localStorage to help track sync issues
   useEffect(() => {
@@ -99,68 +101,75 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <span className="italic text-red-600">*</span> {example}
           </div>
           {/* Mobile note below example */}
-          <div className="mobile-note text-left italic mt-2" style={{ color: '#6b7280', fontSize: '0.8rem' }}>
-            Tap any button (e.g., Next) to enable speech. On Mobile, only one voice may be available.
-          </div>
+          {!searchPreview && (
+            <div
+              className="mobile-note text-left italic mt-2"
+              style={{ color: '#6b7280', fontSize: '0.8rem' }}
+            >
+              Tap any button (e.g., Next) to enable speech. On Mobile, only one voice may be available.
+            </div>
+          )}
         </div>
         {/* Control buttons wrapper - optimized spacing */}
-        <div className="flex flex-wrap gap-1 pt-1">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onToggleMute}
-            className={cn(
-              "h-6 text-xs px-1.5",
-              isMuted ? "text-purple-700 border-purple-300 bg-purple-50" : "text-gray-700"
-            )}
-          >
-            {isMuted ? <VolumeX size={12} className="mr-1" /> : <Volume2 size={12} className="mr-1" />}
-            {isMuted ? "Unmute" : "Mute"}
-          </Button>
-          
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onTogglePause}
-            className={cn(
-              "h-6 text-xs px-1.5",
-              isPaused ? "text-orange-500 border-orange-300 bg-orange-50" : "text-gray-700"
-            )}
-          >
-            {isPaused ? <Play size={12} className="mr-1" /> : <Pause size={12} className="mr-1" />}
-            {isPaused ? "Play" : "Pause"}
-          </Button>
-        
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onNextWord}
-            className="h-6 text-xs px-1.5 text-indigo-700 bg-indigo-50"
-          >
-            <SkipForward size={12} className="mr-1" />
-            Next
-          </Button>
-          
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onSwitchCategory}
-            className="h-6 text-xs px-1.5 text-green-700"
-          >
-            <RefreshCw size={10} className="mr-1" />
-            {/* Removed dynamic category label */}
-          </Button>
-          
-          {/* Single voice toggle button */}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onCycleVoice}
-            className="h-6 text-xs px-1.5 text-blue-700 border-blue-300 bg-blue-50"
-          >
-            {nextVoiceLabel}
-          </Button>
-        </div>
+        {!searchPreview && (
+          <div className="flex flex-wrap gap-1 pt-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onToggleMute}
+              className={cn(
+                "h-6 text-xs px-1.5",
+                isMuted ? "text-purple-700 border-purple-300 bg-purple-50" : "text-gray-700"
+              )}
+            >
+              {isMuted ? <VolumeX size={12} className="mr-1" /> : <Volume2 size={12} className="mr-1" />}
+              {isMuted ? "Unmute" : "Mute"}
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onTogglePause}
+              className={cn(
+                "h-6 text-xs px-1.5",
+                isPaused ? "text-orange-500 border-orange-300 bg-orange-50" : "text-gray-700"
+              )}
+            >
+              {isPaused ? <Play size={12} className="mr-1" /> : <Pause size={12} className="mr-1" />}
+              {isPaused ? "Play" : "Pause"}
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onNextWord}
+              className="h-6 text-xs px-1.5 text-indigo-700 bg-indigo-50"
+            >
+              <SkipForward size={12} className="mr-1" />
+              Next
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onSwitchCategory}
+              className="h-6 text-xs px-1.5 text-green-700"
+            >
+              <RefreshCw size={10} className="mr-1" />
+              {/* Removed dynamic category label */}
+            </Button>
+
+            {/* Single voice toggle button */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCycleVoice}
+              className="h-6 text-xs px-1.5 text-blue-700 border-blue-300 bg-blue-50"
+            >
+              {nextVoiceLabel}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Loader, Search, Volume2 } from 'lucide-react';
+import { Loader, Search } from 'lucide-react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { Badge } from '@/components/ui/badge';
 import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
@@ -198,17 +198,8 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
               nextCategory=""
               selectedVoice={previewVoice}
               nextVoiceLabel=""
+              searchPreview={true}
             />
-            <div className="flex justify-end">
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={handlePlay}
-                title="Play"
-              >
-                <Volume2 className="h-4 w-4" />
-              </Button>
-            </div>
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
## Summary
- add `searchPreview` prop to `VocabularyCard`
- show only the word info when `searchPreview` is true
- simplify selected result rendering in `WordSearchModal`

## Testing
- `npx vitest run`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e2d39431c832f853514dba0164584