### PR TITLE
Match Quick Search font sizes

### DIFF
--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -78,7 +78,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
         <div>
           {/* Word */}
           <h2
-            className="text-left font-semibold text-[0.8rem] text-gray-800 leading-tight mb-2"
+            className="text-left font-semibold text-base md:text-sm text-gray-800 leading-tight mb-2"
             style={{ marginTop: 0 }}
           >
             {main}
@@ -88,14 +88,14 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           </h2>
           {/* Meaning */}
           <div
-            className="text-left text-[0.7rem] text-emerald-400 italic mb-2"
+            className="text-left text-base md:text-sm text-emerald-400 italic mb-2"
             style={{ background: 'transparent', marginTop: 0 }}
           >
             <span className="italic text-emerald-400">*</span> {meaning}
           </div>
           {/* Example */}
           <div
-            className="text-left text-[0.7rem] text-red-600 italic"
+            className="text-left text-base md:text-sm text-red-600 italic"
             style={{ background: 'transparent', marginTop: 0 }}
           >
             <span className="italic text-red-600">*</span> {example}

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -154,13 +154,13 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
             {loadError && (
               <p className="p-2 text-sm text-destructive">{loadError}</p>
             )}
-            {results.map(({ item, matches }) => (
+              {results.map(({ item, matches }) => (
               <div
                 key={`${item.word}-${item.category}`}
                 className="px-2 py-1 cursor-pointer hover:bg-accent flex justify-between"
                 onClick={() => setSelectedWord(item)}
               >
-                <span className="mr-2 flex-1">
+                <span className="mr-2 flex-1 text-base md:text-sm">
                   {highlightMatch(
                     item.word,
                     matches?.find(m => m.key === 'word')


### PR DESCRIPTION
## Summary
- keep search preview card fonts consistent
- size search result text like the input

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685e644c60ac832f9998f0148e701839