### PR TITLE
Improve Quick Search ordering

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -83,13 +83,28 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
     const id = setTimeout(() => {
       if (wordsRef.current) {
         const q = query.toLowerCase();
-        const filtered = wordsRef.current.filter(
+        const matches = wordsRef.current.filter(
           w =>
             w.word.toLowerCase().includes(q) ||
             w.meaning.toLowerCase().includes(q) ||
             w.example.toLowerCase().includes(q)
         );
-        setResults(filtered);
+
+        const inWord = matches.filter(w => w.word.toLowerCase().includes(q));
+        const inMeaning = matches.filter(
+          w =>
+            !w.word.toLowerCase().includes(q) &&
+            w.meaning.toLowerCase().includes(q)
+        );
+        const inExample = matches.filter(
+          w =>
+            !w.word.toLowerCase().includes(q) &&
+            !w.meaning.toLowerCase().includes(q) &&
+            w.example.toLowerCase().includes(q)
+        );
+        const sorted = [...inWord, ...inMeaning, ...inExample];
+
+        setResults(sorted);
       }
     }, 200);
 


### PR DESCRIPTION
## Summary
- prioritize word matches in quick search before meaning and example matches
- implement new sorting logic in `WordSearchModal`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e74b44f68832fa1c0032cb3d1df96