### PR TITLE
Fix Safari speech preload timing

### DIFF
--- a/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
+++ b/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
@@ -9,27 +9,21 @@ import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 export const useSafariSupport = (userInteractionRef: React.MutableRefObject<boolean>) => {
   // Special iOS and Safari initialization
   useEffect(() => {
-    // iOS needs user interaction to enable audio
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    
-    if (isIOS || isSafari) {
-      if (!userInteractionRef.current) {
-        toast.error("Please tap anywhere to enable audio playback", { duration: 5000 });
-      }
+
+    if (!isIOS && !isSafari) {
+      return;
     }
-    
-    // Try to force browser to preload speech synthesis
+
     const preloadSpeech = () => {
       if ('speechSynthesis' in window) {
         try {
-          // Create a minimal utterance - just a space
           const utterance = new SpeechSynthesisUtterance(' ');
           utterance.volume = 0.01;
           utterance.rate = DEFAULT_SPEECH_RATE;
           utterance.pitch = 1;
-          
-          // Try to speak it
+
           window.speechSynthesis.cancel();
           window.speechSynthesis.speak(utterance);
         } catch (e) {
@@ -37,12 +31,27 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
         }
       }
     };
-    
-    // Try preloading once on mount
-    preloadSpeech();
-    
-    // Clean up
+
+    const enableOnGesture = () => {
+      preloadSpeech();
+      document.removeEventListener('click', enableOnGesture);
+      document.removeEventListener('touchstart', enableOnGesture);
+      document.removeEventListener('keydown', enableOnGesture);
+    };
+
+    if (userInteractionRef.current) {
+      preloadSpeech();
+    } else {
+      toast.error('Please tap anywhere to enable audio playback', { duration: 5000 });
+      document.addEventListener('click', enableOnGesture);
+      document.addEventListener('touchstart', enableOnGesture);
+      document.addEventListener('keydown', enableOnGesture);
+    }
+
     return () => {
+      document.removeEventListener('click', enableOnGesture);
+      document.removeEventListener('touchstart', enableOnGesture);
+      document.removeEventListener('keydown', enableOnGesture);
       if (window.speechSynthesis) {
         window.speechSynthesis.cancel();
       }


### PR DESCRIPTION
## Summary
- load iOS/Safari speech preload only after user gesture

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e7540efa4832f94fa19bedd493784