### PR TITLE
Add fallback voice selection

### DIFF
--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -67,6 +67,19 @@ class RealSpeechService {
         );
       }
 
+      if (!utterance.voice) {
+        const allVoices = speechSynthesis.getVoices();
+        const fallback =
+          allVoices.find(v => v.lang.startsWith('en')) || allVoices[0] || null;
+        if (fallback) {
+          utterance.voice = fallback;
+          console.log(
+            "Falling back to voice:",
+            fallback.name,
+          );
+        }
+      }
+
       // Configure speech settings
       utterance.rate = DEFAULT_SPEECH_RATE;
       utterance.pitch = 1.0;


### PR DESCRIPTION
## Summary
- set a default English voice when no specific voice is resolved

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68633fb02d78832f828deed1ed377a14