### PR TITLE
Log available SpeechSynthesis voices on load

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { initializeVoiceLogging } from './utils/speech/voiceLoader'
 
 // Disable console logs in production for better performance
 if (import.meta.env.PROD) {
@@ -9,6 +10,8 @@ if (import.meta.env.PROD) {
   console.warn = () => {};
   console.info = () => {};
 }
+
+initializeVoiceLogging();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/src/utils/speech/voiceLoader.ts
+++ b/src/utils/speech/voiceLoader.ts
@@ -32,9 +32,34 @@ export const ensureVoicesLoaded = (): Promise<SpeechSynthesisVoice[]> => {
 
 export const logAvailableVoices = () => {
   const voices = window.speechSynthesis.getVoices();
-  console.log('Available voices:', voices.map(v => ({
+
+  if (voices.length === 0) {
+    console.warn('[Voices] No voices available (yet). Waiting for voiceschanged event.');
+    return;
+  }
+
+  const voiceInfo = voices.map(v => ({
     name: v.name,
     lang: v.lang,
-    default: v.default
-  })));
+    default: v.default,
+    localService: v.localService,
+  }));
+
+  console.log('[Voices] Available voices:', voiceInfo);
+};
+
+export const initializeVoiceLogging = () => {
+  const logHandler = () => {
+    console.log('[Voices] voiceschanged event triggered');
+    logAvailableVoices();
+  };
+
+  // Log immediately on init
+  logAvailableVoices();
+
+  if ('addEventListener' in window.speechSynthesis) {
+    window.speechSynthesis.addEventListener('voiceschanged', logHandler);
+  } else {
+    window.speechSynthesis.onvoiceschanged = logHandler;
+  }
 };


### PR DESCRIPTION
## Summary
- log voices on startup and whenever the `voiceschanged` event fires
- call the logging from the app entry point

## Testing
- `npm test -- -w` *(all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_686342f41e94832fa9e59dc77ccfc2ce