### PR TITLE
Simplify speech unlock

### DIFF
--- a/src/components/vocabulary-app/AudioStatusIndicator.tsx
+++ b/src/components/vocabulary-app/AudioStatusIndicator.tsx
@@ -1,33 +1,6 @@
 
 import React from 'react';
 
-interface AudioStatusIndicatorProps {
-  isAudioUnlocked: boolean;
-  hasInitialized: boolean;
-}
-
-const AudioStatusIndicator: React.FC<AudioStatusIndicatorProps> = ({
-  isAudioUnlocked,
-  hasInitialized
-}) => {
-  const handleResume = () => {
-    window.dispatchEvent(new Event('resume-speech'));
-  };
-
-  if (hasInitialized && isAudioUnlocked) {
-    return null;
-  }
-
-  return (
-    <div className="flex justify-center mt-2">
-      <button
-        onClick={handleResume}
-        className="px-4 py-2 bg-blue-600 text-white rounded"
-      >
-        {hasInitialized ? 'Resume Audio' : 'Start'}
-      </button>
-    </div>
-  );
-};
+const AudioStatusIndicator: React.FC = () => null;
 
 export default AudioStatusIndicator;

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -4,7 +4,6 @@ import VocabularyLayout from "@/components/VocabularyLayout";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithDataNew from "./ContentWithDataNew";
 import VocabularyCardNew from "./VocabularyCardNew";
-import AudioStatusIndicator from "./AudioStatusIndicator";
 import UserInteractionManager from "./UserInteractionManager";
 import { useWordModalState } from "@/hooks/vocabulary/useWordModalState";
 import { useStableVocabularyState } from "@/hooks/vocabulary-app/useStableVocabularyState";
@@ -89,10 +88,6 @@ const VocabularyAppContainerNew: React.FC = () => {
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
           />
-          <AudioStatusIndicator
-            isAudioUnlocked={userInteractionState.isAudioUnlocked}
-            hasInitialized={userInteractionState.hasInitialized}
-          />
           <VocabularyCardNew
             word="No vocabulary data"
             meaning="Please upload a vocabulary file to get started"
@@ -125,10 +120,6 @@ const VocabularyAppContainerNew: React.FC = () => {
             currentWord={currentWord}
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
-          />
-          <AudioStatusIndicator
-            isAudioUnlocked={userInteractionState.isAudioUnlocked}
-            hasInitialized={userInteractionState.hasInitialized}
           />
           <VocabularyCardNew
             word={`No words in "${currentCategory}" category`}
@@ -163,13 +154,9 @@ const VocabularyAppContainerNew: React.FC = () => {
             playCurrentWord={playCurrentWord}
             onInteractionUpdate={handleInteractionUpdate}
           />
-        <AudioStatusIndicator
-          isAudioUnlocked={userInteractionState.isAudioUnlocked}
-          hasInitialized={userInteractionState.hasInitialized}
-        />
-          <VocabularyCardNew
-            word="Loading vocabulary..."
-            meaning="Please wait while we load your vocabulary data"
+        <VocabularyCardNew
+          word="Loading vocabulary..."
+          meaning="Please wait while we load your vocabulary data"
             example=""
             backgroundColor="#F0F8FF"
             isMuted={isMuted}
@@ -199,12 +186,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             onInteractionUpdate={handleInteractionUpdate}
           />
 
-        <AudioStatusIndicator
-          isAudioUnlocked={userInteractionState.isAudioUnlocked}
-          hasInitialized={userInteractionState.hasInitialized}
-        />
-
-          <ErrorDisplay jsonLoadError={false} />
+        <ErrorDisplay jsonLoadError={false} />
 
           <ContentWithDataNew
             displayWord={currentWord}
@@ -242,11 +224,6 @@ const VocabularyAppContainerNew: React.FC = () => {
           currentWord={currentWord}
           playCurrentWord={playCurrentWord}
           onInteractionUpdate={handleInteractionUpdate}
-        />
-        
-        <AudioStatusIndicator
-          isAudioUnlocked={userInteractionState.isAudioUnlocked}
-          hasInitialized={userInteractionState.hasInitialized}
         />
         
         <ErrorDisplay jsonLoadError={false} />

--- a/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
+++ b/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
@@ -22,14 +22,16 @@ export const useEnhancedUserInteraction = ({
 
   const handleInteraction = useCallback(async () => {
     setInteractionCount((c) => c + 1);
-    if (!hasInitialized) {
+    if (!hasInitialized || !isAudioUnlocked) {
       await initializeSpeechSystem();
-      setHasInitialized(true);
+      if (!hasInitialized) {
+        setHasInitialized(true);
+      }
     }
     setIsAudioUnlocked(true);
     onUserInteraction?.();
     playCurrentWord?.();
-  }, [hasInitialized, onUserInteraction, playCurrentWord]);
+  }, [hasInitialized, isAudioUnlocked, onUserInteraction, playCurrentWord]);
 
   useEffect(() => {
     const listener = () => handleInteraction();
@@ -46,14 +48,11 @@ export const useEnhancedUserInteraction = ({
 
   useEffect(() => {
     const blocked = () => setIsAudioUnlocked(false);
-    const resume = () => handleInteraction();
     window.addEventListener('speechblocked', blocked);
-    window.addEventListener('resume-speech', resume);
     return () => {
       window.removeEventListener('speechblocked', blocked);
-      window.removeEventListener('resume-speech', resume);
     };
-  }, [handleInteraction]);
+  }, []);
 
   return {
     hasInitialized,

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -1,7 +1,6 @@
 
 import { VocabularyWord } from '@/types/vocabulary';
 import { realSpeechService } from './realSpeechService';
-import { toast } from 'sonner';
 
 interface SpeechGuardResult {
   canPlay: boolean;
@@ -40,10 +39,7 @@ class UnifiedSpeechController {
         this.scheduleAutoAdvance();
       },
       onError: (error) => {
-        console.error('Word speech error:', error);
         if ((error as SpeechSynthesisErrorEvent).error === 'not-allowed') {
-          console.warn('Speech blocked: browser requires user interaction.');
-          toast.error('Speech blocked: browser requires user interaction.');
           window.dispatchEvent(new Event('speechblocked'));
           // Do not auto advance when blocked
           return;

--- a/src/utils/speech/core/modules/speechInit.ts
+++ b/src/utils/speech/core/modules/speechInit.ts
@@ -8,17 +8,19 @@ import { loadVoicesAndWait } from "./speechVoiceLoader";
  * Initialize speech synthesis on first user gesture.
  * Subsequent calls return the same promise.
  */
-export const initializeSpeechSystem = (): Promise<void> => {
-  if (speechInitialized) return Promise.resolve();
+export const initializeSpeechSystem = async (): Promise<void> => {
   if (initPromise) return initPromise;
 
   initPromise = (async () => {
     await unlockAudio();
-    await loadVoicesAndWait();
-    speechInitialized = true;
+    if (!speechInitialized) {
+      await loadVoicesAndWait();
+      speechInitialized = true;
+    }
   })();
 
-  return initPromise;
+  await initPromise;
+  initPromise = null;
 };
 
 /**

--- a/src/utils/speech/core/modules/speechUnlock.ts
+++ b/src/utils/speech/core/modules/speechUnlock.ts
@@ -24,7 +24,7 @@ export const unlockAudio = (): Promise<boolean> => {
       }
 
       const u = new SpeechSynthesisUtterance(" ");
-      u.volume = 0;
+      u.volume = 0.01;
       u.onend = () => resolve(true);
       u.onerror = () => resolve(false);
 


### PR DESCRIPTION
## Summary
- remove the AudioStatusIndicator component
- unlock speech on any interaction and retry after `not-allowed`
- drop toast messages for blocked speech
- attempt unlock on every interaction using a quiet utterance
- stop using the start/resume button

## Testing
- `npm run lint` *(fails: cannot satisfy ESLint rules)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863568b14c0832fb45b894c01f0671c