### PR TITLE
Improve Safari speech unlock handling

### DIFF
--- a/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
+++ b/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
@@ -27,6 +27,11 @@ export const useEnhancedUserInteraction = ({
       setHasInitialized(true);
     }
     setIsAudioUnlocked(true);
+    try {
+      localStorage.setItem('hadUserInteraction', 'true');
+    } catch (err) {
+      console.warn('Failed to persist interaction state:', err);
+    }
     onUserInteraction?.();
     playCurrentWord?.();
   }, [hasInitialized, onUserInteraction, playCurrentWord]);
@@ -44,8 +49,23 @@ export const useEnhancedUserInteraction = ({
     };
   }, [handleInteraction]);
 
+  // Detect prior interaction to optionally skip showing the prompt
   useEffect(() => {
-    const blocked = () => setIsAudioUnlocked(false);
+    if (localStorage.getItem('hadUserInteraction') === 'true') {
+      console.log('[USER-INTERACTION] Previous interaction detected');
+    }
+  }, []);
+
+  useEffect(() => {
+    const blocked = () => {
+      setIsAudioUnlocked(false);
+      setHasInitialized(false);
+      try {
+        localStorage.setItem('hadUserInteraction', 'false');
+      } catch (err) {
+        console.warn('Failed to reset interaction state:', err);
+      }
+    };
     const resume = () => handleInteraction();
     window.addEventListener('speechblocked', blocked);
     window.addEventListener('resume-speech', resume);


### PR DESCRIPTION
## Summary
- track user interaction in localStorage and listen for blocked events
- retry unlocking in Safari using new gesture listeners
- block speech until the user interacts
- enhance error logging and dispatch a `speechblocked` event when Safari rejects speech

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686356d1e35c832fb596295a10b4ddbe