### PR TITLE
Add speech rate control

### DIFF
--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Gauge } from 'lucide-react';
+
+interface SpeechRateControlProps {
+  rate: number;
+  onChange: (rate: number) => void;
+}
+
+const RATE_VALUES = [0, 0.2, 0.4, 0.6, 0.8, 1, 1.25, 1.5];
+
+const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 w-8 p-0"
+          title="Speech Rate"
+        >
+          <Gauge size={16} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-44 p-2" side="right" align="start">
+        <div className="grid grid-cols-4 gap-2">
+          {RATE_VALUES.map((v) => (
+            <Button
+              key={v}
+              size="sm"
+              variant={rate === v ? 'default' : 'outline'}
+              className="h-7 px-2 text-xs"
+              onClick={() => onChange(v)}
+            >
+              {v}x
+            </Button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default SpeechRateControl;

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker, Search } from 'lucide-react';
+import SpeechRateControl from './SpeechRateControl';
+import { useSpeechRate } from '@/hooks/useSpeechRate';
 import { toast } from 'sonner';
 import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
@@ -39,6 +41,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenAddModal,
   onOpenEditModal,
 }) => {
+  const { speechRate, setSpeechRate } = useSpeechRate();
   const safeNextCategory = nextCategory || 'Next';
   const nextCategoryLabel = getCategoryLabel(safeNextCategory);
   const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
@@ -130,6 +133,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         <Speaker size={16} />
       </Button>
 
+      <SpeechRateControl rate={speechRate} onChange={setSpeechRate} />
 
       <EditWordButton onClick={onOpenEditModal} disabled={!currentWord} />
       <AddWordButton onClick={onOpenAddModal} />

--- a/src/hooks/useSpeechRate.tsx
+++ b/src/hooks/useSpeechRate.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { SPEECH_RATE_KEY } from '@/utils/storageKeys';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+
+export const useSpeechRate = () => {
+  const [speechRate, setSpeechRate] = useState<number>(() => {
+    try {
+      const stored = localStorage.getItem(SPEECH_RATE_KEY);
+      const parsed = stored ? parseFloat(stored) : NaN;
+      return !isNaN(parsed) ? parsed : DEFAULT_SPEECH_RATE;
+    } catch {
+      return DEFAULT_SPEECH_RATE;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SPEECH_RATE_KEY, speechRate.toString());
+    } catch (e) {
+      console.error('Error saving speech rate', e);
+    }
+  }, [speechRate]);
+
+  return { speechRate, setSpeechRate };
+};

--- a/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
+++ b/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 /**
  * Hook to handle Safari and iOS-specific initialization
@@ -21,7 +21,7 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
         try {
           const utterance = new SpeechSynthesisUtterance(' ');
           utterance.volume = 0.01;
-          utterance.rate = DEFAULT_SPEECH_RATE;
+          utterance.rate = getSpeechRate();
           utterance.pitch = 1;
 
           window.speechSynthesis.cancel();

--- a/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/hooks/useUtteranceManager.ts
@@ -2,7 +2,7 @@
 import { useCallback, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 /**
  * Hook for managing utterance setup and reference
@@ -45,7 +45,7 @@ export const useUtteranceManager = () => {
     }
     
     // Configure properties
-    utterance.rate = DEFAULT_SPEECH_RATE;
+    utterance.rate = getSpeechRate();
     utterance.pitch = 1;
     utterance.volume = 1.0;
     

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -1,6 +1,6 @@
 
 import { toast } from 'sonner';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 
 /**
@@ -64,7 +64,7 @@ export const useUtteranceSetup = ({
       let fallbackTimer: number | null = null;
 
       // Set speech parameters for better clarity
-      utterance.rate = DEFAULT_SPEECH_RATE;
+      utterance.rate = getSpeechRate();
       utterance.pitch = 1.0;
       utterance.volume = 1.0;
 

--- a/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
@@ -3,7 +3,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { VoiceSelection } from '../useVoiceSelection';
 import { findVoice } from './findVoice';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 
 // Function to create and configure a speech utterance
@@ -62,7 +62,7 @@ export const createUtterance = (
     }
     
     // Configure speech properties
-    utterance.rate = DEFAULT_SPEECH_RATE;
+    utterance.rate = getSpeechRate();
     utterance.pitch = 1.0;  // Default pitch
     utterance.volume = 1.0; // Full volume
     

--- a/src/services/speech/core/SpeechPlatformManager.ts
+++ b/src/services/speech/core/SpeechPlatformManager.ts
@@ -5,7 +5,7 @@ import { VoiceManager } from './VoiceManager';
 import { SpeechEventHandler } from './SpeechEventHandler';
 import { isMobileDevice } from '@/utils/device';
 import { directSpeechService } from '../directSpeechService';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 /**
  * Manages platform-specific speech execution (mobile vs desktop)
@@ -82,7 +82,7 @@ export class SpeechPlatformManager {
     
     const voice = this.voiceManager.findVoice(voiceRegion);
     if (voice) utterance.voice = voice;
-    utterance.rate = DEFAULT_SPEECH_RATE;
+    utterance.rate = getSpeechRate();
     utterance.pitch = 1.0;
     utterance.volume = 1.0;
 

--- a/src/services/speech/core/constants.ts
+++ b/src/services/speech/core/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Shared constants for speech services
  */
-export const DEFAULT_SPEECH_RATE = 1;
+export const DEFAULT_SPEECH_RATE = 0.8;

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -1,5 +1,5 @@
 import { VocabularyWord } from "@/types/vocabulary";
-import { DEFAULT_SPEECH_RATE } from "@/services/speech/core/constants";
+import { getSpeechRate } from "@/utils/speech/core/speechSettings";
 import {
   initializeSpeechSystem,
   speechInitialized,
@@ -93,7 +93,7 @@ class RealSpeechService {
       }
 
       // Configure speech settings
-      utterance.rate = DEFAULT_SPEECH_RATE;
+      utterance.rate = getSpeechRate();
       utterance.pitch = 1.0;
       utterance.volume = 1.0;
 

--- a/src/utils/speech/controller/speechExecutor.ts
+++ b/src/utils/speech/controller/speechExecutor.ts
@@ -6,7 +6,7 @@ import {
 } from '../core/speechEngine';
 import { SpeechStateManager } from './speechStateManager';
 import { SpeechOptions } from './types';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 /**
  * Handles speech execution with comprehensive pause state checking
@@ -68,7 +68,7 @@ export class SpeechExecutor {
           utterance.voice = options.voice;
           console.log(`[SPEECH-EXECUTOR-${speechId}] Using voice:`, options.voice.name);
         }
-        utterance.rate = options.rate || DEFAULT_SPEECH_RATE;
+        utterance.rate = options.rate || getSpeechRate();
         utterance.pitch = options.pitch || 1.0;
         utterance.volume = options.volume || 1.0;
         

--- a/src/utils/speech/core/engineManager.ts
+++ b/src/utils/speech/core/engineManager.ts
@@ -1,7 +1,6 @@
 
 import { getVoiceByRegion } from '../voiceUtils';
-import { getSpeechPitch, getSpeechVolume } from './speechSettings';
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechPitch, getSpeechVolume, getSpeechRate } from './speechSettings';
 
 export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 'US' | 'UK' | 'AU'): void => {
   const langCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
@@ -16,7 +15,7 @@ export const configureUtterance = (utterance: SpeechSynthesisUtterance, region: 
     utterance.lang = langCode;
   }
   
-  utterance.rate = DEFAULT_SPEECH_RATE;
+  utterance.rate = getSpeechRate();
   utterance.pitch = getSpeechPitch();
   utterance.volume = getSpeechVolume();
   

--- a/src/utils/speech/core/speechController.ts
+++ b/src/utils/speech/core/speechController.ts
@@ -1,5 +1,5 @@
 
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 /**
  * Centralized Speech Controller - Single source of truth for all speech operations
@@ -246,7 +246,7 @@ class SpeechController {
         
         // Configure utterance
         if (options.voice) utterance.voice = options.voice;
-        utterance.rate = options.rate || DEFAULT_SPEECH_RATE;
+        utterance.rate = options.rate || getSpeechRate();
         utterance.pitch = options.pitch || 1.0;
         utterance.volume = options.volume || 1.0;
 

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,5 +1,6 @@
 
-import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+import { BUTTON_STATES_KEY, SPEECH_RATE_KEY } from '@/utils/storageKeys';
+import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 
 export const getVoiceRegionFromStorage = (): 'US' | 'UK' | 'AU' => {
   try {
@@ -39,12 +40,30 @@ export const saveVoiceRegionToStorage = (region: 'US' | 'UK' | 'AU'): void => {
 };
 
 
-export const getSpeechRate = (): number => {
-  const region = getVoiceRegionFromStorage();
-  if (region === 'US' || region === 'AU') {
-    return 0.6;
+export const getStoredSpeechRate = (): number => {
+  try {
+    const stored = localStorage.getItem(SPEECH_RATE_KEY);
+    const parsed = stored ? parseFloat(stored) : NaN;
+    if (!isNaN(parsed)) return parsed;
+  } catch (error) {
+    console.error('Error reading speech rate from localStorage:', error);
   }
-  return 1.0;
+  return DEFAULT_SPEECH_RATE;
+};
+
+export const saveSpeechRateToStorage = (rate: number): void => {
+  try {
+    localStorage.setItem(SPEECH_RATE_KEY, rate.toString());
+    console.log(`Speech rate saved: ${rate}`);
+  } catch (error) {
+    console.error('Error saving speech rate to localStorage:', error);
+  }
+};
+
+export const getSpeechRate = (): number => {
+  const rate = getStoredSpeechRate();
+  console.log('[Speech Rate]', rate);
+  return rate;
 };
 
 export const getSpeechPitch = (): number => {

--- a/src/utils/speech/synthesisUtils.ts
+++ b/src/utils/speech/synthesisUtils.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import { getSpeechRate } from '@/utils/speech/core/speechSettings';
 
 export const synthesizeAudio = (text: string, voice: SpeechSynthesisVoice | null): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -22,7 +22,7 @@ export const synthesizeAudio = (text: string, voice: SpeechSynthesisVoice | null
     }
     
     // Set reasonable speech parameters
-    utterance.rate = DEFAULT_SPEECH_RATE;
+    utterance.rate = getSpeechRate();
     utterance.pitch = 1.0; // Normal pitch
     utterance.volume = 1.0; // Full volume
     

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,2 +1,3 @@
 export const BUTTON_STATES_KEY = 'buttonStates';
 export const VOICE_SETTINGS_KEY = 'voiceSettings';
+export const SPEECH_RATE_KEY = 'vocabularySpeechRate';


### PR DESCRIPTION
## Summary
- introduce new `SPEECH_RATE_KEY` and default speech rate
- add hook `useSpeechRate` for persisting rate
- create `SpeechRateControl` popover component
- show speech rate control in the controls column
- apply `getSpeechRate()` to all utterances and log selected rate

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_686360c30fe8832f965a1daa9033acf4