### PR TITLE
Improve voice selection logic

### DIFF
--- a/src/utils/speech/voiceNames.ts
+++ b/src/utils/speech/voiceNames.ts
@@ -1,20 +1,46 @@
 // Default US voice
 export const US_VOICE_NAME = "en-US-Standard-B";
 export const UK_VOICE_NAME = "Google UK English Female";
-export const UK_VOICE_NAMES = [
-  UK_VOICE_NAME,
-  "Daniel",
-  "Kate",
-  "Susan",
-  "Hazel"
-] as const;
-
 export const AU_VOICE_NAME = "en-AU-Standard-C";
-export const AU_VOICE_NAMES = [
-  AU_VOICE_NAME,
-  "Google AU English Male",
-  "Google AU English Female",
-  "Karen",
-  "Catherine"
-] as const;
+
+// Ordered list of preferred voices for each region.
+export const PREFERRED_VOICES_BY_REGION = {
+  US: [
+    "en-US-Standard-B",
+    "en-US-Standard-C",
+    "en-US-Wavenet-B",
+    "Alex",
+    "Samantha",
+    "Aaron",
+    "Fred",
+    "Google US English",
+    "en-US"
+  ],
+  UK: [
+    "Google UK English Female",
+    "Google UK English Male",
+    "en-GB-Standard-A",
+    "en-GB-Standard-B",
+    "Daniel",
+    "Kate",
+    "Arthur",
+    "Serena",
+    "Google UK English",
+    "en-GB"
+  ],
+  AU: [
+    "en-AU-Standard-C",
+    "Google AU English Female",
+    "Google AU English Male",
+    "Karen",
+    "Lee",
+    "Catherine",
+    "Google AU English",
+    "en-AU"
+  ]
+} as const;
+
+// Aliases kept for backwards compatibility in parts of the code base
+export const UK_VOICE_NAMES = PREFERRED_VOICES_BY_REGION.UK;
+export const AU_VOICE_NAMES = PREFERRED_VOICES_BY_REGION.AU;
 

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -1,201 +1,68 @@
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
-import {
-  US_VOICE_NAME,
-  UK_VOICE_NAMES,
-  AU_VOICE_NAMES
-} from '@/utils/speech/voiceNames';
+import { PREFERRED_VOICES_BY_REGION } from './voiceNames';
 
-
-export const findFallbackVoice = (voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null => {
+/**
+ * Return the first English voice available. Used as a final fallback.
+ */
+export const findFallbackVoice = (
+  voices: SpeechSynthesisVoice[]
+): SpeechSynthesisVoice | null => {
   if (!voices || voices.length === 0) {
     return null;
   }
-  
-  // Try to find any English voice first
-  const englishVoice = voices.find(voice => voice.lang.startsWith('en'));
-  if (englishVoice) {
-    return englishVoice;
-  }
-  
-  // If no English voice is available, return the first available voice
-  return voices[0];
+
+  const englishVoice = voices.find(v => v.lang.startsWith('en'));
+  return englishVoice || voices[0];
 };
 
-// Enhanced function to get voice by region with better UK voice selection
-export const getVoiceByRegion = (region: 'US' | 'UK' | 'AU', gender: 'male' | 'female' = 'female'): SpeechSynthesisVoice | null => {
+/**
+ * Get the best available voice for a region using an ordered preference list.
+ */
+export const getVoiceByRegion = (
+  region: 'US' | 'UK' | 'AU'
+): SpeechSynthesisVoice | null => {
   const voices = window.speechSynthesis.getVoices();
-  
+  console.log(`[Voice Picker] Selecting voice for region ${region}. ${voices.length} voices available`);
+
   if (!voices || voices.length === 0) {
-    console.warn('No voices available to select from');
     return null;
   }
-  
-  console.log(`Looking for ${region} voice with ${voices.length} voices available`);
 
-  const isApple =
-    typeof navigator !== 'undefined' &&
-    /iPad|iPhone|iPod|Macintosh/.test(navigator.userAgent);
+  // Filter out problematic voices on Apple platforms
+  const isApple = /iPad|iPhone|iPod|Macintosh/.test(navigator.userAgent);
+  const BAD_APPLE_VOICE_NAMES = ['Eloquence', 'Shelley', 'Moira'];
+  const usableVoices = isApple
+    ? voices.filter(v => !BAD_APPLE_VOICE_NAMES.some(bad => v.name.includes(bad)))
+    : voices;
 
-  if (isApple) {
-    const APPLE_US_VOICES = ["Alex", "Samantha", "Aaron"] as const;
-    const APPLE_UK_VOICES = ["Daniel", "Kate"] as const;
-    const APPLE_AU_VOICES = ["Karen", "Lee"] as const;
-
-    const tryAppleVoices = (names: readonly string[]) =>
-      names.map(name => voices.find(v => v.name === name)).find(Boolean) || null;
-
-    if (region === 'US') {
-      const voice = tryAppleVoices(APPLE_US_VOICES);
-      if (voice) {
-        console.log('[Voice Picker] Selected Apple US voice:', voice.name);
-        return voice;
-      }
-    } else if (region === 'UK') {
-      const voice = tryAppleVoices(APPLE_UK_VOICES);
-      if (voice) {
-        console.log('[Voice Picker] Selected Apple UK voice:', voice.name);
-        return voice;
-      }
-    } else if (region === 'AU') {
-      const voice = tryAppleVoices(APPLE_AU_VOICES);
-      if (voice) {
-        console.log('[Voice Picker] Selected Apple AU voice:', voice.name);
-        return voice;
-      }
-    }
-
-    console.log('[Voice Picker] Falling back to standard selection');
-  }
-  
-  if (region === 'US') {
-    // US voice logic (unchanged)
-    let voice = voices.find(v => v.name === US_VOICE_NAME);
-    
-    if (voice) {
-      console.log(`Found exact US voice: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
-    
-    // Fallback to language code
-    voice = voices.find(v => v.lang === 'en-US');
-    
-    if (voice) {
-      console.log(`Fallback US voice by language: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
-  } else if (region === 'UK') {
-    // Enhanced UK voice selection
-    console.log('Searching for UK voice with enhanced selection...');
-    
-    // Try each UK voice name in order of preference
-    for (const ukVoiceName of UK_VOICE_NAMES) {
-      let voice = voices.find(v => v.name === ukVoiceName);
-      
-      if (voice) {
-        console.log(`Found exact UK voice match: ${voice.name} (${voice.lang})`);
-        return voice;
-      }
-      
-      // Try partial match
-      voice = voices.find(v => v.name.includes(ukVoiceName));
-      
-      if (voice) {
-        console.log(`Found partial UK voice match: ${voice.name} (${voice.lang})`);
-        return voice;
-      }
-    }
-    
-    // Try by language code with gender preference
-    let voice = voices.find(v => 
-      v.lang === 'en-GB' && 
-      (gender === 'female' ? !v.name.toLowerCase().includes('male') : v.name.toLowerCase().includes('male'))
-    );
-    
-    if (voice) {
-      console.log(`Found UK voice by language and gender: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
-    
-    // Fallback to any en-GB voice
-    voice = voices.find(v => v.lang === 'en-GB');
-    
-    if (voice) {
-      console.log(`Fallback UK voice by language: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
-    
-    // Try finding voices with UK indicators in the name
-    const ukIndicators = ['UK', 'British', 'GB', 'English'];
-    for (const indicator of ukIndicators) {
-      voice = voices.find(v => 
-        v.name.includes(indicator) && 
-        v.lang.startsWith('en')
-      );
-      
-      if (voice) {
-        console.log(`Found UK voice by indicator "${indicator}": ${voice.name} (${voice.lang})`);
-        return voice;
-      }
+  const preferredNames = PREFERRED_VOICES_BY_REGION[region];
+  for (const name of preferredNames) {
+    const match = usableVoices.find(v => v.name === name || v.lang === name);
+    if (match) {
+      console.log(`[Voice Picker] Selected voice ${match.name} (${match.lang})`);
+      return match;
     }
   }
 
-  else if (region === 'AU') {
-    console.log('Searching for AU voice...');
-
-    for (const auVoiceName of AU_VOICE_NAMES) {
-      let voice = voices.find(v => v.name === auVoiceName);
-
-      if (voice) {
-        console.log(`Found exact AU voice match: ${voice.name} (${voice.lang})`);
-        return voice;
-      }
-
-      voice = voices.find(v => v.name.includes(auVoiceName));
-
-      if (voice) {
-        console.log(`Found partial AU voice match: ${voice.name} (${voice.lang})`);
-        return voice;
-      }
-    }
-
-    let voice = voices.find(v =>
-      v.lang === 'en-AU' &&
-      (gender === 'female' ? !v.name.toLowerCase().includes('male') : v.name.toLowerCase().includes('male'))
-    );
-
-    if (voice) {
-      console.log(`Found AU voice by language and gender: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
-
-    voice = voices.find(v => v.lang === 'en-AU');
-
-    if (voice) {
-      console.log(`Fallback AU voice by language: ${voice.name} (${voice.lang})`);
-      return voice;
-    }
+  const englishFallback = usableVoices.find(v => v.lang.startsWith('en'));
+  if (englishFallback) {
+    console.log('[Voice Picker] Falling back to generic English voice', englishFallback.name, englishFallback.lang);
+    return englishFallback;
   }
-  
-  // Last resort - any English voice
-  const voice = voices.find(v => v.lang.startsWith('en'));
-  
-  if (voice) {
-    console.log(`Last resort - any English voice: ${voice.name} (${voice.lang})`);
-    return voice;
+
+  if (usableVoices.length > 0) {
+    console.log('[Voice Picker] Falling back to first available voice', usableVoices[0].name, usableVoices[0].lang);
+    return usableVoices[0];
   }
-  
-  // Absolute fallback - first available voice
-  if (voices.length > 0) {
-    console.log(`No matching voice found, using first available: ${voices[0].name}`);
-    return voices[0];
-  }
-  
-  console.log('No voices available at all');
+
+  console.warn('[Voice Picker] No voices available');
   return null;
 };
 
-export const getVoiceBySelection = (voiceSelection: VoiceSelection): SpeechSynthesisVoice | null => {
-  return getVoiceByRegion(voiceSelection.region, voiceSelection.gender);
+export const getVoiceBySelection = (
+  voiceSelection: VoiceSelection
+): SpeechSynthesisVoice | null => {
+  return getVoiceByRegion(voiceSelection.region);
 };
 
 export const hasAvailableVoices = (): boolean => {


### PR DESCRIPTION
## Summary
- define ordered voice preference lists per region
- filter out bad Apple voices
- simplify `getVoiceByRegion` to pick the first available preferred voice

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68636aa1bb8c832f86acd9e8bfb2fe0f