### PR TITLE
Fix speech timing with dynamic rate

### DIFF
--- a/src/hooks/speech/useSimpleSpeech.ts
+++ b/src/hooks/speech/useSimpleSpeech.ts
@@ -14,6 +14,7 @@ export const useSimpleSpeech = () => {
     text: string,
     options: {
       voice?: SpeechSynthesisVoice | null;
+      region?: 'US' | 'UK' | 'AU';
       onComplete?: () => void;
       onError?: () => void;
     } = {}
@@ -47,30 +48,20 @@ export const useSimpleSpeech = () => {
         count: 0
       };
 
-      // Use the correct signature with only word and region
       const success = await unifiedSpeechController.speak(
         wordObject,
-        'US',
-        options.voice?.name
+        options.region || 'US'
       );
 
+      setIsSpeaking(false);
+      currentSpeechRef.current = null;
+
       if (success) {
-        console.log(`[SIMPLE-SPEECH-${speechId}] Speech started successfully`);
-        // Set up completion callback
-        setTimeout(() => {
-          setIsSpeaking(false);
-          currentSpeechRef.current = null;
-          if (options.onComplete) {
-            options.onComplete();
-          }
-        }, 2000); // Estimate completion time
+        console.log(`[SIMPLE-SPEECH-${speechId}] Speech completed successfully`);
+        options.onComplete?.();
       } else {
-        console.log(`[SIMPLE-SPEECH-${speechId}] Speech failed to start`);
-        setIsSpeaking(false);
-        currentSpeechRef.current = null;
-        if (options.onError) {
-          options.onError();
-        }
+        console.log(`[SIMPLE-SPEECH-${speechId}] Speech failed to complete`);
+        options.onError?.();
       }
 
       return success;

--- a/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
@@ -58,9 +58,9 @@ export const useSimpleWordPlayback = (
       if (!speechText || speechText.length === 0) {
         console.log(`[WORD-PLAYBACK-${playbackId}] No content to speak`);
         playingRef.current = false;
-        setTimeout(() => {
-          if (!paused && !muted) goToNextWord();
-        }, 1500);
+        if (!paused && !muted) {
+          goToNextWord();
+        }
         return;
       }
 
@@ -68,21 +68,14 @@ export const useSimpleWordPlayback = (
 
       const success = await speak(speechText, {
         voice,
+        region: selectedVoice.region,
         onComplete: () => {
           console.log(`[WORD-PLAYBACK-${playbackId}] Speech completed, checking auto-advance`);
           playingRef.current = false;
-          
-          // Check all conditions before auto-advancing
+
           if (!paused && !muted && !unifiedSpeechController.isPaused()) {
             console.log(`[WORD-PLAYBACK-${playbackId}] Auto-advancing to next word`);
-            setTimeout(() => {
-              // Double-check state before advancing
-              if (!paused && !muted && !unifiedSpeechController.isPaused()) {
-                goToNextWord();
-              } else {
-                console.log(`[WORD-PLAYBACK-${playbackId}] State changed during delay, skipping auto-advance`);
-              }
-            }, 1500);
+            goToNextWord();
           } else {
             console.log(`[WORD-PLAYBACK-${playbackId}] Not auto-advancing - paused: ${paused}, muted: ${muted}, controllerPaused: ${unifiedSpeechController.isPaused()}`);
           }
@@ -90,10 +83,9 @@ export const useSimpleWordPlayback = (
         onError: () => {
           console.log(`[WORD-PLAYBACK-${playbackId}] Speech error, advancing anyway`);
           playingRef.current = false;
-          
-          // Still advance on error to prevent getting stuck
+
           if (!paused && !muted && !unifiedSpeechController.isPaused()) {
-            setTimeout(() => goToNextWord(), 2000);
+            goToNextWord();
           }
         }
       });
@@ -102,7 +94,7 @@ export const useSimpleWordPlayback = (
         console.log(`[WORD-PLAYBACK-${playbackId}] Speech failed to start, advancing`);
         playingRef.current = false;
         if (!paused && !muted && !unifiedSpeechController.isPaused()) {
-          setTimeout(() => goToNextWord(), 2000);
+          goToNextWord();
         }
       }
 
@@ -110,9 +102,8 @@ export const useSimpleWordPlayback = (
       console.error(`[WORD-PLAYBACK-${playbackId}] Exception:`, error);
       playingRef.current = false;
       
-      // Always advance on exception
       if (!paused && !muted && !unifiedSpeechController.isPaused()) {
-        setTimeout(() => goToNextWord(), 2000);
+        goToNextWord();
       }
     }
   }, [speak, selectedVoice, findVoice, goToNextWord, muted, paused]);


### PR DESCRIPTION
## Summary
- remove fixed advance timers in `unifiedSpeechController`
- rely on queue and onend events for advancing to the next word
- adjust `useSimpleSpeech` to fire callbacks on speech completion
- auto‑advance immediately in `useSimpleWordPlayback`

## Testing
- `npm test`
- `npm run lint` *(fails: 55 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686369c32ef0832f96bd82d06e5724f1