### PR TITLE
Improve speech gesture handling

### DIFF
--- a/src/components/vocabulary-app/EnableAudioButton.tsx
+++ b/src/components/vocabulary-app/EnableAudioButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { markUserInteraction } from '@/utils/userInteraction';
+
+interface Props {
+  onEnable?: () => void;
+}
+
+const EnableAudioButton: React.FC<Props> = ({ onEnable }) => {
+  const handleClick = () => {
+    markUserInteraction();
+    onEnable?.();
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="px-4 py-2 rounded-md bg-blue-600 text-white text-sm"
+    >
+      Tap to enable audio
+    </button>
+  );
+};
+
+export default EnableAudioButton;

--- a/src/components/vocabulary-app/UserInteractionManager.tsx
+++ b/src/components/vocabulary-app/UserInteractionManager.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { useEnhancedUserInteraction } from '@/hooks/vocabulary-app/useEnhancedUserInteraction';
+import EnableAudioButton from './EnableAudioButton';
 
 interface UserInteractionManagerProps {
   currentWord: VocabularyWord | null;
@@ -36,6 +37,14 @@ const UserInteractionManager: React.FC<UserInteractionManagerProps> = ({
       onInteractionUpdate({ hasInitialized, interactionCount, isAudioUnlocked });
     }
   }, [hasInitialized, interactionCount, isAudioUnlocked, onInteractionUpdate]);
+
+  if (!isAudioUnlocked) {
+    return (
+      <div className="my-2 text-center">
+        <EnableAudioButton onEnable={playCurrentWord} />
+      </div>
+    );
+  }
 
   return null; // This component only manages state
 };

--- a/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
@@ -2,6 +2,8 @@
 import { useEffect, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { speechController } from '@/utils/speech/core/speechController';
+import { hasUserInteracted } from '@/utils/userInteraction';
+import { toast } from 'sonner';
 
 /**
  * Hook for auto-playing the current word when it changes
@@ -68,6 +70,10 @@ export const useAutoPlay = (
       autoPlayTimeoutRef.current = null;
       
       // Double-check conditions before playing
+      if (!hasUserInteracted()) {
+        toast.error('Tap to enable audio playback');
+        return;
+      }
       if (!muted && !paused && !speechController.isActive()) {
         console.log(`[AUTO-PLAY] Executing auto-play for: ${currentWord.word}`);
         playCurrentWord();

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -25,10 +25,6 @@ export const useUtteranceSetup = ({
   paused,
   incrementRetryAttempts,
   userInteractionRef
-<<<<<<< codex/enhance-logging-for-autoplay-issues
-=======
-
->>>>>>> main
 }) => {
   // If we've already exceeded the retry limit, log and advance once
   if (retryCount > maxRetries) {
@@ -173,10 +169,6 @@ export const useUtteranceSetup = ({
                 paused,
                 incrementRetryAttempts,
                 userInteractionRef
-<<<<<<< codex/enhance-logging-for-autoplay-issues
-=======
-
->>>>>>> main
               });
             }
           }, 500);
@@ -229,10 +221,6 @@ export const useUtteranceSetup = ({
                 paused,
                 incrementRetryAttempts,
                 userInteractionRef
-<<<<<<< codex/enhance-logging-for-autoplay-issues
-=======
-
->>>>>>> main
               });
             } else {
               // If we've tried enough times, move on

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -5,6 +5,7 @@ import {
   speechInitialized,
 } from "@/utils/speech/core/modules/speechInit";
 import { logSpeechEvent } from "@/utils/speechLogger";
+import { hasUserInteracted, resetUserInteraction } from "@/utils/userInteraction";
 
 interface SpeechOptions {
   voiceRegion: "US" | "UK" | "AU";
@@ -27,7 +28,7 @@ class RealSpeechService {
     }
 
     try {
-      if (localStorage.getItem('hadUserInteraction') !== 'true') {
+      if (localStorage.getItem('hadUserInteraction') !== 'true' || !hasUserInteracted()) {
         console.warn('[SPEECH] Blocked: waiting for user interaction');
         if (options.onError) {
           const evt = new Event('error') as SpeechSynthesisErrorEvent;
@@ -152,11 +153,7 @@ class RealSpeechService {
           );
         }
         if (event.error === "not-allowed") {
-          try {
-            localStorage.setItem('hadUserInteraction', 'false');
-          } catch (e) {
-            console.warn('Failed to update interaction state after block:', e);
-          }
+          resetUserInteraction();
           window.dispatchEvent(new Event('speechblocked'));
         }
         this.isActive = false;

--- a/src/utils/userInteraction.ts
+++ b/src/utils/userInteraction.ts
@@ -1,0 +1,44 @@
+let userInteracted = false;
+
+export const markUserInteraction = () => {
+  userInteracted = true;
+  try {
+    localStorage.setItem('hadUserInteraction', 'true');
+  } catch {}
+};
+
+export const resetUserInteraction = () => {
+  userInteracted = false;
+  try {
+    localStorage.setItem('hadUserInteraction', 'false');
+  } catch {}
+};
+
+export const hasUserInteracted = () => userInteracted;
+
+export const setupUserInteractionListeners = () => {
+  const enable = () => {
+    markUserInteraction();
+    preloadSpeech();
+    document.removeEventListener('click', enable);
+    document.removeEventListener('keydown', enable);
+    document.removeEventListener('touchstart', enable);
+  };
+
+  document.addEventListener('click', enable);
+  document.addEventListener('keydown', enable);
+  document.addEventListener('touchstart', enable);
+};
+
+export const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+export const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+
+const preloadSpeech = () => {
+  try {
+    const u = new SpeechSynthesisUtterance(' ');
+    u.volume = 0.01;
+    window.speechSynthesis.speak(u);
+  } catch (e) {
+    console.warn('Speech preload failed:', e);
+  }
+};


### PR DESCRIPTION
## Summary
- add a user interaction helper to track browser gesture state
- show `Tap to enable audio` button until speech is unlocked
- gate autoplay on interaction and warn when blocked
- reset interaction flag when Chrome blocks speech
- clean merge markers in speech code

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686386e43ff4832faf372eaa177bf6b4