### PR TITLE
Improve speech voice availability handling

### DIFF
--- a/src/components/vocabulary-app/ContentWithData.tsx
+++ b/src/components/vocabulary-app/ContentWithData.tsx
@@ -74,6 +74,7 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
         nextVoiceLabel={nextVoiceLabel}
         onOpenAddModal={handleOpenAddWordModal}
         onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
+        voiceRegion={selectedVoice.region}
       />
       
       

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -11,6 +11,7 @@ import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { getCategoryLabel, getCategoryMessageLabel } from '@/utils/categoryLabels';
+import { useRegionVoices } from '@/hooks/useRegionVoices';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -25,6 +26,7 @@ interface VocabularyControlsColumnProps {
   currentWord: VocabularyWord | null;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
+  voiceRegion: 'US' | 'UK' | 'AU';
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -40,8 +42,10 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   currentWord,
   onOpenAddModal,
   onOpenEditModal,
+  voiceRegion
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
+  const regionVoices = useRegionVoices(voiceRegion);
   const safeNextCategory = nextCategory || 'Next';
   const nextCategoryLabel = getCategoryLabel(safeNextCategory);
   const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
@@ -66,6 +70,10 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const handleCycleVoice = () => {
+    if (regionVoices.length === 0) {
+      toast.warning('No voices available for this region');
+      return;
+    }
     onCycleVoice();
     toast(`Voice changed to ${nextVoiceLabel}`);
   };
@@ -127,7 +135,12 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         size="sm"
         onClick={handleCycleVoice}
         className="h-8 w-8 p-0 text-blue-700 border-blue-300 bg-blue-50"
-        title={`Change to ${nextVoiceLabel}`}
+        title={
+          regionVoices.length === 0
+            ? 'No voices available for this region'
+            : `Change to ${nextVoiceLabel}`
+        }
+        disabled={regionVoices.length === 0}
         aria-label={nextVoiceLabel}
       >
         <Speaker size={16} />

--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -23,6 +23,7 @@ interface VocabularyMainProps {
   nextVoiceLabel: string;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
+  voiceRegion: 'US' | 'UK' | 'AU';
 }
 
 const VocabularyMain: React.FC<VocabularyMainProps> = ({
@@ -42,6 +43,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
   nextVoiceLabel,
   onOpenAddModal,
   onOpenEditModal,
+  voiceRegion,
 }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -79,6 +81,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
         currentWord={currentWord}
         onOpenAddModal={onOpenAddModal}
         onOpenEditModal={onOpenEditModal}
+        voiceRegion={selectedVoice.region}
       />
     </div>
   );

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -84,10 +84,11 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
           onCycleVoice={handleCycleVoice}
           nextCategory={nextCategory || 'Next'}
           nextVoiceLabel={nextVoiceLabel}
-          currentWord={currentWord}
-          onOpenAddModal={onOpenAddModal}
-          onOpenEditModal={onOpenEditModal}
-        />
+        currentWord={currentWord}
+        onOpenAddModal={onOpenAddModal}
+        onOpenEditModal={onOpenEditModal}
+        voiceRegion={voiceRegion}
+      />
       </div>
     </div>
   );

--- a/src/hooks/useRegionVoices.ts
+++ b/src/hooks/useRegionVoices.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export const useRegionVoices = (region: 'US' | 'UK' | 'AU') => {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+
+  const loadVoices = useCallback(() => {
+    if (!window.speechSynthesis) return;
+    const allVoices = window.speechSynthesis.getVoices();
+    const regionLangCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
+    const filtered = allVoices
+      .filter(v => v && v.lang && v.lang.toLowerCase().startsWith(regionLangCode.toLowerCase()))
+      .filter((v, i, arr) => arr.findIndex(o => o.name === v.name) === i);
+    setVoices(filtered);
+    console.log(`[useRegionVoices] ${filtered.length} voices for ${region}`);
+  }, [region]);
+
+  useEffect(() => {
+    loadVoices();
+    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
+    return () => {
+      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+    };
+  }, [loadVoices]);
+
+  return voices;
+};

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -8,6 +8,11 @@ import userEvent from '@testing-library/user-event';
 globalThis.expect = expect;
 beforeAll(async () => {
   await import('@testing-library/jest-dom');
+  (window as any).speechSynthesis = {
+    getVoices: () => [{ name: 'Test', lang: 'en-GB' }],
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
 });
 import VocabularyControlsColumn from '../src/components/vocabulary-app/VocabularyControlsColumn';
 import { VocabularyWord } from '../src/types/vocabulary';
@@ -33,13 +38,14 @@ describe('VocabularyControlsColumn voice toggle', () => {
             onTogglePause={() => {}}
             onNextWord={() => {}}
             onSwitchCategory={() => {}}
-            onCycleVoice={toggleVoice}
-            nextCategory="next"
-            nextVoiceLabel={nextVoiceLabel}
-            currentWord={word}
-            onOpenAddModal={() => {}}
-            onOpenEditModal={() => {}}
-          />
+          onCycleVoice={toggleVoice}
+          nextCategory="next"
+          nextVoiceLabel={nextVoiceLabel}
+          currentWord={word}
+          onOpenAddModal={() => {}}
+          onOpenEditModal={() => {}}
+          voiceRegion={voiceRegion}
+        />
       );
     };
 


### PR DESCRIPTION
## Summary
- add `useRegionVoices` hook to filter voices for a region
- disable Change Voice button when no regional voices
- show warning toast if user attempts voice change with no voices
- plumb `voiceRegion` into controls components
- update tests for new prop

## Testing
- `npx vitest run` *(fails: `npm err canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_6863a49b5dcc832fa0e429d99ae9d23d