### PR TITLE
Fix Chrome speech playback issues

### DIFF
--- a/src/hooks/audio/useAudioCleanup.tsx
+++ b/src/hooks/audio/useAudioCleanup.tsx
@@ -15,24 +15,27 @@ export const useAudioCleanup = (
 
   // Set up document-level interaction handler for speech permissions
   useEffect(() => {
+    if (localStorage.getItem('speechUnlocked') === 'true') {
+      return () => {
+        clearAllAudioState();
+      };
+    }
+
     const documentClickHandler = () => {
-      // This empty handler helps enable speech in browsers that require user gesture
       if (window.speechSynthesis && !speechSynthesis.speaking) {
         try {
-          // Just create a silent utterance to "unlock" speech
           const silentUtterance = new SpeechSynthesisUtterance('');
           silentUtterance.volume = 0;
           window.speechSynthesis.speak(silentUtterance);
-        } catch (error) {
-          // Ignore errors here, just trying to enable speech
+          localStorage.setItem('speechUnlocked', 'true');
+        } catch {
+          // Ignore errors
         }
       }
     };
 
-    // Add the event listener to the document
-    document.addEventListener('click', documentClickHandler);
-    
-    // Clean up
+    document.addEventListener('click', documentClickHandler, { once: true });
+
     return () => {
       document.removeEventListener('click', documentClickHandler);
       clearAllAudioState();

--- a/src/hooks/speech/useSpeechError.tsx
+++ b/src/hooks/speech/useSpeechError.tsx
@@ -9,7 +9,7 @@ export const useSpeechError = () => {
 
   // Function to reset speech state after errors
   const resetSpeechState = useCallback(() => {
-    if (window.speechSynthesis) {
+    if (window.speechSynthesis && window.speechSynthesis.speaking) {
       window.speechSynthesis.cancel();
     }
     console.log('Speech state reset after error');
@@ -27,7 +27,7 @@ export const useSpeechError = () => {
     setHasSpeechPermission(true);
     setSpeechError(null);
     retryAttemptsRef.current = 0;
-    if (window.speechSynthesis) {
+    if (window.speechSynthesis && window.speechSynthesis.speaking) {
       window.speechSynthesis.cancel();
     }
   }, []);

--- a/src/hooks/speech/useSpeechState.tsx
+++ b/src/hooks/speech/useSpeechState.tsx
@@ -12,7 +12,7 @@ export const useSpeechState = () => {
   // Function to stop current speech
   const stopSpeakingLocal = useCallback(() => {
     // Cancel any ongoing speech synthesis
-    if (window.speechSynthesis) {
+    if (window.speechSynthesis && window.speechSynthesis.speaking) {
       window.speechSynthesis.cancel();
     }
     

--- a/src/hooks/speech/useSpeechSynthesis.tsx
+++ b/src/hooks/speech/useSpeechSynthesis.tsx
@@ -54,7 +54,7 @@ export const useSpeechSynthesis = () => {
   // Clean up speech synthesis when component unmounts
   useEffect(() => {
     return () => {
-      if (window.speechSynthesis) {
+      if (window.speechSynthesis && window.speechSynthesis.speaking) {
         window.speechSynthesis.cancel();
       }
     };

--- a/src/hooks/vocabulary-app/useAudioInitialization.ts
+++ b/src/hooks/vocabulary-app/useAudioInitialization.ts
@@ -30,7 +30,9 @@ export const useAudioInitialization = ({
       // Clean up
       return () => {
         window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
-        window.speechSynthesis.cancel();
+        if (window.speechSynthesis.speaking) {
+          window.speechSynthesis.cancel();
+        }
       };
     }
   }, []);

--- a/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
+++ b/src/hooks/vocabulary-app/useEnhancedUserInteraction.ts
@@ -5,7 +5,8 @@ import { initializeSpeechSystem } from '@/utils/speech';
 import {
   setupUserInteractionListeners,
   markUserInteraction,
-  resetUserInteraction
+  resetUserInteraction,
+  loadUserInteractionState
 } from '@/utils/userInteraction';
 
 interface UseEnhancedUserInteractionProps {
@@ -55,7 +56,9 @@ export const useEnhancedUserInteraction = ({
 
   // Detect prior interaction to optionally skip showing the prompt
   useEffect(() => {
-    if (localStorage.getItem('hadUserInteraction') === 'true') {
+    if (loadUserInteractionState()) {
+      setIsAudioUnlocked(true);
+      setHasInitialized(true);
       console.log('[USER-INTERACTION] Previous interaction detected');
     }
   }, []);

--- a/src/hooks/vocabulary-app/useUserInteractionHandler.ts
+++ b/src/hooks/vocabulary-app/useUserInteractionHandler.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useEffect, useRef } from "react";
+import { loadUserInteractionState } from "@/utils/userInteraction";
 import {
   initializeSpeechSystem,
   registerSpeechInitGesture,
@@ -25,6 +26,13 @@ export const useUserInteractionHandler = ({
   useEffect(() => {
     console.log("[USER-INTERACTION] Handler mounted");
 
+    if (loadUserInteractionState()) {
+      initializedRef.current = true;
+      userInteractionRef.current = true;
+      initializeSpeechSystem();
+      return;
+    }
+
     registerSpeechInitGesture();
 
     const enableAudioPlayback = async () => {
@@ -41,7 +49,7 @@ export const useUserInteractionHandler = ({
       // Mark that we've had user interaction
       userInteractionRef.current = true;
       initializedRef.current = true;
-      localStorage.setItem("hadUserInteraction", "true");
+      localStorage.setItem("speechUnlocked", "true");
 
       // Initialize speech system (unlock audio and preload voices)
       await initializeSpeechSystem();
@@ -56,7 +64,7 @@ export const useUserInteractionHandler = ({
 
     // Check if we've had interaction before. We still wait for a new user
     // gesture to actually unlock audio again, so simply log this information.
-    if (localStorage.getItem("hadUserInteraction") === "true") {
+    if (localStorage.getItem("speechUnlocked") === "true") {
       console.log(
         "[USER-INTERACTION] Previous interaction found; waiting for new gesture to unlock audio",
       );

--- a/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
+++ b/src/hooks/vocabulary-playback/core/ios-support/useSafariSupport.ts
@@ -24,7 +24,9 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
           utterance.rate = getSpeechRate();
           utterance.pitch = 1;
 
-          window.speechSynthesis.cancel();
+          if (window.speechSynthesis.speaking) {
+            window.speechSynthesis.cancel();
+          }
           window.speechSynthesis.speak(utterance);
         } catch (e) {
           console.warn('Speech preload failed:', e);
@@ -36,7 +38,7 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
       preloadSpeech();
       userInteractionRef.current = true;
       try {
-        localStorage.setItem('hadUserInteraction', 'true');
+        localStorage.setItem('speechUnlocked', 'true');
       } catch (err) {
         console.warn('Failed to persist interaction state:', err);
       }
@@ -73,7 +75,7 @@ export const useSafariSupport = (userInteractionRef: React.MutableRefObject<bool
       document.removeEventListener('touchstart', enableOnGesture);
       document.removeEventListener('keydown', enableOnGesture);
       window.removeEventListener('speechblocked', handleBlocked);
-      if (window.speechSynthesis) {
+      if (window.speechSynthesis && window.speechSynthesis.speaking) {
         window.speechSynthesis.cancel();
       }
     };

--- a/src/hooks/vocabulary-playback/core/playback-states/useUserInteraction.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useUserInteraction.ts
@@ -11,7 +11,7 @@ export const useUserInteraction = (onUserInteraction?: () => void) => {
   // Set up interaction tracking
   useEffect(() => {
     // Try to load from localStorage
-    if (localStorage.getItem('hadUserInteraction') === 'true') {
+    if (localStorage.getItem('speechUnlocked') === 'true') {
       console.log('User interaction detected from localStorage');
       userInteractionRef.current = true;
       onUserInteraction?.();
@@ -23,7 +23,7 @@ export const useUserInteraction = (onUserInteraction?: () => void) => {
         console.log('User interaction detected');
         userInteractionRef.current = true;
         onUserInteraction?.();
-        localStorage.setItem('hadUserInteraction', 'true');
+        localStorage.setItem('speechUnlocked', 'true');
         
         // Try to initialize speech synthesis
         try {

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -181,7 +181,9 @@ export const useUtteranceSetup = ({
       // Attempt to wait for any potential race conditions to resolve
       setTimeout(() => {
         // Cancel any existing speech just before speaking
-        window.speechSynthesis.cancel();
+        if (window.speechSynthesis.speaking) {
+          window.speechSynthesis.cancel();
+        }
 
         // Actually start speaking
         window.speechSynthesis.speak(utterance);

--- a/src/hooks/vocabulary-playback/useAudioControl.tsx
+++ b/src/hooks/vocabulary-playback/useAudioControl.tsx
@@ -38,7 +38,7 @@ export const useAudioControl = (wordList: VocabularyWord[]) => {
   
   // Function to cancel any speech
   const cancelSpeech = useCallback(() => {
-    if (window.speechSynthesis) {
+    if (window.speechSynthesis && window.speechSynthesis.speaking) {
       window.speechSynthesis.cancel();
     }
     utteranceRef.current = null;

--- a/src/hooks/vocabulary-playback/useVocabularyPlaybackCore.ts
+++ b/src/hooks/vocabulary-playback/useVocabularyPlaybackCore.ts
@@ -35,7 +35,7 @@ export const useVocabularyPlaybackCore = (wordList: VocabularyWord[]) => {
 
   useEffect(() => {
     try {
-      if (localStorage.getItem('hadUserInteraction') === 'true') {
+      if (localStorage.getItem('speechUnlocked') === 'true') {
         setHasUserInteracted(true);
       }
     } catch (e) {

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -28,7 +28,7 @@ class RealSpeechService {
     }
 
     try {
-      if (localStorage.getItem('hadUserInteraction') !== 'true' || !hasUserInteracted()) {
+      if (localStorage.getItem('speechUnlocked') !== 'true' || !hasUserInteracted()) {
         console.warn('[SPEECH] Blocked: waiting for user interaction');
         if (options.onError) {
           const evt = new Event('error') as SpeechSynthesisErrorEvent;
@@ -131,13 +131,14 @@ class RealSpeechService {
       };
 
       utterance.onerror = (event) => {
-        console.error(
-          "[Speech ERROR]",
+        const logFn = event.error === 'canceled' ? console.info : console.error;
+        logFn(
+          event.error === 'canceled' ? '[Speech canceled]' : '[Speech ERROR]',
           event.error,
           text.substring(0, 60),
           utterance.voice?.name,
           utterance.voice?.lang,
-          "speaking:",
+          'speaking:',
           window.speechSynthesis.speaking,
         );
         logSpeechEvent({
@@ -211,7 +212,9 @@ class RealSpeechService {
         this.currentUtterance.onend = null;
         this.currentUtterance.onerror = null;
       }
-      window.speechSynthesis.cancel();
+      if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+        window.speechSynthesis.cancel();
+      }
     }
     this.isActive = false;
     this.currentUtterance = null;

--- a/src/utils/speech/core/modules/speechControl.ts
+++ b/src/utils/speech/core/modules/speechControl.ts
@@ -13,7 +13,7 @@ export const stopSpeaking = (): void => {
     pending: window.speechSynthesis?.pending
   });
   
-  if (window.speechSynthesis) {
+  if (window.speechSynthesis && window.speechSynthesis.speaking) {
     window.speechSynthesis.cancel();
     console.log('[ENGINE] Speech stopped');
   }

--- a/src/utils/userInteraction.ts
+++ b/src/utils/userInteraction.ts
@@ -1,16 +1,23 @@
 let userInteracted = false;
 
+export const loadUserInteractionState = () => {
+  try {
+    userInteracted = localStorage.getItem('speechUnlocked') === 'true';
+  } catch {}
+  return userInteracted;
+};
+
 export const markUserInteraction = () => {
   userInteracted = true;
   try {
-    localStorage.setItem('hadUserInteraction', 'true');
+    localStorage.setItem('speechUnlocked', 'true');
   } catch {}
 };
 
 export const resetUserInteraction = () => {
   userInteracted = false;
   try {
-    localStorage.setItem('hadUserInteraction', 'false');
+    localStorage.setItem('speechUnlocked', 'false');
   } catch {}
 };
 
@@ -18,23 +25,28 @@ export const hasUserInteracted = () => userInteracted;
 
 export const setupUserInteractionListeners = () => {
   const enableAudio = () => {
+    if (userInteracted) return;
     markUserInteraction();
     try {
-      speechSynthesis.cancel();
+      if (speechSynthesis.speaking) {
+        speechSynthesis.cancel();
+      }
       const silent = new SpeechSynthesisUtterance(' ');
       silent.volume = 0.01;
       speechSynthesis.speak(silent);
     } catch (e) {
       console.warn('Speech preload failed:', e);
     }
-    document.removeEventListener('click', enableAudio);
-    document.removeEventListener('keydown', enableAudio);
-    document.removeEventListener('touchstart', enableAudio);
   };
 
-  document.addEventListener('click', enableAudio);
-  document.addEventListener('keydown', enableAudio);
-  document.addEventListener('touchstart', enableAudio);
+  if (userInteracted) {
+    enableAudio();
+    return;
+  }
+
+  document.addEventListener('click', enableAudio, { once: true });
+  document.addEventListener('keydown', enableAudio, { once: true });
+  document.addEventListener('touchstart', enableAudio, { once: true });
 };
 
 export const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);


### PR DESCRIPTION
## Summary
- persist audio unlock state across sessions
- unlock speech synthesis once using global listeners
- avoid canceling speech when nothing is speaking
- downgrade canceled events to info level
- load prior unlock state automatically on page load

## Testing
- `npx -y vitest` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6863b630d5e4832fa8a2beba89856734