### PR TITLE
Fix Safari speech playback on Next button

### DIFF
--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -21,7 +21,7 @@ const VocabularyAppContainerNew: React.FC = () => {
     isMuted,
     voiceRegion,
     isSpeaking,
-    goToNext,
+    goToNextAndSpeak,
     togglePause,
     toggleMute,
     toggleVoice,
@@ -99,7 +99,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             onTogglePause={togglePause}
             onCycleVoice={toggleVoice}
             onSwitchCategory={switchCategory}
-            onNextWord={goToNext}
+            onNextWord={goToNextAndSpeak}
             currentCategory={currentCategory}
             nextCategory={nextCategory}
             isSpeaking={false}
@@ -132,7 +132,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             onTogglePause={togglePause}
             onCycleVoice={toggleVoice}
             onSwitchCategory={switchCategory}
-            onNextWord={goToNext}
+            onNextWord={goToNextAndSpeak}
             currentCategory={currentCategory}
             nextCategory={nextCategory}
             isSpeaking={false}
@@ -165,7 +165,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             onTogglePause={togglePause}
             onCycleVoice={toggleVoice}
             onSwitchCategory={switchCategory}
-            onNextWord={goToNext}
+            onNextWord={goToNextAndSpeak}
             currentCategory={currentCategory}
             nextCategory={nextCategory}
             isSpeaking={false}
@@ -200,7 +200,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             currentCategory={currentCategory}
             nextCategory={nextCategory}
             isSpeaking={isSpeaking}
-            handleManualNext={goToNext}
+            handleManualNext={goToNextAndSpeak}
             displayTime={5000}
             voiceRegion={voiceRegion}
             debugPanelData={debugData}
@@ -240,7 +240,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           currentCategory={currentCategory}
           nextCategory={nextCategory}
           isSpeaking={isSpeaking}
-          handleManualNext={goToNext}
+          handleManualNext={goToNextAndSpeak}
           displayTime={5000}
           voiceRegion={voiceRegion}
           debugPanelData={debugData}

--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -107,7 +107,7 @@ const VocabularyContainer: React.FC = () => {
         onTogglePause={controllerState.togglePause}
         onCycleVoice={controllerState.toggleVoice}
         onSwitchCategory={controllerState.switchCategory}
-        onNextWord={controllerState.goToNext}
+        onNextWord={controllerState.goToNextAndSpeak}
         currentCategory={currentCategory}
         nextCategory={nextCategory}
         selectedVoice={selectedVoice}


### PR DESCRIPTION
## Summary
- call speech playback directly from Next button handler
- export new `goToNextAndSpeak` action from the unified controller
- use the new action in vocabulary containers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b6790188832f9162486cdc00ab14