### PR TITLE
Fix speech auto-advance on Android

### DIFF
--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -57,6 +57,11 @@ class RealSpeechService {
     // Stop any current speech
     this.stop();
 
+    // Ensure no lingering utterances remain
+    if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
+      window.speechSynthesis.cancel();
+    }
+
     // Wait for voices to be loaded
     await this.ensureVoicesLoaded();
 
@@ -124,10 +129,14 @@ class RealSpeechService {
           text: text.substring(0, 60),
           voice: utterance.voice?.name,
         });
-        if (options.onEnd) {
-          options.onEnd();
-        }
-        resolve(true);
+        const finalize = () => {
+          if (options.onEnd) {
+            options.onEnd();
+          }
+          resolve(true);
+        };
+        // Wait briefly to allow speaking state to reset
+        setTimeout(finalize, 100);
       };
 
       utterance.onerror = (event) => {

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -44,7 +44,9 @@ class UnifiedSpeechController {
 
     if (window.speechSynthesis.speaking || window.speechSynthesis.pending) {
       console.log('Speech engine busy, waiting to speak');
-      setTimeout(() => this.queue.unshift({ word, region, resolve }), 50);
+      this.queue.unshift({ word, region, resolve });
+      window.speechSynthesis.cancel();
+      setTimeout(() => this.processQueue(), 100);
       return;
     }
 


### PR DESCRIPTION
## Summary
- cancel stuck speech and retry queue processing
- guard against lingering speech before playing new utterances
- wait briefly after each utterance ends so `speaking` resets

## Testing
- `npm test` *(fails: useAutoPlayResume > replays current word when unpaused/unmuted)*

------
https://chatgpt.com/codex/tasks/task_e_6863b6b767d0832fb05da705d8ac8ac8