### PR TITLE
Refactor voice selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ characters intact when preparing text for speech.
 
 ## Voice Settings
 
-The controls panel includes a speaker button that cycles through the available voice regions (US, UK, AU).
-Your last selection is stored in `localStorage` under the `vocabularySettings` key so the chosen region persists between sessions.
+The controls panel includes a "Change Voice" button. Clicking it cycles through all voices returned by `speechSynthesis.getVoices()`.
+Your selected voice name is saved in `localStorage` so it persists between sessions.
 
 ## Word display
 

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -11,14 +11,13 @@ interface ContentWithDataNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
-  nextVoiceLabel: string;
   handleSwitchCategory: () => void;
   currentCategory: string;
   nextCategory: string | null;
   isSpeaking: boolean;
   handleManualNext: () => void;
   displayTime: number;
-  voiceRegion: 'US' | 'UK' | 'AU';
+  selectedVoiceName: string;
   debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
@@ -36,14 +35,13 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
-  nextVoiceLabel,
   handleSwitchCategory,
   currentCategory,
   nextCategory,
   isSpeaking,
   handleManualNext,
   displayTime,
-  voiceRegion,
+  selectedVoiceName,
   debugPanelData,
   isAddWordModalOpen,
   handleCloseModal,
@@ -69,9 +67,8 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         isSoundPlaying={isSpeaking}
         handleManualNext={handleManualNext}
         displayTime={displayTime}
-        voiceRegion={voiceRegion}
-        nextVoiceLabel={nextVoiceLabel}
-        onOpenAddModal={handleOpenAddWordModal}
+        selectedVoiceName={selectedVoiceName}
+      onOpenAddModal={handleOpenAddWordModal}
         onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       />
 
@@ -84,7 +81,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       {/* Debug Panel */}
       <DebugPanel
         isMuted={muted}
-        voiceRegion={voiceRegion}
+        voiceRegion={selectedVoiceName}
         isPaused={paused}
         currentWord={debugPanelData}
       />

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -19,7 +19,8 @@ const VocabularyAppContainerNew: React.FC = () => {
     currentCategory,
     isPaused,
     isMuted,
-    voiceRegion,
+    selectedVoiceName,
+    allVoices,
     isSpeaking,
     goToNextAndSpeak,
     togglePause,
@@ -28,7 +29,6 @@ const VocabularyAppContainerNew: React.FC = () => {
     switchCategory,
     playCurrentWord,
     userInteractionState,
-    nextVoiceLabel,
     nextCategory,
     handleInteractionUpdate
   } = useStableVocabularyState();
@@ -104,8 +104,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             nextCategory={nextCategory}
             isSpeaking={false}
             category="No Data"
-            voiceRegion={voiceRegion}
-            nextVoiceLabel={nextVoiceLabel}
+            selectedVoiceName={selectedVoiceName}
           />
         </div>
         </VocabularyLayout>
@@ -137,8 +136,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             nextCategory={nextCategory}
             isSpeaking={false}
             category={currentCategory}
-            voiceRegion={voiceRegion}
-            nextVoiceLabel={nextVoiceLabel}
+            selectedVoiceName={selectedVoiceName}
           />
         </div>
         </VocabularyLayout>
@@ -170,8 +168,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             nextCategory={nextCategory}
             isSpeaking={false}
             category="Loading"
-            voiceRegion={voiceRegion}
-            nextVoiceLabel={nextVoiceLabel}
+            selectedVoiceName={selectedVoiceName}
           />
         </div>
       </VocabularyLayout>
@@ -195,14 +192,13 @@ const VocabularyAppContainerNew: React.FC = () => {
             toggleMute={toggleMute}
             handleTogglePause={togglePause}
             handleCycleVoice={toggleVoice}
-            nextVoiceLabel={nextVoiceLabel}
             handleSwitchCategory={switchCategory}
             currentCategory={currentCategory}
             nextCategory={nextCategory}
             isSpeaking={isSpeaking}
             handleManualNext={goToNextAndSpeak}
             displayTime={5000}
-            voiceRegion={voiceRegion}
+            selectedVoiceName={selectedVoiceName}
             debugPanelData={debugData}
             isAddWordModalOpen={isAddWordModalOpen}
             handleCloseModal={handleCloseModal}
@@ -235,14 +231,13 @@ const VocabularyAppContainerNew: React.FC = () => {
           toggleMute={toggleMute}
           handleTogglePause={togglePause}
           handleCycleVoice={toggleVoice}
-          nextVoiceLabel={nextVoiceLabel}
           handleSwitchCategory={switchCategory}
           currentCategory={currentCategory}
           nextCategory={nextCategory}
           isSpeaking={isSpeaking}
           handleManualNext={goToNextAndSpeak}
           displayTime={5000}
-          voiceRegion={voiceRegion}
+          selectedVoiceName={selectedVoiceName}
           debugPanelData={debugData}
           isAddWordModalOpen={isAddWordModalOpen}
           handleCloseModal={handleCloseModal}

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -23,8 +23,7 @@ interface VocabularyCardNewProps {
   nextCategory: string;
   isSpeaking: boolean;
   category: string;
-  voiceRegion: 'US' | 'UK' | 'AU';
-  nextVoiceLabel: string;
+  selectedVoiceName: string;
   showWordCount?: boolean;
 }
 
@@ -44,8 +43,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   nextCategory,
   isSpeaking,
   category,
-  voiceRegion,
-  nextVoiceLabel,
+  selectedVoiceName,
   showWordCount = false
 }) => {
   const categoryLabel = getCategoryLabel(category);

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -11,7 +11,7 @@ import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { getCategoryLabel, getCategoryMessageLabel } from '@/utils/categoryLabels';
-import { useRegionVoices } from '@/hooks/useRegionVoices';
+import { useVoiceContext } from '@/hooks/useVoiceContext';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -22,11 +22,10 @@ interface VocabularyControlsColumnProps {
   onSwitchCategory: () => void;
   onCycleVoice: () => void;
   nextCategory: string;
-  nextVoiceLabel: string;
   currentWord: VocabularyWord | null;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
-  voiceRegion: 'US' | 'UK' | 'AU';
+  selectedVoiceName: string;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -38,14 +37,13 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onSwitchCategory,
   onCycleVoice,
   nextCategory,
-  nextVoiceLabel,
   currentWord,
   onOpenAddModal,
   onOpenEditModal,
-  voiceRegion
+  selectedVoiceName
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
-  const regionVoices = useRegionVoices(voiceRegion);
+  const { allVoices } = useVoiceContext();
   const safeNextCategory = nextCategory || 'Next';
   const nextCategoryLabel = getCategoryLabel(safeNextCategory);
   const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
@@ -70,12 +68,11 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const handleCycleVoice = () => {
-    if (regionVoices.length === 0) {
-      toast.warning('No voices available for this region');
+    if (allVoices.length === 0) {
+      toast.warning('No voices available');
       return;
     }
     onCycleVoice();
-    toast(`Voice changed to ${nextVoiceLabel}`);
   };
 
   const [isSearchOpen, setIsSearchOpen] = React.useState(false);
@@ -135,15 +132,11 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         size="sm"
         onClick={handleCycleVoice}
         className="h-8 w-8 p-0 text-blue-700 border-blue-300 bg-blue-50"
-        title={
-          regionVoices.length === 0
-            ? 'No voices available for this region'
-            : `Change to ${nextVoiceLabel}`
-        }
-        disabled={regionVoices.length === 0}
-        aria-label={nextVoiceLabel}
+        title={allVoices.length === 0 ? 'No voices available' : `Change Voice`}
+        disabled={allVoices.length === 0}
+        aria-label="Change Voice"
       >
-        <Speaker size={16} />
+        <Speaker size={16} /> {selectedVoiceName || 'Default'}
       </Button>
 
       <SpeechRateControl rate={speechRate} onChange={setSpeechRate} />

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -18,8 +18,7 @@ interface VocabularyMainNewProps {
   nextCategory: string | null;
   isSoundPlaying: boolean;
   displayTime: number;
-  voiceRegion: 'US' | 'UK' | 'AU';
-  nextVoiceLabel: string;
+  selectedVoiceName: string;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
   showWordCount?: boolean;
@@ -38,8 +37,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   isSoundPlaying,
   handleManualNext,
   displayTime,
-  voiceRegion,
-  nextVoiceLabel,
+  selectedVoiceName,
   onOpenAddModal,
   onOpenEditModal,
   showWordCount = false,
@@ -66,8 +64,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
           nextCategory={nextCategory || 'Next'}
           isSpeaking={isSoundPlaying}
           category={currentWord.category || currentCategory}
-          voiceRegion={voiceRegion}
-          nextVoiceLabel={nextVoiceLabel}
+          selectedVoiceName={selectedVoiceName}
           showWordCount={showWordCount}
         />
       </div>
@@ -83,11 +80,10 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
           onSwitchCategory={handleSwitchCategory}
           onCycleVoice={handleCycleVoice}
           nextCategory={nextCategory || 'Next'}
-          nextVoiceLabel={nextVoiceLabel}
-        currentWord={currentWord}
+          currentWord={currentWord}
         onOpenAddModal={onOpenAddModal}
         onOpenEditModal={onOpenEditModal}
-        voiceRegion={voiceRegion}
+          selectedVoiceName={selectedVoiceName}
       />
       </div>
     </div>

--- a/src/components/vocabulary-app/useVocabularyAppHandlers.ts
+++ b/src/components/vocabulary-app/useVocabularyAppHandlers.ts
@@ -22,7 +22,7 @@ export function useVocabularyAppHandlers({
   handleToggleMute,
   handleChangeVoice,
   handleSwitchCategory,
-  voiceRegion,
+  selectedVoiceName,
   setBackgroundColorIndex,
   backgroundColors
 }: any) {
@@ -63,14 +63,14 @@ export function useVocabularyAppHandlers({
     resetLastSpokenWord();
 
     setBackgroundColorIndex((prevIndex: number) => (prevIndex + 1) % backgroundColors.length);
-    handleSwitchCategory(isMuted, voiceRegion);
+    handleSwitchCategory(isMuted, selectedVoiceName);
 
     setTimeout(() => {
       if (!isMuted && !isPaused) {
         speakCurrentWord(true);
       }
     }, 1500);
-  }, [isMuted, voiceRegion, isPaused, handleSwitchCategory, resetLastSpokenWord, speakCurrentWord, clearAllTimeouts, setBackgroundColorIndex, backgroundColors.length]);
+  }, [isMuted, selectedVoiceName, isPaused, handleSwitchCategory, resetLastSpokenWord, speakCurrentWord, clearAllTimeouts, setBackgroundColorIndex, backgroundColors.length]);
 
   return {
     handleToggleMuteWithSpeaking,

--- a/src/hooks/vocabulary-app/useStableVocabularyState.ts
+++ b/src/hooks/vocabulary-app/useStableVocabularyState.ts
@@ -14,10 +14,12 @@ export const useStableVocabularyState = () => {
   const controllerState = useUnifiedVocabularyController();
   
   // Memoize computed values to prevent recalculation
-  const nextVoiceLabel = useMemo(() => 
-    controllerState.voiceRegion === 'UK' ? 'US' : 
-    controllerState.voiceRegion === 'US' ? 'AU' : 'UK'
-  , [controllerState.voiceRegion]);
+  const nextVoiceLabel = useMemo(() => {
+    if (controllerState.allVoices.length === 0) return 'Default';
+    const index = controllerState.allVoices.findIndex(v => v.name === controllerState.selectedVoiceName);
+    const nextIndex = (index + 1) % controllerState.allVoices.length;
+    return controllerState.allVoices[nextIndex].name;
+  }, [controllerState.selectedVoiceName, controllerState.allVoices]);
 
   const nextCategory = useMemo(() => {
     const sheets = vocabularyService.getAllSheetNames();

--- a/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
+++ b/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
@@ -2,12 +2,11 @@
 import * as React from 'react';
 import { useEffect, useCallback, useState } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
-import { VoiceRegion } from '@/types/speech';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
 interface SpeechIntegrationProps {
   currentWord: VocabularyWord | null;
-  voiceRegion: VoiceRegion;
+  selectedVoiceName: string;
   isPaused: boolean;
   isMuted: boolean;
   isTransitioningRef: React.MutableRefObject<boolean>;
@@ -15,7 +14,7 @@ interface SpeechIntegrationProps {
 
 export const useSpeechIntegration = (
   currentWord: VocabularyWord | null,
-  voiceRegion: VoiceRegion,
+  selectedVoiceName: string,
   isPaused: boolean,
   isMuted: boolean,
   isTransitioningRef: React.MutableRefObject<boolean>
@@ -41,13 +40,13 @@ export const useSpeechIntegration = (
     setSpeechState(prev => ({ ...prev, isActive: true, phase: 'speaking' }));
     
     try {
-      await unifiedSpeechController.speak(currentWord, voiceRegion);
+      await unifiedSpeechController.speak(currentWord, selectedVoiceName);
     } catch (error) {
       console.error('[SPEECH-INTEGRATION] Error playing word:', error);
     } finally {
       setSpeechState(prev => ({ ...prev, isActive: false, phase: 'idle' }));
     }
-  }, [currentWord, voiceRegion, isPaused, isMuted, isTransitioningRef]);
+  }, [currentWord, selectedVoiceName, isPaused, isMuted, isTransitioningRef]);
 
   // Effect to trigger speech when dependencies change
   useEffect(() => {
@@ -64,7 +63,7 @@ export const useSpeechIntegration = (
     console.log('[SPEECH-INTEGRATION] Dependencies changed, attempting to speak:', currentWord.word);
     playCurrentWord();
 
-  }, [currentWord, isMuted, isPaused, voiceRegion, playCurrentWord]);
+  }, [currentWord, isMuted, isPaused, selectedVoiceName, playCurrentWord]);
 
   return {
     speechState,

--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -2,7 +2,6 @@
 import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
-import { saveVoiceRegionToStorage } from '@/utils/speech/core/speechSettings';
 import { SpeechState } from '@/services/speech/core/SpeechState';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 
@@ -15,8 +14,9 @@ export const useVocabularyControls = (
   setIsPaused: (paused: boolean) => void,
   isMuted: boolean,
   setIsMuted: (muted: boolean) => void,
-  voiceRegion: 'US' | 'UK' | 'AU',
-  setVoiceRegion: (region: 'US' | 'UK' | 'AU') => void,
+  allVoices: SpeechSynthesisVoice[],
+  selectedVoiceName: string,
+  setSelectedVoiceName: (name: string) => void,
   speechState: SpeechState
 ) => {
   // Toggle pause with immediate feedback for mobile
@@ -47,17 +47,15 @@ export const useVocabularyControls = (
     }
   }, [isMuted, setIsMuted]);
 
-  // Toggle voice region
+  // Cycle to the next available voice
   const toggleVoice = useCallback(() => {
-    const voiceOrder: ('US' | 'UK' | 'AU')[] = ['US', 'UK', 'AU'];
-    const currentIndex = voiceOrder.indexOf(voiceRegion);
-    const nextIndex = (currentIndex + 1) % voiceOrder.length;
-    const nextRegion = voiceOrder[nextIndex];
-    
-    console.log(`[VOCABULARY-CONTROLS] Toggle voice: ${voiceRegion} -> ${nextRegion}`);
-    setVoiceRegion(nextRegion);
-    saveVoiceRegionToStorage(nextRegion);
-  }, [voiceRegion, setVoiceRegion]);
+    if (allVoices.length === 0) return;
+    const currentIndex = allVoices.findIndex(v => v.name === selectedVoiceName);
+    const nextIndex = (currentIndex + 1) % allVoices.length;
+    const nextVoice = allVoices[nextIndex];
+    setSelectedVoiceName(nextVoice.name);
+    localStorage.setItem('selectedVoiceName', nextVoice.name);
+  }, [allVoices, selectedVoiceName, setSelectedVoiceName]);
 
   // Switch category with mobile-friendly handling
   const switchCategory = useCallback(() => {

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -13,20 +13,20 @@ export const useVocabularyDataLoader = (
   setWordList: (words: VocabularyWord[]) => void,
   setHasData: (hasData: boolean) => void,
   setCurrentIndex: (index: number) => void,
-  voiceRegion: 'US' | 'UK' | 'AU',
+  selectedVoiceName: string,
   clearAutoAdvanceTimer: () => void
 ) => {
-  // Persist voice region whenever it changes
+  // Persist selected voice whenever it changes
   useEffect(() => {
     try {
       const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const states = storedStates ? JSON.parse(storedStates) : {};
-      states.voiceRegion = voiceRegion;
+      states.selectedVoiceName = selectedVoiceName;
       localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(states));
     } catch (error) {
-      console.error('Error saving voice region to localStorage:', error);
+      console.error('Error saving voice to localStorage:', error);
     }
-  }, [voiceRegion]);
+  }, [selectedVoiceName]);
 
   // Load initial data
   useEffect(() => {

--- a/src/hooks/vocabulary-controller/core/useVocabularyState.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyState.ts
@@ -16,8 +16,9 @@ export const useVocabularyState = () => {
   const [isPaused, setIsPaused] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const {
-    voiceRegion,
-    setVoiceRegion
+    allVoices,
+    selectedVoiceName,
+    setSelectedVoiceName
   } = useVoiceContext();
 
   // Derived state - calculate currentWord safely
@@ -39,8 +40,9 @@ export const useVocabularyState = () => {
     setIsPaused,
     isMuted,
     setIsMuted,
-    voiceRegion,
-    setVoiceRegion,
+    selectedVoiceName,
+    setSelectedVoiceName,
+    allVoices,
     currentWord,
     
     // Refs

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -28,8 +28,9 @@ export const useUnifiedVocabularyController = () => {
     setIsPaused,
     isMuted,
     setIsMuted,
-    voiceRegion,
-    setVoiceRegion,
+    selectedVoiceName,
+    setSelectedVoiceName,
+    allVoices,
     currentWord,
     isTransitioningRef,
     lastWordChangeRef
@@ -45,7 +46,7 @@ export const useUnifiedVocabularyController = () => {
   const {
     speechState,
     playCurrentWord
-  } = useSpeechIntegration(currentWord, voiceRegion, isPaused, isMuted, isTransitioningRef);
+  } = useSpeechIntegration(currentWord, selectedVoiceName, isPaused, isMuted, isTransitioningRef);
 
   // Word navigation with proper state management
   const {
@@ -75,7 +76,7 @@ export const useUnifiedVocabularyController = () => {
     if (nextWord) {
       saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
       if (!isMuted && !isPaused) {
-        unifiedSpeechController.speak(nextWord, voiceRegion);
+        unifiedSpeechController.speak(nextWord, selectedVoiceName);
       }
     }
 
@@ -88,7 +89,7 @@ export const useUnifiedVocabularyController = () => {
     setCurrentIndex,
     isMuted,
     isPaused,
-    voiceRegion,
+    selectedVoiceName,
     clearAutoAdvanceTimer
   ]);
 
@@ -103,8 +104,9 @@ export const useUnifiedVocabularyController = () => {
     setIsPaused,
     isMuted,
     setIsMuted,
-    voiceRegion,
-    setVoiceRegion,
+    allVoices,
+    selectedVoiceName,
+    setSelectedVoiceName,
     speechState
   );
 
@@ -113,7 +115,7 @@ export const useUnifiedVocabularyController = () => {
     setWordList,
     setHasData,
     setCurrentIndex,
-    voiceRegion,
+    selectedVoiceName,
     clearAutoAdvanceTimer
   );
 
@@ -173,7 +175,8 @@ export const useUnifiedVocabularyController = () => {
     // Control state
     isPaused,
     isMuted,
-    voiceRegion,
+    selectedVoiceName,
+    allVoices,
     isSpeaking: speechState.isActive,
 
     // Actions

--- a/src/utils/speech/voiceNames.ts
+++ b/src/utils/speech/voiceNames.ts
@@ -3,44 +3,7 @@ export const US_VOICE_NAME = "en-US-Standard-B";
 export const UK_VOICE_NAME = "Google UK English Female";
 export const AU_VOICE_NAME = "en-AU-Standard-C";
 
-// Ordered list of preferred voices for each region.
-export const PREFERRED_VOICES_BY_REGION = {
-  US: [
-    "en-US-Standard-B",
-    "en-US-Standard-C",
-    "en-US-Wavenet-B",
-    "Alex",
-    "Samantha",
-    "Aaron",
-    "Fred",
-    "Google US English",
-    "en-US"
-  ],
-  UK: [
-    "Google UK English Female",
-    "Google UK English Male",
-    "en-GB-Standard-A",
-    "en-GB-Standard-B",
-    "Daniel",
-    "Kate",
-    "Arthur",
-    "Serena",
-    "Google UK English",
-    "en-GB"
-  ],
-  AU: [
-    "en-AU-Standard-C",
-    "Google AU English Female",
-    "Google AU English Male",
-    "Karen",
-    "Lee",
-    "Catherine",
-    "Google AU English",
-    "en-AU"
-  ]
-} as const;
+// Region-based voice lists were removed. Constants above are kept only for
+// backwards compatibility with older code paths that may still reference them.
 
-// Aliases kept for backwards compatibility in parts of the code base
-export const UK_VOICE_NAMES = PREFERRED_VOICES_BY_REGION.UK;
-export const AU_VOICE_NAMES = PREFERRED_VOICES_BY_REGION.AU;
 

--- a/src/utils/speech/voiceUtils.ts
+++ b/src/utils/speech/voiceUtils.ts
@@ -1,5 +1,4 @@
-import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
-import { PREFERRED_VOICES_BY_REGION } from './voiceNames';
+// Utilities for selecting speech synthesis voices
 
 /**
  * Return the first English voice available. Used as a final fallback.
@@ -16,53 +15,17 @@ export const findFallbackVoice = (
 };
 
 /**
- * Get the best available voice for a region using an ordered preference list.
+ * Find a specific voice by name. Falls back to the first English voice or the
+ * first available voice if no exact match is found.
  */
-export const getVoiceByRegion = (
-  region: 'US' | 'UK' | 'AU'
-): SpeechSynthesisVoice | null => {
+export const getVoiceByName = (name: string): SpeechSynthesisVoice | null => {
   const voices = window.speechSynthesis.getVoices();
-  console.log(`[Voice Picker] Selecting voice for region ${region}. ${voices.length} voices available`);
+  if (!voices || voices.length === 0) return null;
 
-  if (!voices || voices.length === 0) {
-    return null;
-  }
+  const match = voices.find(v => v.name === name);
+  if (match) return match;
 
-  // Filter out problematic voices on Apple platforms
-  const isApple = /iPad|iPhone|iPod|Macintosh/.test(navigator.userAgent);
-  const BAD_APPLE_VOICE_NAMES = ['Eloquence', 'Shelley', 'Moira'];
-  const usableVoices = isApple
-    ? voices.filter(v => !BAD_APPLE_VOICE_NAMES.some(bad => v.name.includes(bad)))
-    : voices;
-
-  const preferredNames = PREFERRED_VOICES_BY_REGION[region];
-  for (const name of preferredNames) {
-    const match = usableVoices.find(v => v.name === name || v.lang === name);
-    if (match) {
-      console.log(`[Voice Picker] Selected voice ${match.name} (${match.lang})`);
-      return match;
-    }
-  }
-
-  const englishFallback = usableVoices.find(v => v.lang.startsWith('en'));
-  if (englishFallback) {
-    console.log('[Voice Picker] Falling back to generic English voice', englishFallback.name, englishFallback.lang);
-    return englishFallback;
-  }
-
-  if (usableVoices.length > 0) {
-    console.log('[Voice Picker] Falling back to first available voice', usableVoices[0].name, usableVoices[0].lang);
-    return usableVoices[0];
-  }
-
-  console.warn('[Voice Picker] No voices available');
-  return null;
-};
-
-export const getVoiceBySelection = (
-  voiceSelection: VoiceSelection
-): SpeechSynthesisVoice | null => {
-  return getVoiceByRegion(voiceSelection.region);
+  return findFallbackVoice(voices);
 };
 
 export const hasAvailableVoices = (): boolean => {


### PR DESCRIPTION
## Summary
- remove regional voice preference constants
- add unified voice context storing selected voice name
- revise vocabulary controller hooks to use selected voice name
- update UI components to cycle through all voices
- document new Change Voice button behavior

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6863f6fa7aa4832f9cc12745c079439c