### PR TITLE
Simplify speech voice selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ characters intact when preparing text for speech.
 
 ## Voice Settings
 
-The controls panel includes a "Change Voice" button. Clicking it cycles through all voices returned by `speechSynthesis.getVoices()`.
-Your selected voice name is saved in `localStorage` so it persists between sessions.
+The controls panel includes a single **Change Voice** button. Clicking it cycles through the voices available on the current device via `speechSynthesis.getVoices()`. The chosen voice name is stored in `localStorage` so it persists between sessions and is loaded on start.
 
 ## Word display
 

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -4,7 +4,7 @@ import { vocabularyService } from '@/services/vocabularyService';
 
 interface DebugPanelProps {
   isMuted: boolean;
-  voiceRegion: 'US' | 'UK' | 'AU';
+  selectedVoiceName: string;
   isPaused: boolean;
   currentWord?: {
     word: string;
@@ -14,7 +14,7 @@ interface DebugPanelProps {
 
 const DebugPanel: React.FC<DebugPanelProps> = ({
   isMuted,
-  voiceRegion,
+  selectedVoiceName,
   isPaused,
   currentWord
 }) => {
@@ -35,7 +35,7 @@ const DebugPanel: React.FC<DebugPanelProps> = ({
       <pre>
         {`DEBUG:
 Audio: ${isMuted ? 'MUTED' : 'UNMUTED'}
-Accent: ${voiceRegion}
+Voice: ${selectedVoiceName}
 State: ${isPaused ? 'PAUSED' : 'PLAYING'}
 UI Category: ${currentCategory}
 Word Category: ${currentWord?.category || 'N/A'}

--- a/src/components/NotificationManager.tsx
+++ b/src/components/NotificationManager.tsx
@@ -26,13 +26,11 @@ const requestNotificationPermission = async () => {
 interface NotificationManagerProps {
   onNotificationsEnabled: () => void;
   currentWord?: VocabularyWord | null;
-  voiceRegion?: 'US' | 'UK' | 'AU';
 }
 
-const NotificationManager: React.FC<NotificationManagerProps> = ({ 
+const NotificationManager: React.FC<NotificationManagerProps> = ({
   onNotificationsEnabled,
-  currentWord,
-  voiceRegion = 'US'
+  currentWord
 }) => {
   const [notificationsEnabled, setNotificationsEnabled] = useState(false);
   const [permissionState, setPermissionState] = useState<string>('default');

--- a/src/hooks/useVoiceContext.tsx
+++ b/src/hooks/useVoiceContext.tsx
@@ -4,16 +4,23 @@ export interface VoiceContext {
   allVoices: SpeechSynthesisVoice[];
   selectedVoiceName: string;
   setSelectedVoiceName: (name: string) => void;
+  cycleVoice: () => void;
 }
 
 export const useVoiceContext = (): VoiceContext => {
   const [allVoices, setAllVoices] = useState<SpeechSynthesisVoice[]>([]);
-  const [selectedVoiceName, setSelectedVoiceName] = useState(
-    localStorage.getItem('selectedVoiceName') || ''
-  );
+  const [selectedVoiceName, setSelectedVoiceName] = useState('');
 
   useEffect(() => {
-    const loadVoices = () => setAllVoices(window.speechSynthesis.getVoices());
+    const loadVoices = () => {
+      const voices = window.speechSynthesis.getVoices();
+      setAllVoices(voices);
+      if (voices.length > 0) {
+        const stored = localStorage.getItem('selectedVoiceName');
+        const match = stored ? voices.find(v => v.name === stored) : null;
+        setSelectedVoiceName(match ? match.name : voices[0].name);
+      }
+    };
     window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
     loadVoices();
     return () => {
@@ -27,5 +34,15 @@ export const useVoiceContext = (): VoiceContext => {
     }
   }, [selectedVoiceName]);
 
-  return { allVoices, selectedVoiceName, setSelectedVoiceName };
+  const cycleVoice = () => {
+    if (allVoices.length === 0) return;
+    const index = allVoices.findIndex(v => v.name === selectedVoiceName);
+    const nextIndex = (index + 1) % allVoices.length;
+    const nextVoice = allVoices[nextIndex];
+    setSelectedVoiceName(nextVoice.name);
+    localStorage.setItem('selectedVoiceName', nextVoice.name);
+    alert(`Voice "${nextVoice.name}" selected!`);
+  };
+
+  return { allVoices, selectedVoiceName, setSelectedVoiceName, cycleVoice };
 };

--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -17,7 +17,8 @@ export const useVocabularyControls = (
   allVoices: SpeechSynthesisVoice[],
   selectedVoiceName: string,
   setSelectedVoiceName: (name: string) => void,
-  speechState: SpeechState
+  speechState: SpeechState,
+  currentWord: VocabularyWord | null
 ) => {
   // Toggle pause with immediate feedback for mobile
   const togglePause = useCallback(() => {
@@ -55,7 +56,19 @@ export const useVocabularyControls = (
     const nextVoice = allVoices[nextIndex];
     setSelectedVoiceName(nextVoice.name);
     localStorage.setItem('selectedVoiceName', nextVoice.name);
-  }, [allVoices, selectedVoiceName, setSelectedVoiceName]);
+    if (currentWord && !isMuted && !isPaused) {
+      unifiedSpeechController.stop();
+      unifiedSpeechController.speak(currentWord, nextVoice.name);
+    }
+    alert(`Voice "${nextVoice.name}" selected!`);
+  }, [
+    allVoices,
+    selectedVoiceName,
+    setSelectedVoiceName,
+    currentWord,
+    isMuted,
+    isPaused
+  ]);
 
   // Switch category with mobile-friendly handling
   const switchCategory = useCallback(() => {

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -107,7 +107,8 @@ export const useUnifiedVocabularyController = () => {
     allVoices,
     selectedVoiceName,
     setSelectedVoiceName,
-    speechState
+    speechState,
+    currentWord
   );
 
   // Data loading

--- a/src/services/speech/core/SpeechOptions.ts
+++ b/src/services/speech/core/SpeechOptions.ts
@@ -3,5 +3,5 @@ export interface SpeechOptions {
   onStart?: () => void;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
-  voiceRegion?: 'US' | 'UK' | 'AU';
+  voiceName?: string;
 }

--- a/src/services/speech/directSpeechService.ts
+++ b/src/services/speech/directSpeechService.ts
@@ -2,7 +2,7 @@
 import { realSpeechService } from './realSpeechService';
 
 interface SpeechOptions {
-  voiceRegion: 'US' | 'UK' | 'AU';
+  voiceName?: string;
   onEnd?: () => void;
   onError?: (error: SpeechSynthesisErrorEvent) => void;
   muted?: boolean;

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -17,19 +17,18 @@ beforeAll(async () => {
 import VocabularyControlsColumn from '../src/components/vocabulary-app/VocabularyControlsColumn';
 import { VocabularyWord } from '../src/types/vocabulary';
 
-type Region = 'US' | 'UK' | 'AU';
-
 describe('VocabularyControlsColumn voice toggle', () => {
   it('cycles voice label and updates state', async () => {
     const word: VocabularyWord = { word: 'water', meaning: 'H2O', example: 'Drink', category: 'general' };
-    const controllerState = { voiceRegion: 'UK' as Region };
+    const voices = ['Voice 1', 'Voice 2'];
+    const controllerState = { voiceName: voices[0] };
     const Wrapper: React.FC = () => {
-      const [voiceRegion, setVoiceRegion] = React.useState<Region>(controllerState.voiceRegion);
+      const [voiceName, setVoiceName] = React.useState(controllerState.voiceName);
       React.useEffect(() => {
-        controllerState.voiceRegion = voiceRegion;
-      }, [voiceRegion]);
-      const nextVoiceLabel = voiceRegion === 'UK' ? 'US' : voiceRegion === 'US' ? 'AU' : 'UK';
-      const toggleVoice = () => setVoiceRegion(r => (r === 'UK' ? 'US' : r === 'US' ? 'AU' : 'UK'));
+        controllerState.voiceName = voiceName;
+      }, [voiceName]);
+      const nextVoiceLabel = voiceName === voices[0] ? voices[1] : voices[0];
+      const toggleVoice = () => setVoiceName(v => (v === voices[0] ? voices[1] : voices[0]));
       return (
           <VocabularyControlsColumn
             isMuted={false}
@@ -38,25 +37,24 @@ describe('VocabularyControlsColumn voice toggle', () => {
             onTogglePause={() => {}}
             onNextWord={() => {}}
             onSwitchCategory={() => {}}
-          onCycleVoice={toggleVoice}
-          nextCategory="next"
-          nextVoiceLabel={nextVoiceLabel}
-          currentWord={word}
-          onOpenAddModal={() => {}}
-          onOpenEditModal={() => {}}
-          voiceRegion={voiceRegion}
-        />
+            onCycleVoice={toggleVoice}
+            nextCategory="next"
+            selectedVoiceName={voiceName}
+            currentWord={word}
+            onOpenAddModal={() => {}}
+            onOpenEditModal={() => {}}
+          />
       );
     };
 
     render(<Wrapper />);
 
-    const toggleBtn = screen.getByRole('button', { name: 'US' });
-    expect(controllerState.voiceRegion).toBe('UK');
+    const toggleBtn = screen.getByRole('button', { name: voices[1] });
+    expect(controllerState.voiceName).toBe(voices[0]);
 
     await userEvent.click(toggleBtn);
 
-    expect(screen.getByRole('button', { name: 'AU' })).toBeInTheDocument();
-    expect(controllerState.voiceRegion).toBe('US');
+    expect(screen.getByRole('button', { name: voices[0] })).toBeInTheDocument();
+    expect(controllerState.voiceName).toBe(voices[1]);
   });
 });


### PR DESCRIPTION
## Summary
- refactor voice context to cycle through local device voices
- play current word when cycling voice
- adapt unified speech controller to accept voice names
- update real speech service for voice names
- drop region-based props from UI
- adjust README and tests

## Testing
- `npm test` *(fails: Unable to find button by name; some assertions failing)*
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686403b8bc08832fadb9fcd26166c45b