### PR TITLE
Refactor voice selection

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -5,6 +5,7 @@ import { vocabularyService } from '@/services/vocabularyService';
 import { SpeechState } from '@/services/speech/core/SpeechState';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 import { toast } from 'sonner';
+import { PREFERRED_VOICE_KEY } from '@/utils/storageKeys';
 
 /**
  * Vocabulary control actions
@@ -56,7 +57,7 @@ export const useVocabularyControls = (
     const nextIndex = (currentIndex + 1) % allVoices.length;
     const nextVoice = allVoices[nextIndex];
     setSelectedVoiceName(nextVoice.name);
-    localStorage.setItem('selectedVoiceName', nextVoice.name);
+    localStorage.setItem(PREFERRED_VOICE_KEY, nextVoice.name);
     if (currentWord && !isMuted && !isPaused) {
       unifiedSpeechController.stop();
       unifiedSpeechController.speak(currentWord, nextVoice.name);

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -2,7 +2,7 @@
 import { useEffect } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
-import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+import { BUTTON_STATES_KEY, PREFERRED_VOICE_KEY } from '@/utils/storageKeys';
 import { getLastWord } from '@/utils/lastWordStorage';
 import { findFuzzyIndex } from '@/utils/text/findFuzzyIndex';
 
@@ -21,8 +21,9 @@ export const useVocabularyDataLoader = (
     try {
       const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       const states = storedStates ? JSON.parse(storedStates) : {};
-      states.selectedVoiceName = selectedVoiceName;
+      states.preferredVoiceName = selectedVoiceName;
       localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify(states));
+      localStorage.setItem(PREFERRED_VOICE_KEY, selectedVoiceName);
     } catch (error) {
       console.error('Error saving voice to localStorage:', error);
     }

--- a/src/utils/speech/index.ts
+++ b/src/utils/speech/index.ts
@@ -28,7 +28,6 @@ import { splitTextIntoChunks } from "./core/textChunker";
 import { speakChunksInSequence } from "./core/chunkSequencer";
 import { createSpeechMonitor, clearSpeechMonitor } from "./core/speechMonitor";
 import { synthesizeAudio } from "./synthesisUtils";
-import { US_VOICE_NAME, UK_VOICE_NAME, AU_VOICE_NAME } from "./voiceNames";
 import { formatSpeechText } from "./formatSpeechText";
 import {
   initializeSpeechSystem,
@@ -63,9 +62,6 @@ export {
   createSpeechMonitor,
   clearSpeechMonitor,
   synthesizeAudio,
-  US_VOICE_NAME,
-  UK_VOICE_NAME,
-  AU_VOICE_NAME,
   formatSpeechText,
 };
 

--- a/src/utils/speech/voiceNames.ts
+++ b/src/utils/speech/voiceNames.ts
@@ -1,9 +1,0 @@
-// Default US voice
-export const US_VOICE_NAME = "en-US-Standard-B";
-export const UK_VOICE_NAME = "Google UK English Female";
-export const AU_VOICE_NAME = "en-AU-Standard-C";
-
-// Region-based voice lists were removed. Constants above are kept only for
-// backwards compatibility with older code paths that may still reference them.
-
-

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,3 +1,4 @@
 export const BUTTON_STATES_KEY = 'buttonStates';
 export const VOICE_SETTINGS_KEY = 'voiceSettings';
 export const SPEECH_RATE_KEY = 'vocabularySpeechRate';
+export const PREFERRED_VOICE_KEY = 'preferredVoiceName';


### PR DESCRIPTION
## Summary
- remove region-based voice configs
- persist preferred voice name using `preferredVoiceName`
- expose English voices only and cycle through them
- store new voice selection in localStorage

## Testing
- `npm test` *(fails: useAutoPlayResume tests)*
- `npm run lint` *(fails: 59 errors, 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686409e2d118832f8ead358fbc8b9e2c