### PR TITLE
Add browser voice debug panel

### DIFF
--- a/src/components/VoiceDebugPanel.tsx
+++ b/src/components/VoiceDebugPanel.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+const VoiceDebugPanel: React.FC = () => {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+
+  const loadVoices = () => {
+    const list = window.speechSynthesis.getVoices();
+    setVoices(list);
+  };
+
+  useEffect(() => {
+    loadVoices();
+    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
+    return () => {
+      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+    };
+  }, []);
+
+  if (!import.meta.env.DEV) return null;
+
+  return (
+    <div className="voice-debug-panel">
+      <div>[Speech] Available voices from device/browser:</div>
+      {voices.map((v) => (
+        <div key={`${v.name}-${v.lang}`}>
+          [Voice] name: {v.name}, lang: {v.lang}, local: {String(v.localService)}, default: {String(v.default)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default VoiceDebugPanel;

--- a/src/index.css
+++ b/src/index.css
@@ -99,3 +99,14 @@
     @apply bg-background text-foreground;
   }
 }
+.voice-debug-panel {
+  font-size: 10px;
+  color: white;
+  background: transparent;
+  white-space: pre-wrap;
+  max-height: 200px;
+  overflow-y: auto;
+  padding-top: 10px;
+  font-family: monospace;
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import VocabularyApp from '@/components/VocabularyApp';
+import VoiceDebugPanel from '@/components/VoiceDebugPanel';
 
 const Index = () => {
   return (
@@ -20,6 +21,7 @@ const Index = () => {
       <footer className="mt-6 text-center text-sm text-muted-foreground">
         <p>© 2025 Lazy Vocabulary - hoctusach@gmail.com</p>
       </footer>
+      <VoiceDebugPanel />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show available speech synthesis voices in new `VoiceDebugPanel`
- mount the debug panel below the footer
- add styling for the panel

## Testing
- `npm run lint` *(fails: 59 errors, 40 warnings)*
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6864b45f6ecc832f99c70dbe1842fbe4