### PR TITLE
Fix voice/lang usage for speech synthesis

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -8,6 +8,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { Badge } from '@/components/ui/badge';
 import VocabularyCard from './VocabularyCard';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
+import { findVoice } from '@/hooks/vocabulary-playback/speech-playback/findVoice';
 
 interface WordSearchModalProps {
   isOpen: boolean;
@@ -103,6 +104,14 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
       .filter(Boolean)
       .join('. ');
     const utterance = new SpeechSynthesisUtterance(text);
+    const voices = window.speechSynthesis.getVoices();
+    const voice = findVoice(voices, previewVoice);
+    if (voice) {
+      utterance.voice = voice;
+      utterance.lang = voice.lang;
+    } else {
+      utterance.lang = previewVoice.region === 'US' ? 'en-US' : 'en-GB';
+    }
     window.speechSynthesis.speak(utterance);
   };
 

--- a/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/core/word-playback/useUtteranceSetup.ts
@@ -48,11 +48,12 @@ export const useUtteranceSetup = ({
       
       // Set language based on selected voice
       utterance.lang = selectedVoice.region === 'UK' ? 'en-GB' : 'en-US';
-      
+
       // Find and apply the voice
       const voice = findVoice(selectedVoice.region);
       if (voice) {
         utterance.voice = voice;
+        utterance.lang = voice.lang;
         console.log(`Using voice: ${voice.name}`);
       } else {
         console.log('No matching voice found, using system default');

--- a/src/services/speech/core/SpeechPlatformManager.ts
+++ b/src/services/speech/core/SpeechPlatformManager.ts
@@ -81,7 +81,17 @@ export class SpeechPlatformManager {
     const utterance = new SpeechSynthesisUtterance(speechText);
     
     const voice = this.voiceManager.findVoice(voiceRegion);
-    if (voice) utterance.voice = voice;
+    if (voice) {
+      utterance.voice = voice;
+      utterance.lang = voice.lang;
+    } else {
+      utterance.lang =
+        voiceRegion === 'UK'
+          ? 'en-GB'
+          : voiceRegion === 'US'
+          ? 'en-US'
+          : 'en-AU';
+    }
     utterance.rate = getSpeechRate();
     utterance.pitch = 1.0;
     utterance.volume = 1.0;

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -77,6 +77,7 @@ class RealSpeechService {
         : null;
       if (voice) {
         utterance.voice = voice;
+        utterance.lang = voice.lang;
         console.log(
           "Using voice:",
           voice.name,
@@ -95,6 +96,7 @@ class RealSpeechService {
           allVoices.find(v => v.lang.startsWith('en')) || allVoices[0] || null;
         if (fallback) {
           utterance.voice = fallback;
+          utterance.lang = fallback.lang;
           console.log(
             "Falling back to voice:",
             fallback.name,

--- a/src/utils/speech/controller/speechExecutor.ts
+++ b/src/utils/speech/controller/speechExecutor.ts
@@ -66,6 +66,7 @@ export class SpeechExecutor {
         // Set properties
         if (options.voice) {
           utterance.voice = options.voice;
+          utterance.lang = options.voice.lang;
           console.log(`[SPEECH-EXECUTOR-${speechId}] Using voice:`, options.voice.name);
         }
         utterance.rate = options.rate || getSpeechRate();

--- a/src/utils/speech/core/speechController.ts
+++ b/src/utils/speech/core/speechController.ts
@@ -245,7 +245,10 @@ class SpeechController {
         const utterance = new SpeechSynthesisUtterance(text);
         
         // Configure utterance
-        if (options.voice) utterance.voice = options.voice;
+        if (options.voice) {
+          utterance.voice = options.voice;
+          utterance.lang = options.voice.lang;
+        }
         utterance.rate = options.rate || getSpeechRate();
         utterance.pitch = options.pitch || 1.0;
         utterance.volume = options.volume || 1.0;


### PR DESCRIPTION
## Summary
- set `utterance.voice` and `utterance.lang` together when a voice is chosen
- update vocabulary search preview playback to use selected voice language

## Testing
- `npm test` *(fails: Failed to resolve import "@/utils/speech/voiceNames"; useAutoPlayResume tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2e84924832fb6851018996ac6c5