### PR TITLE
Filter debug panel voices to English only

### DIFF
--- a/src/components/VoiceDebugPanel.tsx
+++ b/src/components/VoiceDebugPanel.tsx
@@ -6,16 +6,22 @@ const VoiceDebugPanel: React.FC = () => {
   const loadVoices = () => {
     const list = window.speechSynthesis.getVoices();
     if (list.length > 0) {
-      setVoices(list);
-      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+      const filtered = list.filter(
+        (v) =>
+          v.lang &&
+          (v.lang.toLowerCase().startsWith('en-us') ||
+            v.lang.toLowerCase().startsWith('en-gb') ||
+            v.lang.toLowerCase().startsWith('en-au'))
+      );
+      setVoices(filtered);
     }
   };
 
   useEffect(() => {
     loadVoices();
-    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
+    window.speechSynthesis.onvoiceschanged = loadVoices;
     return () => {
-      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
+      window.speechSynthesis.onvoiceschanged = null;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- filter `VoiceDebugPanel` to only show English voices (US/UK/AU)
- rewire loading to use `onvoiceschanged` handler

## Testing
- `npm test` *(fails: useAutoPlayResume tests)*
- `npm run lint` *(fails: 59 errors, 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2331f24832fb68ea11d19d629ff