### PR TITLE
Style app header name

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,3 +110,9 @@
   font-family: monospace;
 }
 
+.app-name {
+  color: #333333;
+  font-size: 1.2em;
+  font-weight: 400;
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,8 +7,8 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-gray-50 py-4">
       <header className="mb-4">
-        <h1 className="text-xl font-bold text-center text-blue-900">Lazy Vocabulary</h1>
-        <p className="text-center text-blue-600 mt-1 text-sm font-medium">
+        <h1 className="app-name text-center">Lazy Vocabulary</h1>
+        <p className="text-center text-blue-600 mt-1 text-xl font-medium">
           Master vocabulary with passive learning
         </p>
         {/* Removed "Are you new?" section */}


### PR DESCRIPTION
## Summary
- tweak the header title class to `.app-name`
- add `.app-name` style to global CSS
- enlarge the slogan so the name is subtler

## Testing
- `npm test` *(fails: useAutoPlay resume tests)*
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865e4133eb0832f966e5e85569ab4e3