### PR TITLE
Add note under main slogan

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,3 +110,10 @@
   font-family: monospace;
 }
 
+.slogan-note {
+  color: #FF6F00;
+  font-style: italic;
+  margin-top: 8px;
+  font-size: 0.95em;
+}
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,9 @@ const Index = () => {
         <p className="text-center text-blue-600 mt-1 text-sm font-medium">
           Master vocabulary with passive learning
         </p>
+        <p className="slogan-note">
+          Don’t memorize. Just skim, get it, and read examples out loud if you can!
+        </p>
         {/* Removed "Are you new?" section */}
       </header>
       


### PR DESCRIPTION
## Summary
- add an italic note below the main slogan on the homepage
- style the note via `slogan-note` class

## Testing
- `npm test` *(fails: useAutoPlayResume.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6865e3440820832f8c2c6b73090258ef