### PR TITLE
Fix CSS syntax error blocking build

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,7 @@
   font-style: italic;
   margin-top: 8px;
   font-size: 0.95em;
+}
 .app-name {
   color: #333333;
   font-size: 1.2em;


### PR DESCRIPTION
## Summary
- close `.slogan-note` rule in `index.css`

## Testing
- `npm test` *(fails: `useAutoPlay resume` tests)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865ece29780832f925380cb10bd32d2