### PR TITLE
Insert line break in home page slogan

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,9 @@ const Index = () => {
           Master vocabulary with passive learning!
         </p>
         <p className="slogan-note">
-          Don’t memorize. Just skim, get it, and read examples out loud if you can!
+          Don’t memorize. Just skim, get it,
+          <br />
+          and read examples out loud if you can!
         </p>
         {/* Removed "Are you new?" section */}
       </header>


### PR DESCRIPTION
## Summary
- break the slogan line in `Index.tsx` so that the phrase after "get it" appears on a new line

## Testing
- `npm test` *(fails: useAutoPlay resume tests)*
- `npm run lint` *(fails: 59 errors, 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686619970f30832fabba0045bb0db6c4