### PR TITLE
Improve spacing for slogan note

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,10 @@
   text-align: center;
   margin-top: 8px;
   font-size: 0.85em;
+  padding: 0 20px;
+  word-wrap: break-word;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 .app-name {
   color: #333333;


### PR DESCRIPTION
## Summary
- add padding and wrapping to the small orange note

## Testing
- `npm test` *(fails: useAutoPlay resume tests fail)*
- `npm run lint` *(fails: 59 errors, 40 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68660ac016c4832f9965ca9bae2d45ad