### PR TITLE
Fix HTML heading hierarchy

### DIFF
--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -64,11 +64,11 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
         <div className="space-y-2">
           {/* Category and Word Count */}
           <div className="flex items-center justify-between">
-            <div className="text-sm font-medium text-gray-600 bg-white/80 px-3 py-1 rounded-full">
+            <h3 className="text-sm font-medium text-gray-600 bg-white/80 px-3 py-1 rounded-full">
               {categoryLabel}
-            </div>
-            <WordCountDisplay 
-              word={currentWordObj} 
+            </h3>
+            <WordCountDisplay
+              word={currentWordObj}
               showCount={showWordCount}
             />
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,9 +8,9 @@ const Index = () => {
     <div className="min-h-screen bg-gray-50 py-4">
       <header className="mb-4">
         <h1 className="text-xl font-bold text-center text-blue-900">Lazy Vocabulary</h1>
-        <p className="text-center text-[#333333] mt-1 text-sm font-medium">
+        <h2 className="text-center text-[#333333] mt-1 text-sm font-medium">
           Master vocabulary with passive learning!
-        </p>
+        </h2>
         <p className="slogan-note">
           Don’t memorize. Just skim, get it,
           <br />


### PR DESCRIPTION
## Summary
- standardize hero text with `<h1>` & `<h2>`
- mark vocabulary category sections with `<h3>`

## Testing
- `npm test` *(fails: useAutoPlay resume tests)*
- `npm run lint` *(fails: found 59 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b6f735138832fbfb2a01037ba6924