### PR TITLE
Add invisible SEO block

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
 
   <body>
     <div id="root"></div>
+    <div class="seo-hidden">
+      <p>Learn English Vocabulary with Lazy Vocabulary. Master English words and phrases passively. Skim, listen, and understand examples out loud. Categories include Idioms, Phrasal Verbs, Academic Words, and Common Expressions. Practice with audio and improve your pronunciation naturally.</p>
+      <p>Học từ vựng tiếng Anh với Lazy Vocabulary. Nắm vững từ và cụm từ tiếng Anh một cách thụ động. Lướt qua, nghe và hiểu ví dụ đọc to. Các chủ đề bao gồm Thành ngữ, Cụm động từ, Từ học thuật và Cụm thông dụng. Luyện nghe và cải thiện phát âm tự nhiên.</p>
+    </div>
     <!-- Script removed due to CORS issues causing audio playback failures -->
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/index.css
+++ b/src/index.css
@@ -123,3 +123,13 @@
   font-weight: 400;
 }
 
+.seo-hidden {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+


### PR DESCRIPTION
## Summary
- hide SEO block text with `seo-hidden` styling in index.css
- include English and Vietnamese SEO text in index.html

## Testing
- `npx vitest` *(fails: Need to install the following packages: vitest@3.2.4)*

------
https://chatgpt.com/codex/tasks/task_e_686b8072d300832fb723541392115bac