### PR TITLE
Add ES module type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 This project requires **Node.js >=18**. A `.nvmrc` file is provided so you can
 quickly switch to the correct version with
-[`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating):
+[`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+This project uses Node's ES module syntax; `package.json` specifies `"type": "module"`.
 
 ```sh
 nvm install

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lazy-vocabulary",
   "version": "1.0.0",
   "description": "Vocabulary learning app",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- add `"type": "module"` to `package.json`
- document the ES module setup in README

## Testing
- `npm run dev` *(fails: uses watch server, ended manually)*
- `npm run build`
- `npx vitest run`
- `npm run lint` *(fails: ESLint found problems)*

------
https://chatgpt.com/codex/tasks/task_e_686c7963ac30832f9f2b8a724070da20