### PR TITLE
Add daily usage tracker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,31 +6,35 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { useDailyUsageTracker } from "./hooks/useDailyUsageTracker";
 
 const queryClient = new QueryClient();
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Helmet>
+const App = () => {
+  useDailyUsageTracker();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Helmet>
         <title>Lazy Vocabulary – Master English Vocabulary with Passive Learning</title>
         <meta
           name="description"
           content="Learn English vocabulary easily. Passive learning with audio, examples, and categorized words. Improve fluency by skimming and listening."
         />
         <link rel="canonical" href="https://your-domain.com/" />
-      </Helmet>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+        </Helmet>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/src/hooks/useDailyUsageTracker.tsx
+++ b/src/hooks/useDailyUsageTracker.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+
+const STICKERS_KEY = 'stickers';
+const MINUTES_15 = 15 * 60 * 1000;
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function getTodayKey() {
+  return `dailyTime_${formatDate(new Date())}`;
+}
+
+export const useDailyUsageTracker = () => {
+  const sessionStart = useRef<number | null>(null);
+
+  const startSession = () => {
+    if (sessionStart.current === null) {
+      sessionStart.current = Date.now();
+    }
+  };
+
+  const stopSession = () => {
+    if (sessionStart.current === null) return;
+    const duration = Date.now() - sessionStart.current;
+    sessionStart.current = null;
+
+    const key = getTodayKey();
+    const previous = parseInt(localStorage.getItem(key) || '0', 10);
+    const total = previous + duration;
+    localStorage.setItem(key, total.toString());
+
+    if (total >= MINUTES_15) {
+      try {
+        const today = formatDate(new Date());
+        const stickers: string[] = JSON.parse(localStorage.getItem(STICKERS_KEY) || '[]');
+        if (!stickers.includes(today)) {
+          stickers.push(today);
+          localStorage.setItem(STICKERS_KEY, JSON.stringify(stickers));
+        }
+      } catch (err) {
+        console.error('Failed to update stickers', err);
+      }
+    }
+  };
+
+  useEffect(() => {
+    startSession();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        stopSession();
+      } else if (document.visibilityState === 'visible') {
+        startSession();
+      }
+    };
+
+    window.addEventListener('beforeunload', stopSession);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      stopSession();
+      window.removeEventListener('beforeunload', stopSession);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+};
+
+export { formatDate };

--- a/tests/dailyUsageTracker.test.ts
+++ b/tests/dailyUsageTracker.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useDailyUsageTracker } from '../src/hooks/useDailyUsageTracker';
+import { formatDate } from '../src/hooks/useDailyUsageTracker';
+
+const advanceSession = async (ms: number) => {
+  vi.advanceTimersByTime(ms);
+  await Promise.resolve();
+};
+
+describe('useDailyUsageTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('records time and awards sticker after 15 minutes', async () => {
+    renderHook(() => useDailyUsageTracker());
+    await advanceSession(16 * 60 * 1000);
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload'));
+    });
+
+    const today = formatDate(new Date());
+    const key = `dailyTime_${today}`;
+    expect(parseInt(localStorage.getItem(key) || '0', 10)).toBe(16 * 60 * 1000);
+    const stickers = JSON.parse(localStorage.getItem('stickers') || '[]');
+    expect(stickers).toContain(today);
+  });
+
+  it('accumulates time across sessions without duplicate stickers', async () => {
+    const today = formatDate(new Date());
+    const key = `dailyTime_${today}`;
+
+    renderHook(() => useDailyUsageTracker());
+    await advanceSession(5 * 60 * 1000);
+    act(() => window.dispatchEvent(new Event('beforeunload')));
+
+    renderHook(() => useDailyUsageTracker());
+    await advanceSession(10 * 60 * 1000);
+    act(() => window.dispatchEvent(new Event('beforeunload')));
+
+    expect(parseInt(localStorage.getItem(key) || '0', 10)).toBe(15 * 60 * 1000);
+    const stickers = JSON.parse(localStorage.getItem('stickers') || '[]');
+    expect(stickers).toEqual([today]);
+  });
+});


### PR DESCRIPTION
## Summary
- track session time and award stickers
- add hook to start/stop timer and persist totals
- call the hook from the app entry
- test daily time accumulation and sticker logic

## Testing
- `npm run build`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_687225c30e70832f8197885416679f57