### PR TITLE
Implement streak day tracking

### DIFF
--- a/src/hooks/useDailyUsageTracker.tsx
+++ b/src/hooks/useDailyUsageTracker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { addStreakDay } from '@/utils/streak';
 
 const STICKERS_KEY = 'stickers';
 const MINUTES_15 = 15 * 60 * 1000;
@@ -37,6 +38,7 @@ export const useDailyUsageTracker = () => {
         if (!stickers.includes(today)) {
           stickers.push(today);
           localStorage.setItem(STICKERS_KEY, JSON.stringify(stickers));
+          addStreakDay(today);
         }
       } catch (err) {
         console.error('Failed to update stickers', err);

--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -1,0 +1,34 @@
+export const STREAK_DAYS_KEY = 'streakDays';
+export const USED_STREAK_DAYS_KEY = 'usedStreakDays';
+
+export function loadStreakDays(): string[] {
+  let streakDays: string[] = [];
+  let usedDays: string[] = [];
+  try {
+    streakDays = JSON.parse(localStorage.getItem(STREAK_DAYS_KEY) || '[]');
+  } catch {
+    streakDays = [];
+  }
+  try {
+    usedDays = JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY) || '[]');
+  } catch {
+    usedDays = [];
+  }
+  const filtered = streakDays.filter(day => !usedDays.includes(day));
+  if (filtered.length !== streakDays.length) {
+    try {
+      localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
+    } catch {}
+  }
+  return filtered;
+}
+
+export function addStreakDay(date: string): void {
+  const current = loadStreakDays();
+  if (!current.includes(date)) {
+    current.push(date);
+    try {
+      localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(current));
+    } catch {}
+  }
+}

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadStreakDays, addStreakDay, STREAK_DAYS_KEY, USED_STREAK_DAYS_KEY } from '../src/utils/streak';
+
+describe('streak days loading', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('filters out used streak days on load', () => {
+    localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(['2024-07-01', '2024-07-03']));
+    localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(['2024-07-01', '2024-07-02']));
+
+    const result = loadStreakDays();
+    expect(result).toEqual(['2024-07-03']);
+    expect(JSON.parse(localStorage.getItem(STREAK_DAYS_KEY)!)).toEqual(['2024-07-03']);
+  });
+
+  it('adds new streak day when not used', () => {
+    localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(['2024-07-01']));
+    addStreakDay('2024-07-02');
+    expect(loadStreakDays()).toEqual(['2024-07-02']);
+  });
+});


### PR DESCRIPTION
## Summary
- update daily usage tracker to record streak days
- track streak days separately from used medal days in `src/utils/streak.ts`
- add new tests for streak day logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6873c6cb00c0832f98c61e3f3b29fb81