### PR TITLE
Validate streak continuity on load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,15 @@ import { Helmet } from "react-helmet";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import { useDailyUsageTracker } from "./hooks/useDailyUsageTracker";
+import { useEffect } from "react";
+import { loadStreakDays } from "./utils/streak";
 
 const queryClient = new QueryClient();
 
 const App = () => {
+  useEffect(() => {
+    loadStreakDays();
+  }, []);
   useDailyUsageTracker();
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -1,6 +1,13 @@
 export const STREAK_DAYS_KEY = 'streakDays';
 export const USED_STREAK_DAYS_KEY = 'usedStreakDays';
 
+function dayDiff(a: Date, b: Date): number {
+  const ms = 24 * 60 * 60 * 1000;
+  const da = new Date(a.getFullYear(), a.getMonth(), a.getDate());
+  const db = new Date(b.getFullYear(), b.getMonth(), b.getDate());
+  return Math.round((da.getTime() - db.getTime()) / ms);
+}
+
 export function loadStreakDays(): string[] {
   let streakDays: string[] = [];
   let usedDays: string[] = [];
@@ -14,12 +21,33 @@ export function loadStreakDays(): string[] {
   } catch {
     usedDays = [];
   }
-  const filtered = streakDays.filter(day => !usedDays.includes(day));
+  let filtered = streakDays.filter(day => !usedDays.includes(day));
   if (filtered.length !== streakDays.length) {
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
     } catch {}
   }
+
+  if (filtered.length > 0) {
+    const today = new Date();
+    const last = new Date(filtered[filtered.length - 1]);
+    if (dayDiff(today, last) > 1) {
+      filtered = [];
+    } else {
+      for (let i = filtered.length - 1; i > 0; i--) {
+        const cur = new Date(filtered[i]);
+        const prev = new Date(filtered[i - 1]);
+        if (dayDiff(cur, prev) !== 1) {
+          filtered = [];
+          break;
+        }
+      }
+    }
+    try {
+      localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
+    } catch {}
+  }
+
   return filtered;
 }
 

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { loadStreakDays, addStreakDay, STREAK_DAYS_KEY, USED_STREAK_DAYS_KEY } from '../src/utils/streak';
 
 describe('streak days loading', () => {
@@ -10,6 +10,7 @@ describe('streak days loading', () => {
   });
 
   it('filters out used streak days on load', () => {
+    vi.setSystemTime(new Date('2024-07-04T00:00:00Z'));
     localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(['2024-07-01', '2024-07-03']));
     localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(['2024-07-01', '2024-07-02']));
 
@@ -19,8 +20,21 @@ describe('streak days loading', () => {
   });
 
   it('adds new streak day when not used', () => {
+    vi.setSystemTime(new Date('2024-07-02T00:00:00Z'));
     localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(['2024-07-01']));
     addStreakDay('2024-07-02');
     expect(loadStreakDays()).toEqual(['2024-07-02']);
+  });
+
+  it('resets streak if last date is older than yesterday', () => {
+    vi.setSystemTime(new Date('2024-07-12T00:00:00Z'));
+    localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(['2024-07-08','2024-07-09','2024-07-10']));
+    expect(loadStreakDays()).toEqual([]);
+  });
+
+  it('keeps streak when continuous up to yesterday', () => {
+    vi.setSystemTime(new Date('2024-07-12T00:00:00Z'));
+    localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(['2024-07-10','2024-07-11']));
+    expect(loadStreakDays()).toEqual(['2024-07-10','2024-07-11']);
   });
 });


### PR DESCRIPTION
## Summary
- validate streak continuity when loading from localStorage
- load streak days once when the app mounts
- update streak tests for continuity rules

## Testing
- `npm test` *(fails: PASS with watcher but manual check)*
- `npm run lint` *(fails: 62 errors, 41 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68743d016460832fae5ba2942ea14c8b