### PR TITLE
Add streak badge unlocks

### DIFF
--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -1,5 +1,7 @@
 export const STREAK_DAYS_KEY = 'streakDays';
 export const USED_STREAK_DAYS_KEY = 'usedStreakDays';
+export const BADGES_KEY = 'badges';
+export const REDEEMABLE_STREAKS_KEY = 'redeemableStreaks';
 
 function dayDiff(a: Date, b: Date): number {
   const ms = 24 * 60 * 60 * 1000;
@@ -58,5 +60,38 @@ export function addStreakDay(date: string): void {
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(current));
     } catch {}
+    handleStreakMilestone(current);
   }
+}
+
+const MILESTONES = [5, 10, 15, 20, 30];
+
+function handleStreakMilestone(days: string[]): void {
+  if (!MILESTONES.includes(days.length)) {
+    return;
+  }
+
+  const count = days.length;
+
+  try {
+    const badges = JSON.parse(localStorage.getItem(BADGES_KEY) || '{}');
+    badges[`${count}_day_streak`] = true;
+    localStorage.setItem(BADGES_KEY, JSON.stringify(badges));
+  } catch {}
+
+  try {
+    const used = JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY) || '[]');
+    const updated = used.concat(days);
+    localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(updated));
+  } catch {}
+
+  try {
+    localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify([]));
+  } catch {}
+
+  try {
+    const redeem = JSON.parse(localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '[]');
+    redeem.push(days);
+    localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
+  } catch {}
 }

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -37,4 +37,35 @@ describe('streak days loading', () => {
     localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(['2024-07-10','2024-07-11']));
     expect(loadStreakDays()).toEqual(['2024-07-10','2024-07-11']);
   });
+
+  it('unlocks badge at milestone and resets streak', () => {
+    for (let i = 1; i <= 5; i++) {
+      const date = `2024-07-0${i}`;
+      vi.setSystemTime(new Date(`${date}T00:00:00Z`));
+      addStreakDay(date);
+    }
+
+    const badges = JSON.parse(localStorage.getItem('badges') || '{}');
+    expect(badges['5_day_streak']).toBe(true);
+
+    expect(JSON.parse(localStorage.getItem(STREAK_DAYS_KEY)!)).toEqual([]);
+
+    expect(JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY)!)).toEqual([
+      '2024-07-01',
+      '2024-07-02',
+      '2024-07-03',
+      '2024-07-04',
+      '2024-07-05'
+    ]);
+
+    expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '[]')).toEqual([
+      [
+        '2024-07-01',
+        '2024-07-02',
+        '2024-07-03',
+        '2024-07-04',
+        '2024-07-05'
+      ]
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- track badges and redeemable streaks in `streak.ts`
- unlock milestone badges and reset streaks when hitting 5+ days
- test badge unlocking behaviour

## Testing
- `npm run lint` *(fails: 66 errors)*
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_687449773c90832fa73aba8d4f6588ed