### PR TITLE
Implement redeemable streaks store

### DIFF
--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -90,8 +90,18 @@ function handleStreakMilestone(days: string[]): void {
   } catch {}
 
   try {
-    const redeem = JSON.parse(localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '[]');
-    redeem.push(days);
+    const redeem = JSON.parse(localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '{}');
+    redeem[`${count}_day_streak`] = days;
     localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
+  } catch {}
+}
+
+export function redeemBadge(badgeKey: string): void {
+  try {
+    const redeem = JSON.parse(localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '{}');
+    if (redeem[badgeKey]) {
+      delete redeem[badgeKey];
+      localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
+    }
   } catch {}
 }

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { loadStreakDays, addStreakDay, STREAK_DAYS_KEY, USED_STREAK_DAYS_KEY } from '../src/utils/streak';
+import { loadStreakDays, addStreakDay, STREAK_DAYS_KEY, USED_STREAK_DAYS_KEY, redeemBadge } from '../src/utils/streak';
 
 describe('streak days loading', () => {
   beforeEach(() => {
@@ -58,14 +58,22 @@ describe('streak days loading', () => {
       '2024-07-05'
     ]);
 
-    expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '[]')).toEqual([
-      [
+    expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '{}')).toEqual({
+      '5_day_streak': [
         '2024-07-01',
         '2024-07-02',
         '2024-07-03',
         '2024-07-04',
         '2024-07-05'
       ]
-    ]);
+    });
+  });
+
+  it('allows redeeming a badge', () => {
+    localStorage.setItem('redeemableStreaks', JSON.stringify({
+      '5_day_streak': ['2024-07-01']
+    }));
+    redeemBadge('5_day_streak');
+    expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '{}')).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary
- store each redeemable streak keyed by badge
- add helper to redeem a badge
- test redeemable streak storage and redemption

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687450042de8832f9e18d579ec449589