### PR TITLE
Add medal redemption UI

### DIFF
--- a/src/components/MedalCabinet.tsx
+++ b/src/components/MedalCabinet.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { saveMedalRedemption, loadMedalRedemptions } from '@/utils/medals';
+import { redeemBadge } from '@/utils/streak';
+
+interface MedalInfo {
+  key: string;
+  redeemed: boolean;
+  text: string;
+}
+
+const MedalCabinet: React.FC = () => {
+  const [medals, setMedals] = useState<MedalInfo[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    const load = () => {
+      let badges: Record<string, boolean> = {};
+      try {
+        badges = JSON.parse(localStorage.getItem('badges') || '{}');
+      } catch {
+        badges = {};
+      }
+      const redemptions = loadMedalRedemptions();
+      const list: MedalInfo[] = Object.keys(badges).map(key => ({
+        key,
+        redeemed: !!redemptions[key],
+        text: redemptions[key] || ''
+      }));
+      setMedals(list);
+    };
+    load();
+  }, []);
+
+  const openRedeem = (key: string) => {
+    setActive(key);
+    setInput('');
+  };
+
+  const closeRedeem = () => {
+    setActive(null);
+    setInput('');
+  };
+
+  const handleSave = () => {
+    if (!active || input.trim() === '') return;
+    saveMedalRedemption(active, input.trim());
+    redeemBadge(active);
+    const updated = medals.map(m =>
+      m.key === active ? { ...m, redeemed: true, text: input.trim() } : m
+    );
+    setMedals(updated);
+    closeRedeem();
+  };
+
+  if (medals.length === 0) return null;
+
+  return (
+    <div className="mt-6 space-y-2">
+      <h3 className="font-semibold">Medals</h3>
+      {medals.map(medal => (
+        <div
+          key={medal.key}
+          className="flex items-center justify-between border rounded-md p-2"
+        >
+          <div>
+            <p className="text-sm font-medium">{medal.key}</p>
+            {medal.redeemed && (
+              <p className="text-xs text-muted-foreground">
+                Redeemed: {medal.text}
+              </p>
+            )}
+          </div>
+          {!medal.redeemed && (
+            <Button size="sm" onClick={() => openRedeem(medal.key)}>
+              Redeem
+            </Button>
+          )}
+        </div>
+      ))}
+      <Dialog open={!!active} onOpenChange={closeRedeem}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>🎁 Redeem Your Reward</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder="Enter your reward request"
+            required
+          />
+          <DialogFooter>
+            <Button variant="secondary" onClick={closeRedeem}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default MedalCabinet;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import VocabularyApp from '@/components/VocabularyApp';
 import VoiceDebugPanel from '@/components/VoiceDebugPanel';
+import MedalCabinet from '@/components/MedalCabinet';
 
 const Index = () => {
   return (
@@ -21,6 +22,7 @@ const Index = () => {
       
       <main className="container mx-auto px-2">
         <VocabularyApp />
+        <MedalCabinet />
       </main>
       
       <footer className="mt-6 text-center text-sm text-muted-foreground">

--- a/src/utils/medals.ts
+++ b/src/utils/medals.ts
@@ -1,0 +1,17 @@
+export const MEDAL_REDEMPTIONS_KEY = 'medalRedemptions';
+
+export function loadMedalRedemptions(): Record<string, string> {
+  try {
+    return JSON.parse(localStorage.getItem(MEDAL_REDEMPTIONS_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+export function saveMedalRedemption(key: string, text: string): void {
+  const data = loadMedalRedemptions();
+  data[key] = text;
+  try {
+    localStorage.setItem(MEDAL_REDEMPTIONS_KEY, JSON.stringify(data));
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- allow redemption of medals that have been earned
- add `MedalCabinet` component with redeem modal
- expose medal redemption utilities
- display medal cabinet on the main page

## Testing
- `npm install` *(to install dependencies)*
- `npx vitest run` *(fails: include/exclude output only)*
- `npx eslint src` *(fails: include/exclude output only)*

------
https://chatgpt.com/codex/tasks/task_e_687452291e7c832f860520c54f6468d6