### PR TITLE
Prevent medal streak day reuse

### DIFF
--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -24,6 +24,7 @@ export function loadStreakDays(): string[] {
     usedDays = [];
   }
   let filtered = streakDays.filter(day => !usedDays.includes(day));
+  filtered = Array.from(new Set(filtered));
   if (filtered.length !== streakDays.length) {
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
@@ -81,7 +82,7 @@ function handleStreakMilestone(days: string[]): void {
 
   try {
     const used = JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY) || '[]');
-    const updated = used.concat(days);
+    const updated = Array.from(new Set(used.concat(days)));
     localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(updated));
   } catch {}
 

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -76,4 +76,32 @@ describe('streak days loading', () => {
     redeemBadge('5_day_streak');
     expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '{}')).toEqual({});
   });
+
+  it('does not reuse days across milestones', () => {
+    for (let i = 1; i <= 5; i++) {
+      const date = `2024-07-0${i}`;
+      vi.setSystemTime(new Date(`${date}T00:00:00Z`));
+      addStreakDay(date);
+    }
+
+    for (let i = 6; i <= 10; i++) {
+      const date = `2024-07-${i < 10 ? '0' + i : i}`;
+      vi.setSystemTime(new Date(`${date}T00:00:00Z`));
+      addStreakDay(date);
+    }
+
+    const used = JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY) || '[]');
+    expect(used).toEqual([
+      '2024-07-01',
+      '2024-07-02',
+      '2024-07-03',
+      '2024-07-04',
+      '2024-07-05',
+      '2024-07-06',
+      '2024-07-07',
+      '2024-07-08',
+      '2024-07-09',
+      '2024-07-10'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- deduplicate streak days when filtering
- avoid saving duplicate dates in `usedStreakDays`
- test that streak days aren't reused across milestones

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687458027c64832fbfabf83b93c59961