### PR TITLE
Fix streak overlap cleanup

### DIFF
--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -91,7 +91,18 @@ function handleStreakMilestone(days: string[]): void {
   } catch {}
 
   try {
-    const redeem = JSON.parse(localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '{}');
+    const redeem: Record<string, string[]> = JSON.parse(
+      localStorage.getItem(REDEEMABLE_STREAKS_KEY) || '{}'
+    );
+    for (const key of Object.keys(redeem)) {
+      const match = key.match(/^(\d+)_day_streak$/);
+      if (match && parseInt(match[1], 10) < count) {
+        const oldDays: string[] = redeem[key];
+        if (oldDays.some(d => days.includes(d))) {
+          delete redeem[key];
+        }
+      }
+    }
     redeem[`${count}_day_streak`] = days;
     localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
   } catch {}

--- a/tests/streakTracking.test.ts
+++ b/tests/streakTracking.test.ts
@@ -104,4 +104,48 @@ describe('streak days loading', () => {
       '2024-07-10'
     ]);
   });
+
+  it('removes overlapping lower redeemable streaks', () => {
+    vi.setSystemTime(new Date('2024-07-10T00:00:00Z'));
+    localStorage.setItem('redeemableStreaks', JSON.stringify({
+      '5_day_streak': [
+        '2024-07-01',
+        '2024-07-02',
+        '2024-07-03',
+        '2024-07-04',
+        '2024-07-05'
+      ]
+    }));
+    localStorage.setItem(
+      STREAK_DAYS_KEY,
+      JSON.stringify([
+        '2024-07-01',
+        '2024-07-02',
+        '2024-07-03',
+        '2024-07-04',
+        '2024-07-05',
+        '2024-07-06',
+        '2024-07-07',
+        '2024-07-08',
+        '2024-07-09'
+      ])
+    );
+
+    addStreakDay('2024-07-10');
+
+    expect(JSON.parse(localStorage.getItem('redeemableStreaks') || '{}')).toEqual({
+      '10_day_streak': [
+        '2024-07-01',
+        '2024-07-02',
+        '2024-07-03',
+        '2024-07-04',
+        '2024-07-05',
+        '2024-07-06',
+        '2024-07-07',
+        '2024-07-08',
+        '2024-07-09',
+        '2024-07-10'
+      ]
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- clear overlapping lower streaks once a higher streak is unlocked
- test removal of overlapping streaks when a 10-day medal is earned

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 109 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68746ad9e99c832fb83b2e983e673f63