### PR TITLE
Add sticker history UI and persistence test

### DIFF
--- a/src/components/StickerHistory.tsx
+++ b/src/components/StickerHistory.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+const STICKERS_KEY = 'stickers';
+
+const StickerHistory: React.FC = () => {
+  const [dates, setDates] = useState<string[]>([]);
+
+  useEffect(() => {
+    try {
+      const data = JSON.parse(localStorage.getItem(STICKERS_KEY) || '[]');
+      if (Array.isArray(data)) {
+        setDates(data);
+      }
+    } catch {
+      setDates([]);
+    }
+  }, []);
+
+  if (dates.length === 0) return null;
+
+  return (
+    <div className="mt-6 space-y-1">
+      <h3 className="font-semibold">Learning Days</h3>
+      <ul className="list-disc pl-4">
+        {dates.map(date => (
+          <li key={date} className="text-sm">
+            {date}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StickerHistory;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import VocabularyApp from '@/components/VocabularyApp';
 import VoiceDebugPanel from '@/components/VoiceDebugPanel';
 import MedalCabinet from '@/components/MedalCabinet';
+import StickerHistory from '@/components/StickerHistory';
 
 const Index = () => {
   return (
@@ -23,6 +24,7 @@ const Index = () => {
       <main className="container mx-auto px-2">
         <VocabularyApp />
         <MedalCabinet />
+        <StickerHistory />
       </main>
       
       <footer className="mt-6 text-center text-sm text-muted-foreground">

--- a/tests/stickerHistory.test.ts
+++ b/tests/stickerHistory.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useDailyUsageTracker } from '../src/hooks/useDailyUsageTracker';
+
+const advanceSession = async (ms: number) => {
+  vi.advanceTimersByTime(ms);
+  await Promise.resolve();
+};
+
+describe('sticker history persistence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('keeps sticker dates after earning a medal', async () => {
+    const start = new Date('2024-07-01T00:00:00Z');
+
+    for (let i = 0; i < 5; i++) {
+      vi.setSystemTime(new Date(start.getTime() + i * 24 * 60 * 60 * 1000));
+      const { unmount } = renderHook(() => useDailyUsageTracker());
+      await advanceSession(16 * 60 * 1000);
+      act(() => window.dispatchEvent(new Event('beforeunload')));
+      unmount();
+    }
+
+    const stickers = JSON.parse(localStorage.getItem('stickers') || '[]');
+    expect(stickers).toEqual([
+      '2024-07-01',
+      '2024-07-02',
+      '2024-07-03',
+      '2024-07-04',
+      '2024-07-05'
+    ]);
+
+    expect(JSON.parse(localStorage.getItem('streakDays') || '[]')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- display all sticker dates with `StickerHistory` component
- show sticker history below medals on the index page
- test that sticker dates remain after a medal is earned

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68746f28d214832faa007783281d6f9b