### PR TITLE
Show star sticker icons

### DIFF
--- a/src/components/StickerHistory.tsx
+++ b/src/components/StickerHistory.tsx
@@ -21,13 +21,20 @@ const StickerHistory: React.FC = () => {
   return (
     <div className="mt-6 space-y-1">
       <h3 className="font-semibold">Learning Days</h3>
-      <ul className="list-disc pl-4">
+      <div className="flex flex-wrap gap-2 justify-start">
         {dates.map(date => (
-          <li key={date} className="text-sm">
-            {date}
-          </li>
+          <div key={date} className="flex flex-col items-center w-16">
+            <img
+              src="/assets/star-sticker.png"
+              alt={`Sticker earned on ${date}`}
+              className="w-12 h-12"
+            />
+            <span className="text-[0.75rem] text-gray-600 mt-1">
+              {date}
+            </span>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- display earned stickers as star icons
- remove `star-sticker.png` as requested

## Testing
- `npx vitest run`
- `npm run lint` *(fails: `no-empty` and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687486328ef8832fa02a40d1f6aa67b8