### PR TITLE
Adjust layout order of medals and stickers

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -3,6 +3,8 @@ import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyMainNew from './VocabularyMainNew';
 import DebugPanel from '@/components/DebugPanel';
 import AddWordModal from './AddWordModal';
+import MedalCabinet from '@/components/MedalCabinet';
+import StickerHistory from '@/components/StickerHistory';
 
 interface ContentWithDataNewProps {
   displayWord: VocabularyWord;
@@ -67,10 +69,14 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         isSoundPlaying={isSpeaking}
         handleManualNext={handleManualNext}
         displayTime={displayTime}
-        selectedVoiceName={selectedVoiceName}
+      selectedVoiceName={selectedVoiceName}
       onOpenAddModal={handleOpenAddWordModal}
-        onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
+      onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       />
+
+      {/* Achievements and learning days */}
+      <MedalCabinet />
+      <StickerHistory />
 
       {/* Mobile speech note statically above debug panel */}
       <div className="mobile-note text-xs italic text-gray-500 text-left my-2">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,8 +23,6 @@ const Index = () => {
       
       <main className="container mx-auto px-2">
         <VocabularyApp />
-        <MedalCabinet />
-        <StickerHistory />
       </main>
       
       <footer className="mt-6 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- render `MedalCabinet` and `StickerHistory` inside `ContentWithDataNew`
- remove medal and sticker components from the page layout

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6874b20d1578832f8992c605a996d310