### PR TITLE
Move debug below footer

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,11 +1,12 @@
 
-import React from 'react';
+import React, { useContext } from 'react';
 import { vocabularyService } from '@/services/vocabularyService';
+import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 
 interface DebugPanelProps {
-  isMuted: boolean;
-  selectedVoiceName: string;
-  isPaused: boolean;
+  isMuted?: boolean;
+  selectedVoiceName?: string;
+  isPaused?: boolean;
   currentWord?: {
     word: string;
     category: string;
@@ -13,11 +14,16 @@ interface DebugPanelProps {
 }
 
 const DebugPanel: React.FC<DebugPanelProps> = ({
-  isMuted,
-  selectedVoiceName,
-  isPaused,
-  currentWord
+  isMuted: mutedProp,
+  selectedVoiceName: voiceProp,
+  isPaused: pausedProp,
+  currentWord: wordProp
 }) => {
+  const context = useContext(DebugInfoContext);
+  const isMuted = mutedProp ?? context?.isMuted ?? false;
+  const selectedVoiceName = voiceProp ?? context?.selectedVoiceName ?? '';
+  const isPaused = pausedProp ?? context?.isPaused ?? false;
+  const currentWord = wordProp ?? context?.currentWord ?? null;
   const currentCategory = vocabularyService.getCurrentSheetName();
   
   return (

--- a/src/components/vocabulary-app/ContentWithData.tsx
+++ b/src/components/vocabulary-app/ContentWithData.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyMain from './VocabularyMain';
-import DebugPanel from '@/components/DebugPanel';
 import AddWordModal from './AddWordModal';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 
@@ -20,7 +19,6 @@ interface ContentWithDataProps {
   displayTime: number;
   selectedVoice: VoiceSelection;
   nextVoiceLabel: string;
-  debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
   handleSaveWord: (wordData: { word: string; meaning: string; example: string; category: string }) => void;
@@ -45,7 +43,6 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
   displayTime,
   selectedVoice,
   nextVoiceLabel,
-  debugPanelData,
   isAddWordModalOpen,
   handleCloseModal,
   handleSaveWord,
@@ -78,13 +75,7 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
       />
       
       
-      {/* Debug Panel */}
-      <DebugPanel 
-        isMuted={muted}
-        voiceRegion={selectedVoice.region}
-        isPaused={paused}
-        currentWord={debugPanelData}
-      />
+
       
       {/* Enhanced Word Modal (handles both add and edit) */}
       <AddWordModal 

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyMainNew from './VocabularyMainNew';
-import DebugPanel from '@/components/DebugPanel';
 import AddWordModal from './AddWordModal';
 import MedalCabinet from '@/components/MedalCabinet';
 import StickerHistory from '@/components/StickerHistory';
@@ -20,7 +19,6 @@ interface ContentWithDataNewProps {
   handleManualNext: () => void;
   displayTime: number;
   selectedVoiceName: string;
-  debugPanelData: any;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
   handleSaveWord: (wordData: { word: string; meaning: string; example: string; category: string }) => void;
@@ -44,7 +42,6 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleManualNext,
   displayTime,
   selectedVoiceName,
-  debugPanelData,
   isAddWordModalOpen,
   handleCloseModal,
   handleSaveWord,
@@ -91,13 +88,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         </p>
       </div>
 
-      {/* Debug Panel */}
-      <DebugPanel
-        isMuted={muted}
-        voiceRegion={selectedVoiceName}
-        isPaused={paused}
-        currentWord={debugPanelData}
-      />
+
       
       {/* Enhanced Word Modal (handles both add and edit) */}
       <AddWordModal 

--- a/src/components/vocabulary-app/VocabularyAppContainer.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainer.tsx
@@ -1,5 +1,5 @@
 
-import React from "react";
+import React, { useMemo } from "react";
 import VocabularyLayout from "@/components/VocabularyLayout";
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { useAudioInitialization } from "@/hooks/vocabulary-app/useAudioInitialization";
@@ -10,6 +10,7 @@ import { useVocabularyAppState } from "./hooks/useVocabularyAppState";
 import { useDisplayWord } from "./hooks/useDisplayWord";
 import { useVoiceLabels } from "./hooks/useVoiceLabels";
 import VocabularyAppContent from "./components/VocabularyAppContent";
+import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 
 const VocabularyAppContainer: React.FC = () => {
   console.log('[VOCAB-CONTAINER] === Component Render ===');
@@ -58,6 +59,13 @@ const VocabularyAppContainer: React.FC = () => {
 
   // Determine display word with fallback logic
   const { displayWord, debugData } = useDisplayWord(playbackCurrentWord, wordList || [], hasData);
+
+  const debugInfo = useMemo(() => ({
+    isMuted: muted,
+    selectedVoiceName: typeof selectedVoice === 'string' ? selectedVoice : selectedVoice?.region || 'UK',
+    isPaused: paused,
+    currentWord: debugData
+  }), [muted, selectedVoice, paused, debugData]);
 
   // Ensure selectedVoice has all required properties for voice labels
   // Handle both VoiceSelection and simplified { region } objects
@@ -139,6 +147,7 @@ const VocabularyAppContainer: React.FC = () => {
   const displaySelectedVoice = typeof selectedVoice === 'string' ? selectedVoice : selectedVoice?.region || 'UK';
 
   return (
+    <DebugInfoContext.Provider value={debugInfo}>
     <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
         <VocabularyAppContent
         hasData={hasData}
@@ -153,7 +162,6 @@ const VocabularyAppContainer: React.FC = () => {
         currentCategory={currentCategory}
         nextCategory={nextCategory}
         displayTime={displayTime}
-        debugData={debugData}
         isAddWordModalOpen={isAddWordModalOpen}
         isEditMode={isEditMode}
         wordToEdit={wordToEdit}
@@ -168,6 +176,7 @@ const VocabularyAppContainer: React.FC = () => {
         handleOpenEditWordModal={handleOpenEditWordModal}
       />
     </VocabularyLayout>
+    </DebugInfoContext.Provider>
   );
 };
 

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -10,6 +10,7 @@ import { useStableVocabularyState } from "@/hooks/vocabulary-app/useStableVocabu
 import { useOptimizedAutoPlay } from "@/hooks/vocabulary-app/useOptimizedAutoPlay";
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { vocabularyService } from '@/services/vocabularyService';
+import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 
 const VocabularyAppContainerNew: React.FC = () => {
   // Use stable state management
@@ -77,10 +78,18 @@ const VocabularyAppContainerNew: React.FC = () => {
       : null;
   }, [currentWord?.word, currentWord?.category, currentCategory]);
 
+  const debugInfo = useMemo(() => ({
+    isMuted,
+    selectedVoiceName,
+    isPaused,
+    currentWord: debugData
+  }), [isMuted, selectedVoiceName, isPaused, debugData]);
+
   let content: React.ReactNode;
 
   if (!hasData && !vocabularyService.hasData()) {
     return (
+      <DebugInfoContext.Provider value={debugInfo}>
       <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -108,11 +117,13 @@ const VocabularyAppContainerNew: React.FC = () => {
           />
         </div>
         </VocabularyLayout>
-      );
+      </DebugInfoContext.Provider>
+    );
   }
 
   if (!hasData) {
     return (
+      <DebugInfoContext.Provider value={debugInfo}>
       <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -140,11 +151,13 @@ const VocabularyAppContainerNew: React.FC = () => {
           />
         </div>
         </VocabularyLayout>
-      );
+      </DebugInfoContext.Provider>
+    );
   }
 
   if (!currentWord) {
     return (
+      <DebugInfoContext.Provider value={debugInfo}>
       <VocabularyLayout showWordCard={true} hasData={true} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -172,6 +185,7 @@ const VocabularyAppContainerNew: React.FC = () => {
           />
         </div>
       </VocabularyLayout>
+      </DebugInfoContext.Provider>
       );
   } else {
     content = (
@@ -199,7 +213,6 @@ const VocabularyAppContainerNew: React.FC = () => {
             handleManualNext={goToNextAndSpeak}
             displayTime={5000}
             selectedVoiceName={selectedVoiceName}
-            debugPanelData={debugData}
             isAddWordModalOpen={isAddWordModalOpen}
             handleCloseModal={handleCloseModal}
             handleSaveWord={handleSaveWord}
@@ -214,6 +227,7 @@ const VocabularyAppContainerNew: React.FC = () => {
   }
 
   return (
+    <DebugInfoContext.Provider value={debugInfo}>
     <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
       <div className="space-y-4">
         <UserInteractionManager
@@ -238,7 +252,6 @@ const VocabularyAppContainerNew: React.FC = () => {
           handleManualNext={goToNextAndSpeak}
           displayTime={5000}
           selectedVoiceName={selectedVoiceName}
-          debugPanelData={debugData}
           isAddWordModalOpen={isAddWordModalOpen}
           handleCloseModal={handleCloseModal}
           handleSaveWord={handleSaveWord}
@@ -249,6 +262,7 @@ const VocabularyAppContainerNew: React.FC = () => {
         />
       </div>
     </VocabularyLayout>
+    </DebugInfoContext.Provider>
   );
 };
 

--- a/src/components/vocabulary-app/components/VocabularyAppContent.tsx
+++ b/src/components/vocabulary-app/components/VocabularyAppContent.tsx
@@ -19,7 +19,6 @@ interface VocabularyAppContentProps {
   currentCategory: string;
   nextCategory: string | null;
   displayTime: number;
-  debugData: any;
   isAddWordModalOpen: boolean;
   isEditMode: boolean;
   wordToEdit: any;
@@ -47,7 +46,6 @@ const VocabularyAppContent: React.FC<VocabularyAppContentProps> = ({
   currentCategory,
   nextCategory,
   displayTime,
-  debugData,
   isAddWordModalOpen,
   isEditMode,
   wordToEdit,
@@ -82,7 +80,6 @@ const VocabularyAppContent: React.FC<VocabularyAppContentProps> = ({
           handleManualNext={handleManualNext}
           displayTime={displayTime}
           selectedVoice={selectedVoice}
-          debugPanelData={debugData}
           isAddWordModalOpen={isAddWordModalOpen}
           handleCloseModal={handleCloseModal}
           handleSaveWord={handleSaveWord}

--- a/src/contexts/DebugInfoContext.tsx
+++ b/src/contexts/DebugInfoContext.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface DebugInfo {
+  isMuted: boolean;
+  selectedVoiceName: string;
+  isPaused: boolean;
+  currentWord?: {
+    word: string;
+    category: string;
+  } | null;
+}
+
+export const DebugInfoContext = React.createContext<DebugInfo | null>(null);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import VocabularyApp from '@/components/VocabularyApp';
 import VoiceDebugPanel from '@/components/VoiceDebugPanel';
-import MedalCabinet from '@/components/MedalCabinet';
-import StickerHistory from '@/components/StickerHistory';
+import DebugPanel from '@/components/DebugPanel';
 
 const Index = () => {
   return (
@@ -29,6 +28,7 @@ const Index = () => {
         <p>© 2025 Lazy Vocabulary - hoctusach@gmail.com</p>
       </footer>
       <VoiceDebugPanel />
+      <DebugPanel />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `DebugInfoContext` to expose audio debug state
- use context in `DebugPanel`
- remove in-place debug panel from main content
- wrap vocabulary containers with provider
- render `DebugPanel` after the footer on the index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874bfa87858832f84b6290a63d7a89c