### PR TITLE
Update voice toggling behaviour

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -55,19 +55,9 @@ export const useVocabularyControls = (
     const nextVoice = allVoices[nextIndex];
     setSelectedVoiceName(nextVoice.name);
     localStorage.setItem('preferredVoiceName', nextVoice.name);
-    if (currentWord && !isMuted && !isPaused) {
-      unifiedSpeechController.stop();
-      unifiedSpeechController.speak(currentWord, nextVoice.name);
-    }
+    unifiedSpeechController.stop();
     toast.success(`Voice changed to ${nextVoice.name} (${nextVoice.lang})`);
-  }, [
-    allVoices,
-    selectedVoiceName,
-    setSelectedVoiceName,
-    currentWord,
-    isMuted,
-    isPaused
-  ]);
+  }, [allVoices, selectedVoiceName, setSelectedVoiceName]);
 
 
   // Switch category with mobile-friendly handling

--- a/tests/useSpeechIntegrationVoiceChange.test.ts
+++ b/tests/useSpeechIntegrationVoiceChange.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useSpeechIntegration } from '../src/hooks/vocabulary-controller/core/useSpeechIntegration';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+vi.mock('../src/services/speech/unifiedSpeechController', () => ({
+  unifiedSpeechController: { speak: vi.fn(), stop: vi.fn() }
+}));
+
+import { unifiedSpeechController } from '../src/services/speech/unifiedSpeechController';
+
+describe('useSpeechIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replays current word when voice changes', async () => {
+    const word: VocabularyWord = { word: 'water', meaning: '', example: '', category: 'c' };
+    const isTrans = { current: false };
+    let voice = 'Voice 1';
+    const { rerender } = renderHook(({ voiceName }) =>
+      useSpeechIntegration(word, voiceName, false, false, isTrans),
+      { initialProps: { voiceName: voice } }
+    );
+
+    await Promise.resolve();
+    expect(unifiedSpeechController.speak).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      voice = 'Voice 2';
+      rerender({ voiceName: voice });
+    });
+
+    await Promise.resolve();
+    expect(unifiedSpeechController.speak).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/useVocabularyControlsVoiceToggle.test.ts
+++ b/tests/useVocabularyControlsVoiceToggle.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useVocabularyControls } from '../src/hooks/vocabulary-controller/core/useVocabularyControls';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+vi.mock('../src/services/speech/unifiedSpeechController', () => ({
+  unifiedSpeechController: { stop: vi.fn(), speak: vi.fn() }
+}));
+
+import { unifiedSpeechController } from '../src/services/speech/unifiedSpeechController';
+
+describe('useVocabularyControls toggleVoice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates voice and stops speech without speaking immediately', () => {
+    const voices = [
+      { name: 'Voice 1', lang: 'en-US' } as SpeechSynthesisVoice,
+      { name: 'Voice 2', lang: 'en-US' } as SpeechSynthesisVoice
+    ];
+    const word: VocabularyWord = { word: 'test', meaning: '', example: '', category: 'c' };
+    let voiceName = voices[0].name;
+    const { result } = renderHook(() =>
+      useVocabularyControls(
+        false,
+        () => {},
+        false,
+        () => {},
+        voices,
+        voiceName,
+        n => (voiceName = n),
+        { phase: 'idle', isActive: false, isPaused: false, isMuted: false, currentWord: word, currentUtterance: null },
+        word
+      )
+    );
+
+    act(() => {
+      result.current.toggleVoice();
+    });
+
+    expect(voiceName).toBe(voices[1].name);
+    expect(unifiedSpeechController.stop).toHaveBeenCalled();
+    expect(unifiedSpeechController.speak).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- stop speech on voice toggle without immediately replaying
- automatically replay current word when voice changes
- add tests for new behaviour

## Testing
- `npx vitest run`
- `npm run lint` *(fails: no-empty blocks and other issues)*
- `npm run dev` *(started Vite server)*

------
https://chatgpt.com/codex/tasks/task_e_6875d68bb4a0832fa92196045ca4d22b