### PR TITLE
Enable region-specific voice cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ characters intact when preparing text for speech.
 
 ## Voice Settings
 
-The controls panel includes a single **Change Voice** button. Clicking it cycles through the voices available on the current device via `speechSynthesis.getVoices()`. The chosen voice name is stored in `localStorage` so it persists between sessions and is loaded on start.
+The controls panel includes a **Change Voice** button. Voices are organised by region (US, UK and AU). Clicking the button cycles through the voices for the currently selected region. Each region remembers its last chosen voice under `voiceSettings.us`, `voiceSettings.uk` and `voiceSettings.au` in `localStorage` so your preference persists between sessions.
 
 ## Word display
 

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -21,12 +21,13 @@ interface VocabularyControlsColumnProps {
   onTogglePause: () => void;
   onNextWord: () => void;
   onSwitchCategory: () => void;
-  onCycleVoice: () => void;
+  onCycleVoice: (region: 'US' | 'UK' | 'AU') => void;
   nextCategory: string;
   currentWord: VocabularyWord | null;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
-  selectedVoiceName: string;
+  voiceRegion: 'US' | 'UK' | 'AU';
+  nextVoiceLabel?: string;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,7 +42,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   currentWord,
   onOpenAddModal,
   onOpenEditModal,
-  selectedVoiceName
+  voiceRegion,
+  nextVoiceLabel
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
@@ -69,18 +71,19 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const handleCycleVoice = () => {
-    if (allVoices.length === 0) {
+    const regionVoices = allVoices[voiceRegion];
+    if (regionVoices.length === 0) {
       toast.warning('No voices available');
       return;
     }
-    onCycleVoice();
+    onCycleVoice(voiceRegion);
   };
 
   const handleRateChange = (r: number) => {
     setSpeechRate(r);
     if (currentWord && !isMuted && !isPaused) {
       unifiedSpeechController.stop();
-      unifiedSpeechController.speak(currentWord, selectedVoiceName);
+      unifiedSpeechController.speak(currentWord, voiceRegion);
     }
   };
 
@@ -145,8 +148,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         size="sm"
         onClick={handleCycleVoice}
         className="h-8 w-8 p-0 text-blue-700 border-blue-300 bg-blue-50 flex items-center justify-center"
-        title={allVoices.length < 2 ? 'No other voices available' : 'Change Voice'}
-        disabled={allVoices.length < 2}
+        title={allVoices[voiceRegion].length < 2 ? 'No other voices available' : `Change Voice (${nextVoiceLabel})`}
+        disabled={allVoices[voiceRegion].length < 2}
         aria-label="Change Voice"
       >
         <Speaker size={16} />

--- a/src/hooks/useRegionVoices.ts
+++ b/src/hooks/useRegionVoices.ts
@@ -1,20 +1,31 @@
 import { useState, useEffect, useCallback } from 'react';
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
 
-export const useRegionVoices = (region: 'US' | 'UK' | 'AU') => {
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+export const useRegionVoices = () => {
+  const [usVoices, setUsVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [ukVoices, setUkVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [auVoices, setAuVoices] = useState<SpeechSynthesisVoice[]>([]);
 
   const loadVoices = useCallback(() => {
     if (!window.speechSynthesis) return;
     const allVoices = window.speechSynthesis.getVoices();
     logAvailableVoices(allVoices);
-    const regionLangCode = region === 'US' ? 'en-US' : region === 'UK' ? 'en-GB' : 'en-AU';
-    const filtered = allVoices
-      .filter(v => v && v.lang && v.lang.toLowerCase().startsWith(regionLangCode.toLowerCase()))
-      .filter((v, i, arr) => arr.findIndex(o => o.name === v.name) === i);
-    setVoices(filtered);
-    console.log(`[useRegionVoices] ${filtered.length} voices for ${region}`);
-  }, [region]);
+
+    const filterByLang = (lang: string) =>
+      allVoices
+        .filter(v => v && v.lang && v.lang.toLowerCase().startsWith(lang.toLowerCase()))
+        .filter((v, i, arr) => arr.findIndex(o => o.name === v.name) === i);
+
+    const us = filterByLang('en-US');
+    const uk = filterByLang('en-GB');
+    const au = filterByLang('en-AU');
+
+    setUsVoices(us);
+    setUkVoices(uk);
+    setAuVoices(au);
+
+    console.log(`[useRegionVoices] US:${us.length} UK:${uk.length} AU:${au.length}`);
+  }, []);
 
   useEffect(() => {
     loadVoices();
@@ -24,5 +35,5 @@ export const useRegionVoices = (region: 'US' | 'UK' | 'AU') => {
     };
   }, [loadVoices]);
 
-  return voices;
+  return { usVoices, ukVoices, auVoices };
 };

--- a/src/hooks/useVoiceContext.tsx
+++ b/src/hooks/useVoiceContext.tsx
@@ -1,55 +1,69 @@
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
+import { useRegionVoices } from './useRegionVoices';
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
+
+export interface VoiceMap {
+  US: SpeechSynthesisVoice[];
+  UK: SpeechSynthesisVoice[];
+  AU: SpeechSynthesisVoice[];
+}
+
 export interface VoiceContext {
-  allVoices: SpeechSynthesisVoice[];
-  selectedVoiceName: string;
-  setSelectedVoiceName: (name: string) => void;
-  cycleVoice: () => void;
+  allVoices: VoiceMap;
+  selectedVoiceNames: { US: string; UK: string; AU: string };
+  setSelectedVoiceName: (region: 'US' | 'UK' | 'AU', name: string) => void;
+  cycleVoice: (region: 'US' | 'UK' | 'AU') => void;
 }
 
 export const useVoiceContext = (): VoiceContext => {
-  const [allVoices, setAllVoices] = useState<SpeechSynthesisVoice[]>([]);
-  const [selectedVoiceName, setSelectedVoiceName] = useState('');
+  const { usVoices, ukVoices, auVoices } = useRegionVoices();
+  const [selectedVoiceNames, setSelectedVoiceNames] = useState<{ US: string; UK: string; AU: string }>({ US: '', UK: '', AU: '' });
 
   useEffect(() => {
-    const loadVoices = () => {
-      const voices = window.speechSynthesis
-        .getVoices()
-        .filter(v => v.lang && v.lang.toLowerCase().startsWith('en'));
-      logAvailableVoices(voices);
-      setAllVoices(voices);
-      const saved = localStorage.getItem('preferredVoiceName');
-      const preferred = voices.find(v => v.name === saved);
-      if (preferred) {
-        setSelectedVoiceName(preferred.name);
-      } else if (voices.length > 0) {
-        setSelectedVoiceName(voices[0].name);
+    const stored = localStorage.getItem('voiceSettings');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        setSelectedVoiceNames({
+          US: parsed.us || '',
+          UK: parsed.uk || '',
+          AU: parsed.au || ''
+        });
+      } catch (e) {
+        console.error('Failed to parse voiceSettings:', e);
       }
-    };
-
-    window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
-    loadVoices();
-
-    return () => {
-      window.speechSynthesis.removeEventListener('voiceschanged', loadVoices);
-    };
+    }
   }, []);
 
   useEffect(() => {
-    if (selectedVoiceName) {
-      localStorage.setItem('preferredVoiceName', selectedVoiceName);
-    }
-  }, [selectedVoiceName]);
+    const settings = {
+      us: selectedVoiceNames.US,
+      uk: selectedVoiceNames.UK,
+      au: selectedVoiceNames.AU
+    };
+    localStorage.setItem('voiceSettings', JSON.stringify(settings));
+  }, [selectedVoiceNames]);
 
-  const cycleVoice = () => {
-    if (allVoices.length < 2) return;
-    const index = allVoices.findIndex(v => v.name === selectedVoiceName);
-    const nextIndex = (index + 1) % allVoices.length;
-    const nextVoice = allVoices[nextIndex];
-    setSelectedVoiceName(nextVoice.name);
-    localStorage.setItem('preferredVoiceName', nextVoice.name);
+  const getArrayForRegion = (region: 'US' | 'UK' | 'AU') =>
+    region === 'US' ? usVoices : region === 'UK' ? ukVoices : auVoices;
+
+  const setSelectedVoiceName = (region: 'US' | 'UK' | 'AU', name: string) => {
+    setSelectedVoiceNames(prev => ({ ...prev, [region]: name }));
   };
 
-  return { allVoices, selectedVoiceName, setSelectedVoiceName, cycleVoice };
+  const cycleVoice = (region: 'US' | 'UK' | 'AU') => {
+    const list = getArrayForRegion(region);
+    if (list.length < 2) return;
+    const currentName = selectedVoiceNames[region];
+    const index = list.findIndex(v => v.name === currentName);
+    const nextIndex = (index + 1) % list.length;
+    const nextVoice = list[nextIndex];
+    setSelectedVoiceNames(prev => ({ ...prev, [region]: nextVoice.name }));
+    toast.success(`Voice changed to ${nextVoice.name} (${nextVoice.lang})`);
+  };
+
+  const allVoices: VoiceMap = { US: usVoices, UK: ukVoices, AU: auVoices };
+
+  return { allVoices, selectedVoiceNames, setSelectedVoiceName, cycleVoice };
 };

--- a/src/hooks/vocabulary-controller/core/useVocabularyState.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyState.ts
@@ -31,7 +31,7 @@ export const useVocabularyState = () => {
   const [isMuted, setIsMuted] = useState<boolean>(() => getInitialFlag('isMuted'));
   const {
     allVoices,
-    selectedVoiceName,
+    selectedVoiceNames,
     setSelectedVoiceName
   } = useVoiceContext();
 
@@ -67,7 +67,7 @@ export const useVocabularyState = () => {
     setIsPaused,
     isMuted,
     setIsMuted,
-    selectedVoiceName,
+    selectedVoiceNames,
     setSelectedVoiceName,
     allVoices,
     currentWord,

--- a/tests/useVocabularyControlsVoiceToggle.test.ts
+++ b/tests/useVocabularyControlsVoiceToggle.test.ts
@@ -30,16 +30,16 @@ describe('useVocabularyControls toggleVoice', () => {
         () => {},
         false,
         () => {},
-        voices,
-        voiceName,
-        n => (voiceName = n),
+        { US: voices, UK: [], AU: [] },
+        { US: voiceName, UK: '', AU: '' },
+        (region, n) => { if(region==='US') voiceName = n; },
         { phase: 'idle', isActive: false, isPaused: false, isMuted: false, currentWord: word, currentUtterance: null },
         word
       )
     );
 
     act(() => {
-      result.current.toggleVoice();
+      result.current.cycleVoice('US');
     });
 
     expect(voiceName).toBe(voices[1].name);


### PR DESCRIPTION
## Summary
- group speech synthesis voices by region
- persist selected voice per region
- update VocabularyControlsColumn to cycle regional voices
- adjust vocabulary hooks for region-aware voices
- expand voice toggle tests for regional support
- document updated voice settings

## Testing
- `npm test`
- `npm run lint` *(fails: 65 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875ed304474832fb258a4a4e70017d1