### PR TITLE
Fix next voice label by region

### DIFF
--- a/src/hooks/vocabulary-app/useStableVocabularyState.ts
+++ b/src/hooks/vocabulary-app/useStableVocabularyState.ts
@@ -2,6 +2,7 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import { useUnifiedVocabularyController } from '@/hooks/vocabulary-controller/useUnifiedVocabularyController';
 import { vocabularyService } from '@/services/vocabularyService';
+import { useVoiceSettings } from '@/hooks/speech/useVoiceSettings';
 
 export const useStableVocabularyState = () => {
   const [userInteractionState, setUserInteractionState] = useState({
@@ -12,14 +13,16 @@ export const useStableVocabularyState = () => {
 
   // Use stable reference for the unified controller
   const controllerState = useUnifiedVocabularyController();
-  
+  const { voiceRegion } = useVoiceSettings();
+
   // Memoize computed values to prevent recalculation
   const nextVoiceLabel = useMemo(() => {
-    if (controllerState.allVoices.length === 0) return 'Default';
-    const index = controllerState.allVoices.findIndex(v => v.name === controllerState.selectedVoiceName);
-    const nextIndex = (index + 1) % controllerState.allVoices.length;
-    return controllerState.allVoices[nextIndex].name;
-  }, [controllerState.selectedVoiceName, controllerState.allVoices]);
+    const regionVoices = controllerState.allVoices[voiceRegion] || [];
+    if (regionVoices.length === 0) return 'Default';
+    const index = regionVoices.findIndex(v => v.name === controllerState.selectedVoiceName);
+    const nextIndex = (index + 1) % regionVoices.length;
+    return regionVoices[nextIndex]?.name ?? 'Default';
+  }, [controllerState.selectedVoiceName, controllerState.allVoices, voiceRegion]);
 
   const nextCategory = useMemo(() => {
     const sheets = vocabularyService.getAllSheetNames();


### PR DESCRIPTION
## Summary
- wire voice region into `useStableVocabularyState`
- compute next voice label using voices for the current region

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty and no-useless-escape errors)*

------
https://chatgpt.com/codex/tasks/task_e_68762e0cbd38832fa57965b756d7ea7a