### PR TITLE
Embed default vocabulary fallback

### DIFF
--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -1,9 +1,32 @@
 import { SheetData } from "@/types/vocabulary";
-//import { SheetData } from "@/data/defaultVocabulary";
 
-export const DEFAULT_VOCABULARY_DATA: SheetData = 
-//import { SheetData } from "@/data/defaultVocabulary";
-//export const DEFAULT_VOCABULARY_DATA: SheetData = 
-{
-  
-}
+export const DEFAULT_VOCABULARY_DATA: SheetData = {
+  "phrasal verbs": [
+    {
+      word: "to be under house arrest",
+      meaning: "the state of being a prisoner in your own house rather than in a prison",
+      example: "She was placed under house arrest.",
+      count: 0
+    },
+    {
+      word: "Knuckle down",
+      meaning: "to start focusing on your work/study. (Inseparable)",
+      example: "I work as a teacher and we’ve got exams coming soon, so we all need to knuckle down. I study law, and I have exams soon, so I need to knuckle down.",
+      count: 0
+    }
+  ],
+  idioms: [
+    {
+      word: "keep a straight face",
+      meaning: "remain serious and not laugh (giữ vẻ mặt nghiêm túc)",
+      example: "I couldn't keep a straight face when I saw Mike’s new haircut.",
+      count: 0
+    },
+    {
+      word: "keep sb posted",
+      meaning: "regularly give someone information about something they are interested in (thường xuyên cập nhật thông tin)",
+      example: "Do please keep me posted about any developments.",
+      count: 0
+    }
+  ]
+};

--- a/src/services/vocabulary/VocabularyDataManager.ts
+++ b/src/services/vocabulary/VocabularyDataManager.ts
@@ -77,42 +77,37 @@ export class VocabularyDataManager {
     try {
       console.log("Loading default vocabulary data");
       
-      // Try to fetch the updated default vocabulary from public directory
-      fetch('/defaultVocabulary.json')
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(`Failed to fetch default vocabulary: ${response.status}`);
-          }
-          return response.json();
-        })
-        .then(fetchedData => {
-          console.log("Successfully loaded default vocabulary from JSON file");
-          console.log("Fetched data preview:", Object.keys(fetchedData).map(key => 
-            `${key}: ${fetchedData[key]?.length || 0} words`
-          ));
-          
-          // Process data to ensure all fields have proper types
-          this.data = this.dataProcessor.processDataTypes(fetchedData);
-          this.storage.saveData(this.data);
-          
-          // Notify listeners about vocabulary change
-          this.notifyVocabularyChange();
-        })
-        .catch(error => {
-          console.warn("Failed to load from JSON file, using embedded default data:", error);
-          
-          // Use the embedded default data as fallback
-          console.log("Using embedded default vocabulary data");
-          this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
-          this.storage.saveData(this.data);
-          
-          console.log("Embedded data loaded:", Object.keys(this.data).map(key => 
-            `${key}: ${this.data[key]?.length || 0} words`
-          ));
-          
-          // Notify listeners about vocabulary change
-          this.notifyVocabularyChange();
-        });
+      // Try to fetch updated default vocabulary if the Fetch API is available
+      if (typeof fetch === 'function') {
+        fetch('/defaultVocabulary.json')
+          .then(response => {
+            if (!response.ok) {
+              throw new Error(`Failed to fetch default vocabulary: ${response.status}`);
+            }
+            return response.json();
+          })
+          .then(fetchedData => {
+            console.log('Successfully loaded default vocabulary from JSON file');
+            console.log(
+              'Fetched data preview:',
+              Object.keys(fetchedData).map(key => `${key}: ${fetchedData[key]?.length || 0} words`)
+            );
+            this.data = this.dataProcessor.processDataTypes(fetchedData);
+            this.storage.saveData(this.data);
+            this.notifyVocabularyChange();
+          })
+          .catch(error => {
+            console.warn('Failed to load from JSON file, using embedded default data:', error);
+            this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
+            this.storage.saveData(this.data);
+            this.notifyVocabularyChange();
+          });
+      } else {
+        console.warn('Fetch API not available, using embedded default vocabulary data');
+        this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
+        this.storage.saveData(this.data);
+        this.notifyVocabularyChange();
+      }
       
       return true;
     } catch (error) {


### PR DESCRIPTION
## Summary
- add a small built‑in vocabulary dataset
- fall back to this data when fetch fails in `VocabularyDataManager`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68766737ba08832fa201901b5380d8a7