### PR TITLE
Fix autoplay after speech rate change

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -23,9 +23,10 @@ interface ContentWithDataNewProps {
   handleCloseModal: () => void;
   handleSaveWord: (wordData: { word: string; meaning: string; example: string; category: string }) => void;
   isEditMode: boolean;
-  wordToEdit: any;
+  wordToEdit: VocabularyWord | null;
   handleOpenAddWordModal: () => void;
   handleOpenEditWordModal: (word: VocabularyWord) => void;
+  playCurrentWord: () => void;
 }
 
 const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
@@ -48,7 +49,8 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   isEditMode,
   wordToEdit,
   handleOpenAddWordModal,
-  handleOpenEditWordModal
+  handleOpenEditWordModal,
+  playCurrentWord
 }) => {
   return (
     <>
@@ -69,6 +71,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       selectedVoiceName={selectedVoiceName}
       onOpenAddModal={handleOpenAddWordModal}
       onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
+      playCurrentWord={playCurrentWord}
       />
 
       {/* Achievements and learning days */}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -220,6 +220,7 @@ const VocabularyAppContainerNew: React.FC = () => {
             wordToEdit={wordToEdit}
             handleOpenAddWordModal={handleOpenAddWordModal}
             handleOpenEditWordModal={handleOpenEditWordModal}
+            playCurrentWord={playCurrentWord}
           />
         </div>
       </VocabularyLayout>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -27,6 +27,7 @@ interface VocabularyControlsColumnProps {
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
   selectedVoiceName: string;
+  playCurrentWord: () => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,7 +42,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   currentWord,
   onOpenAddModal,
   onOpenEditModal,
-  selectedVoiceName
+  selectedVoiceName,
+  playCurrentWord
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
@@ -78,9 +80,9 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 
   const handleRateChange = (r: number) => {
     setSpeechRate(r);
-    if (currentWord && !isMuted && !isPaused) {
-      unifiedSpeechController.stop();
-      unifiedSpeechController.speak(currentWord, selectedVoiceName);
+    unifiedSpeechController.stop();
+    if (!isMuted && !isPaused) {
+      playCurrentWord();
     }
   };
 

--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -24,6 +24,7 @@ interface VocabularyMainProps {
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
   voiceRegion: 'US' | 'UK' | 'AU';
+  playCurrentWord: () => void;
 }
 
 const VocabularyMain: React.FC<VocabularyMainProps> = ({
@@ -44,6 +45,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
   onOpenAddModal,
   onOpenEditModal,
   voiceRegion,
+  playCurrentWord
 }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -82,6 +84,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
         onOpenAddModal={onOpenAddModal}
         onOpenEditModal={onOpenEditModal}
         voiceRegion={selectedVoice.region}
+        playCurrentWord={playCurrentWord}
       />
     </div>
   );

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -22,6 +22,7 @@ interface VocabularyMainNewProps {
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
   showWordCount?: boolean;
+  playCurrentWord: () => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -41,6 +42,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   onOpenAddModal,
   onOpenEditModal,
   showWordCount = false,
+  playCurrentWord,
 }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -83,7 +85,8 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
           currentWord={currentWord}
         onOpenAddModal={onOpenAddModal}
         onOpenEditModal={onOpenEditModal}
-          selectedVoiceName={selectedVoiceName}
+        selectedVoiceName={selectedVoiceName}
+        playCurrentWord={playCurrentWord}
       />
       </div>
     </div>

--- a/tests/vocabularyContainerVoiceToggle.test.tsx
+++ b/tests/vocabularyContainerVoiceToggle.test.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 globalThis.expect = expect;
 beforeAll(async () => {
   await import('@testing-library/jest-dom');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).speechSynthesis = {
     getVoices: () => [
       { name: 'Test 1', lang: 'en-US' },
@@ -45,6 +46,7 @@ describe('VocabularyControlsColumn voice toggle', () => {
             currentWord={word}
             onOpenAddModal={() => {}}
             onOpenEditModal={() => {}}
+            playCurrentWord={() => {}}
           />
       );
     };


### PR DESCRIPTION
## Summary
- replay current word via playback system when speed changes
- pass playback callback through main components to controls
- update test to satisfy lint rules

## Testing
- `npx vitest run --reporter=dot`
- `npx eslint src/components/vocabulary-app/VocabularyControlsColumn.tsx src/components/vocabulary-app/VocabularyMain.tsx src/components/vocabulary-app/VocabularyMainNew.tsx src/components/vocabulary-app/ContentWithDataNew.tsx src/components/vocabulary-app/VocabularyAppContainerNew.tsx tests/vocabularyContainerVoiceToggle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6876f859e210832fab54efbdd9ff7000