### PR TITLE
Fix speech rate popover

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils"
 const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverClose = PopoverPrimitive.Close
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -26,4 +27,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent, PopoverClose }

--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '@/components/ui/popover';
 import { Gauge } from 'lucide-react';
 
 interface SpeechRateControlProps {
@@ -33,15 +33,16 @@ const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange })
       <PopoverContent className="w-44 p-2" side="right" align="start">
         <div className="grid grid-cols-4 gap-2">
           {RATE_VALUES.map((v) => (
-            <Button
-              key={v}
-              size="sm"
-              variant={rate === v ? 'default' : 'outline'}
-              className="h-7 px-2 text-xs"
-              onClick={() => handleChange(v)}
-            >
-              {v}x
-            </Button>
+            <PopoverClose asChild key={v}>
+              <Button
+                size="sm"
+                variant={rate === v ? 'default' : 'outline'}
+                className="h-7 px-2 text-xs"
+                onClick={() => handleChange(v)}
+              >
+                {v}x
+              </Button>
+            </PopoverClose>
           ))}
         </div>
       </PopoverContent>


### PR DESCRIPTION
## Summary
- export `PopoverClose` from popover UI helper
- wrap each speech rate option in `PopoverClose` to auto-dismiss popover

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68782f0f4b14832f8c3d36d24a51ded2