### PR TITLE
Fix autoplay pause after manual next

### DIFF
--- a/src/hooks/vocabulary-controller/core/useWordNavigation.ts
+++ b/src/hooks/vocabulary-controller/core/useWordNavigation.ts
@@ -16,7 +16,8 @@ export const useWordNavigation = (
   currentWord: VocabularyWord | null,
   isTransitioningRef: React.MutableRefObject<boolean>,
   lastWordChangeRef: React.MutableRefObject<number>,
-  clearAutoAdvanceTimer: () => void
+  clearAutoAdvanceTimer: () => void,
+  playCurrentWord: () => void
 ) => {
   // Go to next word with proper mobile handling
   const goToNext = useCallback(() => {
@@ -55,6 +56,8 @@ export const useWordNavigation = (
       const nextWord = wordList[nextIndex];
       if (nextWord) {
         saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
+        // Speak the new word immediately
+        setTimeout(() => playCurrentWord(), 10);
       }
 
     } catch (error) {
@@ -72,7 +75,8 @@ export const useWordNavigation = (
     setCurrentIndex,
     isTransitioningRef,
     lastWordChangeRef,
-    clearAutoAdvanceTimer
+    clearAutoAdvanceTimer,
+    playCurrentWord
   ]);
 
   return {

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -58,7 +58,8 @@ export const useUnifiedVocabularyController = () => {
     currentWord,
     isTransitioningRef,
     lastWordChangeRef,
-    clearAutoAdvanceTimer
+    clearAutoAdvanceTimer,
+    playCurrentWord
   );
 
   const goToNextAndSpeak = useCallback(() => {


### PR DESCRIPTION
## Summary
- ensure auto-play resumes after clicking **Next** by speaking the word inside `useWordNavigation`
- wire new `playCurrentWord` callback into the controller

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687831222068832fb5be3904f7dcaeed