### PR TITLE
Add optional translation field to word model

### DIFF
--- a/src/components/VocabularyCard.tsx
+++ b/src/components/VocabularyCard.tsx
@@ -9,6 +9,7 @@ interface VocabularyCardProps {
   word: string;
   meaning: string;
   example: string;
+  translation?: string;
   backgroundColor: string;
   isMuted: boolean;
   isPaused: boolean;
@@ -30,6 +31,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   word,
   meaning,
   example,
+  translation,
   backgroundColor,
   isMuted,
   isPaused,
@@ -98,6 +100,12 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           <div className="italic" style={{ color: '#B71C1C', fontSize: '1rem', textAlign: 'left' }}>
             <span style={{ color: '#B71C1C', fontStyle: 'italic' }}>* </span>{example}
           </div>
+
+          {translation && (
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+              <em>* Translation: {translation}</em>
+            </div>
+          )}
           
         </div>
       </CardContent>

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -11,6 +11,7 @@ interface VocabularyCardProps {
   word: string;
   meaning: string;
   example: string;
+  translation?: string;
   backgroundColor: string;
   isMuted: boolean;
   isPaused: boolean;
@@ -33,6 +34,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   word,
   meaning,
   example,
+  translation,
   backgroundColor,
   isMuted,
   isPaused,
@@ -100,6 +102,11 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           >
             <span className="italic text-red-600">*</span> {example}
           </div>
+          {translation && (
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+              <em>* Translation: {translation}</em>
+            </div>
+          )}
           {/* Mobile note below example */}
           {!searchPreview && (
             <div

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -11,6 +11,7 @@ interface VocabularyCardNewProps {
   word: string;
   meaning: string;
   example: string;
+  translation?: string;
   backgroundColor: string;
   isMuted: boolean;
   isPaused: boolean;
@@ -31,6 +32,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   word,
   meaning,
   example,
+  translation,
   backgroundColor,
   isMuted,
   isPaused,
@@ -49,7 +51,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   const categoryLabel = getCategoryLabel(category);
   const nextCategoryLabel = getCategoryLabel(nextCategory);
 
-  const currentWordObj = { word, meaning, example, category };
+  const currentWordObj = { word, meaning, example, translation, category };
   const { main, annotations } = parseWordAnnotations(word);
 
   return (
@@ -92,6 +94,11 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
           <div style={{ color: '#B71C1C', fontSize: '0.9rem', textAlign: 'left', fontStyle: 'italic', background: 'transparent' }}>
             <span style={{ color: '#B71C1C', fontStyle: 'italic' }}>* </span>{example}
           </div>
+          {translation && (
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+              <em>* Translation: {translation}</em>
+            </div>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/components/vocabulary-app/VocabularyMain.tsx
+++ b/src/components/vocabulary-app/VocabularyMain.tsx
@@ -55,6 +55,7 @@ const VocabularyMain: React.FC<VocabularyMainProps> = ({
         word={currentWord.word}
         meaning={currentWord.meaning}
         example={currentWord.example}
+        translation={currentWord.translation}
         backgroundColor={backgroundColor}
         isMuted={mute}
         isPaused={isPaused}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -54,6 +54,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
           word={currentWord.word}
           meaning={currentWord.meaning}
           example={currentWord.example}
+          translation={currentWord.translation}
           backgroundColor={backgroundColor}
           isMuted={mute}
           isPaused={isPaused}

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -192,6 +192,7 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
               word={selectedWord.word}
               meaning={selectedWord.meaning}
               example={selectedWord.example}
+              translation={selectedWord.translation}
               backgroundColor="#ffffff"
               isMuted={false}
               isPaused={false}

--- a/src/components/vocabulary-app/components/VocabularyAppContent.tsx
+++ b/src/components/vocabulary-app/components/VocabularyAppContent.tsx
@@ -93,6 +93,7 @@ const VocabularyAppContent: React.FC<VocabularyAppContentProps> = ({
           word="No data for this category"
           meaning=""
           example=""
+          translation={undefined}
           backgroundColor="#F0F8FF"
           isMuted={muted}
           isPaused={paused}

--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -99,6 +99,7 @@ const VocabularyContainer: React.FC = () => {
         word={controllerState.currentWord.word}
         meaning={controllerState.currentWord.meaning}
         example={controllerState.currentWord.example}
+        translation={controllerState.currentWord.translation}
         backgroundColor="#F0F8FF"
         isMuted={controllerState.isMuted}
         isPaused={controllerState.isPaused}

--- a/src/types/vocabulary.ts
+++ b/src/types/vocabulary.ts
@@ -4,6 +4,7 @@ export interface VocabularyWord {
   word: string;
   meaning: string;
   example: string;
+  translation?: string;
   count: number | string; // This allows both number and string types
   category?: string; // Making category optional to support existing default vocabulary data
 }
@@ -13,6 +14,7 @@ export interface EditableWord {
   word: string;
   meaning: string;
   example: string;
+  translation?: string;
   category: string; // Category is required for editable words
   count?: number | string;
 }


### PR DESCRIPTION
## Summary
- include `translation` property in `VocabularyWord` and `EditableWord`
- show translation in vocabulary cards when available
- pass translation through vocabulary views

## Testing
- `npm test` *(fails: playCurrentWord is not a function)*
- `npm run lint` *(fails: 64 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68799ad23f40832f81381873bf2785a3