### PR TITLE
Add translation field to word forms

### DIFF
--- a/src/components/vocabulary-app/AddWordModal.tsx
+++ b/src/components/vocabulary-app/AddWordModal.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { Button } from '@/components/ui/button';
 import { AlertTriangle } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { validateVocabularyWord, validateMeaning, validateExample } from '@/utils/security/inputValidation';
+import { validateVocabularyWord, validateMeaning, validateExample, sanitizeUserInput } from '@/utils/security/inputValidation';
 import { htmlEncode } from '@/utils/security/contentSecurity';
 import { useWordFormState } from '@/hooks/vocabulary/useWordFormState';
 import { useWordFormValidation } from '@/hooks/vocabulary/useWordFormValidation';
@@ -15,9 +15,9 @@ import WordFormFields from './WordFormFields';
 interface AddWordModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (newWord: { word: string; meaning: string; example: string; category: string }) => void;
+  onSave: (newWord: { word: string; meaning: string; example: string; translation: string; category: string }) => void;
   editMode?: boolean;
-  wordToEdit?: { word: string; meaning: string; example: string; category: string };
+  wordToEdit?: { word: string; meaning: string; example: string; translation?: string; category: string };
 }
 
 const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, editMode = false, wordToEdit }) => {
@@ -26,13 +26,16 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
     word,
     meaning,
     example,
+    translation,
     category,
     setMeaning,
     setExample,
+    setTranslation,
     setCategory,
     handleWordChange,
     handleMeaningChange,
     handleExampleChange,
+    handleTranslationChange,
     resetForm
   } = useWordFormState({ editMode, wordToEdit, isOpen });
 
@@ -52,12 +55,14 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
       const wordValidation = validateVocabularyWord(word);
       const meaningValidation = validateMeaning(meaning);
       const exampleValidation = validateExample(example);
+      const sanitizedTranslation = sanitizeUserInput(translation);
       
       if (wordValidation.isValid && meaningValidation.isValid && exampleValidation.isValid) {
         onSave({
           word: wordValidation.sanitizedValue!,
           meaning: meaningValidation.sanitizedValue!,
           example: exampleValidation.sanitizedValue!,
+          translation: sanitizedTranslation,
           category
         });
         
@@ -104,6 +109,8 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
             onMeaningChange={handleMeaningChange}
             example={example}
             onExampleChange={handleExampleChange}
+            translation={translation}
+            onTranslationChange={handleTranslationChange}
             category={category}
             onCategoryChange={setCategory}
             isDisabled={isSearching}

--- a/src/components/vocabulary-app/ContentWithData.tsx
+++ b/src/components/vocabulary-app/ContentWithData.tsx
@@ -21,7 +21,7 @@ interface ContentWithDataProps {
   nextVoiceLabel: string;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
-  handleSaveWord: (wordData: { word: string; meaning: string; example: string; category: string }) => void;
+  handleSaveWord: (wordData: { word: string; meaning: string; example: string; translation: string; category: string }) => void;
   isEditMode: boolean;
   wordToEdit: any;
   handleOpenAddWordModal: () => void;
@@ -78,15 +78,16 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
 
       
       {/* Enhanced Word Modal (handles both add and edit) */}
-      <AddWordModal 
-        isOpen={isAddWordModalOpen} 
-        onClose={handleCloseModal} 
+      <AddWordModal
+        isOpen={isAddWordModalOpen}
+        onClose={handleCloseModal}
         onSave={handleSaveWord}
         editMode={isEditMode}
         wordToEdit={isEditMode && wordToEdit ? {
           word: wordToEdit.word,
           meaning: wordToEdit.meaning,
           example: wordToEdit.example,
+          translation: wordToEdit.translation || '',
           category: wordToEdit.category || currentCategory
         } : undefined}
       />

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -21,7 +21,7 @@ interface ContentWithDataNewProps {
   selectedVoiceName: string;
   isAddWordModalOpen: boolean;
   handleCloseModal: () => void;
-  handleSaveWord: (wordData: { word: string; meaning: string; example: string; category: string }) => void;
+  handleSaveWord: (wordData: { word: string; meaning: string; example: string; translation: string; category: string }) => void;
   isEditMode: boolean;
   wordToEdit: VocabularyWord | null;
   handleOpenAddWordModal: () => void;
@@ -94,15 +94,16 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
 
       
       {/* Enhanced Word Modal (handles both add and edit) */}
-      <AddWordModal 
-        isOpen={isAddWordModalOpen} 
-        onClose={handleCloseModal} 
+      <AddWordModal
+        isOpen={isAddWordModalOpen}
+        onClose={handleCloseModal}
         onSave={handleSaveWord}
         editMode={isEditMode}
         wordToEdit={isEditMode && wordToEdit ? {
           word: wordToEdit.word,
           meaning: wordToEdit.meaning,
           example: wordToEdit.example,
+          translation: wordToEdit.translation || '',
           category: wordToEdit.category || currentCategory
         } : undefined}
       />

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -65,7 +65,7 @@ const VocabularyAppContainerNew: React.FC = () => {
     }) : null;
   }, [currentWord?.word, currentCategory, handleCloseModal]);
 
-  const handleSaveWord = React.useCallback((wordData: { word: string; meaning: string; example: string; category: string }) => {
+  const handleSaveWord = React.useCallback((wordData: { word: string; meaning: string; example: string; translation: string; category: string }) => {
     if (wordManager) {
       wordManager.handleSaveWord(wordData, isEditMode, wordToEdit);
     }

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
@@ -9,6 +10,8 @@ interface WordFormFieldsProps {
   onMeaningChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   example: string;
   onExampleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  translation: string;
+  onTranslationChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   category: string;
   onCategoryChange: (value: string) => void;
   isDisabled: boolean;
@@ -29,6 +32,8 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
   onMeaningChange,
   example,
   onExampleChange,
+  translation,
+  onTranslationChange,
   category,
   onCategoryChange,
   isDisabled
@@ -62,6 +67,20 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
           disabled={isDisabled}
           rows={4}
           maxLength={1000}
+        />
+      </div>
+
+      <div className="grid grid-cols-4 items-center gap-4">
+        <Label htmlFor="translation" className="text-right">
+          Translation
+        </Label>
+        <Input
+          id="translation"
+          value={translation}
+          onChange={onTranslationChange}
+          className="col-span-3"
+          disabled={isDisabled}
+          maxLength={200}
         />
       </div>
       

--- a/src/components/vocabulary-app/word-management/VocabularyWordManager.tsx
+++ b/src/components/vocabulary-app/word-management/VocabularyWordManager.tsx
@@ -17,7 +17,7 @@ const VocabularyWordManager = ({
   onWordSaved 
 }: VocabularyWordManagerProps) => {
   const handleSaveWord = (
-    wordData: { word: string; meaning: string; example: string; category: string },
+    wordData: { word: string; meaning: string; example: string; translation: string; category: string },
     isEditMode: boolean,
     wordToEdit: VocabularyWord | null
   ) => {
@@ -29,6 +29,7 @@ const VocabularyWordManager = ({
             word: wordData.word,
             meaning: wordData.meaning,
             example: wordData.example,
+            translation: wordData.translation,
             count: wordToEdit.count || 1
           }]
         };
@@ -43,6 +44,7 @@ const VocabularyWordManager = ({
             word: wordData.word,
             meaning: wordData.meaning,
             example: wordData.example,
+            translation: wordData.translation,
             count: 1
           }]
         };

--- a/src/hooks/vocabulary/useWordFormState.tsx
+++ b/src/hooks/vocabulary/useWordFormState.tsx
@@ -6,6 +6,7 @@ interface WordFormState {
   word: string;
   meaning: string;
   example: string;
+  translation: string;
   category: string;
 }
 
@@ -13,9 +14,10 @@ interface UseWordFormStateProps {
   initialWord?: string;
   initialMeaning?: string;
   initialExample?: string;
+  initialTranslation?: string;
   initialCategory?: string;
   editMode?: boolean;
-  wordToEdit?: { word: string; meaning: string; example: string; category: string };
+  wordToEdit?: { word: string; meaning: string; example: string; translation?: string; category: string };
   isOpen?: boolean;
 }
 
@@ -24,6 +26,7 @@ export const useWordFormState = (props: UseWordFormStateProps = {}) => {
     initialWord = '',
     initialMeaning = '',
     initialExample = '',
+    initialTranslation = '',
     initialCategory = '',
     editMode = false,
     wordToEdit,
@@ -33,6 +36,7 @@ export const useWordFormState = (props: UseWordFormStateProps = {}) => {
   const [word, setWord] = useState(editMode && wordToEdit ? wordToEdit.word : initialWord);
   const [meaning, setMeaning] = useState(editMode && wordToEdit ? wordToEdit.meaning : initialMeaning);
   const [example, setExample] = useState(editMode && wordToEdit ? wordToEdit.example : initialExample);
+  const [translation, setTranslation] = useState(editMode && wordToEdit ? wordToEdit.translation || '' : initialTranslation);
   const [category, setCategory] = useState(editMode && wordToEdit ? wordToEdit.category : initialCategory);
 
   // Reset form when modal opens/closes or when switching between edit/add modes
@@ -42,15 +46,17 @@ export const useWordFormState = (props: UseWordFormStateProps = {}) => {
         setWord(wordToEdit.word);
         setMeaning(wordToEdit.meaning);
         setExample(wordToEdit.example);
+        setTranslation(wordToEdit.translation || '');
         setCategory(wordToEdit.category);
       } else {
         setWord(initialWord);
         setMeaning(initialMeaning);
         setExample(initialExample);
+        setTranslation(initialTranslation);
         setCategory(initialCategory);
       }
     }
-  }, [isOpen, editMode, wordToEdit, initialWord, initialMeaning, initialExample, initialCategory]);
+  }, [isOpen, editMode, wordToEdit, initialWord, initialMeaning, initialExample, initialTranslation, initialCategory]);
 
   const handleWordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setWord(e.target.value);
@@ -64,6 +70,10 @@ export const useWordFormState = (props: UseWordFormStateProps = {}) => {
     setExample(e.target.value);
   }, []);
 
+  const handleTranslationChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setTranslation(e.target.value);
+  }, []);
+
   const handleCategoryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setCategory(e.target.value);
   }, []);
@@ -72,22 +82,26 @@ export const useWordFormState = (props: UseWordFormStateProps = {}) => {
     setWord(initialWord);
     setMeaning(initialMeaning);
     setExample(initialExample);
+    setTranslation(initialTranslation);
     setCategory(initialCategory);
-  }, [initialWord, initialMeaning, initialExample, initialCategory]);
+  }, [initialWord, initialMeaning, initialExample, initialTranslation, initialCategory]);
 
   return {
     word,
     meaning,
     example,
+    translation,
     category,
     handleWordChange,
     handleMeaningChange,
     handleExampleChange,
+    handleTranslationChange,
     handleCategoryChange,
     resetForm,
     setWord,
     setMeaning,
     setExample,
+    setTranslation,
     setCategory
   };
 };


### PR DESCRIPTION
## Summary
- allow entering a translation for each word
- display Translation input in the add/edit word form
- prefill translation when editing words

## Testing
- `npm test` *(fails: playCurrentWord is not a function)*
- `npm run lint` *(fails: 64 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6879bd707654832fb9c74c4b9cc38fc0