### PR TITLE
Add LibreTranslate API integration

### DIFF
--- a/src/components/vocabulary-app/AddWordModal.tsx
+++ b/src/components/vocabulary-app/AddWordModal.tsx
@@ -112,6 +112,7 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
             onExampleChange={handleExampleChange}
             translation={translation}
             onTranslationChange={handleTranslationChange}
+            setTranslation={setTranslation}
             category={category}
             onCategoryChange={setCategory}
             isDisabled={isSearching}

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -11,7 +11,8 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { translate } from '@/services/translationService';
+import { translate } from '@/utils/translate';
+import { toast } from 'sonner';
 
 interface WordFormFieldsProps {
   word: string;
@@ -21,6 +22,7 @@ interface WordFormFieldsProps {
   onExampleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   translation: string;
   onTranslationChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setTranslation: (value: string) => void;
   category: string;
   onCategoryChange: (value: string) => void;
   isDisabled: boolean;
@@ -55,10 +57,21 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
   onExampleChange,
   translation,
   onTranslationChange,
+  setTranslation,
   category,
   onCategoryChange,
   isDisabled
 }) => {
+  const handleTranslate = async (lang: { code: string; label: string }) => {
+    try {
+      const result = await translate(word, lang.code);
+      setTranslation(result);
+      toast.success(`✅ Translated to ${lang.label}!`);
+    } catch (error) {
+      console.error('Translation error', error);
+      toast.error('Failed to translate');
+    }
+  };
   return (
     <>
       <div className="grid grid-cols-4 items-center gap-4">
@@ -106,7 +119,7 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
               {LANGUAGES.map((lang) => (
                 <DropdownMenuItem
                   key={lang.code}
-                  onSelect={() => translate(word, lang.code)}
+                  onSelect={() => handleTranslate(lang)}
                 >
                   {lang.label}
                 </DropdownMenuItem>

--- a/src/services/translationService.ts
+++ b/src/services/translationService.ts
@@ -1,5 +1,0 @@
-export async function translate(word: string, lang: string): Promise<string> {
-  console.log(`Translating "${word}" to ${lang}`)
-  // TODO: replace with real translation API call
-  return ''
-}

--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -1,0 +1,14 @@
+export async function translate(word: string, targetLang: string): Promise<string> {
+  const res = await fetch("https://libretranslate.com/translate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      q: word,
+      source: "en",
+      target: targetLang,
+      format: "text"
+    })
+  });
+  const data = await res.json();
+  return data.translatedText;
+}


### PR DESCRIPTION
## Summary
- implement LibreTranslate API call in `src/utils/translate.ts`
- auto-fill translation in `WordFormFields` using the new helper and show success toast
- update `AddWordModal` to pass setter for translation
- remove unused `translationService`

## Testing
- `npm run lint` *(fails: Empty block statements and other lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879db68f7a8832f9f27a41d7bbd1e8c