### PR TITLE
Add translation input

### DIFF
--- a/src/components/VocabularyCard.tsx
+++ b/src/components/VocabularyCard.tsx
@@ -103,7 +103,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
 
           {translation && (
             <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
-              <em>* Translation: {translation}</em>
+              <em>* {translation}</em>
             </div>
           )}
           

--- a/src/components/vocabulary-app/AddWordModal.tsx
+++ b/src/components/vocabulary-app/AddWordModal.tsx
@@ -30,7 +30,6 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
     category,
     setMeaning,
     setExample,
-    setTranslation,
     setCategory,
     handleWordChange,
     handleMeaningChange,
@@ -112,7 +111,6 @@ const AddWordModal: React.FC<AddWordModalProps> = ({ isOpen, onClose, onSave, ed
             onExampleChange={handleExampleChange}
             translation={translation}
             onTranslationChange={handleTranslationChange}
-            setTranslation={setTranslation}
             category={category}
             onCategoryChange={setCategory}
             isDisabled={isSearching}

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -104,7 +104,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           </div>
           {translation && (
             <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
-              <em>* Translation: {translation}</em>
+              <em>* {translation}</em>
             </div>
           )}
           {/* Mobile note below example */}

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -96,7 +96,7 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
           </div>
           {translation && (
             <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
-              <em>* Translation: {translation}</em>
+              <em>* {translation}</em>
             </div>
           )}
         </div>

--- a/src/components/vocabulary-app/WordFormFields.tsx
+++ b/src/components/vocabulary-app/WordFormFields.tsx
@@ -4,15 +4,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu';
-import { Button } from '@/components/ui/button';
-import { translate } from '@/utils/translate';
-import { toast } from 'sonner';
 
 interface WordFormFieldsProps {
   word: string;
@@ -22,7 +13,6 @@ interface WordFormFieldsProps {
   onExampleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   translation: string;
   onTranslationChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  setTranslation: (value: string) => void;
   category: string;
   onCategoryChange: (value: string) => void;
   isDisabled: boolean;
@@ -38,16 +28,6 @@ const CATEGORY_OPTIONS = [
   { value: "word formation", label: "Word formation" }
 ];
 
-const LANGUAGES = [
-  { code: 'vi', label: 'Vietnamese' },
-  { code: 'fr', label: 'French' },
-  { code: 'es', label: 'Spanish' },
-  { code: 'ja', label: 'Japanese' },
-  { code: 'zh', label: 'Chinese' },
-  { code: 'ko', label: 'Korean' },
-  { code: 'de', label: 'German' },
-  { code: 'ru', label: 'Russian' }
-];
 
 const WordFormFields: React.FC<WordFormFieldsProps> = ({
   word,
@@ -57,21 +37,10 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
   onExampleChange,
   translation,
   onTranslationChange,
-  setTranslation,
   category,
   onCategoryChange,
   isDisabled
 }) => {
-  const handleTranslate = async (lang: { code: string; label: string }) => {
-    try {
-      const result = await translate(word, lang.code);
-      setTranslation(result);
-      toast.success(`✅ Translated to ${lang.label}!`);
-    } catch (error) {
-      console.error('Translation error', error);
-      toast.error('Failed to translate');
-    }
-  };
   return (
     <>
       <div className="grid grid-cols-4 items-center gap-4">
@@ -105,28 +74,9 @@ const WordFormFields: React.FC<WordFormFieldsProps> = ({
       </div>
 
       <div className="grid grid-cols-4 items-center gap-4">
-        <div className="flex justify-between items-center">
-          <Label htmlFor="translation" className="text-right whitespace-nowrap">
-            Translation
-          </Label>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="button" variant="ghost" size="sm" className="px-1">
-                🌐 Translate To
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {LANGUAGES.map((lang) => (
-                <DropdownMenuItem
-                  key={lang.code}
-                  onSelect={() => handleTranslate(lang)}
-                >
-                  {lang.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        <Label htmlFor="translation" className="text-right whitespace-nowrap">
+          <span role="img" aria-label="translation">🌐</span> Translation
+        </Label>
         <Input
           id="translation"
           value={translation}


### PR DESCRIPTION
## Summary
- add plain Translation input below Example
- show translation italicized on vocabulary cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a05098454832f8d303ce2d3b5e0f9