### PR TITLE
Switch to MyMemory translation API

### DIFF
--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -1,14 +1,15 @@
-export async function translate(word: string, targetLang: string): Promise<string> {
-  const res = await fetch("https://libretranslate.com/translate", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      q: word,
-      source: "en",
-      target: targetLang,
-      format: "text"
-    })
-  });
+export async function translate(
+  word: string,
+  targetLang: string,
+  sourceLang = "en"
+): Promise<string> {
+  const q = encodeURIComponent(word);
+  const langpair = encodeURIComponent(`${sourceLang}|${targetLang}`);
+  const url = `https://api.mymemory.translated.net/get?q=${q}&langpair=${langpair}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Translation API error: ${res.status}`);
+  }
   const data = await res.json();
-  return data.translatedText;
+  return data.responseData?.translatedText ?? "";
 }


### PR DESCRIPTION
## Summary
- replace LibreTranslate with MyMemory API
- keep existing translation behavior

## Testing
- `npx vitest run --reporter=dot`
- `npm run lint` *(fails: 64 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687a173f8dd0832fa123fa11b588b8bc