### PR TITLE
Fix translation handling

### DIFF
--- a/src/services/vocabulary/VocabularyDataProcessor.ts
+++ b/src/services/vocabulary/VocabularyDataProcessor.ts
@@ -17,6 +17,7 @@ export class VocabularyDataProcessor {
             word: String(word.word || ""),
             meaning: String(word.meaning || ""),
             example: String(word.example || ""),
+            translation: String(word.translation || ""),
             count: word.count !== undefined ? word.count : 0,
             category: word.category || sheetName // Use sheet name as default category
           });

--- a/src/services/vocabulary/VocabularyImporter.ts
+++ b/src/services/vocabulary/VocabularyImporter.ts
@@ -42,6 +42,7 @@ export class VocabularyImporter {
           word: String(importedWord.word),
           meaning: String(importedWord.meaning || ""),
           example: String(importedWord.example || ""),
+          translation: String(importedWord.translation || ""),
           count: importedWord.count !== undefined ? importedWord.count : 0,
           category: importedWord.category || sheetName // Use sheet name as default category if not provided
         };

--- a/src/services/vocabulary/storage/DataValidator.ts
+++ b/src/services/vocabulary/storage/DataValidator.ts
@@ -94,6 +94,7 @@ export class DataValidator {
         word: word.word,
         meaning: word.meaning,
         example: word.example,
+        translation: word.translation,
         count: word.count,
         category: word.category
       }));

--- a/src/services/vocabulary/storage/TypeProcessor.ts
+++ b/src/services/vocabulary/storage/TypeProcessor.ts
@@ -101,6 +101,7 @@ export class TypeProcessor {
               word: prepareTextForDisplay(wordValidation.sanitizedValue!),
               meaning: prepareTextForDisplay(meaningValidation.sanitizedValue!),
               example: prepareTextForDisplay(exampleValidation.sanitizedValue!),
+              translation: prepareTextForDisplay(String(word.translation || "")),
               count: this.wordValidator.sanitizeCount(String(word.count || 0)),
               category: sanitizeInput(String(word.category || sanitizedSheetName))
             };


### PR DESCRIPTION
## Summary
- keep translation when processing vocabulary
- merge translation field during import
- load translation strings during type processing
- include translations in default data conversion

## Testing
- `npm test` *(fails: PASS but then watch mode; canceled)*
- `npm run lint` *(fails to lint)*

------
https://chatgpt.com/codex/tasks/task_e_687e08cb683c832f88e2c980c1522778