### PR TITLE
Preserve translation data

### DIFF
--- a/src/services/vocabulary/VocabularyDataProcessor.ts
+++ b/src/services/vocabulary/VocabularyDataProcessor.ts
@@ -17,6 +17,7 @@ export class VocabularyDataProcessor {
             word: String(word.word || ""),
             meaning: String(word.meaning || ""),
             example: String(word.example || ""),
+            translation: String(word.translation || ""),
             count: word.count !== undefined ? word.count : 0,
             category: word.category || sheetName // Use sheet name as default category
           });

--- a/src/services/vocabulary/VocabularyImporter.ts
+++ b/src/services/vocabulary/VocabularyImporter.ts
@@ -42,6 +42,7 @@ export class VocabularyImporter {
           word: String(importedWord.word),
           meaning: String(importedWord.meaning || ""),
           example: String(importedWord.example || ""),
+          translation: String(importedWord.translation || ""),
           count: importedWord.count !== undefined ? importedWord.count : 0,
           category: importedWord.category || sheetName // Use sheet name as default category if not provided
         };

--- a/src/services/vocabulary/storage/DataValidator.ts
+++ b/src/services/vocabulary/storage/DataValidator.ts
@@ -89,14 +89,15 @@ export class DataValidator {
   getDefaultData(): SheetData {
     // Convert DEFAULT_VOCABULARY_DATA to the expected format for ensureDataTypes
     const convertedData: Record<string, Array<Record<string, unknown>>> = {};
-    for (const [sheetName, words] of Object.entries(DEFAULT_VOCABULARY_DATA)) {
-      convertedData[sheetName] = words.map(word => ({
-        word: word.word,
-        meaning: word.meaning,
-        example: word.example,
-        count: word.count,
-        category: word.category
-      }));
+      for (const [sheetName, words] of Object.entries(DEFAULT_VOCABULARY_DATA)) {
+        convertedData[sheetName] = words.map(word => ({
+          word: word.word,
+          meaning: word.meaning,
+          example: word.example,
+          translation: word.translation,
+          count: word.count,
+          category: word.category
+        }));
     }
     return this.ensureDataTypes(convertedData);
   }

--- a/src/services/vocabulary/storage/TypeProcessor.ts
+++ b/src/services/vocabulary/storage/TypeProcessor.ts
@@ -101,6 +101,7 @@ export class TypeProcessor {
               word: prepareTextForDisplay(wordValidation.sanitizedValue!),
               meaning: prepareTextForDisplay(meaningValidation.sanitizedValue!),
               example: prepareTextForDisplay(exampleValidation.sanitizedValue!),
+              translation: prepareTextForDisplay(String(word.translation || "")),
               count: this.wordValidator.sanitizeCount(String(word.count || 0)),
               category: sanitizeInput(String(word.category || sanitizedSheetName))
             };

--- a/src/services/vocabularyStorage.ts
+++ b/src/services/vocabularyStorage.ts
@@ -67,6 +67,7 @@ export class VocabularyStorage {
           word: word.word,
           meaning: word.meaning,
           example: word.example,
+          translation: word.translation,
           count: word.count,
           category: word.category
         }));


### PR DESCRIPTION
## Summary
- keep translation when processing vocabulary words
- store translations when importing and validating data
- save translation field to localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1c4f1814832f8cddb653d17272e7