### PR TITLE
Add calculateHighestStreak utility

### DIFF
--- a/src/utils/calculateHighestStreak.ts
+++ b/src/utils/calculateHighestStreak.ts
@@ -1,0 +1,58 @@
+export interface ActivityDay {
+  date: string;
+  isRedeemed: boolean;
+}
+
+function parseDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split('-').map(n => parseInt(n, 10));
+  return new Date(y, m - 1, d);
+}
+
+function dayDiff(a: string, b: string): number {
+  const ms = 24 * 60 * 60 * 1000;
+  return Math.round((parseDate(a).getTime() - parseDate(b).getTime()) / ms);
+}
+
+export interface HighestStreakResult {
+  highestStreak: number;
+  streakDates: string[];
+}
+
+export function calculateHighestStreak(days: ActivityDay[]): HighestStreakResult {
+  if (!Array.isArray(days) || days.length === 0) {
+    return { highestStreak: 0, streakDates: [] };
+  }
+
+  const sorted = [...days].sort((a, b) => (a.date > b.date ? 1 : a.date < b.date ? -1 : 0));
+
+  let bestLength = 0;
+  let bestDates: string[] = [];
+
+  let currentLength = 0;
+  let currentDates: string[] = [];
+  let lastDate: string | null = null;
+
+  for (const day of sorted) {
+    if (!day.isRedeemed) {
+      if (currentLength > 0 && lastDate && dayDiff(day.date, lastDate) === 1) {
+        currentLength += 1;
+        currentDates.push(day.date);
+      } else {
+        currentLength = 1;
+        currentDates = [day.date];
+      }
+
+      if (currentLength > bestLength) {
+        bestLength = currentLength;
+        bestDates = [...currentDates];
+      }
+    } else {
+      currentLength = 0;
+      currentDates = [];
+    }
+
+    lastDate = day.date;
+  }
+
+  return { highestStreak: bestLength, streakDates: bestDates };
+}

--- a/tests/calculateHighestStreak.test.ts
+++ b/tests/calculateHighestStreak.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { calculateHighestStreak, ActivityDay } from '../src/utils/calculateHighestStreak';
+
+describe('calculateHighestStreak', () => {
+  it('calculates longest streak from unordered input', () => {
+    const data: ActivityDay[] = [
+      { date: '2024-07-03', isRedeemed: false },
+      { date: '2024-07-01', isRedeemed: false },
+      { date: '2024-07-02', isRedeemed: false }
+    ];
+    const result = calculateHighestStreak(data);
+    expect(result).toEqual({
+      highestStreak: 3,
+      streakDates: ['2024-07-01', '2024-07-02', '2024-07-03']
+    });
+  });
+
+  it('resets streak on redemption or date gap', () => {
+    const data: ActivityDay[] = [
+      { date: '2024-07-01', isRedeemed: false },
+      { date: '2024-07-02', isRedeemed: true },
+      { date: '2024-07-03', isRedeemed: false },
+      { date: '2024-07-04', isRedeemed: false },
+      { date: '2024-07-06', isRedeemed: false }
+    ];
+    const result = calculateHighestStreak(data);
+    expect(result).toEqual({
+      highestStreak: 2,
+      streakDates: ['2024-07-03', '2024-07-04']
+    });
+  });
+
+  it('returns earliest streak when multiple are equal length', () => {
+    const data: ActivityDay[] = [
+      { date: '2024-07-05', isRedeemed: false },
+      { date: '2024-07-06', isRedeemed: false },
+      { date: '2024-07-01', isRedeemed: false },
+      { date: '2024-07-02', isRedeemed: false }
+    ];
+    const result = calculateHighestStreak(data);
+    expect(result).toEqual({
+      highestStreak: 2,
+      streakDates: ['2024-07-01', '2024-07-02']
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `calculateHighestStreak` for unredeemed streaks
- cover edge cases with new vitest suite

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880e4521240832f96c9f6d970ff4730