### PR TITLE
Fix speech text to strip annotations

### DIFF
--- a/src/hooks/vocabulary-playback/speech-playback/core/useContentProcessor.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/core/useContentProcessor.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
 import { formatSpeechText } from '@/utils/speech';
+import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
 
 /**
  * Hook for processing vocabulary word content into speechable text
@@ -10,7 +11,8 @@ import { formatSpeechText } from '@/utils/speech';
 export const useContentProcessor = () => {
   // Create speech text from vocabulary word
   const createSpeechText = useCallback((word: VocabularyWord) => {
-    const sanitizedWord = sanitizeForDisplay(word.word || '');
+    const cleanedWord = parseWordAnnotations(word.word || '').main;
+    const sanitizedWord = sanitizeForDisplay(cleanedWord);
     const sanitizedMeaning = sanitizeForDisplay(word.meaning || '');
     const sanitizedExample = sanitizeForDisplay(word.example || '');
 

--- a/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
+++ b/src/hooks/vocabulary-playback/speech-playback/utteranceSetup.ts
@@ -4,6 +4,7 @@ import { VoiceSelection } from '../useVoiceSelection';
 import { findVoice } from './findVoice';
 import { sanitizeForDisplay } from '@/utils/security/contentSecurity';
 import { getSpeechRate } from '@/utils/speech/core/speechSettings';
+import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
 
 
 // Function to create and configure a speech utterance
@@ -20,7 +21,8 @@ export const createUtterance = (
   
   try {
     // Sanitize input text for security
-    const sanitizedWord = sanitizeForDisplay(word.word || '');
+    const cleanedWord = parseWordAnnotations(word.word || '').main;
+    const sanitizedWord = sanitizeForDisplay(cleanedWord);
     const sanitizedMeaning = sanitizeForDisplay(word.meaning || '');
     const sanitizedExample = sanitizeForDisplay(word.example || '');
     

--- a/tests/parseWordAnnotations.test.ts
+++ b/tests/parseWordAnnotations.test.ts
@@ -13,4 +13,10 @@ describe('parseWordAnnotations', () => {
     expect(main).toBe('add up');
     expect(annotations).toEqual(['(/æd ʌp tə/)']);
   });
+
+  it('handles multiple annotations', () => {
+    const { main, annotations } = parseWordAnnotations('word (noun) /wɜːd/');
+    expect(main).toBe('word');
+    expect(annotations).toEqual(['(noun)', '/wɜːd/']);
+  });
 });

--- a/tests/useContentProcessor.test.ts
+++ b/tests/useContentProcessor.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useContentProcessor } from '../src/hooks/vocabulary-playback/speech-playback/core/useContentProcessor';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+describe('useContentProcessor', () => {
+  it('strips annotations from word when creating speech text', () => {
+    const { result } = renderHook(() => useContentProcessor());
+    const word: VocabularyWord = {
+      word: 'word (noun) /wɜːd/',
+      meaning: 'a single distinct meaningful element of speech',
+      example: '',
+      count: 1
+    };
+    const speech = result.current.createSpeechText(word);
+    expect(speech).toBe(
+      'word<break time="300ms"/>a single distinct meaningful element of speech'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize parsed word when building speech text
- handle word annotations when creating utterances
- test annotation parsing with multiple annotations
- add unit test for createSpeechText stripping annotations

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688369ff1d6c832fa93e7d6be56dbeeb