### PR TITLE
Ensure modal fields remain editable

### DIFF
--- a/src/components/vocabulary-app/ContentWithData.tsx
+++ b/src/components/vocabulary-app/ContentWithData.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyMain from './VocabularyMain';
 import AddWordModal from './AddWordModal';
@@ -51,6 +51,18 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
   handleOpenAddWordModal,
   handleOpenEditWordModal
 }) => {
+  const editingWordData = useMemo(
+    () => (
+      isEditMode && wordToEdit
+        ? {
+            ...wordToEdit,
+            translation: wordToEdit.translation || '',
+            category: wordToEdit.category || currentCategory
+          }
+        : undefined
+    ),
+    [isEditMode, wordToEdit, currentCategory]
+  );
   return (
     <>
       {/* Main vocabulary display */}
@@ -83,13 +95,7 @@ const ContentWithData: React.FC<ContentWithDataProps> = ({
         onClose={handleCloseModal}
         onSave={handleSaveWord}
         editMode={isEditMode}
-        wordToEdit={isEditMode && wordToEdit ? {
-          word: wordToEdit.word,
-          meaning: wordToEdit.meaning,
-          example: wordToEdit.example,
-          translation: wordToEdit.translation || '',
-          category: wordToEdit.category || currentCategory
-        } : undefined}
+        wordToEdit={editingWordData}
       />
     </>
   );

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyMainNew from './VocabularyMainNew';
 import AddWordModal from './AddWordModal';
@@ -52,6 +52,18 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenEditWordModal,
   playCurrentWord
 }) => {
+  const editingWordData = useMemo(
+    () => (
+      isEditMode && wordToEdit
+        ? {
+            ...wordToEdit,
+            translation: wordToEdit.translation || '',
+            category: wordToEdit.category || currentCategory
+          }
+        : undefined
+    ),
+    [isEditMode, wordToEdit, currentCategory]
+  );
   return (
     <>
       {/* Main vocabulary display */}
@@ -99,13 +111,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         onClose={handleCloseModal}
         onSave={handleSaveWord}
         editMode={isEditMode}
-        wordToEdit={isEditMode && wordToEdit ? {
-          word: wordToEdit.word,
-          meaning: wordToEdit.meaning,
-          example: wordToEdit.example,
-          translation: wordToEdit.translation || '',
-          category: wordToEdit.category || currentCategory
-        } : undefined}
+        wordToEdit={editingWordData}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- memoize editingWordData in ContentWithData components
- pass the memoized data to AddWordModal

## Testing
- `npm test` *(fails: TypeError: playCurrentWord is not a function)*
- `npm run lint` *(fails with various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68837068ade4832f978091dbb6973f9d