### PR TITLE
Update speech instruction message

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -92,7 +92,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
 
       {/* Mobile speech note statically above debug panel */}
       <div className="mobile-note text-xs italic text-gray-500 text-left my-2">
-        <p>⭐ Tap any button (e.g., Next) to enable speech.</p>
+        <p>⭐ Speech won’t autoplay due to security. Sometimes, tap anywhere or any button (e.g. Next) to enable it.</p>
         <p>⭐ On Mobile, only one voice may be available.</p>
         <p>
           ⭐ No personal login or data is stored on any server. Your progress

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -113,7 +113,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
               className="mobile-note text-left italic mt-2"
               style={{ color: '#6b7280', fontSize: '0.8rem' }}
             >
-              <p>⭐ Tap any button (e.g., Next) to enable speech.</p>
+              <p>⭐ Speech won’t autoplay due to security. Sometimes, tap anywhere or any button (e.g. Next) to enable it.</p>
               <p>⭐ On Mobile, only one voice may be available.</p>
               <p>
                 ⭐ No personal login or data is stored on any server. Your


### PR DESCRIPTION
## Summary
- tweak the mobile speech notification wording in the vocabulary app components

## Testing
- `npm test` *(fails: playCurrentWord is not a function)*
- `npx vitest run` *(fails: playCurrentWord is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688bfa203df8832fad0b773640f7ba40