### PR TITLE
feat: add GA event tracking

### DIFF
--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -15,6 +15,13 @@ const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange })
 
   const handleChange = (v: number) => {
     onChange(v);
+    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+      window.gtag('event', 'speech_rate_change', {
+        event_category: 'interaction',
+        event_label: `${v}x`,
+        value: v
+      });
+    }
     setOpen(false); // close popup after selecting rate
   };
 

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -68,6 +68,42 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   const wordType = wordParts.length > 1 ? `(${wordParts[1]})` : '';
   const phoneticPart = wordParts.length > 2 ? wordParts.slice(2).join(' ').trim() : '';
   const { main, annotations } = parseWordAnnotations(word);
+  const nextCategoryLabel = getCategoryLabel(nextCategory);
+
+  const trackEvent = (name: string, label: string, value?: number) => {
+    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+      window.gtag('event', name, {
+        event_category: 'interaction',
+        event_label: label,
+        ...(typeof value === 'number' ? { value } : {})
+      });
+    }
+  };
+
+  const handleMuteClick = () => {
+    trackEvent(isMuted ? 'unmute' : 'mute', isMuted ? 'Unmute' : 'Mute');
+    onToggleMute();
+  };
+
+  const handlePauseClick = () => {
+    trackEvent(isPaused ? 'play' : 'pause', isPaused ? 'Play' : 'Pause');
+    onTogglePause();
+  };
+
+  const handleNextClick = () => {
+    trackEvent('next_word', 'Next');
+    onNextWord();
+  };
+
+  const handleSwitchCategoryClick = () => {
+    trackEvent('switch_category', nextCategoryLabel);
+    onSwitchCategory();
+  };
+
+  const handleCycleVoiceClick = () => {
+    trackEvent('cycle_voice', nextVoiceLabel);
+    onCycleVoice();
+  };
 
   return (
     <Card 
@@ -131,7 +167,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onToggleMute}
+              onClick={handleMuteClick}
               className={cn(
                 "h-6 text-xs px-1.5",
                 isMuted ? "text-purple-700 border-purple-300 bg-purple-50" : "text-gray-700"
@@ -144,7 +180,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onTogglePause}
+              onClick={handlePauseClick}
               className={cn(
                 "h-6 text-xs px-1.5",
                 isPaused ? "text-orange-500 border-orange-300 bg-orange-50" : "text-gray-700"
@@ -157,7 +193,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onNextWord}
+              onClick={handleNextClick}
               className="h-6 text-xs px-1.5 text-indigo-700 bg-indigo-50"
             >
               <SkipForward size={12} className="mr-1" />
@@ -167,7 +203,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onSwitchCategory}
+              onClick={handleSwitchCategoryClick}
               className="h-6 text-xs px-1.5 text-green-700"
             >
               <RefreshCw size={10} className="mr-1" />
@@ -178,7 +214,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onCycleVoice}
+              onClick={handleCycleVoiceClick}
               className="h-6 text-xs px-1.5 text-blue-700 border-blue-300 bg-blue-50"
             >
               {nextVoiceLabel}

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -51,22 +51,36 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   const nextCategoryLabel = getCategoryLabel(safeNextCategory);
   const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
 
+  const trackEvent = (name: string, label: string, value?: number) => {
+    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+      window.gtag('event', name, {
+        event_category: 'interaction',
+        event_label: label,
+        ...(typeof value === 'number' ? { value } : {})
+      });
+    }
+  };
+
   const handleToggleMute = () => {
     onToggleMute();
+    trackEvent(isMuted ? 'unmute' : 'mute', isMuted ? 'Unmute' : 'Mute');
     toast(isMuted ? 'Audio unmuted' : 'Audio muted');
   };
 
   const handleTogglePause = () => {
     onTogglePause();
+    trackEvent(isPaused ? 'play' : 'pause', isPaused ? 'Play' : 'Pause');
     toast(isPaused ? 'Playback resumed' : 'Playback paused');
   };
 
   const handleNextWord = () => {
     onNextWord();
+    trackEvent('next_word', 'Next Word');
   };
 
   const handleSwitchCategory = () => {
     onSwitchCategory();
+    trackEvent('switch_category', nextCategoryLabel);
     toast(`Switched to ${nextCategoryMessageLabel}`);
   };
 
@@ -76,10 +90,12 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       return;
     }
     onCycleVoice();
+    trackEvent('cycle_voice', selectedVoiceName);
   };
 
   const handleRateChange = (r: number) => {
     setSpeechRate(r);
+    trackEvent('speech_rate_change', `${r}x`, r);
     unifiedSpeechController.stop();
     if (!isMuted && !isPaused) {
       playCurrentWord();


### PR DESCRIPTION
## Summary
- track interactions like mute, pause, next word, category switch, voice change and speech rate
- send GA4 events from vocabulary controls and card buttons

## Testing
- `npm test -- --run` *(fails: TypeError: playCurrentWord is not a function)*
- `npm run lint` *(fails: 106 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689160d21660832f9ddafb59686ffb32