### PR TITLE
Persist selected learning intensity and word list

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -86,6 +86,9 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
               <Badge variant="outline" className="text-blue-600 border-0">
                 Review: {dailySelection.reviewWords.length}
               </Badge>
+              <Badge variant="outline" className="border-0">
+                Level: {dailySelection.severity}
+              </Badge>
             </div>
             
             {/* Category breakdown for all words in today's selection */}

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -230,7 +230,8 @@ export class LearningProgressService {
     const selection: DailySelection = {
       newWords: selectedNew,
       reviewWords: selectedReview,
-      totalCount: selectedNew.length + selectedReview.length
+      totalCount: selectedNew.length + selectedReview.length,
+      severity
     };
 
     // Cache the selection

--- a/src/types/learning.ts
+++ b/src/types/learning.ts
@@ -15,6 +15,7 @@ export interface DailySelection {
   newWords: LearningProgress[];
   reviewWords: LearningProgress[];
   totalCount: number;
+  severity: SeverityLevel;
 }
 
 export type SeverityLevel = 'light' | 'moderate' | 'intense';

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -216,7 +216,8 @@ describe('LearningProgressService', () => {
       const mockSelection = {
         newWords: [],
         reviewWords: [],
-        totalCount: 20
+        totalCount: 20,
+        severity: 'moderate'
       };
 
       localStorageMock.getItem.mockImplementation((key) => {


### PR DESCRIPTION
## Summary
- store chosen daily learning level alongside word list in localStorage
- display saved learning intensity in daily progress panel
- update tests to expect cached severity

## Testing
- `npm test` *(fails: expected 'due' to be 'not_due')*
- `npm run lint` *(fails: eslint reported errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fbca84a9c832f9a975eb1a303de08