### PR TITLE
Load today's vocabulary selection on startup

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -19,7 +19,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     refreshStats,
     getDueReviewWords,
     getRetiredWords,
-    retireCurrentWord
+    retireCurrentWord,
+    todayWords
   } = useLearningProgress(allWords);
 
   // Load vocabulary data
@@ -148,8 +149,9 @@ const VocabularyAppWithLearning: React.FC = () => {
           </TabsContent>
           
           <TabsContent value="practice" className="space-y-4">
-            <VocabularyAppContainerNew 
-              isActive={activeTab === 'practice'} 
+            <VocabularyAppContainerNew
+              isActive={activeTab === 'practice'}
+              initialWords={todayWords}
               onRetireWord={() => {
                 const currentWord = vocabularyService.getCurrentWord();
                 if (currentWord) {

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -11,13 +11,15 @@ import { useOptimizedAutoPlay } from "@/hooks/vocabulary-app/useOptimizedAutoPla
 import VocabularyWordManager from "./word-management/VocabularyWordManager";
 import { vocabularyService } from '@/services/vocabularyService';
 import { DebugInfoContext } from '@/contexts/DebugInfoContext';
+import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
   isActive?: boolean;
   onRetireWord?: () => void;
+  initialWords?: VocabularyWord[];
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ isActive = true, onRetireWord }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ isActive = true, onRetireWord, initialWords }) => {
   // Use stable state management
   const {
     currentWord,
@@ -37,7 +39,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
     userInteractionState,
     nextCategory,
     handleInteractionUpdate
-  } = useStableVocabularyState();
+  } = useStableVocabularyState(initialWords);
 
   // Optimized auto-play with reduced re-renders
   useOptimizedAutoPlay({

--- a/src/hooks/vocabulary-app/useStableVocabularyState.ts
+++ b/src/hooks/vocabulary-app/useStableVocabularyState.ts
@@ -1,9 +1,10 @@
 
-import { useState, useCallback, useMemo, useRef } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useUnifiedVocabularyController } from '@/hooks/vocabulary-controller/useUnifiedVocabularyController';
 import { vocabularyService } from '@/services/vocabularyService';
+import { VocabularyWord } from '@/types/vocabulary';
 
-export const useStableVocabularyState = () => {
+export const useStableVocabularyState = (initialWords?: VocabularyWord[]) => {
   const [userInteractionState, setUserInteractionState] = useState({
     hasInitialized: false,
     interactionCount: 0,
@@ -11,7 +12,7 @@ export const useStableVocabularyState = () => {
   });
 
   // Use stable reference for the unified controller
-  const controllerState = useUnifiedVocabularyController();
+  const controllerState = useUnifiedVocabularyController(initialWords);
   
   // Memoize computed values to prevent recalculation
   const nextVoiceLabel = useMemo(() => {

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -14,7 +14,8 @@ export const useVocabularyDataLoader = (
   setHasData: (hasData: boolean) => void,
   setCurrentIndex: (index: number) => void,
   selectedVoiceName: string,
-  clearAutoAdvanceTimer: () => void
+  clearAutoAdvanceTimer: () => void,
+  initialWords?: VocabularyWord[]
 ) => {
   // Persist selected voice whenever it changes
   useEffect(() => {
@@ -31,8 +32,15 @@ export const useVocabularyDataLoader = (
 
   // Load initial data
   useEffect(() => {
+    if (initialWords && initialWords.length > 0) {
+      setWordList(initialWords);
+      setHasData(true);
+      setCurrentIndex(0);
+      return;
+    }
+
     console.log('[DATA-LOADER] Loading initial vocabulary data');
-    
+
     const loadData = () => {
       try {
         const words = vocabularyService.getWordList();
@@ -69,10 +77,10 @@ export const useVocabularyDataLoader = (
     };
 
     vocabularyService.addVocabularyChangeListener(handleVocabularyChange);
-    
+
     return () => {
       vocabularyService.removeVocabularyChangeListener(handleVocabularyChange);
       clearAutoAdvanceTimer(); // Clean up on unmount
     };
-  }, [setWordList, setHasData, setCurrentIndex, clearAutoAdvanceTimer]);
+  }, [initialWords, setWordList, setHasData, setCurrentIndex, clearAutoAdvanceTimer]);
 };

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -9,11 +9,12 @@ import { useWordNavigation } from './core/useWordNavigation';
 import { useVocabularyControls } from './core/useVocabularyControls';
 import { useVocabularyDataLoader } from './core/useVocabularyDataLoader';
 import { saveLastWord } from '@/utils/lastWordStorage';
+import { VocabularyWord } from '@/types/vocabulary';
 
 /**
  * Unified Vocabulary Controller - Single source of truth for vocabulary state
  */
-export const useUnifiedVocabularyController = () => {
+export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) => {
   console.log('[UNIFIED-CONTROLLER] Initializing controller');
 
   // Core state management
@@ -118,7 +119,8 @@ export const useUnifiedVocabularyController = () => {
     setHasData,
     setCurrentIndex,
     selectedVoiceName,
-    clearAutoAdvanceTimer
+    clearAutoAdvanceTimer,
+    initialWords
   );
 
   // Set up word completion callback with auto-advance


### PR DESCRIPTION
## Summary
- Generate or load today's vocabulary selection automatically when the app starts
- Pipe today's words into the practice component so playback begins with daily words
- Allow vocabulary state hooks to accept an initial word list for custom playback

## Testing
- `npm test` *(fails: LearningProgressService expectation and unhandled timeout)*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fc08794b0832fa800df2e18767a84