### PR TITLE
preserve practice state across tabs

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -148,7 +148,7 @@ const VocabularyAppWithLearning: React.FC = () => {
             )}
           </TabsContent>
           
-          <TabsContent value="practice" className="space-y-4">
+          <TabsContent value="practice" className="space-y-4" forceMount>
             <VocabularyAppContainerNew
               isActive={activeTab === 'practice'}
               initialWords={todayWords}


### PR DESCRIPTION
## Summary
- keep practice session mounted to retain current word when switching tabs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fcd4ba7ac832f81dcb1c1b604d23d