### PR TITLE
Remove category switching in vocabulary app

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -15,9 +15,6 @@ interface ContentWithDataNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
-  handleSwitchCategory: () => void;
-  currentCategory: string;
-  nextCategory: string | null;
   isSpeaking: boolean;
   handleManualNext: () => void;
   displayTime: number;
@@ -40,9 +37,6 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
-  handleSwitchCategory,
-  currentCategory,
-  nextCategory,
   isSpeaking,
   handleManualNext,
   displayTime,
@@ -63,11 +57,11 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         ? {
             ...wordToEdit,
             translation: wordToEdit.translation || '',
-            category: wordToEdit.category || currentCategory
+            category: wordToEdit.category || displayWord.category
           }
         : undefined
     ),
-    [isEditMode, wordToEdit, currentCategory]
+    [isEditMode, wordToEdit, displayWord.category]
   );
   const [open, setOpen] = useState(false);
   return (
@@ -80,13 +74,10 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         toggleMute={toggleMute}
         handleTogglePause={handleTogglePause}
         handleCycleVoice={handleCycleVoice}
-        handleSwitchCategory={handleSwitchCategory}
-        currentCategory={currentCategory}
-        nextCategory={nextCategory}
         isSoundPlaying={isSpeaking}
         handleManualNext={handleManualNext}
         displayTime={displayTime}
-      selectedVoiceName={selectedVoiceName}
+        selectedVoiceName={selectedVoiceName}
       onOpenAddModal={handleOpenAddWordModal}
       onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       playCurrentWord={playCurrentWord}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -34,10 +34,8 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
     togglePause,
     toggleMute,
     toggleVoice,
-    switchCategory,
     playCurrentWord,
     userInteractionState,
-    nextCategory,
     handleInteractionUpdate
   } = useStableVocabularyState(initialWords);
 
@@ -110,18 +108,8 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
             meaning="Please upload a vocabulary file to get started"
             example=""
             backgroundColor="#F0F8FF"
-            isMuted={isMuted}
-            isPaused={isPaused}
-            onToggleMute={toggleMute}
-            onTogglePause={togglePause}
-            onCycleVoice={toggleVoice}
-            onSwitchCategory={switchCategory}
-            onNextWord={goToNextAndSpeak}
-            currentCategory={currentCategory}
-            nextCategory={nextCategory}
             isSpeaking={false}
             category="No Data"
-            selectedVoiceName={selectedVoiceName}
           />
         </div>
         </VocabularyLayout>
@@ -144,18 +132,8 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
             meaning="Try switching to another category"
             example=""
             backgroundColor="#F0F8FF"
-            isMuted={isMuted}
-            isPaused={isPaused}
-            onToggleMute={toggleMute}
-            onTogglePause={togglePause}
-            onCycleVoice={toggleVoice}
-            onSwitchCategory={switchCategory}
-            onNextWord={goToNextAndSpeak}
-            currentCategory={currentCategory}
-            nextCategory={nextCategory}
             isSpeaking={false}
             category={currentCategory}
-            selectedVoiceName={selectedVoiceName}
           />
         </div>
         </VocabularyLayout>
@@ -176,21 +154,11 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
         <VocabularyCardNew
           word="Loading vocabulary..."
           meaning="Please wait while we load your vocabulary data"
-            example=""
-            backgroundColor="#F0F8FF"
-            isMuted={isMuted}
-            isPaused={isPaused}
-            onToggleMute={toggleMute}
-            onTogglePause={togglePause}
-            onCycleVoice={toggleVoice}
-            onSwitchCategory={switchCategory}
-            onNextWord={goToNextAndSpeak}
-            currentCategory={currentCategory}
-            nextCategory={nextCategory}
-            isSpeaking={false}
-            category="Loading"
-            selectedVoiceName={selectedVoiceName}
-          />
+          example=""
+          backgroundColor="#F0F8FF"
+          isSpeaking={false}
+          category="Loading"
+        />
         </div>
       </VocabularyLayout>
       </DebugInfoContext.Provider>
@@ -214,9 +182,6 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
             toggleMute={toggleMute}
             handleTogglePause={togglePause}
             handleCycleVoice={toggleVoice}
-            handleSwitchCategory={switchCategory}
-            currentCategory={currentCategory}
-            nextCategory={nextCategory}
             isSpeaking={isSpeaking}
             handleManualNext={goToNextAndSpeak}
             displayTime={5000}
@@ -255,9 +220,6 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
           toggleMute={toggleMute}
           handleTogglePause={togglePause}
           handleCycleVoice={toggleVoice}
-          handleSwitchCategory={switchCategory}
-          currentCategory={currentCategory}
-          nextCategory={nextCategory}
           isSpeaking={isSpeaking}
           handleManualNext={goToNextAndSpeak}
           displayTime={5000}

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -2,8 +2,7 @@ import React, { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward } from 'lucide-react';
-import { getCategoryLabel } from '@/utils/categoryLabels';
+import { Volume2, VolumeX, Pause, Play, SkipForward } from 'lucide-react';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
 
@@ -18,16 +17,17 @@ interface VocabularyCardProps {
   onToggleMute: () => void;
   onTogglePause: () => void;
   onCycleVoice: () => void;
-  onSwitchCategory: () => void;
   onNextWord: () => void;
-  currentCategory: string;
-  nextCategory: string;
   isSpeaking?: boolean;
   displayTime?: number;
   category?: string;
   selectedVoice: VoiceSelection;
   nextVoiceLabel: string;
   searchPreview?: boolean;
+  // Optional legacy props kept for backward compatibility
+  onSwitchCategory?: () => void;
+  currentCategory?: string;
+  nextCategory?: string;
 }
 
 const VocabularyCard: React.FC<VocabularyCardProps> = ({
@@ -41,10 +41,7 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   onToggleMute,
   onTogglePause,
   onCycleVoice,
-  onSwitchCategory,
   onNextWord,
-  currentCategory,
-  nextCategory,
   isSpeaking = false,
   category,
   selectedVoice,
@@ -68,7 +65,6 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   const wordType = wordParts.length > 1 ? `(${wordParts[1]})` : '';
   const phoneticPart = wordParts.length > 2 ? wordParts.slice(2).join(' ').trim() : '';
   const { main, annotations } = parseWordAnnotations(word);
-  const nextCategoryLabel = getCategoryLabel(nextCategory);
 
   const trackEvent = (name: string, label: string, value?: number) => {
     if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
@@ -93,11 +89,6 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   const handleNextClick = () => {
     trackEvent('next_word', 'Next');
     onNextWord();
-  };
-
-  const handleSwitchCategoryClick = () => {
-    trackEvent('switch_category', nextCategoryLabel);
-    onSwitchCategory();
   };
 
   const handleCycleVoiceClick = () => {
@@ -198,16 +189,6 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             >
               <SkipForward size={12} className="mr-1" />
               Next
-            </Button>
-
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleSwitchCategoryClick}
-              className="h-6 text-xs px-1.5 text-green-700"
-            >
-              <RefreshCw size={10} className="mr-1" />
-              {/* Removed dynamic category label */}
             </Button>
 
             {/* Single voice toggle button */}

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getCategoryLabel } from '@/utils/categoryLabels';
 import WordCountDisplay from './WordCountDisplay';
@@ -13,18 +11,8 @@ interface VocabularyCardNewProps {
   example: string;
   translation?: string;
   backgroundColor: string;
-  isMuted: boolean;
-  isPaused: boolean;
-  onToggleMute: () => void;
-  onTogglePause: () => void;
-  onCycleVoice: () => void;
-  onSwitchCategory: () => void;
-  onNextWord: () => void;
-  currentCategory: string;
-  nextCategory: string;
   isSpeaking: boolean;
   category: string;
-  selectedVoiceName: string;
   showWordCount?: boolean;
 }
 
@@ -34,22 +22,11 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
   example,
   translation,
   backgroundColor,
-  isMuted,
-  isPaused,
-  onToggleMute,
-  onTogglePause,
-  onCycleVoice,
-  onSwitchCategory,
-  onNextWord,
-  currentCategory,
-  nextCategory,
   isSpeaking,
   category,
-  selectedVoiceName,
   showWordCount = false
 }) => {
   const categoryLabel = getCategoryLabel(category);
-  const nextCategoryLabel = getCategoryLabel(nextCategory);
 
   const currentWordObj = { word, meaning, example, translation, category };
   const { main, annotations } = parseWordAnnotations(word);

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Volume2, VolumeX, Pause, Play, RefreshCw, SkipForward, Speaker, Search, Archive } from 'lucide-react';
+import { Volume2, VolumeX, Pause, Play, SkipForward, Speaker, Search, Archive } from 'lucide-react';
 import SpeechRateControl from './SpeechRateControl';
 import { useSpeechRate } from '@/hooks/useSpeechRate';
 import { toast } from 'sonner';
@@ -10,7 +10,6 @@ import EditWordButton from './EditWordButton';
 import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
-import { getCategoryLabel, getCategoryMessageLabel } from '@/utils/categoryLabels';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 import { RetireWordDialog } from '@/components/RetireWordDialog';
@@ -21,9 +20,7 @@ interface VocabularyControlsColumnProps {
   onToggleMute: () => void;
   onTogglePause: () => void;
   onNextWord: () => void;
-  onSwitchCategory: () => void;
   onCycleVoice: () => void;
-  nextCategory: string;
   currentWord: VocabularyWord | null;
   onOpenAddModal: () => void;
   onOpenEditModal: () => void;
@@ -38,9 +35,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onToggleMute,
   onTogglePause,
   onNextWord,
-  onSwitchCategory,
   onCycleVoice,
-  nextCategory,
   currentWord,
   onOpenAddModal,
   onOpenEditModal,
@@ -50,10 +45,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
-  const safeNextCategory = nextCategory || 'Next';
-  const nextCategoryLabel = getCategoryLabel(safeNextCategory);
-  const nextCategoryMessageLabel = getCategoryMessageLabel(safeNextCategory);
-
+  
   const trackEvent = (name: string, label: string, value?: number) => {
     if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
       window.gtag('event', name, {
@@ -79,12 +71,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   const handleNextWord = () => {
     onNextWord();
     trackEvent('next_word', 'Next Word');
-  };
-
-  const handleSwitchCategory = () => {
-    onSwitchCategory();
-    trackEvent('switch_category', nextCategoryLabel);
-    toast(`Switched to ${nextCategoryMessageLabel}`);
   };
 
   const handleCycleVoice = () => {
@@ -156,17 +142,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         aria-label="Next Word"
       >
         <SkipForward size={16} />
-      </Button>
-
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={handleSwitchCategory}
-        className="h-8 w-8 p-0 text-green-700"
-        title={`Switch to ${nextCategoryLabel}`}
-        aria-label={`Switch to ${nextCategoryLabel}`}
-      >
-        <RefreshCw size={16} />
       </Button>
 
       <Button

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -12,10 +12,7 @@ interface VocabularyMainNewProps {
   toggleMute: () => void;
   handleTogglePause: () => void;
   handleCycleVoice: () => void;
-  handleSwitchCategory: () => void;
   handleManualNext: () => void;
-  currentCategory: string;
-  nextCategory: string | null;
   isSoundPlaying: boolean;
   displayTime: number;
   selectedVoiceName: string;
@@ -33,11 +30,8 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   toggleMute,
   handleTogglePause,
   handleCycleVoice,
-  handleSwitchCategory,
-  currentCategory,
-  nextCategory,
-  isSoundPlaying,
   handleManualNext,
+  isSoundPlaying,
   displayTime,
   selectedVoiceName,
   onOpenAddModal,
@@ -45,56 +39,44 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   showWordCount = false,
   playCurrentWord,
   onRetireWord,
-}) => {
+  }) => {
   const { backgroundColor } = useBackgroundColor();
 
   return (
     <div className="flex flex-row items-start gap-2 sm:gap-4 w-full max-w-5xl mx-auto">
       {/* Main card - takes most of the space */}
-      <div className="flex-1 min-w-0">
-        <VocabularyCardNew
-          word={currentWord.word}
-          meaning={currentWord.meaning}
-          example={currentWord.example}
-          translation={currentWord.translation}
-          backgroundColor={backgroundColor}
-          isMuted={mute}
-          isPaused={isPaused}
-          onToggleMute={toggleMute}
-          onTogglePause={handleTogglePause}
-          onCycleVoice={handleCycleVoice}
-          onSwitchCategory={handleSwitchCategory}
-          onNextWord={handleManualNext}
-          currentCategory={currentCategory}
-          nextCategory={nextCategory || 'Next'}
-          isSpeaking={isSoundPlaying}
-          category={currentWord.category || currentCategory}
-          selectedVoiceName={selectedVoiceName}
-          showWordCount={showWordCount}
-        />
-      </div>
+        <div className="flex-1 min-w-0">
+          <VocabularyCardNew
+            word={currentWord.word}
+            meaning={currentWord.meaning}
+            example={currentWord.example}
+            translation={currentWord.translation}
+            backgroundColor={backgroundColor}
+            isSpeaking={isSoundPlaying}
+            category={currentWord.category || ''}
+            showWordCount={showWordCount}
+          />
+        </div>
       
       {/* Controls column - positioned on the right side */}
-      <div className="flex-none flex flex-col justify-start items-end">
-        <VocabularyControlsColumn
-          isMuted={mute}
-          isPaused={isPaused}
-          onToggleMute={toggleMute}
-          onTogglePause={handleTogglePause}
-          onNextWord={handleManualNext}
-          onSwitchCategory={handleSwitchCategory}
-          onCycleVoice={handleCycleVoice}
-          nextCategory={nextCategory || 'Next'}
-          currentWord={currentWord}
-        onOpenAddModal={onOpenAddModal}
-        onOpenEditModal={onOpenEditModal}
-        selectedVoiceName={selectedVoiceName}
-        playCurrentWord={playCurrentWord}
-        onRetireWord={onRetireWord}
-      />
+        <div className="flex-none flex flex-col justify-start items-end">
+          <VocabularyControlsColumn
+            isMuted={mute}
+            isPaused={isPaused}
+            onToggleMute={toggleMute}
+            onTogglePause={handleTogglePause}
+            onNextWord={handleManualNext}
+            onCycleVoice={handleCycleVoice}
+            currentWord={currentWord}
+            onOpenAddModal={onOpenAddModal}
+            onOpenEditModal={onOpenEditModal}
+            selectedVoiceName={selectedVoiceName}
+            playCurrentWord={playCurrentWord}
+            onRetireWord={onRetireWord}
+          />
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };
 
 export default VocabularyMainNew;

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -8,7 +8,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   const [dailySelection, setDailySelection] = useState<DailySelection | null>(null);
   const [currentWordProgress, setCurrentWordProgress] = useState<LearningProgress | null>(null);
   const [todayWords, setTodayWords] = useState<VocabularyWord[]>([]);
-  const [selectedCategory, setSelectedCategory] = useState('ALL');
   const [progressStats, setProgressStats] = useState({
     total: 0,
     learned: 0,
@@ -60,11 +59,11 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
       dailySelection.newWords,
       dailySelection.reviewWords,
       allWords,
-      selectedCategory
+      'ALL'
     );
 
     setTodayWords(words);
-  }, [dailySelection, allWords, selectedCategory]);
+  }, [dailySelection, allWords]);
 
   const getDueReviewWords = useCallback(() => {
     return learningProgressService.getDueReviewWords();
@@ -90,17 +89,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getDueReviewWords,
     getRetiredWords,
     retireCurrentWord,
-    todayWords,
-    selectedCategory,
-    setSelectedCategory,
-    getTodayWords: (category: string) =>
-      dailySelection
-        ? buildTodaysWords(
-            dailySelection.newWords,
-            dailySelection.reviewWords,
-            allWords,
-            category
-          )
-        : []
+    todayWords
   };
 };

--- a/src/hooks/vocabulary-app/useStableVocabularyState.ts
+++ b/src/hooks/vocabulary-app/useStableVocabularyState.ts
@@ -1,7 +1,6 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { useUnifiedVocabularyController } from '@/hooks/vocabulary-controller/useUnifiedVocabularyController';
-import { vocabularyService } from '@/services/vocabularyService';
 import { VocabularyWord } from '@/types/vocabulary';
 
 export const useStableVocabularyState = (initialWords?: VocabularyWord[]) => {
@@ -22,13 +21,6 @@ export const useStableVocabularyState = (initialWords?: VocabularyWord[]) => {
     return controllerState.allVoices[nextIndex].name;
   }, [controllerState.selectedVoiceName, controllerState.allVoices]);
 
-  const nextCategory = useMemo(() => {
-    const sheets = vocabularyService.getAllSheetNames();
-    const currentIndex = sheets.indexOf(controllerState.currentCategory);
-    const nextIndex = (currentIndex + 1) % sheets.length;
-    return sheets[nextIndex] || 'Next';
-  }, [controllerState.currentCategory]);
-
   // Stable callback for user interaction updates
   const handleInteractionUpdate = useCallback((newState: typeof userInteractionState) => {
     setUserInteractionState(prev => {
@@ -45,7 +37,6 @@ export const useStableVocabularyState = (initialWords?: VocabularyWord[]) => {
     ...controllerState,
     userInteractionState,
     nextVoiceLabel,
-    nextCategory,
     handleInteractionUpdate
   };
 };

--- a/src/hooks/vocabulary-controller/core/useWordNavigation.ts
+++ b/src/hooks/vocabulary-controller/core/useWordNavigation.ts
@@ -57,7 +57,9 @@ export const useWordNavigation = (
       if (nextWord) {
         saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
         // Speak the new word immediately
-        setTimeout(() => playCurrentWord(), 10);
+        if (typeof playCurrentWord === 'function') {
+          setTimeout(() => playCurrentWord(), 10);
+        }
       }
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- Drop Change Category controls so playback only cycles through daily words
- Build daily practice list from all categories without filtering
- Guard word navigation playback when no play function is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fce8bca88832fb9971d5588c8c1ad