### PR TITLE
Consolidate practice and learning views

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import VocabularyAppContainerNew from './vocabulary-app/VocabularyAppContainerNew';
 import { LearningProgressPanel } from './LearningProgressPanel';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
@@ -9,7 +8,6 @@ import ToastProvider from './vocabulary-app/ToastProvider';
 
 const VocabularyAppWithLearning: React.FC = () => {
   const [allWords, setAllWords] = useState<VocabularyWord[]>([]);
-  const [activeTab, setActiveTab] = useState('practice');
 
   const {
     dailySelection,
@@ -56,111 +54,104 @@ const VocabularyAppWithLearning: React.FC = () => {
     };
   }, [markWordAsPlayed]);
 
+  const learningSection = (
+    <div className="space-y-4 mt-4">
+      <LearningProgressPanel
+        dailySelection={dailySelection}
+        progressStats={progressStats}
+        onGenerateDaily={generateDailyWords}
+        onRefresh={refreshStats}
+      />
+
+      {dailySelection && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Word Summary</h3>
+          <div className="grid gap-4 md:grid-cols-4">
+            {dailySelection.newWords.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="font-medium text-green-600">New Words ({dailySelection.newWords.length})</h4>
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {dailySelection.newWords.map((word, index) => (
+                    <div key={index} className="text-sm p-2 bg-green-50 rounded border">
+                      <div className="font-medium">{word.word}</div>
+                      <div className="text-xs text-gray-600">{word.category}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {dailySelection.reviewWords.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="font-medium text-blue-600">Review Words ({dailySelection.reviewWords.length})</h4>
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {dailySelection.reviewWords.map((word, index) => (
+                    <div key={index} className="text-sm p-2 bg-blue-50 rounded border">
+                      <div className="font-medium">{word.word}</div>
+                      <div className="text-xs text-gray-600">
+                        {word.category} • Review #{word.reviewCount}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {progressStats.due > 0 && (
+              <div className="space-y-2">
+                <h4 className="font-medium text-red-600">Due Review Words ({progressStats.due})</h4>
+                <div className="space-y-1 max-h-60 overflow-y-auto">
+                  {getDueReviewWords().map((word, index) => (
+                    <div key={index} className="text-sm p-2 bg-red-50 rounded border">
+                      <div className="font-medium">{word.word}</div>
+                      <div className="text-xs text-gray-600">
+                        {word.category} • Review #{word.reviewCount}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
+              <div className="space-y-1 max-h-60 overflow-y-auto">
+                {progressStats.retired > 0 ? (
+                  getRetiredWords().map((word, index) => (
+                    <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
+                      <div className="font-medium text-gray-700">{word.word}</div>
+                      <div className="text-xs text-gray-500">
+                        {word.category} • Retired {word.retiredDate}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
+                    No retired words
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <>
       <ToastProvider />
       <div className="w-full max-w-6xl mx-auto p-4">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="practice">Practice</TabsTrigger>
-            <TabsTrigger value="learning">Learning Progress</TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="learning" className="space-y-4">
-            <LearningProgressPanel
-              dailySelection={dailySelection}
-              progressStats={progressStats}
-              onGenerateDaily={generateDailyWords}
-              onRefresh={refreshStats}
-            />
-            
-            {dailySelection && (
-              <div className="space-y-4">
-                <h3 className="text-lg font-semibold">Word Summary</h3>
-                <div className="grid gap-4 md:grid-cols-4">
-                  {dailySelection.newWords.length > 0 && (
-                    <div className="space-y-2">
-                      <h4 className="font-medium text-green-600">New Words ({dailySelection.newWords.length})</h4>
-                      <div className="space-y-1 max-h-60 overflow-y-auto">
-                        {dailySelection.newWords.map((word, index) => (
-                          <div key={index} className="text-sm p-2 bg-green-50 rounded border">
-                            <div className="font-medium">{word.word}</div>
-                            <div className="text-xs text-gray-600">{word.category}</div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  
-                  {dailySelection.reviewWords.length > 0 && (
-                    <div className="space-y-2">
-                      <h4 className="font-medium text-blue-600">Review Words ({dailySelection.reviewWords.length})</h4>
-                      <div className="space-y-1 max-h-60 overflow-y-auto">
-                        {dailySelection.reviewWords.map((word, index) => (
-                          <div key={index} className="text-sm p-2 bg-blue-50 rounded border">
-                            <div className="font-medium">{word.word}</div>
-                            <div className="text-xs text-gray-600">
-                              {word.category} • Review #{word.reviewCount}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  
-                  {progressStats.due > 0 && (
-                    <div className="space-y-2">
-                      <h4 className="font-medium text-red-600">Due Review Words ({progressStats.due})</h4>
-                      <div className="space-y-1 max-h-60 overflow-y-auto">
-                        {getDueReviewWords().map((word, index) => (
-                          <div key={index} className="text-sm p-2 bg-red-50 rounded border">
-                            <div className="font-medium">{word.word}</div>
-                            <div className="text-xs text-gray-600">
-                              {word.category} • Review #{word.reviewCount}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  
-                  <div className="space-y-2">
-                    <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
-                    <div className="space-y-1 max-h-60 overflow-y-auto">
-                      {progressStats.retired > 0 ? (
-                        getRetiredWords().map((word, index) => (
-                          <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
-                            <div className="font-medium text-gray-700">{word.word}</div>
-                            <div className="text-xs text-gray-500">
-                              {word.category} • Retired {word.retiredDate}
-                            </div>
-                          </div>
-                        ))
-                      ) : (
-                        <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
-                          No retired words
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-          </TabsContent>
-          
-          <TabsContent value="practice" className="space-y-4" forceMount>
-            <VocabularyAppContainerNew
-              isActive={activeTab === 'practice'}
-              initialWords={todayWords}
-              onRetireWord={() => {
-                const currentWord = vocabularyService.getCurrentWord();
-                if (currentWord) {
-                  retireCurrentWord(currentWord.word);
-                }
-              }}
-            />
-          </TabsContent>
-        </Tabs>
+        <VocabularyAppContainerNew
+          initialWords={todayWords}
+          onRetireWord={() => {
+            const currentWord = vocabularyService.getCurrentWord();
+            if (currentWord) {
+              retireCurrentWord(currentWord.word);
+            }
+          }}
+          additionalContent={learningSection}
+        />
       </div>
     </>
   );

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -28,6 +28,7 @@ interface ContentWithDataNewProps {
   handleOpenEditWordModal: (word: VocabularyWord) => void;
   playCurrentWord: () => void;
   onRetireWord?: () => void;
+  additionalContent?: React.ReactNode;
 }
 
 const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
@@ -49,7 +50,8 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenAddWordModal,
   handleOpenEditWordModal,
   playCurrentWord,
-  onRetireWord
+  onRetireWord,
+  additionalContent
 }) => {
   const editingWordData = useMemo(
     () => (
@@ -83,6 +85,8 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       playCurrentWord={playCurrentWord}
       onRetireWord={onRetireWord}
       />
+
+      {additionalContent}
 
       {/* Achievements and learning days */}
       <Collapsible open={open} onOpenChange={setOpen}>

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -14,12 +14,12 @@ import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
-  isActive?: boolean;
   onRetireWord?: () => void;
   initialWords?: VocabularyWord[];
+  additionalContent?: React.ReactNode;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ isActive = true, onRetireWord, initialWords }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onRetireWord, initialWords, additionalContent }) => {
   // Use stable state management
   const {
     currentWord,
@@ -48,8 +48,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
     isMuted,
     isSpeaking,
     isAudioUnlocked: userInteractionState.isAudioUnlocked,
-    playCurrentWord,
-    isActive
+    playCurrentWord
   });
 
   // Modal state management
@@ -91,27 +90,25 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
     currentWord: debugData
   }), [isMuted, selectedVoiceName, isPaused, debugData]);
 
-  let content: React.ReactNode;
-
   if (!hasData && !vocabularyService.hasData()) {
     return (
       <DebugInfoContext.Provider value={debugInfo}>
-      <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
-        <div className="space-y-4">
-          <UserInteractionManager
-            currentWord={currentWord}
-            playCurrentWord={playCurrentWord}
-            onInteractionUpdate={handleInteractionUpdate}
-          />
-          <VocabularyCardNew
-            word="No vocabulary data"
-            meaning="Please upload a vocabulary file to get started"
-            example=""
-            backgroundColor="#F0F8FF"
-            isSpeaking={false}
-            category="No Data"
-          />
-        </div>
+        <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
+          <div className="space-y-4">
+            <UserInteractionManager
+              currentWord={currentWord}
+              playCurrentWord={playCurrentWord}
+              onInteractionUpdate={handleInteractionUpdate}
+            />
+            <VocabularyCardNew
+              word="No vocabulary data"
+              meaning="Please upload a vocabulary file to get started"
+              example=""
+              backgroundColor="#F0F8FF"
+              isSpeaking={false}
+              category="No Data"
+            />
+          </div>
         </VocabularyLayout>
       </DebugInfoContext.Provider>
     );
@@ -120,22 +117,22 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
   if (!hasData) {
     return (
       <DebugInfoContext.Provider value={debugInfo}>
-      <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
-        <div className="space-y-4">
-          <UserInteractionManager
-            currentWord={currentWord}
-            playCurrentWord={playCurrentWord}
-            onInteractionUpdate={handleInteractionUpdate}
-          />
-          <VocabularyCardNew
-            word={`No words in "${currentCategory}" category`}
-            meaning="Try switching to another category"
-            example=""
-            backgroundColor="#F0F8FF"
-            isSpeaking={false}
-            category={currentCategory}
-          />
-        </div>
+        <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
+          <div className="space-y-4">
+            <UserInteractionManager
+              currentWord={currentWord}
+              playCurrentWord={playCurrentWord}
+              onInteractionUpdate={handleInteractionUpdate}
+            />
+            <VocabularyCardNew
+              word={`No words in "${currentCategory}" category`}
+              meaning="Try switching to another category"
+              example=""
+              backgroundColor="#F0F8FF"
+              isSpeaking={false}
+              category={currentCategory}
+            />
+          </div>
         </VocabularyLayout>
       </DebugInfoContext.Provider>
     );
@@ -144,27 +141,29 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
   if (!currentWord) {
     return (
       <DebugInfoContext.Provider value={debugInfo}>
-      <VocabularyLayout showWordCard={true} hasData={true} onToggleView={() => {}}>
-        <div className="space-y-4">
-          <UserInteractionManager
-            currentWord={currentWord}
-            playCurrentWord={playCurrentWord}
-            onInteractionUpdate={handleInteractionUpdate}
-          />
-        <VocabularyCardNew
-          word="Loading vocabulary..."
-          meaning="Please wait while we load your vocabulary data"
-          example=""
-          backgroundColor="#F0F8FF"
-          isSpeaking={false}
-          category="Loading"
-        />
-        </div>
-      </VocabularyLayout>
+        <VocabularyLayout showWordCard={true} hasData={true} onToggleView={() => {}}>
+          <div className="space-y-4">
+            <UserInteractionManager
+              currentWord={currentWord}
+              playCurrentWord={playCurrentWord}
+              onInteractionUpdate={handleInteractionUpdate}
+            />
+            <VocabularyCardNew
+              word="Loading vocabulary..."
+              meaning="Please wait while we load your vocabulary data"
+              example=""
+              backgroundColor="#F0F8FF"
+              isSpeaking={false}
+              category="Loading"
+            />
+          </div>
+        </VocabularyLayout>
       </DebugInfoContext.Provider>
-      );
-  } else {
-    content = (
+    );
+  }
+
+  return (
+    <DebugInfoContext.Provider value={debugInfo}>
       <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
         <div className="space-y-4">
           <UserInteractionManager
@@ -173,7 +172,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
             onInteractionUpdate={handleInteractionUpdate}
           />
 
-        <ErrorDisplay jsonLoadError={false} />
+          <ErrorDisplay jsonLoadError={false} />
 
           <ContentWithDataNew
             displayWord={currentWord}
@@ -193,48 +192,11 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ i
             wordToEdit={wordToEdit}
             handleOpenAddWordModal={handleOpenAddWordModal}
             handleOpenEditWordModal={handleOpenEditWordModal}
-            playCurrentWord={playCurrentWord}
             onRetireWord={onRetireWord}
+            additionalContent={additionalContent}
           />
         </div>
       </VocabularyLayout>
-    );
-  }
-
-  return (
-    <DebugInfoContext.Provider value={debugInfo}>
-    <VocabularyLayout showWordCard={true} hasData={hasData} onToggleView={() => {}}>
-      <div className="space-y-4">
-        <UserInteractionManager
-          currentWord={currentWord}
-          playCurrentWord={playCurrentWord}
-          onInteractionUpdate={handleInteractionUpdate}
-        />
-        
-        <ErrorDisplay jsonLoadError={false} />
-        
-        <ContentWithDataNew
-          displayWord={currentWord}
-          muted={isMuted}
-          paused={isPaused}
-          toggleMute={toggleMute}
-          handleTogglePause={togglePause}
-          handleCycleVoice={toggleVoice}
-          isSpeaking={isSpeaking}
-          handleManualNext={goToNextAndSpeak}
-          displayTime={5000}
-          selectedVoiceName={selectedVoiceName}
-          isAddWordModalOpen={isAddWordModalOpen}
-          handleCloseModal={handleCloseModal}
-          handleSaveWord={handleSaveWord}
-          isEditMode={isEditMode}
-          wordToEdit={wordToEdit}
-          handleOpenAddWordModal={handleOpenAddWordModal}
-          handleOpenEditWordModal={handleOpenEditWordModal}
-          onRetireWord={onRetireWord}
-        />
-      </div>
-    </VocabularyLayout>
     </DebugInfoContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- Remove tabbed navigation and render practice, progress panel, and word summary on a single page
- Allow `VocabularyAppContainerNew` to accept custom content before the Streaks section
- Display learning progress and daily word summary beneath the practice card

## Testing
- `npm run lint` *(fails: Empty block statements and no-useless-escape in existing files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdaff2d6c832fab2995b863180eb8