### PR TITLE
Fix due review count

### DIFF
--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -296,23 +296,23 @@ export class LearningProgressService {
   }
 
   getProgressStats() {
+    this.updateWordStatuses();
     const progressMap = this.getLearningProgress();
     const all = Array.from(progressMap.values());
-    const today = this.getToday();
 
     return {
       total: all.length,
       learned: all.filter(p => p.isLearned).length,
       new: all.filter(p => !p.isLearned).length,
-      due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
+      due: all.filter(p => p.status === 'due').length,
       retired: all.filter(p => p.status === 'retired').length
     };
   }
 
   getDueReviewWords(): LearningProgress[] {
+    this.updateWordStatuses();
     const progressMap = this.getLearningProgress();
-    const today = this.getToday();
-    return Array.from(progressMap.values()).filter(p => p.isLearned && p.nextReviewDate <= today);
+    return Array.from(progressMap.values()).filter(p => p.status === 'due');
   }
 
   getRetiredWords(): LearningProgress[] {

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -225,9 +225,9 @@ describe('LearningProgressService', () => {
       const today = new Date().toISOString().split('T')[0];
       const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
       const mockProgress = {
-        'word1': { isLearned: true, status: 'not_due', nextReviewDate: today },
+        'word1': { isLearned: true, status: 'due', nextReviewDate: today },
         'word2': { isLearned: false, status: 'new', nextReviewDate: today },
-        'word3': { isLearned: true, status: 'not_due', nextReviewDate: yesterday },
+        'word3': { isLearned: true, status: 'due', nextReviewDate: yesterday },
         'word4': { isLearned: false, status: 'new', nextReviewDate: today },
       };
 
@@ -268,9 +268,13 @@ describe('LearningProgressService', () => {
         }
       };
 
+      let store = JSON.stringify(progressData);
       localStorageMock.getItem.mockImplementation((key) => {
-        if (key === 'learningProgress') return JSON.stringify(progressData);
+        if (key === 'learningProgress') return store;
         return null;
+      });
+      localStorageMock.setItem.mockImplementation((key, value) => {
+        if (key === 'learningProgress') store = value;
       });
 
       const dueWords = service.getDueReviewWords();


### PR DESCRIPTION
## Summary
- ensure learning progress stats update word statuses and count due reviews correctly
- adjust due review word retrieval to use updated statuses
- update tests for due review calculation

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement, no-useless-escape in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689febde45e0832f85c01b1e84bcca58