### PR TITLE
Streamline Daily Learning Progress panel

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { DailySelection, SeverityLevel } from '@/types/learning';
@@ -18,14 +17,12 @@ interface LearningProgressPanelProps {
     retired: number;
   };
   onGenerateDaily: (severity: SeverityLevel) => void;
-  onRefresh: () => void;
 }
 
 export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
   dailySelection,
   progressStats,
-  onGenerateDaily,
-  onRefresh
+  onGenerateDaily
 }) => {
   const learnedPercentage = progressStats.total > 0
     ? (progressStats.learned / progressStats.total) * 100
@@ -38,12 +35,9 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CollapsibleTrigger className="flex items-center gap-2">
-              <CardTitle>Daily Learning Progress</CardTitle>
+              <CardTitle className="text-lg">Daily Learning Progress</CardTitle>
               <ChevronDown className={cn('h-4 w-4 transition-transform', open && 'rotate-180')} />
             </CollapsibleTrigger>
-            <Button variant="outline" size="sm" onClick={onRefresh}>
-              Refresh
-            </Button>
           </div>
         </CardHeader>
         <CollapsibleContent>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import VocabularyAppContainerNew from './vocabulary-app/VocabularyAppContainerNew';
 import { LearningProgressPanel } from './LearningProgressPanel';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
@@ -18,7 +18,6 @@ const VocabularyAppWithLearning: React.FC = () => {
     progressStats,
     generateDailyWords,
     markWordAsPlayed,
-    refreshStats,
     getDueReviewWords,
     getRetiredWords,
     retireCurrentWord,
@@ -42,17 +41,18 @@ const VocabularyAppWithLearning: React.FC = () => {
   }, []);
 
   // Track when words are played (integrate with existing word navigation)
+  const previousWordRef = useRef<VocabularyWord | null>(null);
   useEffect(() => {
+    previousWordRef.current = vocabularyService.getCurrentWord();
+
     const handleWordChange = () => {
-      const currentWord = vocabularyService.getCurrentWord();
-      if (currentWord) {
-        markWordAsPlayed(currentWord.word);
+      if (previousWordRef.current) {
+        markWordAsPlayed(previousWordRef.current.word);
       }
+      previousWordRef.current = vocabularyService.getCurrentWord();
     };
 
-    // Listen for word changes
     vocabularyService.addVocabularyChangeListener(handleWordChange);
-    
     return () => {
       vocabularyService.removeVocabularyChangeListener(handleWordChange);
     };
@@ -64,7 +64,6 @@ const VocabularyAppWithLearning: React.FC = () => {
         dailySelection={dailySelection}
         progressStats={progressStats}
         onGenerateDaily={generateDailyWords}
-        onRefresh={refreshStats}
       />
 
       {dailySelection && (


### PR DESCRIPTION
## Summary
- Shrink Daily Learning Progress title and remove manual Refresh button
- Automatically mark previous word as learned on navigation to update progress stats

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Empty block statement and no-useless-escape in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689ffa6dd928832fba1abcda56780b5c