### PR TITLE
Rename onRetireWord prop to onMarkWordLearned

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -152,7 +152,7 @@ const VocabularyAppWithLearning: React.FC = () => {
       <div className="w-full max-w-6xl mx-auto p-4">
         <VocabularyAppContainerNew
           initialWords={todayWords}
-          onRetireWord={() => {
+          onMarkWordLearned={() => {
             const currentWord = vocabularyService.getCurrentWord();
             if (currentWord) {
               retireCurrentWord(currentWord.word);

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -27,7 +27,7 @@ interface ContentWithDataNewProps {
   handleOpenAddWordModal: () => void;
   handleOpenEditWordModal: (word: VocabularyWord) => void;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordLearned?: () => void;
   additionalContent?: React.ReactNode;
 }
 
@@ -50,7 +50,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenAddWordModal,
   handleOpenEditWordModal,
   playCurrentWord,
-  onRetireWord,
+  onMarkWordLearned,
   additionalContent
 }) => {
   const editingWordData = useMemo(
@@ -83,7 +83,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       onOpenAddModal={handleOpenAddWordModal}
       onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       playCurrentWord={playCurrentWord}
-      onRetireWord={onRetireWord}
+      onMarkWordLearned={onMarkWordLearned}
       />
 
       {additionalContent}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -14,12 +14,12 @@ import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
-  onRetireWord?: () => void;
+  onMarkWordLearned?: () => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onRetireWord, initialWords, additionalContent }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent }) => {
   // Use stable state management
   const {
     currentWord,
@@ -192,7 +192,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ o
             wordToEdit={wordToEdit}
             handleOpenAddWordModal={handleOpenAddWordModal}
             handleOpenEditWordModal={handleOpenEditWordModal}
-            onRetireWord={onRetireWord}
+            onMarkWordLearned={onMarkWordLearned}
             additionalContent={additionalContent}
           />
         </div>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -26,7 +26,7 @@ interface VocabularyControlsColumnProps {
   onOpenEditModal: () => void;
   selectedVoiceName: string;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordLearned?: () => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,7 +41,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenEditModal,
   selectedVoiceName,
   playCurrentWord,
-  onRetireWord
+  onMarkWordLearned
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
@@ -98,7 +98,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   
   const handleRetireClick = () => setIsRetireDialogOpen(true);
   const handleRetireConfirm = () => {
-    if (onRetireWord) onRetireWord();
+    if (onMarkWordLearned) onMarkWordLearned();
     setIsRetireDialogOpen(false);
     toast('Word retired for 100 days');
   };
@@ -171,7 +171,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         <Search size={16} />
       </Button>
       
-      {onRetireWord && (
+      {onMarkWordLearned && (
         <Button
           variant="outline"
           size="sm"

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -20,7 +20,7 @@ interface VocabularyMainNewProps {
   onOpenEditModal: () => void;
   showWordCount?: boolean;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordLearned?: () => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -38,7 +38,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   onOpenEditModal,
   showWordCount = false,
   playCurrentWord,
-  onRetireWord,
+  onMarkWordLearned,
   }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -72,7 +72,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
             onOpenEditModal={onOpenEditModal}
             selectedVoiceName={selectedVoiceName}
             playCurrentWord={playCurrentWord}
-            onRetireWord={onRetireWord}
+            onMarkWordLearned={onMarkWordLearned}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename `onRetireWord` prop to `onMarkWordLearned` throughout vocabulary app components
- update parent components to pass the new callback

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Empty block statement, no-useless-escape, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a006fd10a8832f9b2461ea1bd49340