### PR TITLE
Rename retired words to learned

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -19,8 +19,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     generateDailyWords,
     markWordAsPlayed,
     getDueReviewWords,
-    getRetiredWords,
-    retireCurrentWord,
+    getRetiredWords: getLearnedWords,
+    retireCurrentWord: markCurrentWordLearned,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -121,20 +121,20 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({progressStats.retired})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
                   {progressStats.retired > 0 ? (
-                    getRetiredWords().map((word, index) => (
+                    getLearnedWords().map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">
-                          {word.category} • Retired {word.retiredDate}
+                          {word.category} • Learned {word.learnedDate}
                         </div>
                       </div>
                     ))
                   ) : (
                     <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
-                      No retired words
+                      No learned words
                     </div>
                   )}
                 </div>
@@ -155,7 +155,7 @@ const VocabularyAppWithLearning: React.FC = () => {
           onRetireWord={() => {
             const currentWord = vocabularyService.getCurrentWord();
             if (currentWord) {
-              retireCurrentWord(currentWord.word);
+              markCurrentWordLearned(currentWord.word);
             }
           }}
           additionalContent={learningSection}

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -74,7 +74,7 @@ export class LearningProgressService {
   private migrateProgressData(progress: LearningProgress): LearningProgress {
     const DEFAULT_VALUES = {
       status: 'new' as const,
-      retiredDate: undefined,
+      learnedDate: undefined,
       nextReviewDate: this.getToday(),
       createdDate: this.getToday()
     };
@@ -84,7 +84,10 @@ export class LearningProgressService {
       status: progress.status || (progress.isLearned ? 'due' : DEFAULT_VALUES.status),
       nextReviewDate: progress.nextReviewDate || DEFAULT_VALUES.nextReviewDate,
       createdDate: progress.createdDate || DEFAULT_VALUES.createdDate,
-      retiredDate: progress.retiredDate || DEFAULT_VALUES.retiredDate
+      learnedDate:
+        (progress as any).learnedDate ||
+        (progress as any).retiredDate ||
+        DEFAULT_VALUES.learnedDate
     };
   }
 
@@ -132,7 +135,7 @@ export class LearningProgressService {
     if (progress) {
       const today = this.getToday();
       progress.status = 'retired';
-      progress.retiredDate = today;
+      progress.learnedDate = today;
       progress.nextReviewDate = this.addDays(today, 100);
       
       progressMap.set(wordKey, progress);

--- a/src/types/learning.ts
+++ b/src/types/learning.ts
@@ -8,7 +8,7 @@ export interface LearningProgress {
   status: 'due' | 'not_due' | 'new' | 'retired';
   nextReviewDate: string;
   createdDate: string;
-  retiredDate?: string;
+  learnedDate?: string;
 }
 
 export interface DailySelection {


### PR DESCRIPTION
## Summary
- rename progress display section to “Learned” with new fallback message
- expose `getLearnedWords` and `markCurrentWordLearned` in vocabulary app
- track `learnedDate` instead of `retiredDate` in learning progress service

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement; Unnecessary escape character)*

------
https://chatgpt.com/codex/tasks/task_e_68a006fcb920832f9e0f957e46607ca8