### PR TITLE
Rename retired progress stat to learned

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -15,7 +15,7 @@ interface LearningProgressPanelProps {
     learned: number;
     new: number;
     due: number;
-    retired: number;
+    learnedCompleted: number;
   };
   onGenerateDaily: (severity: SeverityLevel) => void;
 }
@@ -62,8 +62,8 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
             <div className="text-sm text-gray-600">Due Review</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-gray-600">{progressStats.retired}</div>
-            <div className="text-sm text-gray-600">Retired</div>
+            <div className="text-2xl font-bold text-gray-600">{progressStats.learnedCompleted}</div>
+            <div className="text-sm text-gray-600">Learned</div>
           </div>
         </div>
 

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -121,9 +121,9 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
+                <h4 className="font-medium text-gray-600">Retired ({progressStats.learnedCompleted})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
-                  {progressStats.retired > 0 ? (
+                  {progressStats.learnedCompleted > 0 ? (
                     getRetiredWords().map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -13,7 +13,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     learned: 0,
     new: 0,
     due: 0,
-    retired: 0
+    learnedCompleted: 0
   });
 
   const refreshStats = useCallback(() => {

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -305,7 +305,7 @@ export class LearningProgressService {
       learned: all.filter(p => p.isLearned).length,
       new: all.filter(p => !p.isLearned).length,
       due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
-      retired: all.filter(p => p.status === 'retired').length
+      learnedCompleted: all.filter(p => p.status === 'retired').length
     };
   }
 


### PR DESCRIPTION
## Summary
- display learned words instead of retired in progress panel
- track learnedCompleted stat instead of retired in progress and service

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a006fad528832fa1aece8a67e95a2c