### PR TITLE
Rename retired status to learned

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -63,7 +63,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
           </div>
           <div className="text-center">
             <div className="text-2xl font-bold text-gray-600">{progressStats.retired}</div>
-            <div className="text-sm text-gray-600">Retired</div>
+            <div className="text-sm text-gray-600">Learned</div>
           </div>
         </div>
 

--- a/src/components/RetireWordDialog.tsx
+++ b/src/components/RetireWordDialog.tsx
@@ -27,17 +27,17 @@ export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Retire Word</AlertDialogTitle>
+          <AlertDialogTitle>Mark as Learned</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to retire "{wordText}"? 
+            Are you sure you want to mark "{wordText}" as learned?
             <br /><br />
-            This word will be hidden from your daily practice and will automatically 
+            This word will be hidden from your daily practice and will automatically
             reappear after 100 days for review.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Retire Word</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm}>Mark as Learned</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -121,20 +121,20 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({progressStats.retired})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
                   {progressStats.retired > 0 ? (
                     getRetiredWords().map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">
-                          {word.category} • Retired {word.retiredDate}
+                          {word.category} • Learned {word.learnedDate}
                         </div>
                       </div>
                     ))
                   ) : (
                     <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
-                      No retired words
+                      No learned words
                     </div>
                   )}
                 </div>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -100,7 +100,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   const handleRetireConfirm = () => {
     if (onRetireWord) onRetireWord();
     setIsRetireDialogOpen(false);
-    toast('Word retired for 100 days');
+    toast('Word learned for 100 days');
   };
 
   return (
@@ -177,8 +177,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
           size="sm"
           onClick={handleRetireClick}
           className="h-8 w-8 p-0 text-red-600 border-red-300 bg-red-50"
-          title="Retire Word"
-          aria-label="Retire Word"
+          title="Mark as Learned"
+          aria-label="Mark as Learned"
           disabled={!currentWord}
         >
           <Archive size={16} />

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -74,7 +74,7 @@ export class LearningProgressService {
   private migrateProgressData(progress: LearningProgress): LearningProgress {
     const DEFAULT_VALUES = {
       status: 'new' as const,
-      retiredDate: undefined,
+      learnedDate: undefined,
       nextReviewDate: this.getToday(),
       createdDate: this.getToday()
     };
@@ -84,7 +84,7 @@ export class LearningProgressService {
       status: progress.status || (progress.isLearned ? 'due' : DEFAULT_VALUES.status),
       nextReviewDate: progress.nextReviewDate || DEFAULT_VALUES.nextReviewDate,
       createdDate: progress.createdDate || DEFAULT_VALUES.createdDate,
-      retiredDate: progress.retiredDate || DEFAULT_VALUES.retiredDate
+      learnedDate: progress.learnedDate || DEFAULT_VALUES.learnedDate
     };
   }
 
@@ -131,8 +131,8 @@ export class LearningProgressService {
     
     if (progress) {
       const today = this.getToday();
-      progress.status = 'retired';
-      progress.retiredDate = today;
+      progress.status = 'learned';
+      progress.learnedDate = today;
       progress.nextReviewDate = this.addDays(today, 100);
       
       progressMap.set(wordKey, progress);
@@ -146,7 +146,7 @@ export class LearningProgressService {
     let hasChanges = false;
 
     progressMap.forEach((progress, key) => {
-      if (progress.status === 'retired') return;
+      if (progress.status === 'learned') return;
 
       if (progress.isLearned) {
         if (progress.nextReviewDate <= today && progress.status !== 'due') {
@@ -207,7 +207,7 @@ export class LearningProgressService {
     const totalCount = Math.min(idealCount, maxPossibleCount);
 
     // Get available words
-    const newWords = Array.from(progressMap.values()).filter(p => !p.isLearned && p.status !== 'retired');
+    const newWords = Array.from(progressMap.values()).filter(p => !p.isLearned && p.status !== 'learned');
     const dueWords = Array.from(progressMap.values()).filter(p => p.isLearned && p.nextReviewDate <= today);
 
     // Always include all due review words
@@ -305,7 +305,7 @@ export class LearningProgressService {
       learned: all.filter(p => p.isLearned).length,
       new: all.filter(p => !p.isLearned).length,
       due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
-      retired: all.filter(p => p.status === 'retired').length
+      retired: all.filter(p => p.status === 'learned').length
     };
   }
 
@@ -318,7 +318,7 @@ export class LearningProgressService {
   getRetiredWords(): LearningProgress[] {
     const progressMap = this.getLearningProgress();
     return Array.from(progressMap.values())
-      .filter(p => p.status === 'retired')
+      .filter(p => p.status === 'learned')
       .sort((a, b) => a.word.localeCompare(b.word)); // Sort alphabetically
   }
 }

--- a/src/types/learning.ts
+++ b/src/types/learning.ts
@@ -5,10 +5,10 @@ export interface LearningProgress {
   isLearned: boolean;
   reviewCount: number;
   lastPlayedDate: string;
-  status: 'due' | 'not_due' | 'new' | 'retired';
+  status: 'due' | 'not_due' | 'new' | 'learned';
   nextReviewDate: string;
   createdDate: string;
-  retiredDate?: string;
+  learnedDate?: string;
 }
 
 export interface DailySelection {


### PR DESCRIPTION
## Summary
- Replace `retired` status with `learned` and rename `retiredDate` to `learnedDate`
- Adjust learning progress service to track learned words and dates
- Update UI copy to refer to learned words

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement & unnecessary escape character errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a007005b88832f93e2fb841f72d63e