### PR TITLE
Add learner session time tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const App = () => {
   useEffect(() => {
     loadStreakDays();
   }, []);
-  useDailyUsageTracker();
+  useDailyUsageTracker('default');
   useSessionTracker();
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -7,6 +7,7 @@ import { DailySelection, SeverityLevel } from '@/types/learning';
 import { ChevronDown } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
+import { useLearnerHours } from '@/hooks/useLearnerHours';
 
 interface LearningProgressPanelProps {
   dailySelection: DailySelection | null;
@@ -18,17 +19,20 @@ interface LearningProgressPanelProps {
     retired: number;
   };
   onGenerateDaily: (severity: SeverityLevel) => void;
+  learnerId: string;
 }
 
 export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
   dailySelection,
   progressStats,
-  onGenerateDaily
+  onGenerateDaily,
+  learnerId
 }) => {
   const learnedPercentage = progressStats.total > 0
     ? (progressStats.learned / progressStats.total) * 100
     : 0;
   const [open, setOpen] = useState(false);
+  const { totalHours } = useLearnerHours(learnerId);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="w-full">
@@ -44,7 +48,11 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         <CollapsibleContent>
           <CardContent className="space-y-4">
         {/* Progress Stats */}
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-purple-600">{totalHours.toFixed(1)}</div>
+            <div className="text-sm text-gray-600">Hours Learned</div>
+          </div>
           <div className="text-center">
             <div className="text-2xl font-bold text-blue-600">{progressStats.total}</div>
             <div className="text-sm text-gray-600">Total Words</div>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -64,6 +64,7 @@ const VocabularyAppWithLearning: React.FC = () => {
         dailySelection={dailySelection}
         progressStats={progressStats}
         onGenerateDaily={generateDailyWords}
+        learnerId="default"
       />
 
       {dailySelection && (

--- a/src/hooks/useLearnerHours.ts
+++ b/src/hooks/useLearnerHours.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState, useCallback } from 'react';
+
+type HoursByDate = Record<string, number>;
+
+function getStorageKey(id: string) {
+  return `learningTime_${id}`;
+}
+
+export function useLearnerHours(learnerId: string) {
+  const [totalHours, setTotalHours] = useState(0);
+  const [hoursByDate, setHoursByDate] = useState<HoursByDate>({});
+
+  const load = useCallback(() => {
+    try {
+      const raw = localStorage.getItem(getStorageKey(learnerId));
+      const record: Record<string, number> = raw ? JSON.parse(raw) : {};
+      const byDate: HoursByDate = {};
+      let total = 0;
+      Object.entries(record).forEach(([date, ms]) => {
+        const hours = ms / (1000 * 60 * 60);
+        byDate[date] = hours;
+        total += hours;
+      });
+      setHoursByDate(byDate);
+      setTotalHours(total);
+    } catch {
+      setHoursByDate({});
+      setTotalHours(0);
+    }
+  }, [learnerId]);
+
+  useEffect(() => {
+    load();
+    const handler = (e: StorageEvent) => {
+      if (e.key === getStorageKey(learnerId)) {
+        load();
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [learnerId, load]);
+
+  return { totalHours, hoursByDate };
+}
+
+export default useLearnerHours;

--- a/src/services/learningTimeService.ts
+++ b/src/services/learningTimeService.ts
@@ -1,0 +1,63 @@
+export interface LearningTimeRecord {
+  [date: string]: number; // milliseconds
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function getStorageKey(learnerId: string) {
+  return `learningTime_${learnerId}`;
+}
+
+function loadRecord(learnerId: string): LearningTimeRecord {
+  try {
+    const data = localStorage.getItem(getStorageKey(learnerId));
+    return data ? JSON.parse(data) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveRecord(learnerId: string, record: LearningTimeRecord) {
+  try {
+    localStorage.setItem(getStorageKey(learnerId), JSON.stringify(record));
+  } catch {
+    // ignore write errors
+  }
+}
+
+const sessionStarts: Record<string, number | null> = {};
+
+function startSession(learnerId: string) {
+  if (sessionStarts[learnerId] == null) {
+    sessionStarts[learnerId] = Date.now();
+  }
+}
+
+function stopSession(learnerId: string): number {
+  const start = sessionStarts[learnerId];
+  if (start == null) return 0;
+  const duration = Date.now() - start;
+  sessionStarts[learnerId] = null;
+
+  const record = loadRecord(learnerId);
+  const today = formatDate(new Date());
+  record[today] = (record[today] || 0) + duration;
+  saveRecord(learnerId, record);
+  return duration;
+}
+
+function getTotalHours(learnerId: string): number {
+  const record = loadRecord(learnerId);
+  const totalMs = Object.values(record).reduce((sum, ms) => sum + ms, 0);
+  return totalMs / (1000 * 60 * 60);
+}
+
+export const learningTimeService = {
+  startSession,
+  stopSession,
+  getTotalHours,
+};
+
+export default learningTimeService;

--- a/tests/dailyUsageTracker.test.ts
+++ b/tests/dailyUsageTracker.test.ts
@@ -23,7 +23,7 @@ describe('useDailyUsageTracker', () => {
   });
 
   it('records time and awards sticker after 15 minutes', async () => {
-    renderHook(() => useDailyUsageTracker());
+    renderHook(() => useDailyUsageTracker('learner1'));
     await advanceSession(16 * 60 * 1000);
 
     act(() => {
@@ -41,11 +41,11 @@ describe('useDailyUsageTracker', () => {
     const today = formatDate(new Date());
     const key = `dailyTime_${today}`;
 
-    renderHook(() => useDailyUsageTracker());
+    renderHook(() => useDailyUsageTracker('learner1'));
     await advanceSession(5 * 60 * 1000);
     act(() => window.dispatchEvent(new Event('beforeunload')));
 
-    renderHook(() => useDailyUsageTracker());
+    renderHook(() => useDailyUsageTracker('learner1'));
     await advanceSession(10 * 60 * 1000);
     act(() => window.dispatchEvent(new Event('beforeunload')));
 

--- a/tests/stickerHistory.test.ts
+++ b/tests/stickerHistory.test.ts
@@ -26,7 +26,7 @@ describe('sticker history persistence', () => {
 
     for (let i = 0; i < 5; i++) {
       vi.setSystemTime(new Date(start.getTime() + i * 24 * 60 * 60 * 1000));
-      const { unmount } = renderHook(() => useDailyUsageTracker());
+      const { unmount } = renderHook(() => useDailyUsageTracker('learner1'));
       await advanceSession(16 * 60 * 1000);
       act(() => window.dispatchEvent(new Event('beforeunload')));
       unmount();


### PR DESCRIPTION
## Summary
- Persist learner session durations in localStorage and expose session control helpers
- Track usage by learner and surface total hours in learning progress panel
- Add hook for retrieving cumulative learner hours

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement, no-useless-escape, etc.)*
- `npx eslint src/App.tsx src/components/LearningProgressPanel.tsx src/components/VocabularyAppWithLearning.tsx src/hooks/useDailyUsageTracker.tsx src/hooks/useLearnerHours.ts src/services/learningTimeService.ts tests/dailyUsageTracker.test.ts tests/stickerHistory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a00721b80c832fbc5a7225acfc4795