### PR TITLE
Rename retire dialog to mark-as-learned

### DIFF
--- a/src/components/MarkAsLearnedDialog.tsx
+++ b/src/components/MarkAsLearnedDialog.tsx
@@ -10,34 +10,35 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 
-interface RetireWordDialogProps {
+interface MarkAsLearnedDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   wordText: string;
 }
 
-export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
+export const MarkAsLearnedDialog: React.FC<MarkAsLearnedDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,
-  wordText
+  wordText,
 }) => {
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Retire Word</AlertDialogTitle>
+          <AlertDialogTitle>Mark as Learned</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to retire "{wordText}"? 
-            <br /><br />
-            This word will be hidden from your daily practice and will automatically 
+            Are you sure you want to mark "{wordText}" as learned?
+            <br />
+            <br />
+            This word will be hidden from your daily practice and will automatically
             reappear after 100 days for review.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Retire Word</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm}>Mark as Learned</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -12,7 +12,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
-import { RetireWordDialog } from '@/components/RetireWordDialog';
+import { MarkAsLearnedDialog } from '@/components/MarkAsLearnedDialog';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -187,7 +187,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       
       <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
       
-      <RetireWordDialog
+      <MarkAsLearnedDialog
         isOpen={isRetireDialogOpen}
         onClose={() => setIsRetireDialogOpen(false)}
         onConfirm={handleRetireConfirm}


### PR DESCRIPTION
## Summary
- rename RetireWordDialog to MarkAsLearnedDialog
- use "Mark as Learned" phrasing in the dialog
- update vocabulary controls to use the renamed dialog

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty and no-useless-escape)*

------
https://chatgpt.com/codex/tasks/task_e_68a006f8d350832facddeb22d5260700