### PR TITLE
Mark words as learned instead of retired

### DIFF
--- a/src/components/MarkAsLearnedDialog.tsx
+++ b/src/components/MarkAsLearnedDialog.tsx
@@ -10,34 +10,34 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 
-interface RetireWordDialogProps {
+interface MarkAsLearnedDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   wordText: string;
 }
 
-export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
+export const MarkAsLearnedDialog: React.FC<MarkAsLearnedDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,
-  wordText
+  wordText,
 }) => {
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Retire Word</AlertDialogTitle>
+          <AlertDialogTitle>Mark as Learned</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to retire "{wordText}"? 
+            Are you sure you want to mark "{wordText}" as learned?
             <br /><br />
-            This word will be hidden from your daily practice and will automatically 
+            This word will be hidden from your daily practice and will automatically
             reappear after 100 days for review.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Retire Word</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm}>Mark as Learned</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Volume2, VolumeX, Pause, Play, SkipForward, Speaker, Search, Archive } from 'lucide-react';
+import { Volume2, VolumeX, Pause, Play, SkipForward, Speaker, Search, CheckCircle } from 'lucide-react';
 import SpeechRateControl from './SpeechRateControl';
 import { useSpeechRate } from '@/hooks/useSpeechRate';
 import { toast } from 'sonner';
@@ -12,7 +12,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
-import { RetireWordDialog } from '@/components/RetireWordDialog';
+import { MarkAsLearnedDialog } from '@/components/MarkAsLearnedDialog';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -92,15 +92,15 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const [isSearchOpen, setIsSearchOpen] = React.useState(false);
-  const [isRetireDialogOpen, setIsRetireDialogOpen] = React.useState(false);
+  const [isMarkAsLearnedDialogOpen, setIsMarkAsLearnedDialogOpen] = React.useState(false);
   const openSearch = () => setIsSearchOpen(true);
   const closeSearch = () => setIsSearchOpen(false);
   
-  const handleRetireClick = () => setIsRetireDialogOpen(true);
-  const handleRetireConfirm = () => {
+  const handleMarkAsLearnedClick = () => setIsMarkAsLearnedDialogOpen(true);
+  const handleMarkAsLearnedConfirm = () => {
     if (onRetireWord) onRetireWord();
-    setIsRetireDialogOpen(false);
-    toast('Word retired for 100 days');
+    setIsMarkAsLearnedDialogOpen(false);
+    toast('Word marked as learned.');
   };
 
   return (
@@ -175,22 +175,22 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         <Button
           variant="outline"
           size="sm"
-          onClick={handleRetireClick}
+          onClick={handleMarkAsLearnedClick}
           className="h-8 w-8 p-0 text-red-600 border-red-300 bg-red-50"
-          title="Retire Word"
-          aria-label="Retire Word"
+          title="Mark as Learned"
+          aria-label="Mark as Learned"
           disabled={!currentWord}
         >
-          <Archive size={16} />
+          <CheckCircle size={16} />
         </Button>
       )}
       
       <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
       
-      <RetireWordDialog
-        isOpen={isRetireDialogOpen}
-        onClose={() => setIsRetireDialogOpen(false)}
-        onConfirm={handleRetireConfirm}
+      <MarkAsLearnedDialog
+        isOpen={isMarkAsLearnedDialogOpen}
+        onClose={() => setIsMarkAsLearnedDialogOpen(false)}
+        onConfirm={handleMarkAsLearnedConfirm}
         wordText={currentWord?.word || ''}
       />
     </div>


### PR DESCRIPTION
## Summary
- swap Archive icon for CheckCircle in vocabulary controls
- rename Retire actions and dialog to Mark as Learned and adjust toast text
- add MarkAsLearnedDialog component replacing RetireWordDialog

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: no-empty, no-useless-escape, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a006fad198832fb07fafd64a4bbc07