### PR TITLE
Rename retired word logic to learned

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -12,10 +12,10 @@ interface LearningProgressPanelProps {
   dailySelection: DailySelection | null;
   progressStats: {
     total: number;
-    learned: number;
+    learning: number;
     new: number;
     due: number;
-    retired: number;
+    learned: number;
   };
   onGenerateDaily: (severity: SeverityLevel) => void;
 }
@@ -50,7 +50,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
             <div className="text-sm text-gray-600">Total Words</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-green-600">{progressStats.learned}</div>
+            <div className="text-2xl font-bold text-green-600">{progressStats.learning}</div>
             <div className="text-sm text-gray-600">Learning</div>
           </div>
           <div className="text-center">
@@ -62,8 +62,8 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
             <div className="text-sm text-gray-600">Due Review</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-gray-600">{progressStats.retired}</div>
-            <div className="text-sm text-gray-600">Retired</div>
+            <div className="text-2xl font-bold text-gray-600">{progressStats.learned}</div>
+            <div className="text-sm text-gray-600">Learned</div>
           </div>
         </div>
 
@@ -94,7 +94,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
                 Level: {dailySelection.severity}
               </Badge>
             </div>
-            
+
             {/* Category breakdown for all words in today's selection */}
             {(dailySelection.newWords.length > 0 || dailySelection.reviewWords.length > 0) && (
               <div className="text-sm">
@@ -120,22 +120,22 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         <div className="space-y-3">
           <h4 className="font-semibold">Generate New Daily Selection</h4>
           <div className="flex flex-wrap gap-2">
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={() => onGenerateDaily('light')}
             >
               Light (15-25)
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={() => onGenerateDaily('moderate')}
             >
               Moderate (30-50)
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="sm"
               onClick={() => onGenerateDaily('intense')}
             >

--- a/src/components/MarkWordAsLearnedDialog.tsx
+++ b/src/components/MarkWordAsLearnedDialog.tsx
@@ -10,14 +10,14 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 
-interface RetireWordDialogProps {
+interface MarkWordAsLearnedDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   wordText: string;
 }
 
-export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
+export const MarkWordAsLearnedDialog: React.FC<MarkWordAsLearnedDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,
@@ -27,17 +27,17 @@ export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Retire Word</AlertDialogTitle>
+          <AlertDialogTitle>Mark Word as Learned</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to retire "{wordText}"? 
+            Are you sure you want to mark "{wordText}" as learned?
             <br /><br />
-            This word will be hidden from your daily practice and will automatically 
+            This word will be hidden from your daily practice and will automatically
             reappear after 100 days for review.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Retire Word</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm}>Mark as Learned</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -19,8 +19,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     generateDailyWords,
     markWordAsPlayed,
     getDueReviewWords,
-    getRetiredWords,
-    retireCurrentWord,
+    getLearnedWords,
+    markCurrentWordAsLearned,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -121,20 +121,20 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Retired ({progressStats.retired})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({progressStats.learned})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
-                  {progressStats.retired > 0 ? (
-                    getRetiredWords().map((word, index) => (
+                  {progressStats.learned > 0 ? (
+                    getLearnedWords().map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">
-                          {word.category} • Retired {word.retiredDate}
+                          {word.category} • Learned {word.learnedDate}
                         </div>
                       </div>
                     ))
                   ) : (
                     <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
-                      No retired words
+                      No learned words
                     </div>
                   )}
                 </div>
@@ -152,10 +152,10 @@ const VocabularyAppWithLearning: React.FC = () => {
       <div className="w-full max-w-6xl mx-auto p-4">
         <VocabularyAppContainerNew
           initialWords={todayWords}
-          onRetireWord={() => {
+          onMarkWordAsLearned={() => {
             const currentWord = vocabularyService.getCurrentWord();
             if (currentWord) {
-              retireCurrentWord(currentWord.word);
+              markCurrentWordAsLearned(currentWord.word);
             }
           }}
           additionalContent={learningSection}

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -27,7 +27,7 @@ interface ContentWithDataNewProps {
   handleOpenAddWordModal: () => void;
   handleOpenEditWordModal: (word: VocabularyWord) => void;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordAsLearned?: () => void;
   additionalContent?: React.ReactNode;
 }
 
@@ -50,7 +50,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenAddWordModal,
   handleOpenEditWordModal,
   playCurrentWord,
-  onRetireWord,
+  onMarkWordAsLearned,
   additionalContent
 }) => {
   const editingWordData = useMemo(
@@ -83,7 +83,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
       onOpenAddModal={handleOpenAddWordModal}
       onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
       playCurrentWord={playCurrentWord}
-      onRetireWord={onRetireWord}
+      onMarkWordAsLearned={onMarkWordAsLearned}
       />
 
       {additionalContent}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -14,12 +14,12 @@ import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
-  onRetireWord?: () => void;
+  onMarkWordAsLearned?: () => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onRetireWord, initialWords, additionalContent }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordAsLearned, initialWords, additionalContent }) => {
   // Use stable state management
   const {
     currentWord,
@@ -192,7 +192,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ o
             wordToEdit={wordToEdit}
             handleOpenAddWordModal={handleOpenAddWordModal}
             handleOpenEditWordModal={handleOpenEditWordModal}
-            onRetireWord={onRetireWord}
+            onMarkWordAsLearned={onMarkWordAsLearned}
             additionalContent={additionalContent}
           />
         </div>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, SkipForward, Speaker, Search, Archive } from 'lucide-react';
@@ -12,7 +11,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
-import { RetireWordDialog } from '@/components/RetireWordDialog';
+import { MarkWordAsLearnedDialog } from '@/components/MarkWordAsLearnedDialog';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -26,7 +25,7 @@ interface VocabularyControlsColumnProps {
   onOpenEditModal: () => void;
   selectedVoiceName: string;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordAsLearned?: () => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,11 +40,11 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenEditModal,
   selectedVoiceName,
   playCurrentWord,
-  onRetireWord
+  onMarkWordAsLearned
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
-  
+
   const trackEvent = (name: string, label: string, value?: number) => {
     if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
       window.gtag('event', name, {
@@ -92,15 +91,15 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const [isSearchOpen, setIsSearchOpen] = React.useState(false);
-  const [isRetireDialogOpen, setIsRetireDialogOpen] = React.useState(false);
+  const [isLearnedDialogOpen, setIsLearnedDialogOpen] = React.useState(false);
   const openSearch = () => setIsSearchOpen(true);
   const closeSearch = () => setIsSearchOpen(false);
-  
-  const handleRetireClick = () => setIsRetireDialogOpen(true);
-  const handleRetireConfirm = () => {
-    if (onRetireWord) onRetireWord();
-    setIsRetireDialogOpen(false);
-    toast('Word retired for 100 days');
+
+  const handleMarkAsLearnedClick = () => setIsLearnedDialogOpen(true);
+  const handleMarkAsLearnedConfirm = () => {
+    if (onMarkWordAsLearned) onMarkWordAsLearned();
+    setIsLearnedDialogOpen(false);
+    toast('Word marked as learned');
   };
 
   return (
@@ -170,27 +169,27 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       >
         <Search size={16} />
       </Button>
-      
-      {onRetireWord && (
+
+      {onMarkWordAsLearned && (
         <Button
           variant="outline"
           size="sm"
-          onClick={handleRetireClick}
+          onClick={handleMarkAsLearnedClick}
           className="h-8 w-8 p-0 text-red-600 border-red-300 bg-red-50"
-          title="Retire Word"
-          aria-label="Retire Word"
+          title="Mark as Learned"
+          aria-label="Mark as Learned"
           disabled={!currentWord}
         >
           <Archive size={16} />
         </Button>
       )}
-      
+
       <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
-      
-      <RetireWordDialog
-        isOpen={isRetireDialogOpen}
-        onClose={() => setIsRetireDialogOpen(false)}
-        onConfirm={handleRetireConfirm}
+
+      <MarkWordAsLearnedDialog
+        isOpen={isLearnedDialogOpen}
+        onClose={() => setIsLearnedDialogOpen(false)}
+        onConfirm={handleMarkAsLearnedConfirm}
         wordText={currentWord?.word || ''}
       />
     </div>

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyCardNew from './VocabularyCardNew';
@@ -20,7 +19,7 @@ interface VocabularyMainNewProps {
   onOpenEditModal: () => void;
   showWordCount?: boolean;
   playCurrentWord: () => void;
-  onRetireWord?: () => void;
+  onMarkWordAsLearned?: () => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -38,7 +37,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   onOpenEditModal,
   showWordCount = false,
   playCurrentWord,
-  onRetireWord,
+  onMarkWordAsLearned,
   }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -57,7 +56,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
             showWordCount={showWordCount}
           />
         </div>
-      
+
       {/* Controls column - positioned on the right side */}
         <div className="flex-none flex flex-col justify-start items-end">
           <VocabularyControlsColumn
@@ -72,7 +71,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
             onOpenEditModal={onOpenEditModal}
             selectedVoiceName={selectedVoiceName}
             playCurrentWord={playCurrentWord}
-            onRetireWord={onRetireWord}
+            onMarkWordAsLearned={onMarkWordAsLearned}
           />
         </div>
       </div>

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -10,10 +10,10 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   const [todayWords, setTodayWords] = useState<VocabularyWord[]>([]);
   const [progressStats, setProgressStats] = useState({
     total: 0,
-    learned: 0,
+    learning: 0,
     new: 0,
     due: 0,
-    retired: 0
+    learned: 0
   });
 
   const refreshStats = useCallback(() => {
@@ -23,7 +23,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
 
   const generateDailyWords = useCallback((severity: SeverityLevel = 'moderate') => {
     if (allWords.length === 0) return;
-    
+
     // Force regeneration when user clicks the buttons
     const selection = learningProgressService.forceGenerateDailySelection(allWords, severity);
     setDailySelection(selection);
@@ -69,12 +69,12 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     return learningProgressService.getDueReviewWords();
   }, []);
 
-  const getRetiredWords = useCallback(() => {
-    return learningProgressService.getRetiredWords();
+  const getLearnedWords = useCallback(() => {
+    return learningProgressService.getLearnedWords();
   }, []);
 
-  const retireCurrentWord = useCallback((word: string) => {
-    learningProgressService.retireWord(word);
+  const markCurrentWordAsLearned = useCallback((word: string) => {
+    learningProgressService.markWordAsLearned(word);
     refreshStats();
   }, [refreshStats]);
 
@@ -87,8 +87,8 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getWordProgress,
     refreshStats,
     getDueReviewWords,
-    getRetiredWords,
-    retireCurrentWord,
+    getLearnedWords,
+    markCurrentWordAsLearned,
     todayWords
   };
 };

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -74,7 +74,7 @@ export class LearningProgressService {
   private migrateProgressData(progress: LearningProgress): LearningProgress {
     const DEFAULT_VALUES = {
       status: 'new' as const,
-      retiredDate: undefined,
+      learnedDate: undefined,
       nextReviewDate: this.getToday(),
       createdDate: this.getToday()
     };
@@ -84,7 +84,7 @@ export class LearningProgressService {
       status: progress.status || (progress.isLearned ? 'due' : DEFAULT_VALUES.status),
       nextReviewDate: progress.nextReviewDate || DEFAULT_VALUES.nextReviewDate,
       createdDate: progress.createdDate || DEFAULT_VALUES.createdDate,
-      retiredDate: progress.retiredDate || DEFAULT_VALUES.retiredDate
+      learnedDate: progress.learnedDate || DEFAULT_VALUES.learnedDate
     };
   }
 
@@ -125,14 +125,14 @@ export class LearningProgressService {
     }
   }
 
-  retireWord(wordKey: string): void {
+  markWordAsLearned(wordKey: string): void {
     const progressMap = this.getLearningProgress();
     const progress = progressMap.get(wordKey);
     
     if (progress) {
       const today = this.getToday();
-      progress.status = 'retired';
-      progress.retiredDate = today;
+      progress.status = 'learned';
+      progress.learnedDate = today;
       progress.nextReviewDate = this.addDays(today, 100);
       
       progressMap.set(wordKey, progress);
@@ -146,7 +146,7 @@ export class LearningProgressService {
     let hasChanges = false;
 
     progressMap.forEach((progress, key) => {
-      if (progress.status === 'retired') return;
+      if (progress.status === 'learned') return;
 
       if (progress.isLearned) {
         if (progress.nextReviewDate <= today && progress.status !== 'due') {
@@ -207,7 +207,7 @@ export class LearningProgressService {
     const totalCount = Math.min(idealCount, maxPossibleCount);
 
     // Get available words
-    const newWords = Array.from(progressMap.values()).filter(p => !p.isLearned && p.status !== 'retired');
+    const newWords = Array.from(progressMap.values()).filter(p => !p.isLearned && p.status !== 'learned');
     const dueWords = Array.from(progressMap.values()).filter(p => p.isLearned && p.nextReviewDate <= today);
 
     // Always include all due review words
@@ -302,10 +302,10 @@ export class LearningProgressService {
 
     return {
       total: all.length,
-      learned: all.filter(p => p.isLearned).length,
+      learning: all.filter(p => p.isLearned && p.status !== 'learned').length,
       new: all.filter(p => !p.isLearned).length,
       due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
-      retired: all.filter(p => p.status === 'retired').length
+      learned: all.filter(p => p.status === 'learned').length
     };
   }
 
@@ -315,10 +315,10 @@ export class LearningProgressService {
     return Array.from(progressMap.values()).filter(p => p.isLearned && p.nextReviewDate <= today);
   }
 
-  getRetiredWords(): LearningProgress[] {
+  getLearnedWords(): LearningProgress[] {
     const progressMap = this.getLearningProgress();
     return Array.from(progressMap.values())
-      .filter(p => p.status === 'retired')
+      .filter(p => p.status === 'learned')
       .sort((a, b) => a.word.localeCompare(b.word)); // Sort alphabetically
   }
 }

--- a/src/types/learning.ts
+++ b/src/types/learning.ts
@@ -5,10 +5,10 @@ export interface LearningProgress {
   isLearned: boolean;
   reviewCount: number;
   lastPlayedDate: string;
-  status: 'due' | 'not_due' | 'new' | 'retired';
+  status: 'due' | 'not_due' | 'new' | 'learned';
   nextReviewDate: string;
   createdDate: string;
-  retiredDate?: string;
+  learnedDate?: string;
 }
 
 export interface DailySelection {


### PR DESCRIPTION
## Summary
- rename retired word APIs to mark words as learned
- track `learnedDate` and `learned` status in progress service
- update progress stats and panels to show learning vs learned counts

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a006ff79d4832fa2fea1bf050736dc