### PR TITLE
feat: hide daily selection display

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { DailySelection, SeverityLevel } from '@/types/learning';
 
@@ -19,7 +18,6 @@ interface LearningProgressPanelProps {
 }
 
 export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
-  dailySelection,
   progressStats,
   onGenerateDaily,
   onRefresh
@@ -71,46 +69,6 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
           </div>
           <Progress value={learnedPercentage} className="h-2" />
         </div>
-
-        {/* Daily Selection Info */}
-        {dailySelection && (
-          <div className="space-y-3">
-            <h4 className="font-semibold">Today's Selection</h4>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="secondary" className="border-0">
-                Total: {dailySelection.totalCount}
-              </Badge>
-              <Badge variant="outline" className="text-green-600 border-0">
-                New: {dailySelection.newWords.length}
-              </Badge>
-              <Badge variant="outline" className="text-blue-600 border-0">
-                Review: {dailySelection.reviewWords.length}
-              </Badge>
-              <Badge variant="outline" className="border-0">
-                Level: {dailySelection.severity}
-              </Badge>
-            </div>
-            
-            {/* Category breakdown for all words in today's selection */}
-            {(dailySelection.newWords.length > 0 || dailySelection.reviewWords.length > 0) && (
-              <div className="text-sm">
-                <div className="font-medium mb-1">By Category:</div>
-                <div className="flex flex-wrap gap-1">
-                  {Object.entries(
-                    [...dailySelection.newWords, ...dailySelection.reviewWords].reduce((acc, word) => {
-                      acc[word.category] = (acc[word.category] || 0) + 1;
-                      return acc;
-                    }, {} as Record<string, number>)
-                  ).map(([category, count]) => (
-                    <Badge key={category} variant="outline" className="text-xs border-0">
-                      {category}: {count}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
 
         {/* Generate Daily Selection */}
         <div className="space-y-3">


### PR DESCRIPTION
## Summary
- remove "Today's Selection" badge section from learning progress panel

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement errors in unrelated files)*
- `npx eslint src/components/LearningProgressPanel.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689fe9bd5d58832f9a51c55752319f4e