### PR TITLE
feat: add intra-day exposure timing

### DIFF
--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -1,6 +1,7 @@
 import { LearningProgress, DailySelection, SeverityLevel, CategoryWeights } from '@/types/learning';
 import { VocabularyWord } from '@/types/vocabulary';
 import { getLocalDateISO } from '@/utils/date';
+import { calculateNextAllowedTime } from './timingCalculator';
 
 const LEARNING_PROGRESS_KEY = 'learningProgress';
 const DAILY_SELECTION_KEY = 'dailySelection';
@@ -59,32 +60,59 @@ export class LearningProgressService {
   private getLearningProgress(): Map<string, LearningProgress> {
     const stored = localStorage.getItem(LEARNING_PROGRESS_KEY);
     const progressMap = new Map<string, LearningProgress>();
-    
+    let hasChanges = false;
+
     if (stored) {
       const data = JSON.parse(stored);
       Object.entries(data).forEach(([key, value]) => {
         const progress = this.migrateProgressData(value as LearningProgress);
         progressMap.set(key, progress);
+        const original = value as LearningProgress;
+        if (
+          progress.exposuresToday !== original.exposuresToday ||
+          progress.lastExposureTime !== original.lastExposureTime ||
+          progress.nextAllowedTime !== original.nextAllowedTime
+        ) {
+          hasChanges = true;
+        }
       });
     }
-    
+
+    if (hasChanges) {
+      this.saveLearningProgress(progressMap);
+    }
+
     return progressMap;
   }
 
   private migrateProgressData(progress: LearningProgress): LearningProgress {
+    const today = this.getToday();
     const DEFAULT_VALUES = {
       status: 'new' as const,
       learnedDate: undefined,
-      nextReviewDate: this.getToday(),
-      createdDate: this.getToday(),
+      nextReviewDate: today,
+      createdDate: today,
+      exposuresToday: 0,
+      lastExposureTime: '',
       nextAllowedTime: new Date().toISOString()
     };
+
+    let lastExposureTime = progress.lastExposureTime || DEFAULT_VALUES.lastExposureTime;
+    let exposuresToday = progress.exposuresToday ?? DEFAULT_VALUES.exposuresToday;
+    if (lastExposureTime) {
+      const lastDate = lastExposureTime.split('T')[0];
+      if (lastDate !== today) {
+        exposuresToday = 0;
+      }
+    }
 
     return {
       ...progress,
       status: progress.status || (progress.isLearned ? 'due' : DEFAULT_VALUES.status),
       nextReviewDate: progress.nextReviewDate || DEFAULT_VALUES.nextReviewDate,
       createdDate: progress.createdDate || DEFAULT_VALUES.createdDate,
+      exposuresToday,
+      lastExposureTime,
       nextAllowedTime: progress.nextAllowedTime || DEFAULT_VALUES.nextAllowedTime,
       learnedDate:
         (progress as any).learnedDate ||
@@ -110,6 +138,8 @@ export class LearningProgressService {
       status: 'new',
       nextReviewDate: today,
       createdDate: today,
+      exposuresToday: 0,
+      lastExposureTime: '',
       nextAllowedTime: new Date().toISOString()
     };
   }
@@ -117,16 +147,26 @@ export class LearningProgressService {
   updateWordProgress(wordKey: string): void {
     const progressMap = this.getLearningProgress();
     const progress = progressMap.get(wordKey);
-    
+
     if (progress) {
       const today = this.getToday();
+      const nowIso = new Date().toISOString();
+
+      // Reset daily exposure count if last exposure was on a different day
+      if (progress.lastExposureTime && progress.lastExposureTime.split('T')[0] !== today) {
+        progress.exposuresToday = 0;
+      }
+
+      progress.exposuresToday = (progress.exposuresToday || 0) + 1;
+      progress.lastExposureTime = nowIso;
+      progress.nextAllowedTime = calculateNextAllowedTime(progress.exposuresToday, nowIso);
+
       progress.lastPlayedDate = today;
       progress.isLearned = true;
       progress.reviewCount += 1;
       progress.nextReviewDate = this.calculateNextReviewDate(progress.reviewCount);
       progress.status = 'due';
-      progress.nextAllowedTime = new Date().toISOString();
-      
+
       progressMap.set(wordKey, progress);
       this.saveLearningProgress(progressMap);
     }

--- a/src/services/timingCalculator.ts
+++ b/src/services/timingCalculator.ts
@@ -1,0 +1,8 @@
+export const EXPOSURE_DELAYS = [0, 5, 7, 10, 15, 30, 60, 90, 120]; // minutes
+
+export function calculateNextAllowedTime(exposureCount: number, lastExposureTime: string): string {
+  const index = Math.min(exposureCount, EXPOSURE_DELAYS.length - 1);
+  const delayMinutes = EXPOSURE_DELAYS[index];
+  const baseTime = new Date(lastExposureTime).getTime();
+  return new Date(baseTime + delayMinutes * 60000).toISOString();
+}

--- a/src/types/learning.ts
+++ b/src/types/learning.ts
@@ -9,6 +9,8 @@ export interface LearningProgress {
   nextReviewDate: string;
   createdDate: string;
   learnedDate?: string;
+  exposuresToday?: number;
+  lastExposureTime?: string;
   nextAllowedTime?: string;
 }
 

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { LearningProgressService } from '@/services/learningProgressService';
 import { VocabularyWord } from '@/types/vocabulary';
 import { LearningProgress } from '@/types/learning';
+import { calculateNextAllowedTime } from '@/services/timingCalculator';
 
 // Mock localStorage
 const localStorageMock = {
@@ -217,6 +218,62 @@ describe('LearningProgressService', () => {
       const expected = expectedDate.toISOString().split('T')[0];
       
       expect(updated.nextReviewDate).toBe(expected);
+    });
+
+    it('should track exposures and next allowed time', () => {
+      vi.useFakeTimers();
+      const baseTime = new Date('2024-01-01T10:00:00Z');
+      vi.setSystemTime(baseTime);
+
+      const word = mockWords[0];
+      const progress = service.initializeWord(word);
+
+      const store: Record<string, string> = {
+        learningProgress: JSON.stringify({ [word.word]: progress })
+      };
+
+      localStorageMock.getItem.mockImplementation((key: string) => store[key] || null);
+      localStorageMock.setItem.mockImplementation((key: string, value: string) => {
+        store[key] = value;
+      });
+
+      service.updateWordProgress(word.word);
+
+      let saved = JSON.parse(store.learningProgress);
+      let updated = saved[word.word];
+      expect(updated.exposuresToday).toBe(1);
+      expect(updated.lastExposureTime).toBe(baseTime.toISOString());
+      expect(updated.nextAllowedTime).toBe(
+        calculateNextAllowedTime(1, baseTime.toISOString())
+      );
+
+      const secondTime = new Date(baseTime.getTime() + 5 * 60000);
+      vi.setSystemTime(secondTime);
+
+      service.updateWordProgress(word.word);
+
+      saved = JSON.parse(store.learningProgress);
+      updated = saved[word.word];
+      expect(updated.exposuresToday).toBe(2);
+      expect(updated.lastExposureTime).toBe(secondTime.toISOString());
+      expect(updated.nextAllowedTime).toBe(
+        calculateNextAllowedTime(2, secondTime.toISOString())
+      );
+
+      const nextDay = new Date('2024-01-02T00:01:00Z');
+      vi.setSystemTime(nextDay);
+
+      service.updateWordProgress(word.word);
+
+      saved = JSON.parse(store.learningProgress);
+      updated = saved[word.word];
+      expect(updated.exposuresToday).toBe(1);
+      expect(updated.lastExposureTime).toBe(nextDay.toISOString());
+      expect(updated.nextAllowedTime).toBe(
+        calculateNextAllowedTime(1, nextDay.toISOString())
+      );
+
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary
- extend learning progress with exposuresToday and timing fields
- add timing calculator based on EXPOSURE_DELAYS
- reset daily exposures and compute next allowed time when words are played

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Empty block statement, Unnecessary escape character)*

------
https://chatgpt.com/codex/tasks/task_e_68a03dd100ac832f9f736b523407aa51