### PR TITLE
Rename RetireWordDialog to MarkAsLearnedDialog

### DIFF
--- a/src/components/MarkAsLearnedDialog.tsx
+++ b/src/components/MarkAsLearnedDialog.tsx
@@ -10,14 +10,14 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 
-interface RetireWordDialogProps {
+interface MarkAsLearnedDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   wordText: string;
 }
 
-export const RetireWordDialog: React.FC<RetireWordDialogProps> = ({
+export const MarkAsLearnedDialog: React.FC<MarkAsLearnedDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -12,7 +12,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
-import { RetireWordDialog } from '@/components/RetireWordDialog';
+import { MarkAsLearnedDialog } from '@/components/MarkAsLearnedDialog';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -92,14 +92,14 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const [isSearchOpen, setIsSearchOpen] = React.useState(false);
-  const [isRetireDialogOpen, setIsRetireDialogOpen] = React.useState(false);
+  const [isMarkDialogOpen, setIsMarkDialogOpen] = React.useState(false);
   const openSearch = () => setIsSearchOpen(true);
   const closeSearch = () => setIsSearchOpen(false);
-  
-  const handleRetireClick = () => setIsRetireDialogOpen(true);
-  const handleRetireConfirm = () => {
+
+  const handleMarkClick = () => setIsMarkDialogOpen(true);
+  const handleMarkConfirm = () => {
     if (onMarkWordLearned) onMarkWordLearned();
-    setIsRetireDialogOpen(false);
+    setIsMarkDialogOpen(false);
     toast('Word learned for 100 days');
   };
 
@@ -175,7 +175,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         <Button
           variant="outline"
           size="sm"
-          onClick={handleRetireClick}
+          onClick={handleMarkClick}
           className="h-8 w-8 p-0 text-red-600 border-red-300 bg-red-50"
           title="Mark as Learned"
           aria-label="Mark as Learned"
@@ -187,10 +187,10 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       
       <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
       
-      <RetireWordDialog
-        isOpen={isRetireDialogOpen}
-        onClose={() => setIsRetireDialogOpen(false)}
-        onConfirm={handleRetireConfirm}
+      <MarkAsLearnedDialog
+        isOpen={isMarkDialogOpen}
+        onClose={() => setIsMarkDialogOpen(false)}
+        onConfirm={handleMarkConfirm}
         wordText={currentWord?.word || ''}
       />
     </div>


### PR DESCRIPTION
## Summary
- rename RetireWordDialog component and file to MarkAsLearnedDialog
- update VocabularyControlsColumn to import and use MarkAsLearnedDialog

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type and others)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0581fef98832f879e6a1faae5f77f