### PR TITLE
Rename retire functions to learned equivalents

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -19,8 +19,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     generateDailyWords,
     markWordAsPlayed,
     getDueReviewWords,
-    getRetiredWords: getLearnedWords,
-    retireCurrentWord: markCurrentWordLearned,
+    getLearnedWords,
+    markCurrentWordLearned,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -122,10 +122,10 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Learned ({progressStats.retired})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({progressStats.learnedCompleted})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
                   {progressStats.learnedCompleted > 0 ? (
-                    getRetiredWords().map((word, index) => (
+                    getLearnedWords().map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -69,12 +69,12 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     return learningProgressService.getDueReviewWords();
   }, []);
 
-  const getRetiredWords = useCallback(() => {
-    return learningProgressService.getRetiredWords();
+  const getLearnedWords = useCallback(() => {
+    return learningProgressService.getLearnedWords();
   }, []);
 
-  const retireCurrentWord = useCallback((word: string) => {
-    learningProgressService.retireWord(word);
+  const markCurrentWordLearned = useCallback((word: string) => {
+    learningProgressService.markWordLearned(word);
     refreshStats();
   }, [refreshStats]);
 
@@ -87,8 +87,8 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getWordProgress,
     refreshStats,
     getDueReviewWords,
-    getRetiredWords,
-    retireCurrentWord,
+    getLearnedWords,
+    markCurrentWordLearned,
     todayWords
   };
 };

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -132,16 +132,20 @@ export class LearningProgressService {
     }
   }
 
-  retireWord(wordKey: string): void {
+  /**
+   * Permanently marks a word as learned and removes it from the review cycle
+   */
+  markWordLearned(wordKey: string): void {
     const progressMap = this.getLearningProgress();
     const progress = progressMap.get(wordKey);
-    
+
     if (progress) {
       const today = this.getToday();
       progress.status = 'learned';
       progress.learnedDate = today;
+      // push review far into the future so it no longer appears in daily selections
       progress.nextReviewDate = this.addDays(today, 100);
-      
+
       progressMap.set(wordKey, progress);
       this.saveLearningProgress(progressMap);
     }
@@ -312,7 +316,7 @@ export class LearningProgressService {
       learned: all.filter(p => p.isLearned).length,
       new: all.filter(p => !p.isLearned).length,
       due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
-      retired: all.filter(p => p.status === 'learned').length
+      learnedCompleted: all.filter(p => p.status === 'learned').length
     };
   }
 
@@ -322,7 +326,7 @@ export class LearningProgressService {
     return Array.from(progressMap.values()).filter(p => p.isLearned && p.nextReviewDate <= today);
   }
 
-  getRetiredWords(): LearningProgress[] {
+  getLearnedWords(): LearningProgress[] {
     const progressMap = this.getLearningProgress();
     return Array.from(progressMap.values())
       .filter(p => p.status === 'learned')


### PR DESCRIPTION
## Summary
- rename `retireWord` to `markWordLearned`
- rename `getRetiredWords` to `getLearnedWords`
- rename progress stat `retired` to `learnedCompleted`

## Testing
- `npm test`
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a05e76aab4832fa0898671598a001a