### PR TITLE
Use direct learning functions and stats

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -20,7 +20,7 @@ const VocabularyAppWithLearning: React.FC = () => {
     markWordAsPlayed,
     getDueReviewWords,
     getLearnedWords,
-    markCurrentWordLearned,
+    markWordLearned,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -57,6 +57,8 @@ const VocabularyAppWithLearning: React.FC = () => {
       vocabularyService.removeVocabularyChangeListener(handleWordChange);
     };
   }, [markWordAsPlayed]);
+
+  const learnedWords = getLearnedWords();
 
   const learningSection = (
     <div className="space-y-4 mt-4">
@@ -122,10 +124,10 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Learned ({progressStats.learnedCompleted})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({learnedWords.length})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
-                  {progressStats.learnedCompleted > 0 ? (
-                    getLearnedWords().map((word, index) => (
+                  {learnedWords.length > 0 ? (
+                    learnedWords.map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">
@@ -156,7 +158,7 @@ const VocabularyAppWithLearning: React.FC = () => {
           onMarkWordLearned={() => {
             const currentWord = vocabularyService.getCurrentWord();
             if (currentWord) {
-              markCurrentWordLearned(currentWord.word);
+              markWordLearned(currentWord.word);
             }
           }}
           additionalContent={learningSection}

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -73,7 +73,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     return learningProgressService.getLearnedWords();
   }, []);
 
-  const markCurrentWordLearned = useCallback((word: string) => {
+  const markWordLearned = useCallback((word: string) => {
     learningProgressService.markWordLearned(word);
     refreshStats();
   }, [refreshStats]);
@@ -88,7 +88,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     refreshStats,
     getDueReviewWords,
     getLearnedWords,
-    markCurrentWordLearned,
+    markWordLearned,
     todayWords
   };
 };


### PR DESCRIPTION
## Summary
- expose `markWordLearned` and `getLearnedWords` directly from learning progress hook
- use `getLearnedWords` count for "Learned" summary

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty and no-useless-escape errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0608a99c8832fb7b0ac63adf54116