### PR TITLE
test: verify learnedCompleted stats across hook and panel

### DIFF
--- a/tests/LearningProgressPanel.test.tsx
+++ b/tests/LearningProgressPanel.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { LearningProgressPanel } from '@/components/LearningProgressPanel';
+
+describe('LearningProgressPanel', () => {
+  it('renders learnedCompleted stat', () => {
+    const progressStats = { total: 10, learned: 5, new: 3, due: 2, learnedCompleted: 4 };
+
+    render(
+      <LearningProgressPanel
+        dailySelection={null}
+        progressStats={progressStats}
+        onGenerateDaily={() => {}}
+        learnerId="test"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Daily Learning Progress'));
+    const learnedLabel = screen.getByText('Learned');
+    expect(learnedLabel.previousElementSibling?.textContent).toBe('4');
+  });
+});

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -224,21 +224,25 @@ describe('LearningProgressService', () => {
     it('should calculate progress stats correctly', () => {
       const today = new Date().toISOString().split('T')[0];
       const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+      const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
+
       const mockProgress = {
         'word1': { isLearned: true, status: 'not_due', nextReviewDate: today },
         'word2': { isLearned: false, status: 'new', nextReviewDate: today },
         'word3': { isLearned: true, status: 'not_due', nextReviewDate: yesterday },
         'word4': { isLearned: false, status: 'new', nextReviewDate: today },
+        'word5': { isLearned: true, status: 'learned', nextReviewDate: tomorrow },
       };
 
       localStorageMock.getItem.mockReturnValue(JSON.stringify(mockProgress));
-      
+
       const stats = service.getProgressStats();
-      
-      expect(stats.total).toBe(4);
-      expect(stats.learned).toBe(2);
+
+      expect(stats.total).toBe(5);
+      expect(stats.learned).toBe(3);
       expect(stats.new).toBe(2);
       expect(stats.due).toBe(2);
+      expect(stats.learnedCompleted).toBe(1);
     });
 
     it('should include words with next review date today in due list', () => {

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+import { learningProgressService } from '@/services/learningProgressService';
+
+describe('useLearningProgress', () => {
+  it('provides learnedCompleted stat from service', () => {
+    const mockStats = { total: 1, learned: 1, new: 0, due: 0, learnedCompleted: 1 };
+    const spy = vi.spyOn(learningProgressService, 'getProgressStats').mockReturnValue(mockStats);
+
+    const { result } = renderHook(() => useLearningProgress([]));
+
+    act(() => {
+      result.current.refreshStats();
+    });
+
+    expect(result.current.progressStats.learnedCompleted).toBe(1);
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- extend progress stats test to include `learnedCompleted`
- test that `useLearningProgress` exposes `learnedCompleted`
- test that `LearningProgressPanel` renders `learnedCompleted`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a062ccb188832f8a4b491579a038a7