### PR TITLE
Prioritize review words in daily selections

### DIFF
--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -56,8 +56,8 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     if (!dailySelection) return;
 
     const words = buildTodaysWords(
-      dailySelection.newWords,
       dailySelection.reviewWords,
+      dailySelection.newWords,
       allWords,
       'ALL'
     );

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -60,7 +60,8 @@ export const useVocabularyDataLoader = (
 
         let todayWords: VocabularyWord[] = [];
         if (selection) {
-          const progressList = [...selection.newWords, ...selection.reviewWords];
+          // Review words should come before new words so playback prioritizes due items
+          const progressList = [...selection.reviewWords, ...selection.newWords];
           const map = new Map<string, VocabularyWord>();
           progressList.forEach(p => {
             const w = allWords.find(

--- a/src/utils/todayWords.ts
+++ b/src/utils/todayWords.ts
@@ -6,13 +6,14 @@ import { VocabularyWord } from '@/types/vocabulary';
  * optionally filtered by category. The original lists are not mutated.
  */
 export function buildTodaysWords(
-  newWords: LearningProgress[],
   reviewWords: LearningProgress[],
+  newWords: LearningProgress[],
   allWords: VocabularyWord[],
   category: string
 ): VocabularyWord[] {
   const map = new Map<string, VocabularyWord>();
-  const combined = [...newWords, ...reviewWords];
+  // Combine review words before new words to prioritize due items
+  const combined = [...reviewWords, ...newWords];
 
   combined.forEach(p => {
     const word = allWords.find(w => w.word === p.word && w.category === p.category);

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -187,6 +187,36 @@ describe('LearningProgressService', () => {
       expect(selection.newWords.length).toBe(2);
       expect(selection.totalCount).toBe(5);
     });
+
+    it('orders review words by earliest nextReviewDate', () => {
+      const today = new Date().toISOString().split('T')[0];
+      const day = 86400000;
+
+      const progressData: Record<string, LearningProgress> = {
+        w1: { word: 'w1', category: 'topic vocab', isLearned: true, reviewCount: 1, lastPlayedDate: '', status: 'due', nextReviewDate: new Date(Date.now() - 3 * day).toISOString().split('T')[0], createdDate: today },
+        w2: { word: 'w2', category: 'topic vocab', isLearned: true, reviewCount: 1, lastPlayedDate: '', status: 'due', nextReviewDate: new Date(Date.now() - 1 * day).toISOString().split('T')[0], createdDate: today },
+        w3: { word: 'w3', category: 'topic vocab', isLearned: true, reviewCount: 1, lastPlayedDate: '', status: 'due', nextReviewDate: new Date(Date.now() - 2 * day).toISOString().split('T')[0], createdDate: today }
+      };
+
+      localStorageMock.getItem.mockImplementation((key) => {
+        if (key === 'learningProgress') return JSON.stringify(progressData);
+        return null;
+      });
+
+      vi.spyOn(service as unknown as { getRandomCount: () => number }, 'getRandomCount').mockReturnValue(5);
+
+      const allWords: VocabularyWord[] = [
+        { word: 'w1', meaning: 'm', example: 'e', category: 'topic vocab', count: 1 },
+        { word: 'w2', meaning: 'm', example: 'e', category: 'topic vocab', count: 1 },
+        { word: 'w3', meaning: 'm', example: 'e', category: 'topic vocab', count: 1 },
+        { word: 'n1', meaning: 'm', example: 'e', category: 'topic vocab', count: 1 },
+        { word: 'n2', meaning: 'm', example: 'e', category: 'topic vocab', count: 1 }
+      ];
+
+      const selection = service.forceGenerateDailySelection(allWords, 'light');
+
+      expect(selection.reviewWords.map(w => w.word)).toEqual(['w1', 'w3', 'w2']);
+    });
   });
 
   describe('Word Progress Tracking', () => {

--- a/tests/todayWordsConstruction.test.ts
+++ b/tests/todayWordsConstruction.test.ts
@@ -21,12 +21,17 @@ describe('buildTodaysWords', () => {
   ];
 
   it('creates a de-duplicated union of new and review words', () => {
-    const result = buildTodaysWords(newWords, reviewWords, allWords, 'ALL');
+    const result = buildTodaysWords(reviewWords, newWords, allWords, 'ALL');
     expect(result.map(w => w.word).sort()).toEqual(['a', 'b', 'c']);
   });
 
   it('filters by category when provided', () => {
-    const result = buildTodaysWords(newWords, reviewWords, allWords, 'cat1');
+    const result = buildTodaysWords(reviewWords, newWords, allWords, 'cat1');
     expect(result.map(w => w.word).sort()).toEqual(['a', 'c']);
+  });
+
+  it('keeps review words before new words in the combined list', () => {
+    const result = buildTodaysWords(reviewWords, newWords, allWords, 'ALL');
+    expect(result.map(w => w.word)).toEqual(['a', 'c', 'b']);
   });
 });


### PR DESCRIPTION
## Summary
- Prioritize review words before new words when building today's vocabulary lists and data loader progress lists
- Adjust hooks to supply review words first
- Add tests ensuring review words stay ahead and are ordered by earliest nextReviewDate

## Testing
- `npm test`
- `npm run lint` *(fails: empty block statements and escape characters in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0685277ec832fb0250b7c96d6c38b