### PR TITLE
Ensure mark learned uses captured word

### DIFF
--- a/src/components/MarkAsLearnedDialog.tsx
+++ b/src/components/MarkAsLearnedDialog.tsx
@@ -14,14 +14,14 @@ interface MarkAsLearnedDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
-  wordText: string;
+  word: string;
 }
 
 export const MarkAsLearnedDialog: React.FC<MarkAsLearnedDialogProps> = ({
   isOpen,
   onClose,
   onConfirm,
-  wordText
+  word
 }) => {
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
@@ -29,7 +29,7 @@ export const MarkAsLearnedDialog: React.FC<MarkAsLearnedDialogProps> = ({
         <AlertDialogHeader>
           <AlertDialogTitle>Mark as Learned</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to mark "{wordText}" as learned?
+            Are you sure you want to mark "{word}" as learned?
             <br /><br />
             This word will be hidden from your daily practice and will automatically
             reappear after 100 days for review.

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -20,7 +20,7 @@ const VocabularyAppWithLearning: React.FC = () => {
     markWordAsPlayed,
     getDueReviewWords,
     getLearnedWords,
-    markWordLearned,
+    markWordLearned: markCurrentWordLearned,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -155,11 +155,8 @@ const VocabularyAppWithLearning: React.FC = () => {
       <div className="w-full max-w-6xl mx-auto p-4">
         <VocabularyAppContainerNew
           initialWords={todayWords}
-          onMarkWordLearned={() => {
-            const currentWord = vocabularyService.getCurrentWord();
-            if (currentWord) {
-              markWordLearned(currentWord.word);
-            }
+          onMarkWordLearned={(word) => {
+            markCurrentWordLearned(word);
           }}
           additionalContent={learningSection}
         />

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -27,7 +27,7 @@ interface ContentWithDataNewProps {
   handleOpenAddWordModal: () => void;
   handleOpenEditWordModal: (word: VocabularyWord) => void;
   playCurrentWord: () => void;
-  onMarkWordLearned?: () => void;
+  onMarkWordLearned?: (word: string) => void;
   additionalContent?: React.ReactNode;
 }
 

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -14,7 +14,7 @@ import { DebugInfoContext } from '@/contexts/DebugInfoContext';
 import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
-  onMarkWordLearned?: () => void;
+  onMarkWordLearned?: (word: string) => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
 }

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -26,7 +26,7 @@ interface VocabularyControlsColumnProps {
   onOpenEditModal: () => void;
   selectedVoiceName: string;
   playCurrentWord: () => void;
-  onMarkWordLearned?: () => void;
+  onMarkWordLearned?: (word: string) => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -93,12 +93,16 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
 
   const [isSearchOpen, setIsSearchOpen] = React.useState(false);
   const [isMarkAsLearnedDialogOpen, setIsMarkAsLearnedDialogOpen] = React.useState(false);
+  const [wordToMark, setWordToMark] = React.useState('');
   const openSearch = () => setIsSearchOpen(true);
   const closeSearch = () => setIsSearchOpen(false);
 
-  const handleMarkAsLearnedClick = () => setIsMarkAsLearnedDialogOpen(true);
+  const handleMarkAsLearnedClick = () => {
+    setWordToMark(currentWord?.word || '');
+    setIsMarkAsLearnedDialogOpen(true);
+  };
   const handleMarkAsLearnedConfirm = () => {
-    if (onMarkWordLearned) onMarkWordLearned();
+    if (onMarkWordLearned && wordToMark) onMarkWordLearned(wordToMark);
     setIsMarkAsLearnedDialogOpen(false);
     toast('Word marked as learned.');
   };
@@ -191,7 +195,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
         isOpen={isMarkAsLearnedDialogOpen}
         onClose={() => setIsMarkAsLearnedDialogOpen(false)}
         onConfirm={handleMarkAsLearnedConfirm}
-        wordText={currentWord?.word || ''}
+        word={wordToMark}
       />
     </div>
   );

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -20,7 +20,7 @@ interface VocabularyMainNewProps {
   onOpenEditModal: () => void;
   showWordCount?: boolean;
   playCurrentWord: () => void;
-  onMarkWordLearned?: () => void;
+  onMarkWordLearned?: (word: string) => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({

--- a/tests/markWordLearnedCapture.test.tsx
+++ b/tests/markWordLearnedCapture.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VocabularyControlsColumn from '../src/components/vocabulary-app/VocabularyControlsColumn';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+// Mock toast to avoid side effects
+vi.mock('sonner', () => ({ toast: vi.fn(), warning: vi.fn() }));
+
+// make expect available for jest-dom extensions
+// eslint-disable-next-line no-undef
+(globalThis as any).expect = expect;
+
+beforeAll(async () => {
+  await import('@testing-library/jest-dom');
+  // minimal speechSynthesis mock for useVoiceContext
+  (window as any).speechSynthesis = {
+    getVoices: () => [{ name: 'Test', lang: 'en-US' }],
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    speak: () => {},
+  };
+});
+
+describe('VocabularyControlsColumn mark as learned', () => {
+  it('uses word captured when dialog opened', async () => {
+    const firstWord: VocabularyWord = { word: 'apple', meaning: '', example: '', category: 'test' };
+    const secondWord: VocabularyWord = { word: 'banana', meaning: '', example: '', category: 'test' };
+    const onMark = vi.fn();
+
+    const { rerender } = render(
+      <VocabularyControlsColumn
+        isMuted={false}
+        isPaused={false}
+        onToggleMute={() => {}}
+        onTogglePause={() => {}}
+        onNextWord={() => {}}
+        onCycleVoice={() => {}}
+        currentWord={firstWord}
+        onOpenAddModal={() => {}}
+        onOpenEditModal={() => {}}
+        selectedVoiceName="Test"
+        playCurrentWord={() => {}}
+        onMarkWordLearned={onMark}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Mark as Learned' }));
+
+    // Simulate service advancing to a new word while dialog is open
+    rerender(
+      <VocabularyControlsColumn
+        isMuted={false}
+        isPaused={false}
+        onToggleMute={() => {}}
+        onTogglePause={() => {}}
+        onNextWord={() => {}}
+        onCycleVoice={() => {}}
+        currentWord={secondWord}
+        onOpenAddModal={() => {}}
+        onOpenEditModal={() => {}}
+        selectedVoiceName="Test"
+        playCurrentWord={() => {}}
+        onMarkWordLearned={onMark}
+      />
+    );
+
+    // Confirm dialog displays original word
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText(/apple/)).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Mark as Learned' }));
+    expect(onMark).toHaveBeenCalledWith('apple');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Capture the current word when opening the "Mark as Learned" dialog and pass it through the confirmation path
- Accept the word string across container components and mark progress with provided word
- Add unit test verifying dialog uses stored word even if current word changes

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Empty block statement errors, unnecessary escape characters)*


------
https://chatgpt.com/codex/tasks/task_e_68a06ba26720832fa14e731ac19fcab8