### PR TITLE
feat: allow resetting learned words

### DIFF
--- a/src/components/MarkAsNewDialog.tsx
+++ b/src/components/MarkAsNewDialog.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface MarkAsNewDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  word: string;
+}
+
+export const MarkAsNewDialog: React.FC<MarkAsNewDialogProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  word
+}) => {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Mark as New</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to mark "{word}" as new?
+            <br /><br />
+            This word will re-enter your learning queue and appear in daily selections.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Mark as New</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -5,13 +5,17 @@ import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { vocabularyService } from '@/services/vocabularyService';
 import { VocabularyWord } from '@/types/vocabulary';
 import ToastProvider from './vocabulary-app/ToastProvider';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, RotateCcw } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
+import { toast } from 'sonner';
+import { MarkAsNewDialog } from './MarkAsNewDialog';
 
 const VocabularyAppWithLearning: React.FC = () => {
   const [allWords, setAllWords] = useState<VocabularyWord[]>([]);
   const [summaryOpen, setSummaryOpen] = useState(false);
+  const [isMarkAsNewDialogOpen, setIsMarkAsNewDialogOpen] = useState(false);
+  const [wordToReset, setWordToReset] = useState<string | null>(null);
 
   const {
     dailySelection,
@@ -21,6 +25,7 @@ const VocabularyAppWithLearning: React.FC = () => {
     getDueReviewWords,
     getLearnedWords,
     markWordLearned: markCurrentWordLearned,
+    markWordAsNew,
     todayWords
   } = useLearningProgress(allWords);
 
@@ -59,6 +64,15 @@ const VocabularyAppWithLearning: React.FC = () => {
   }, [markWordAsPlayed]);
 
   const learnedWords = getLearnedWords();
+
+  const handleMarkAsNew = () => {
+    if (wordToReset) {
+      markWordAsNew(wordToReset);
+      toast.success('Word reset to new.');
+    }
+    setIsMarkAsNewDialogOpen(false);
+    setWordToReset(null);
+  };
 
   const learningSection = (
     <div className="space-y-4 mt-4">
@@ -128,11 +142,26 @@ const VocabularyAppWithLearning: React.FC = () => {
                 <div className="space-y-1 max-h-60 overflow-y-auto">
                   {learnedWords.length > 0 ? (
                     learnedWords.map((word, index) => (
-                      <div key={index} className="text-sm p-2 bg-gray-50 rounded border opacity-75">
-                        <div className="font-medium text-gray-700">{word.word}</div>
-                        <div className="text-xs text-gray-500">
-                          {word.category} • Learned {word.learnedDate}
+                      <div
+                        key={index}
+                        className="text-sm p-2 bg-gray-50 rounded border opacity-75 flex items-center justify-between"
+                      >
+                        <div>
+                          <div className="font-medium text-gray-700">{word.word}</div>
+                          <div className="text-xs text-gray-500">
+                            {word.category} • Learned {word.learnedDate}
+                          </div>
                         </div>
+                        <button
+                          aria-label="Mark as New"
+                          className="text-gray-400 hover:text-gray-600"
+                          onClick={() => {
+                            setWordToReset(word.word);
+                            setIsMarkAsNewDialogOpen(true);
+                          }}
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </button>
                       </div>
                     ))
                   ) : (
@@ -161,6 +190,12 @@ const VocabularyAppWithLearning: React.FC = () => {
           additionalContent={learningSection}
         />
       </div>
+      <MarkAsNewDialog
+        isOpen={isMarkAsNewDialogOpen}
+        onClose={() => setIsMarkAsNewDialogOpen(false)}
+        onConfirm={handleMarkAsNew}
+        word={wordToReset || ''}
+      />
     </>
   );
 };

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -78,6 +78,11 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     refreshStats();
   }, [refreshStats]);
 
+  const markWordAsNew = useCallback((word: string) => {
+    learningProgressService.markWordAsNew(word);
+    refreshStats();
+  }, [refreshStats]);
+
   return {
     dailySelection,
     currentWordProgress,
@@ -89,6 +94,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getDueReviewWords,
     getLearnedWords,
     markWordLearned,
+    markWordAsNew,
     todayWords
   };
 };

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -87,8 +87,8 @@ export class LearningProgressService {
       createdDate: progress.createdDate || DEFAULT_VALUES.createdDate,
       nextAllowedTime: progress.nextAllowedTime || DEFAULT_VALUES.nextAllowedTime,
       learnedDate:
-        (progress as any).learnedDate ||
-        (progress as any).retiredDate ||
+        (progress as Partial<LearningProgress> & { retiredDate?: string }).learnedDate ||
+        (progress as Partial<LearningProgress> & { retiredDate?: string }).retiredDate ||
         DEFAULT_VALUES.learnedDate
     };
   }
@@ -145,6 +145,25 @@ export class LearningProgressService {
       progress.learnedDate = today;
       // push review far into the future so it no longer appears in daily selections
       progress.nextReviewDate = this.addDays(today, 100);
+
+      progressMap.set(wordKey, progress);
+      this.saveLearningProgress(progressMap);
+    }
+  }
+
+  markWordAsNew(wordKey: string): void {
+    const progressMap = this.getLearningProgress();
+    const progress = progressMap.get(wordKey);
+
+    if (progress) {
+      const today = this.getToday();
+      progress.isLearned = false;
+      progress.reviewCount = 0;
+      progress.status = 'new';
+      progress.learnedDate = undefined;
+      progress.nextReviewDate = today;
+      progress.nextAllowedTime = new Date().toISOString();
+      progress.lastPlayedDate = '';
 
       progressMap.set(wordKey, progress);
       this.saveLearningProgress(progressMap);

--- a/tests/markWordAsNew.test.tsx
+++ b/tests/markWordAsNew.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MarkAsNewDialog } from '@/components/MarkAsNewDialog';
+import { learningProgressService } from '@/services/learningProgressService';
+
+// make expect available for jest-dom extensions
+(globalThis as unknown as { expect: typeof expect }).expect = expect;
+
+beforeEach(async () => {
+  await import('@testing-library/jest-dom');
+  localStorage.clear();
+});
+
+describe('Mark as New flow', () => {
+  it('opens dialog and resets word to new state', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    const learnedProgress = {
+      word: 'apple',
+      category: 'test',
+      isLearned: true,
+      reviewCount: 3,
+      lastPlayedDate: today,
+      status: 'learned' as const,
+      nextReviewDate: '2099-01-01',
+      createdDate: today,
+      learnedDate: today,
+      nextAllowedTime: new Date().toISOString(),
+    };
+    localStorage.setItem('learningProgress', JSON.stringify({ apple: learnedProgress }));
+
+    const TestComponent = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <>
+          <button aria-label="Mark as New" onClick={() => setOpen(true)}>
+            reset
+          </button>
+          <MarkAsNewDialog
+            isOpen={open}
+            onClose={() => setOpen(false)}
+            onConfirm={() => {
+              learningProgressService.markWordAsNew('apple');
+              setOpen(false);
+            }}
+            word="apple"
+          />
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Mark as New' }));
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Mark as New' }));
+
+    const progress = learningProgressService.getWordProgress('apple');
+    expect(progress?.isLearned).toBe(false);
+    expect(progress?.status).toBe('new');
+    expect(progress?.reviewCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- allow setting a learned word back to new state
- provide MarkAsNew confirmation dialog and UI action
- test dialog and service reset behavior

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement and other lint errors)*
- `npx eslint src/services/learningProgressService.ts src/hooks/useLearningProgress.tsx src/components/MarkAsNewDialog.tsx src/components/VocabularyAppWithLearning.tsx tests/markWordAsNew.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a07030f2e4832fb4388c992902f9ac