### PR TITLE
Update learning progress wording

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -40,7 +40,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         <CardHeader>
           <div className="flex items-center justify-between">
             <CollapsibleTrigger className="flex items-center gap-2">
-              <CardTitle className="text-lg">Daily Learning Progress</CardTitle>
+              <CardTitle className="text-lg">Learning Progress</CardTitle>
               <ChevronDown className={cn('h-4 w-4 transition-transform', open && 'rotate-180')} />
             </CollapsibleTrigger>
           </div>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -79,7 +79,7 @@ const VocabularyAppWithLearning: React.FC = () => {
             <div className="grid gap-4 md:grid-cols-4">
               {dailySelection.newWords.length > 0 && (
                 <div className="space-y-2">
-                  <h4 className="font-medium text-green-600">New Words ({dailySelection.newWords.length})</h4>
+                  <h4 className="font-medium text-green-600">Today's New Words ({dailySelection.newWords.length})</h4>
                   <div className="space-y-1 max-h-60 overflow-y-auto">
                     {dailySelection.newWords.map((word, index) => (
                       <div key={index} className="text-sm p-2 bg-green-50 rounded border">

--- a/tests/LearningProgressPanel.test.tsx
+++ b/tests/LearningProgressPanel.test.tsx
@@ -18,7 +18,7 @@ describe('LearningProgressPanel', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('Daily Learning Progress'));
+    fireEvent.click(screen.getByRole('heading', { name: 'Learning Progress' }));
     const learnedLabel = screen.getByText('Learned');
     expect(learnedLabel.previousElementSibling?.textContent).toBe('4');
   });


### PR DESCRIPTION
## Summary
- rename "Daily Learning Progress" heading to "Learning Progress"
- adjust test for heading lookup
- rename new words column to "Today's New Words"

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Empty block statement, Unnecessary escape character)*

------
https://chatgpt.com/codex/tasks/task_e_68a06ec95e50832f95758c5289eacbf9