### PR TITLE
Enable due review playback

### DIFF
--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -69,6 +69,11 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     return learningProgressService.getDueReviewWords();
   }, []);
 
+  const getDueReviewWordList = useCallback((): VocabularyWord[] => {
+    const dueProgress = learningProgressService.getDueReviewWords();
+    return buildTodaysWords(dueProgress, [], allWords, 'ALL');
+  }, [allWords]);
+
   const getLearnedWords = useCallback(() => {
     return learningProgressService.getLearnedWords();
   }, []);
@@ -92,6 +97,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getWordProgress,
     refreshStats,
     getDueReviewWords,
+    getDueReviewWordList,
     getLearnedWords,
     markWordLearned,
     markWordAsNew,


### PR DESCRIPTION
## Summary
- Map due review progress to full vocabulary words in learning hook
- Add due review playback handler and button to switch word list to due items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a08512ff6c832fb36769cc911d995c