### PR TITLE
Track session only during active vocabulary activity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
-import { useDailyUsageTracker } from "./hooks/useDailyUsageTracker";
 import { useSessionTracker } from "./hooks/useSessionTracker";
 import { useEffect } from "react";
 import { loadStreakDays } from "./utils/streak";
@@ -17,7 +16,6 @@ const App = () => {
   useEffect(() => {
     loadStreakDays();
   }, []);
-  useDailyUsageTracker('default');
   useSessionTracker();
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -11,8 +11,10 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
 import { saveTodayLastWord } from '@/utils/lastWordStorage';
+import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
 
 const VocabularyAppWithLearning: React.FC = () => {
+  useDailyUsageTracker('default');
   const [allWords, setAllWords] = useState<VocabularyWord[]>([]);
   const [summaryOpen, setSummaryOpen] = useState(false);
   const [isMarkAsNewDialogOpen, setIsMarkAsNewDialogOpen] = useState(false);


### PR DESCRIPTION
## Summary
- start learning time tracking when the vocabulary activity is active
- remove global session tracking from the app shell

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 106 problems (65 errors, 41 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a08e469654832f890bf03186239221