### PR TITLE
Add learning time API and sync service

### DIFF
--- a/src/server/learningTime.ts
+++ b/src/server/learningTime.ts
@@ -1,0 +1,106 @@
+import { lovableCors } from './corsMiddleware';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// Simple JSON file storage for learning time records
+const DB_PATH = path.join(process.cwd(), 'learning-time.json');
+
+interface LearningTimeRecord {
+  [date: string]: number;
+}
+
+interface DbData {
+  [learnerId: string]: LearningTimeRecord;
+}
+
+async function loadDb(): Promise<DbData> {
+  try {
+    const text = await fs.readFile(DB_PATH, 'utf-8');
+    return JSON.parse(text) as DbData;
+  } catch { /* ignore */
+    return {};
+  }
+}
+
+async function saveDb(data: DbData) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+interface Req {
+  method: string;
+  url?: string;
+  body?: unknown;
+  headers?: Record<string, unknown>;
+  on(event: string, cb: (chunk: string) => void): void;
+}
+
+interface Res {
+  statusCode: number;
+  setHeader(name: string, value: string): void;
+  end(body?: string): void;
+}
+
+async function parseBody(req: Req): Promise<Record<string, unknown>> {
+  if (req.body && typeof req.body === 'object') return req.body as Record<string, unknown>;
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: string) => (data += chunk));
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+export default async function handler(req: Req, res: Res) {
+  lovableCors(req, res, () => {});
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 200;
+    res.end();
+    return;
+  }
+
+  if (req.method === 'POST') {
+    try {
+      const body = await parseBody(req);
+      const { learnerId, duration, date } = body;
+      if (!learnerId || typeof duration !== 'number') {
+        res.statusCode = 400;
+        res.end('Invalid payload');
+        return;
+      }
+      const day = date || new Date().toISOString().split('T')[0];
+      const db = await loadDb();
+      db[learnerId] = db[learnerId] || {};
+      db[learnerId][day] = (db[learnerId][day] || 0) + duration;
+      await saveDb(db);
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ total: db[learnerId][day] }));
+    } catch { /* ignore */
+      res.statusCode = 400;
+      res.end('Invalid payload');
+    }
+    return;
+  }
+
+  if (req.method === 'GET') {
+    const url = new URL(req.url || '', 'http://localhost');
+    const learnerId = url.searchParams.get('learnerId');
+    const db = await loadDb();
+    const record = learnerId ? db[learnerId] || {} : {};
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(record));
+    return;
+  }
+
+  res.statusCode = 405;
+  res.setHeader('Allow', 'GET,POST,OPTIONS');
+  res.end('Method not allowed');
+}
+

--- a/src/utils/speech/core/modules/speechUnlock.ts
+++ b/src/utils/speech/core/modules/speechUnlock.ts
@@ -9,7 +9,9 @@ export const unlockAudio = (): Promise<boolean> => {
       console.log("[ENGINE] Attempting audio unlock");
 
       const AudioCtx =
-        window.AudioContext || (window as any).webkitAudioContext;
+        window.AudioContext ||
+        (window as Window & { webkitAudioContext?: typeof AudioContext })
+          .webkitAudioContext;
       if (AudioCtx) {
         try {
           if (!audioCtx) {

--- a/src/utils/streak.ts
+++ b/src/utils/streak.ts
@@ -28,7 +28,7 @@ export function loadStreakDays(): string[] {
   if (filtered.length !== streakDays.length) {
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   if (filtered.length > 0) {
@@ -48,7 +48,7 @@ export function loadStreakDays(): string[] {
     }
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(filtered));
-    } catch {}
+    } catch { /* ignore */ }
   }
 
   return filtered;
@@ -60,7 +60,7 @@ export function addStreakDay(date: string): void {
     current.push(date);
     try {
       localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify(current));
-    } catch {}
+    } catch { /* ignore */ }
     handleStreakMilestone(current);
   }
 }
@@ -78,17 +78,17 @@ function handleStreakMilestone(days: string[]): void {
     const badges = JSON.parse(localStorage.getItem(BADGES_KEY) || '{}');
     badges[`${count}_day_streak`] = true;
     localStorage.setItem(BADGES_KEY, JSON.stringify(badges));
-  } catch {}
+  } catch { /* ignore */ }
 
   try {
     const used = JSON.parse(localStorage.getItem(USED_STREAK_DAYS_KEY) || '[]');
     const updated = Array.from(new Set(used.concat(days)));
     localStorage.setItem(USED_STREAK_DAYS_KEY, JSON.stringify(updated));
-  } catch {}
+  } catch { /* ignore */ }
 
   try {
     localStorage.setItem(STREAK_DAYS_KEY, JSON.stringify([]));
-  } catch {}
+  } catch { /* ignore */ }
 
   try {
     const redeem: Record<string, string[]> = JSON.parse(
@@ -105,7 +105,7 @@ function handleStreakMilestone(days: string[]): void {
     }
     redeem[`${count}_day_streak`] = days;
     localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
-  } catch {}
+  } catch { /* ignore */ }
 }
 
 export function redeemBadge(badgeKey: string): void {
@@ -115,5 +115,5 @@ export function redeemBadge(badgeKey: string): void {
       delete redeem[badgeKey];
       localStorage.setItem(REDEEMABLE_STREAKS_KEY, JSON.stringify(redeem));
     }
-  } catch {}
+  } catch { /* ignore */ }
 }

--- a/src/utils/text/parseWordAnnotations.ts
+++ b/src/utils/text/parseWordAnnotations.ts
@@ -5,7 +5,7 @@ export interface ParsedWord {
 
 export function parseWordAnnotations(word: string): ParsedWord {
   const annotations: string[] = [];
-  const regex = /\[[^\]]+\]|\([^\)]*\)|\/[^\/]+\/(?=\s|$)/g;
+  const regex = /\[[^\]]+\]|\([^)]*\)|\/[^/]+\/(?=\s|$)/g;
   let main = word.replace(regex, (match) => {
     annotations.push(match.trim());
     return ' ';

--- a/src/utils/userInteraction.ts
+++ b/src/utils/userInteraction.ts
@@ -3,7 +3,7 @@ let userInteracted = false;
 export const loadUserInteractionState = () => {
   try {
     userInteracted = localStorage.getItem('speechUnlocked') === 'true';
-  } catch {}
+  } catch { /* ignore */ }
   return userInteracted;
 };
 
@@ -11,14 +11,14 @@ export const markUserInteraction = () => {
   userInteracted = true;
   try {
     localStorage.setItem('speechUnlocked', 'true');
-  } catch {}
+  } catch { /* ignore */ }
 };
 
 export const resetUserInteraction = () => {
   userInteracted = false;
   try {
     localStorage.setItem('speechUnlocked', 'false');
-  } catch {}
+  } catch { /* ignore */ }
 };
 
 export const hasUserInteracted = () => userInteracted;

--- a/tests/learningTimeService.test.ts
+++ b/tests/learningTimeService.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { learningTimeService } from '@/services/learningTimeService';
+
+const learnerId = 'learner1';
+
+describe('learningTimeService sync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as unknown as typeof fetch;
+    localStorage.clear();
+  });
+
+  it('stores duration locally and posts to API', async () => {
+    learningTimeService.startSession(learnerId);
+    // advance time by 5 minutes
+    vi.setSystemTime(new Date('2024-01-01T00:05:00Z'));
+    const duration = learningTimeService.stopSession(learnerId);
+    expect(duration).toBe(5 * 60 * 1000);
+
+    const stored = JSON.parse(localStorage.getItem('learningTime_' + learnerId) || '{}');
+    expect(stored['2024-01-01']).toBe(5 * 60 * 1000);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const mockFetch = fetch as unknown as vi.Mock;
+    const [, postCall] = mockFetch.mock.calls;
+    const [url, options] = postCall;
+    expect(url).toBe('/api/learning-time');
+    expect(options.method).toBe('POST');
+    const body = JSON.parse(options.body);
+    expect(body).toMatchObject({ learnerId, date: '2024-01-01', duration: 5 * 60 * 1000 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `/api/learning-time` endpoint to persist per-date totals
- sync learningTimeService with remote API for cross-device tracking
- cover learning time sync with unit test

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and empty block statement errors in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68a091335fe8832f8d9084f3bafe5a59