### PR TITLE
Add backend route for total learning time

### DIFF
--- a/src/hooks/useLearnerHours.ts
+++ b/src/hooks/useLearnerHours.ts
@@ -31,6 +31,19 @@ export function useLearnerHours(learnerId: string) {
 
   useEffect(() => {
     load();
+    const fetchTotal = async () => {
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+      try {
+        const res = await fetch(`/api/learning-time/total/${encodeURIComponent(learnerId)}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (typeof data.totalHours === 'number') {
+            setTotalHours(data.totalHours);
+          }
+        }
+      } catch { /* ignore */ }
+    };
+    void fetchTotal();
     const handler = (e: StorageEvent) => {
       if (e.key === getStorageKey(learnerId)) {
         load();

--- a/src/server/learningTime.ts
+++ b/src/server/learningTime.ts
@@ -90,6 +90,19 @@ export default async function handler(req: Req, res: Res) {
 
   if (req.method === 'GET') {
     const url = new URL(req.url || '', 'http://localhost');
+    const { pathname } = url;
+    if (pathname.startsWith('/api/learning-time/total/')) {
+      const learnerId = decodeURIComponent(pathname.split('/').pop() || '');
+      const db = await loadDb();
+      const record = db[learnerId] || {};
+      const totalMs = Object.values(record).reduce((sum, ms) => sum + ms, 0);
+      const totalHours = totalMs / (1000 * 60 * 60);
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ totalHours }));
+      return;
+    }
+
     const learnerId = url.searchParams.get('learnerId');
     const db = await loadDb();
     const record = learnerId ? db[learnerId] || {} : {};

--- a/tests/learningTimeTotalRoute.test.ts
+++ b/tests/learningTimeTotalRoute.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import handler from '@/server/learningTime';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DB_PATH = path.join(process.cwd(), 'learning-time.json');
+
+interface Req {
+  method: string;
+  url?: string;
+  headers?: Record<string, unknown>;
+  on(event: string, cb: (chunk: string) => void): void;
+}
+
+interface Res {
+  statusCode: number;
+  headers: Record<string, string>;
+  setHeader(name: string, value: string): void;
+  end(body?: string): void;
+}
+
+describe('learning time total route', () => {
+  beforeEach(async () => {
+    const data = {
+      learner1: {
+        '2024-01-01': 60 * 60 * 1000,
+        '2024-01-02': 30 * 60 * 1000,
+      },
+    };
+    await fs.writeFile(DB_PATH, JSON.stringify(data));
+  });
+
+  afterEach(async () => {
+    await fs.unlink(DB_PATH).catch(() => {});
+  });
+
+  it('returns cumulative hours for learner', async () => {
+    const req: Req = {
+      method: 'GET',
+      url: '/api/learning-time/total/learner1',
+      headers: {},
+      on: () => {},
+    };
+    let body = '';
+    const res: Res = {
+      statusCode: 0,
+      headers: {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+      end(str = '') {
+        body = str;
+      },
+    };
+
+    await handler(req as any, res as any);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('application/json');
+    const data = JSON.parse(body);
+    expect(data.totalHours).toBeCloseTo(1.5);
+  });
+});


### PR DESCRIPTION
## Summary
- add API route for cumulative learning time
- fetch total hours from server with offline fallback
- cover new route with tests

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, Empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_68a09bb93438832f952edff1f5ad8128