### PR TITLE
Remove learned word from daily selection

### DIFF
--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -80,8 +80,31 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
 
   const markWordLearned = useCallback((word: string) => {
     learningProgressService.markWordLearned(word);
+
+    setDailySelection(prev => {
+      if (!prev) return prev;
+
+      const found = [...prev.reviewWords, ...prev.newWords].find(p => p.word === word);
+      const match = (p: LearningProgress) =>
+        p.word === word && (!found || p.category === found.category);
+      const reviewWords = prev.reviewWords.filter(p => !match(p));
+      const newWords = prev.newWords.filter(p => !match(p));
+      const updated: DailySelection = {
+        ...prev,
+        reviewWords,
+        newWords,
+        totalCount: reviewWords.length + newWords.length
+      };
+
+      setTodayWords(
+        buildTodaysWords(updated.reviewWords, updated.newWords, allWords, 'ALL')
+      );
+
+      return updated;
+    });
+
     refreshStats();
-  }, [refreshStats]);
+  }, [allWords, refreshStats]);
 
   const markWordAsNew = useCallback((word: string) => {
     learningProgressService.markWordAsNew(word);

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -148,6 +148,24 @@ export class LearningProgressService {
 
       progressMap.set(wordKey, progress);
       this.saveLearningProgress(progressMap);
+
+      // remove from today's cached selection if present
+      const cached = localStorage.getItem(DAILY_SELECTION_KEY);
+      if (cached) {
+        const selection: DailySelection = JSON.parse(cached);
+        const match = (p: LearningProgress) =>
+          p.word === progress.word && p.category === progress.category;
+
+        const reviewWords = selection.reviewWords.filter(p => !match(p));
+        const newWords = selection.newWords.filter(p => !match(p));
+        const updated: DailySelection = {
+          ...selection,
+          reviewWords,
+          newWords,
+          totalCount: reviewWords.length + newWords.length
+        };
+        localStorage.setItem(DAILY_SELECTION_KEY, JSON.stringify(updated));
+      }
     }
   }
 

--- a/tests/markWordLearnedRemovesTodayWord.test.tsx
+++ b/tests/markWordLearnedRemovesTodayWord.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+import { learningProgressService } from '@/services/learningProgressService';
+import { VocabularyWord } from '@/types/vocabulary';
+
+describe('markWordLearned', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes word from todayWords and cached daily selection', async () => {
+    const word: VocabularyWord = { word: 'apple', meaning: '', example: '', category: 'fruit' };
+
+    // Generate selection with the test word
+    learningProgressService.forceGenerateDailySelection([word], 'light');
+
+    const { result } = renderHook(() => useLearningProgress([word]));
+    await act(() => Promise.resolve());
+    expect(result.current.todayWords.length).toBe(1);
+
+    await act(async () => {
+      result.current.markWordLearned('apple');
+    });
+
+    expect(result.current.todayWords).toHaveLength(0);
+    const cached = JSON.parse(localStorage.getItem('dailySelection')!);
+    expect(cached.newWords).toHaveLength(0);
+    expect(cached.reviewWords).toHaveLength(0);
+    expect(cached.totalCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- remove learned words from cached daily selection in service
- update learning progress hook to drop learned words from state
- add regression test for removing learned words from today list

## Testing
- `npx vitest run tests/markWordLearnedRemovesTodayWord.test.tsx` *(fails: process hung)*
- `npm run lint` *(fails: ESLint found 51 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a19d8bd8832fb08dc0175533a938