### PR TITLE
Include due reviews in daily word list

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
 import { saveTodayLastWord } from '@/utils/lastWordStorage';
+import { buildTodaysWords } from '@/utils/todayWords';
 import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
 
 const VocabularyAppWithLearning: React.FC = () => {
@@ -26,7 +27,6 @@ const VocabularyAppWithLearning: React.FC = () => {
     generateDailyWords,
     markWordAsPlayed,
     getDueReviewWords,
-    getDueReviewWordList,
     getLearnedWords,
     markWordLearned: markCurrentWordLearned,
     markWordAsNew,
@@ -85,7 +85,8 @@ const VocabularyAppWithLearning: React.FC = () => {
   };
 
   const handlePlayDueReviews = (startIndex = 0) => {
-    const dueWords = getDueReviewWordList();
+    const dueProgress = getDueReviewWords();
+    const dueWords = buildTodaysWords(dueProgress, [], allWords, 'ALL');
     if (dueWords.length === 0) return;
     const startWord = dueWords[startIndex];
     if (startWord) {

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -55,8 +55,11 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   useEffect(() => {
     if (!dailySelection) return;
 
+    const dueProgress = learningProgressService.getDueReviewWords();
+    const reviewWords = [...dueProgress, ...dailySelection.reviewWords];
+
     const words = buildTodaysWords(
-      dailySelection.reviewWords,
+      reviewWords,
       dailySelection.newWords,
       allWords,
       'ALL'
@@ -68,11 +71,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   const getDueReviewWords = useCallback(() => {
     return learningProgressService.getDueReviewWords();
   }, []);
-
-  const getDueReviewWordList = useCallback((): VocabularyWord[] => {
-    const dueProgress = learningProgressService.getDueReviewWords();
-    return buildTodaysWords(dueProgress, [], allWords, 'ALL');
-  }, [allWords]);
 
   const getLearnedWords = useCallback(() => {
     return learningProgressService.getLearnedWords();
@@ -120,7 +118,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     getWordProgress,
     refreshStats,
     getDueReviewWords,
-    getDueReviewWordList,
     getLearnedWords,
     markWordLearned,
     markWordAsNew,

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+import { learningProgressService } from '@/services/learningProgressService';
+import { VocabularyWord } from '@/types/vocabulary';
+import { LearningProgress, DailySelection } from '@/types/learning';
+
+describe('useLearningProgress due reviews', () => {
+  const dueWord: VocabularyWord = { word: 'apple', meaning: '', example: '', category: 'fruit' };
+  const newWord: VocabularyWord = { word: 'banana', meaning: '', example: '', category: 'fruit' };
+  const allWords = [dueWord, newWord];
+
+  const dueProgress: LearningProgress = {
+    word: 'apple',
+    category: 'fruit',
+    isLearned: true,
+    reviewCount: 1,
+    lastPlayedDate: '',
+    status: 'due',
+    nextReviewDate: '',
+    createdDate: ''
+  };
+
+  const newProgress: LearningProgress = {
+    word: 'banana',
+    category: 'fruit',
+    isLearned: false,
+    reviewCount: 0,
+    lastPlayedDate: '',
+    status: 'new',
+    nextReviewDate: '',
+    createdDate: ''
+  };
+
+  const selection: DailySelection = {
+    reviewWords: [],
+    newWords: [newProgress],
+    totalCount: 1,
+    severity: 'moderate'
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(learningProgressService, 'getProgressStats').mockReturnValue({
+      total: 0,
+      learned: 0,
+      new: 0,
+      due: 0,
+      learnedCompleted: 0
+    });
+    vi.spyOn(learningProgressService, 'getTodaySelection').mockReturnValue(selection);
+    vi.spyOn(learningProgressService, 'forceGenerateDailySelection').mockReturnValue(selection);
+    vi.spyOn(learningProgressService, 'getDueReviewWords').mockReturnValue([dueProgress]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes due review words in todayWords after generation and regeneration', async () => {
+    const { result } = renderHook(() => useLearningProgress(allWords));
+    await act(() => Promise.resolve());
+    expect(result.current.todayWords.map(w => w.word)).toContain('apple');
+
+    await act(() => {
+      result.current.generateDailyWords('light');
+    });
+    await act(() => Promise.resolve());
+    expect(result.current.todayWords.map(w => w.word)).toContain('apple');
+  });
+});


### PR DESCRIPTION
## Summary
- Merge due-review progress into the daily `todayWords` list so overdue items are always shown
- Remove unused `getDueReviewWordList` helper and adjust due-review playback logic
- Add tests ensuring due-review words appear after initial generation and after intensity-based regeneration

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a82f7c8c832f98f6f6fb2dc728f7