### PR TITLE
Remove manual due review playback and add auto-play test

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -10,8 +10,6 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/component
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
-import { saveTodayLastWord } from '@/utils/lastWordStorage';
-import { buildTodaysWords } from '@/utils/todayWords';
 import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
 
 const VocabularyAppWithLearning: React.FC = () => {
@@ -69,11 +67,6 @@ const VocabularyAppWithLearning: React.FC = () => {
 
   const learnedWords = getLearnedWords();
 
-  const [wordListToPlay, setWordListToPlay] = useState<VocabularyWord[]>(todayWords);
-
-  useEffect(() => {
-    setWordListToPlay(todayWords);
-  }, [todayWords]);
 
   const handleMarkAsNew = () => {
     if (wordToReset) {
@@ -82,17 +75,6 @@ const VocabularyAppWithLearning: React.FC = () => {
     }
     setIsMarkAsNewDialogOpen(false);
     setWordToReset(null);
-  };
-
-  const handlePlayDueReviews = (startIndex = 0) => {
-    const dueProgress = getDueReviewWords();
-    const dueWords = buildTodaysWords(dueProgress, [], allWords, 'ALL');
-    if (dueWords.length === 0) return;
-    const startWord = dueWords[startIndex];
-    if (startWord) {
-      saveTodayLastWord(startWord.word, startWord.category);
-    }
-    setWordListToPlay(dueWords);
   };
 
   const learningSection = (
@@ -145,18 +127,11 @@ const VocabularyAppWithLearning: React.FC = () => {
               {progressStats.due > 0 && (
                 <div className="space-y-2">
                   <h4 className="font-medium text-red-600">Today's Due Review ({progressStats.due})</h4>
-                  <button
-                    className="text-sm px-2 py-1 bg-red-100 text-red-700 rounded border hover:bg-red-200"
-                    onClick={() => handlePlayDueReviews()}
-                  >
-                    Play Due Reviews
-                  </button>
                   <div className="space-y-1 max-h-60 overflow-y-auto">
                     {getDueReviewWords().map((word, index) => (
                       <div
                         key={index}
-                        className="text-sm p-2 bg-red-50 rounded border cursor-pointer hover:bg-red-100"
-                        onClick={() => handlePlayDueReviews(index)}
+                        className="text-sm p-2 bg-red-50 rounded border"
                       >
                         <div className="font-medium">{word.word}</div>
                         <div className="text-xs text-gray-600">
@@ -214,7 +189,7 @@ const VocabularyAppWithLearning: React.FC = () => {
       <ToastProvider />
       <div className="w-full max-w-6xl mx-auto p-4">
         <VocabularyAppContainerNew
-          initialWords={wordListToPlay}
+          initialWords={todayWords}
           onMarkWordLearned={(word) => {
             markCurrentWordLearned(word);
           }}

--- a/tests/vocabularyAppDueReviews.test.tsx
+++ b/tests/vocabularyAppDueReviews.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VocabularyWord } from '@/types/vocabulary';
+import VocabularyAppWithLearning from '@/components/VocabularyAppWithLearning';
+
+// make expect available for jest-dom extensions
+(globalThis as unknown as { expect: typeof expect }).expect = expect;
+
+const initialWordsSpy = vi.fn();
+
+vi.mock('@/components/vocabulary-app/VocabularyAppContainerNew', () => ({
+  default: ({ initialWords }: { initialWords?: VocabularyWord[] }) => {
+    initialWordsSpy(initialWords);
+    return <div data-testid="container" />;
+  }
+}));
+
+vi.mock('@/hooks/useLearningProgress', () => ({
+  useLearningProgress: () => ({
+    dailySelection: { newWords: [], reviewWords: [] },
+    progressStats: { total: 0, learned: 0, new: 0, due: 1, learnedCompleted: 0 },
+    generateDailyWords: vi.fn(),
+    markWordAsPlayed: vi.fn(),
+    getDueReviewWords: () => [{ word: 'apple', category: 'fruit', reviewCount: 1 }],
+    getLearnedWords: () => [],
+    markWordLearned: vi.fn(),
+    markWordAsNew: vi.fn(),
+    todayWords: [
+      { word: 'apple', meaning: '', example: '', category: 'fruit' },
+      { word: 'banana', meaning: '', example: '', category: 'fruit' }
+    ] as VocabularyWord[]
+  })
+}));
+
+vi.mock('@/services/vocabularyService', () => ({
+  vocabularyService: {
+    loadDefaultVocabulary: vi.fn(),
+    getAllSheetNames: vi.fn().mockReturnValue([]),
+    switchSheet: vi.fn(),
+    getWordList: vi.fn().mockReturnValue([]),
+    getCurrentWord: vi.fn().mockReturnValue(null),
+    addVocabularyChangeListener: vi.fn(),
+    removeVocabularyChangeListener: vi.fn()
+  }
+}));
+
+vi.mock('@/services/learningTimeService', () => ({
+  learningTimeService: {
+    startSession: vi.fn(),
+    stopSession: vi.fn().mockReturnValue(0)
+  }
+}));
+
+vi.mock('@/utils/streak', () => ({ addStreakDay: vi.fn() }));
+
+beforeEach(async () => {
+  await import('@testing-library/jest-dom');
+  localStorage.clear();
+  initialWordsSpy.mockClear();
+});
+
+describe('VocabularyAppWithLearning due reviews', () => {
+  it('includes due review words in initial playback without user action', () => {
+    render(<VocabularyAppWithLearning />);
+    expect(initialWordsSpy).toHaveBeenCalled();
+    const words = initialWordsSpy.mock.calls[0][0] as VocabularyWord[];
+    expect(words.map(w => w.word)).toContain('apple');
+    expect(screen.queryByText('Play Due Reviews')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- remove manual due-review playback handler and button
- drive playback list directly from today's words
- add component test verifying due reviews play without user action

## Testing
- `npx eslint src/components/VocabularyAppWithLearning.tsx tests/vocabularyAppDueReviews.test.tsx`
- `npx vitest tests/vocabularyAppDueReviews.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0abac7ec0832fa69d25a5ccfca064