### PR TITLE
feat: keep playback running while muted

### DIFF
--- a/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleWordPlayback.ts
@@ -30,8 +30,8 @@ export const useSimpleWordPlayback = (
     }
 
     // Check local conditions
-    if (muted || paused) {
-      console.log(`[WORD-PLAYBACK-${playbackId}] Skipping - muted: ${muted}, paused: ${paused}`);
+    if (paused) {
+      console.log(`[WORD-PLAYBACK-${playbackId}] Skipping - paused: ${paused}`);
       return;
     }
 
@@ -58,13 +58,15 @@ export const useSimpleWordPlayback = (
       if (!speechText || speechText.length === 0) {
         console.log(`[WORD-PLAYBACK-${playbackId}] No content to speak`);
         playingRef.current = false;
-        if (!paused && !muted) {
+        if (!paused) {
           goToNextWord();
         }
         return;
       }
 
       console.log(`[WORD-PLAYBACK-${playbackId}] Starting speech`);
+
+      unifiedSpeechController.setMuted(muted);
 
       const success = await speak(speechText, {
         voice,
@@ -73,18 +75,18 @@ export const useSimpleWordPlayback = (
           console.log(`[WORD-PLAYBACK-${playbackId}] Speech completed, checking auto-advance`);
           playingRef.current = false;
 
-          if (!paused && !muted && !unifiedSpeechController.isPaused()) {
+          if (!paused && !unifiedSpeechController.isPaused()) {
             console.log(`[WORD-PLAYBACK-${playbackId}] Auto-advancing to next word`);
             goToNextWord();
           } else {
-            console.log(`[WORD-PLAYBACK-${playbackId}] Not auto-advancing - paused: ${paused}, muted: ${muted}, controllerPaused: ${unifiedSpeechController.isPaused()}`);
+            console.log(`[WORD-PLAYBACK-${playbackId}] Not auto-advancing - paused: ${paused}, controllerPaused: ${unifiedSpeechController.isPaused()}, muted: ${muted}`);
           }
         },
         onError: () => {
           console.log(`[WORD-PLAYBACK-${playbackId}] Speech error, advancing anyway`);
           playingRef.current = false;
 
-          if (!paused && !muted && !unifiedSpeechController.isPaused()) {
+          if (!paused && !unifiedSpeechController.isPaused()) {
             goToNextWord();
           }
         }
@@ -93,7 +95,7 @@ export const useSimpleWordPlayback = (
       if (!success) {
         console.log(`[WORD-PLAYBACK-${playbackId}] Speech failed to start, advancing`);
         playingRef.current = false;
-        if (!paused && !muted && !unifiedSpeechController.isPaused()) {
+        if (!paused && !unifiedSpeechController.isPaused()) {
           goToNextWord();
         }
       }
@@ -101,8 +103,8 @@ export const useSimpleWordPlayback = (
     } catch (error) {
       console.error(`[WORD-PLAYBACK-${playbackId}] Exception:`, error);
       playingRef.current = false;
-      
-      if (!paused && !muted && !unifiedSpeechController.isPaused()) {
+
+      if (!paused && !unifiedSpeechController.isPaused()) {
         goToNextWord();
       }
     }

--- a/src/services/speech/core/AutoAdvanceTimer.ts
+++ b/src/services/speech/core/AutoAdvanceTimer.ts
@@ -16,7 +16,7 @@ export class AutoAdvanceTimer {
     this.wordCompleteCallback = callback;
   }
 
-  schedule(delay: number, isPaused: boolean, isMuted: boolean): void {
+  schedule(delay: number, isPaused: boolean, _isMuted: boolean): void {
     const now = Date.now();
     
     // Prevent rapid rescheduling
@@ -29,7 +29,7 @@ export class AutoAdvanceTimer {
     if (now - this.lastClearTime < this.MIN_SCHEDULE_INTERVAL) {
       console.log('[AUTO-ADVANCE] Scheduling too soon after clear, allowing with delay');
       // Allow scheduling but with a small additional delay
-      setTimeout(() => this.schedule(delay, isPaused, isMuted), 100);
+      setTimeout(() => this.schedule(delay, isPaused, _isMuted), 100);
       return;
     }
 
@@ -40,8 +40,8 @@ export class AutoAdvanceTimer {
 
     this.lastScheduleTime = now;
 
-    if (isPaused || isMuted) {
-      console.log('[AUTO-ADVANCE] Not scheduling - paused or muted');
+    if (isPaused) {
+      console.log('[AUTO-ADVANCE] Not scheduling - paused');
       return;
     }
 
@@ -59,8 +59,8 @@ export class AutoAdvanceTimer {
     
     this.timer = window.setTimeout(() => {
       console.log('[AUTO-ADVANCE] Auto-advancing to next word');
-      
-      if (this.wordCompleteCallback && !isPaused && !isMuted) {
+
+      if (this.wordCompleteCallback && !isPaused) {
         try {
           this.wordCompleteCallback();
         } catch (error) {

--- a/src/services/speech/core/SpeechExecutionCore.ts
+++ b/src/services/speech/core/SpeechExecutionCore.ts
@@ -217,13 +217,6 @@ export class SpeechExecutionCore {
 
   setMuted(muted: boolean): void {
     console.log(`[SPEECH-CORE] Setting muted: ${muted}`);
-    
-    if (muted && this.stateManager.getState().isActive) {
-      this.stopInternal();
-    } else if (muted) {
-      this.autoAdvanceTimer.clear();
-    }
-    
     this.stateManager.setMuted(muted);
   }
 

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -107,7 +107,7 @@ class RealSpeechService {
       // Configure speech settings
       utterance.rate = getSpeechRate();
       utterance.pitch = 1.0;
-      utterance.volume = 1.0;
+      utterance.volume = options.muted ? 0 : 1;
 
       // Set up event handlers
       utterance.onstart = () => {

--- a/src/services/speech/unifiedSpeechController.ts
+++ b/src/services/speech/unifiedSpeechController.ts
@@ -19,15 +19,6 @@ class UnifiedSpeechController {
     voiceName: string
   ): Promise<boolean> {
     return new Promise(resolve => {
-      if (this.isMutedState) {
-        console.log('Speech is muted, skipping to next word');
-        if (this.wordCompleteCallback) {
-          this.wordCompleteCallback();
-        }
-        resolve(false);
-        return;
-      }
-
       this.queue.push({ word, voiceName, resolve });
       this.processQueue();
     });
@@ -58,6 +49,7 @@ class UnifiedSpeechController {
 
     realSpeechService.speak(text, {
       voiceName,
+      muted: this.isMutedState,
       onStart: () => {
         console.log('Word speech started:', word.word);
       },
@@ -110,9 +102,6 @@ class UnifiedSpeechController {
   }
 
   canSpeak(): SpeechGuardResult {
-    if (this.isMutedState) {
-      return { canPlay: false, reason: 'muted' };
-    }
     if (this.isPaused()) {
       return { canPlay: false, reason: 'paused' };
     }
@@ -136,9 +125,6 @@ class UnifiedSpeechController {
   setMuted(muted: boolean): void {
     console.log('Setting muted state:', muted);
     this.isMutedState = muted;
-    if (muted && this.isCurrentlyActive()) {
-      this.stop();
-    }
   }
 
   setWordCompleteCallback(callback: (() => void) | null): void {


### PR DESCRIPTION
## Summary
- propagate mute state as volume control in speech service and controller
- keep auto-advance and speech execution active while muted
- allow word playback and controls to operate when muted

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a0afb4e2ec832f96f419f4be75a538