### PR TITLE
Clarify due review tooltip

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -66,8 +66,16 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
                   {progressStats.due}
                 </button>
               </TooltipTrigger>
-              <TooltipContent className="max-w-xs text-center">
-                Reviews use a 2→4→7→12→20→35-day sequence within a 60-day master cycle.
+              <TooltipContent className="max-w-xs text-left">
+                <div className="space-y-1">
+                  <p className="font-bold">How DUE REVIEW work?</p>
+                  <p>
+                    Each correct review pushes the next one farther out, following a
+                    2→4→7→12→20→35-day sequence within a 60-day
+                    master cycle.
+                  </p>
+                  <p>Missed reviews reset the schedule, so stay consistent!</p>
+                </div>
               </TooltipContent>
             </Tooltip>
             <div className="text-sm text-gray-600">Due Review</div>

--- a/tests/LearningProgressPanel.test.tsx
+++ b/tests/LearningProgressPanel.test.tsx
@@ -49,7 +49,7 @@ describe('LearningProgressPanel', () => {
     const dueTrigger = (await screen.findAllByRole('button', { name: /due review count/i }))[0];
     await user.click(dueTrigger);
 
-    const tooltipTexts = await screen.findAllByText(/2→4→7→12→20→35-day sequence within a 60-day master cycle/i);
+    const tooltipTexts = await screen.findAllByText(/Each correct review pushes the next one farther out/i);
     expect(tooltipTexts.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- explain spaced-repetition schedule and add tip to Due Review tooltip
- adjust LearningProgressPanel test for new tooltip text

## Testing
- `npx vitest run tests/LearningProgressPanel.test.tsx --reporter=dot`


------
https://chatgpt.com/codex/tasks/task_e_68a10ef88228832f8db101897d67189d