### PR TITLE
Adjust daily selection to 90% review words

### DIFF
--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -260,8 +260,8 @@ export class LearningProgressService {
       .filter(p => p.isLearned && p.nextReviewDate <= today)
       .sort((a, b) => a.nextReviewDate.localeCompare(b.nextReviewDate));
 
-    // Determine how many review words to include (60% of total)
-    const targetReviewCount = Math.round(totalCount * 0.6);
+    // Determine how many review words to include (90% review / 10% new split)
+    const targetReviewCount = Math.round(totalCount * 0.9);
     const selectedReview = dueWords.slice(0, targetReviewCount);
 
     // Fill remaining slots with new words while keeping total count

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -47,18 +47,18 @@ describe('LearningProgressService', () => {
       expect(totalCount).toBeLessThanOrEqual(mockWords.length);
       expect(totalCount).toBeGreaterThan(0);
       
-      // Check 40/60 ratio (±1 acceptable) when possible and when review words exist
-      if (totalCount >= 5 && reviewCount > 0) {
-        const expectedNew = Math.round(totalCount * 0.4);
-        const expectedReview = totalCount - expectedNew;
-        
-        expect(Math.abs(newCount - expectedNew)).toBeLessThanOrEqual(1);
-        expect(Math.abs(reviewCount - expectedReview)).toBeLessThanOrEqual(1);
-      } else {
-        // When no review words available, all should be new words
-        expect(newCount).toBe(totalCount);
-        expect(reviewCount).toBe(0);
-      }
+        // Check 10/90 ratio (±1 acceptable) when possible and when review words exist
+        if (totalCount >= 5 && reviewCount > 0) {
+          const expectedNew = Math.round(totalCount * 0.1);
+          const expectedReview = totalCount - expectedNew;
+
+          expect(Math.abs(newCount - expectedNew)).toBeLessThanOrEqual(1);
+          expect(Math.abs(reviewCount - expectedReview)).toBeLessThanOrEqual(1);
+        } else {
+          // When no review words available, all should be new words
+          expect(newCount).toBe(totalCount);
+          expect(reviewCount).toBe(0);
+        }
     });
 
     it('should handle fallback when no review words available (TC002)', () => {
@@ -182,9 +182,8 @@ describe('LearningProgressService', () => {
 
       const selection = service.forceGenerateDailySelection(allWords, 'light');
 
-      expect(selection.reviewWords.map(w => w.word)).toEqual(['due1', 'due2', 'due3']);
-      expect(selection.reviewWords.find(w => w.word === 'due4')).toBeUndefined();
-      expect(selection.newWords.length).toBe(2);
+      expect(selection.reviewWords.map(w => w.word)).toEqual(['due1', 'due2', 'due3', 'due4']);
+      expect(selection.newWords.length).toBe(1);
       expect(selection.totalCount).toBe(5);
     });
 


### PR DESCRIPTION
## Summary
- allocate 90% of daily selection to review words, leaving remaining slots for new words
- update tests to enforce the new 90/10 review-to-new ratio

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npx vitest run tests/learningProgress.test.ts`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `npm run lint` *(fails: 92 problems (51 errors, 41 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a1110e768c832f947b2d584e40a51e