### PR TITLE
feat: default daily intensity to light

### DIFF
--- a/inception/units/unit4-learning-progress-integration.md
+++ b/inception/units/unit4-learning-progress-integration.md
@@ -13,7 +13,7 @@ Integrates enhanced learning progress functionality with app lifecycle and provi
 **Acceptance Criteria:**
 - Detect app cold start (first load of the day)
 - Generate daily list if none exists for current date
-- Use existing severity preference or default to 'moderate'
+ - Use existing severity preference or default to 'light'
 - Initialize playback queue with generated list
 
 ### US4.2: Date Change Detection

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -21,7 +21,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     setProgressStats(stats);
   }, []);
 
-  const generateDailyWords = useCallback((severity: SeverityLevel = 'moderate') => {
+  const generateDailyWords = useCallback((severity: SeverityLevel = 'light') => {
     if (allWords.length === 0) return;
     
     // Force regeneration when user clicks the buttons
@@ -46,7 +46,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
 
     let selection = learningProgressService.getTodaySelection();
     if (!selection) {
-      selection = learningProgressService.forceGenerateDailySelection(allWords, 'moderate');
+      selection = learningProgressService.forceGenerateDailySelection(allWords, 'light');
     }
     setDailySelection(selection);
     refreshStats();

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -57,7 +57,7 @@ export const useVocabularyDataLoader = (
 
         const selection =
           learningProgressService.getTodaySelection() ||
-          learningProgressService.forceGenerateDailySelection(allWords, 'moderate');
+          learningProgressService.forceGenerateDailySelection(allWords, 'light');
 
         let todayWords: VocabularyWord[] = [];
         if (selection) {

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -215,8 +215,8 @@ export class LearningProgressService {
   }
 
   generateDailySelection(
-    allWords: VocabularyWord[], 
-    severity: SeverityLevel = 'moderate'
+    allWords: VocabularyWord[],
+    severity: SeverityLevel = 'light'
   ): DailySelection {
     const today = this.getToday();
     const lastSelectionDate = localStorage.getItem(LAST_SELECTION_DATE_KEY);
@@ -233,8 +233,8 @@ export class LearningProgressService {
   }
 
   forceGenerateDailySelection(
-    allWords: VocabularyWord[], 
-    severity: SeverityLevel = 'moderate'
+    allWords: VocabularyWord[],
+    severity: SeverityLevel = 'light'
   ): DailySelection {
     const today = this.getToday();
 

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -130,6 +130,25 @@ describe('LearningProgressService', () => {
       expect(intenseSelection.totalCount).toBeLessThanOrEqual(100);
     });
 
+    it('defaults to light severity when none is provided', () => {
+      const manyWords: VocabularyWord[] = [];
+      for (let i = 0; i < 120; i++) {
+        manyWords.push({
+          word: `word-${i}`,
+          meaning: 'test meaning',
+          example: 'test example',
+          category: 'topic vocab',
+          count: 1
+        });
+      }
+
+      const selection = service.generateDailySelection(manyWords);
+
+      expect(selection.severity).toBe('light');
+      expect(selection.totalCount).toBeGreaterThanOrEqual(15);
+      expect(selection.totalCount).toBeLessThanOrEqual(25);
+    });
+
     it('should include all due words when below target and fill with new words', () => {
       const today = new Date().toISOString().split('T')[0];
       const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -39,7 +39,7 @@ describe('useLearningProgress due reviews', () => {
     reviewWords: [],
     newWords: [newProgress],
     totalCount: 1,
-    severity: 'moderate'
+    severity: 'light'
   };
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- default daily word selection to light intensity when unspecified
- update hooks and data loader to align with light default
- add tests verifying light is the fallback level

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a1109be188832f92cf36951c542d97