### PR TITLE
Persist today's word index for resume

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -85,14 +85,14 @@ export const useVocabularyDataLoader = (
           const saved = getTodayLastWord();
           const now = Date.now();
 
-          if (saved) {
-            const savedIndex = todayWords.findIndex(w =>
-              w.word === saved.word && w.category === saved.category
-            );
-            if (savedIndex >= 0) {
-              setCurrentIndex(savedIndex);
-              return;
-            }
+          if (
+            saved &&
+            typeof saved.index === 'number' &&
+            saved.index >= 0 &&
+            saved.index < todayWords.length
+          ) {
+            setCurrentIndex(saved.index);
+            return;
           }
 
           const dueIndex = todayWords.findIndex(w => {
@@ -105,7 +105,9 @@ export const useVocabularyDataLoader = (
           } else {
             setCurrentIndex(0);
             const nextTimes = todayWords
-              .map(w => w.nextAllowedTime ? Date.parse(w.nextAllowedTime) : Infinity)
+              .map(w =>
+                w.nextAllowedTime ? Date.parse(w.nextAllowedTime) : Infinity
+              )
               .filter(t => !isNaN(t) && t !== Infinity);
             if (nextTimes.length > 0) {
               const earliest = Math.min(...nextTimes);

--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -77,7 +77,7 @@ export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) 
     const nextWord = wordList[nextIndex];
     if (nextWord) {
       saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
-      saveTodayLastWord(nextWord.word, nextWord.category);
+      saveTodayLastWord(nextIndex, nextWord.word, nextWord.category);
       if (!isMuted && !isPaused) {
         unifiedSpeechController.speak(nextWord, selectedVoiceName);
       }
@@ -160,9 +160,9 @@ export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) 
   useEffect(() => {
     if (currentWord) {
       saveLastWord(vocabularyService.getCurrentSheetName(), currentWord.word);
-      saveTodayLastWord(currentWord.word, currentWord.category);
+      saveTodayLastWord(currentIndex, currentWord.word, currentWord.category);
     }
-  }, [currentWord?.word, currentWord?.category]);
+  }, [currentWord?.word, currentWord?.category, currentIndex]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/utils/lastWordStorage.ts
+++ b/src/utils/lastWordStorage.ts
@@ -39,21 +39,25 @@ export const saveLastWord = (category: string, word: string): void => {
 
 interface TodayLastWordRecord {
   date: string;
+  index: number;
   word: string;
   category?: string;
 }
 
-export const getTodayLastWord = (): { word: string; category?: string } | undefined => {
+export const getTodayLastWord = (): TodayLastWordRecord | undefined => {
   if (typeof localStorage === 'undefined') return undefined;
   try {
     const stored = localStorage.getItem(LAST_TODAY_WORD_KEY);
     if (!stored) return undefined;
     const data = JSON.parse(stored) as TodayLastWordRecord;
-    if (data.date === getLocalDateISO()) {
-      return { word: data.word, category: data.category };
+    if (
+      data.date === getLocalDateISO() &&
+      typeof data.index === 'number'
+    ) {
+      return data;
     }
   } catch (error) {
-    console.error('Error reading today\'s last word from localStorage:', error);
+    console.error("Error reading today's last word from localStorage:", error);
   }
   try {
     localStorage.removeItem(LAST_TODAY_WORD_KEY);
@@ -61,16 +65,21 @@ export const getTodayLastWord = (): { word: string; category?: string } | undefi
   return undefined;
 };
 
-export const saveTodayLastWord = (word: string, category?: string): void => {
+export const saveTodayLastWord = (
+  index: number,
+  word: string,
+  category?: string
+): void => {
   if (typeof localStorage === 'undefined') return;
   try {
     const record: TodayLastWordRecord = {
       date: getLocalDateISO(),
+      index,
       word,
       category
     };
     localStorage.setItem(LAST_TODAY_WORD_KEY, JSON.stringify(record));
   } catch (error) {
-    console.error('Error saving today\'s last word to localStorage:', error);
+    console.error("Error saving today's last word to localStorage:", error);
   }
 };

--- a/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
+++ b/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
@@ -105,7 +105,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
       severity: 'light'
     });
 
-    getTodayLastWordMock.mockReturnValue({ word: 'b', category: 'c' });
+    getTodayLastWordMock.mockReturnValue({ index: 1, word: 'b', category: 'c', date: '2024-01-01' });
 
     const setWordList = vi.fn();
     const setHasData = vi.fn();


### PR DESCRIPTION
## Summary
- store and retrieve the current word index alongside today's last word
- load saved index when populating today's words and resume from that position
- persist index whenever the current word changes and update associated tests

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_68a11342564c832fac3c2a883e963344