### PR TITLE
Allow auto-play while muted

### DIFF
--- a/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
@@ -44,8 +44,8 @@ export const useAutoPlay = (
       autoPlayTimeoutRef.current = null;
     }
 
-    // Only proceed if we have a word and conditions are right
-    if (!currentWord || muted || paused) {
+    // Only proceed if we have a word and we're not paused
+    if (!currentWord || paused) {
       return;
     }
 
@@ -73,7 +73,7 @@ export const useAutoPlay = (
       if (!hasUserInteracted()) {
         return;
       }
-      if (!muted && !paused && !speechController.isActive()) {
+      if (!paused && !speechController.isActive()) {
         console.log(`[AUTO-PLAY] Executing auto-play for: ${currentWord.word}`);
         playCurrentWord();
       } else {


### PR DESCRIPTION
## Summary
- let auto-play schedule and execute even when playback is muted

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any/Empty block statement errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a114dc910c832f81bb5544b48e3c8a