### PR TITLE
Ensure timer ignores mute state

### DIFF
--- a/src/hooks/vocabulary-controller/core/useTimerManagement.ts
+++ b/src/hooks/vocabulary-controller/core/useTimerManagement.ts
@@ -35,8 +35,8 @@ export const useTimerManagement = (isPaused: boolean, isMuted: boolean) => {
       return;
     }
 
-    if (isPaused || isMuted) {
-      console.log('[TIMER-MANAGER] Not scheduling - paused or muted');
+    if (isPaused) {
+      console.log('[TIMER-MANAGER] Not scheduling - paused');
       return;
     }
 
@@ -51,7 +51,7 @@ export const useTimerManagement = (isPaused: boolean, isMuted: boolean) => {
       isScheduling.current = false;
       
       // Double-check conditions before executing
-      if (!isPaused && !isMuted) {
+      if (!isPaused) {
         try {
           callback();
         } catch (error) {
@@ -61,7 +61,7 @@ export const useTimerManagement = (isPaused: boolean, isMuted: boolean) => {
         console.log('[TIMER-MANAGER] Skipping auto-advance - conditions changed');
       }
     }, delay);
-  }, [isPaused, isMuted, clearAutoAdvanceTimer]);
+  }, [isPaused, clearAutoAdvanceTimer]);
 
   return {
     clearAutoAdvanceTimer,


### PR DESCRIPTION
## Summary
- remove mute checks from auto-advance timer

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a11bd660e8832fbeaa4899b6d9d7dd