### PR TITLE
Invoke speak even when muted

### DIFF
--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -78,7 +78,7 @@ export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) 
     if (nextWord) {
       saveLastWord(vocabularyService.getCurrentSheetName(), nextWord.word);
       saveTodayLastWord(nextIndex, nextWord.word, nextWord.category);
-      if (!isMuted && !isPaused) {
+      if (!isPaused) {
         unifiedSpeechController.speak(nextWord, selectedVoiceName);
       }
     }
@@ -90,7 +90,6 @@ export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) 
     currentIndex,
     wordList.length,
     setCurrentIndex,
-    isMuted,
     isPaused,
     selectedVoiceName,
     clearAutoAdvanceTimer


### PR DESCRIPTION
## Summary
- Remove `isMuted` check so `goToNextAndSpeak` speaks the next word even while muted
- Rely on existing `unifiedSpeechController.setMuted` to keep audio silent

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a11cb3c5a0832faee61cb8b1cbd52d