### PR TITLE
Allow silent playback during mute

### DIFF
--- a/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
+++ b/src/hooks/vocabulary-controller/core/useSpeechIntegration.ts
@@ -26,12 +26,11 @@ export const useSpeechIntegration = (
   });
 
   const playCurrentWord = useCallback(async () => {
-    if (!currentWord || isPaused || isMuted || isTransitioningRef.current) {
-      console.log('[SPEECH-INTEGRATION] Cannot play word:', { 
-        hasWord: !!currentWord, 
-        isPaused, 
-        isMuted, 
-        isTransitioning: isTransitioningRef.current 
+    if (!currentWord || isPaused || isTransitioningRef.current) {
+      console.log('[SPEECH-INTEGRATION] Cannot play word:', {
+        hasWord: !!currentWord,
+        isPaused,
+        isTransitioning: isTransitioningRef.current
       });
       return;
     }
@@ -46,7 +45,7 @@ export const useSpeechIntegration = (
     } finally {
       setSpeechState(prev => ({ ...prev, isActive: false, phase: 'idle' }));
     }
-  }, [currentWord, selectedVoiceName, isPaused, isMuted, isTransitioningRef]);
+  }, [currentWord, selectedVoiceName, isPaused, isTransitioningRef]);
 
   // Effect to trigger speech when dependencies change
   useEffect(() => {
@@ -55,8 +54,8 @@ export const useSpeechIntegration = (
       return;
     }
 
-    if (isMuted || isPaused) {
-      console.log('[SPEECH-INTEGRATION] Speech is muted or paused, skipping speech');
+    if (isPaused) {
+      console.log('[SPEECH-INTEGRATION] Speech is paused, skipping speech');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Always attempt to play the current word even when muted
- Remove isMuted checks from speech integration logic

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a11cad8d70832f89d0756e43b96dcd