### PR TITLE
Use daily selection for today words and totals

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -113,13 +113,13 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
             <h4 className="font-semibold">Today's Selection</h4>
             <div className="flex flex-wrap gap-2">
               <Badge variant="secondary" className="border-0">
-                Total: {dailySelection.newWords.length + progressStats.due}
+                Total: {dailySelection.newWords.length + dailySelection.reviewWords.length}
               </Badge>
               <Badge variant="outline" className="text-green-600 border-0">
                 New: {dailySelection.newWords.length}
               </Badge>
               <Badge variant="outline" className="text-blue-600 border-0">
-                Review: {progressStats.due}
+                Review: {dailySelection.reviewWords.length}
               </Badge>
               <Badge variant="outline" className="border-0">
                 Level: {dailySelection.severity}

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -55,11 +55,8 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   useEffect(() => {
     if (!dailySelection) return;
 
-    const dueProgress = learningProgressService.getDueReviewWords();
-    const reviewWords = [...dueProgress, ...dailySelection.reviewWords];
-
     const words = buildTodaysWords(
-      reviewWords,
+      dailySelection.reviewWords,
       dailySelection.newWords,
       allWords,
       'ALL'

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -36,9 +36,9 @@ describe('useLearningProgress due reviews', () => {
   };
 
   const selection: DailySelection = {
-    reviewWords: [],
+    reviewWords: [dueProgress],
     newWords: [newProgress],
-    totalCount: 1,
+    totalCount: 2,
     severity: 'light'
   };
 
@@ -53,7 +53,6 @@ describe('useLearningProgress due reviews', () => {
     });
     vi.spyOn(learningProgressService, 'getTodaySelection').mockReturnValue(selection);
     vi.spyOn(learningProgressService, 'forceGenerateDailySelection').mockReturnValue(selection);
-    vi.spyOn(learningProgressService, 'getDueReviewWords').mockReturnValue([dueProgress]);
   });
 
   afterEach(() => {

--- a/tests/vocabularyAppDueReviews.test.tsx
+++ b/tests/vocabularyAppDueReviews.test.tsx
@@ -21,7 +21,23 @@ vi.mock('@/components/vocabulary-app/VocabularyAppContainerNew', () => ({
 
 vi.mock('@/hooks/useLearningProgress', () => ({
   useLearningProgress: () => ({
-    dailySelection: { newWords: [], reviewWords: [] },
+    dailySelection: {
+      newWords: [],
+      reviewWords: [
+        {
+          word: 'apple',
+          category: 'fruit',
+          isLearned: true,
+          reviewCount: 1,
+          lastPlayedDate: '',
+          status: 'due',
+          nextReviewDate: '',
+          createdDate: ''
+        }
+      ],
+      totalCount: 1,
+      severity: 'light'
+    },
     progressStats: { total: 0, learned: 0, new: 0, due: 1, learnedCompleted: 0 },
     generateDailyWords: vi.fn(),
     markWordAsPlayed: vi.fn(),


### PR DESCRIPTION
## Summary
- build today words from dailySelection review and new words only
- compute today's total and review counts from dailySelection
- update due review tests to include reviewWords in daily selection

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a11cbe5d84832fb26981ee2cc94db8