### PR TITLE
fix: retain index when vocabulary list updates

### DIFF
--- a/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
+++ b/src/hooks/vocabulary-controller/useUnifiedVocabularyController.ts
@@ -118,6 +118,7 @@ export const useUnifiedVocabularyController = (initialWords?: VocabularyWord[]) 
     setWordList,
     setHasData,
     setCurrentIndex,
+    currentIndex,
     selectedVoiceName,
     clearAutoAdvanceTimer,
     initialWords

--- a/tests/useVocabularyDataLoaderInitialWordsIndex.test.ts
+++ b/tests/useVocabularyDataLoaderInitialWordsIndex.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useVocabularyDataLoader } from '@/hooks/vocabulary-controller/core/useVocabularyDataLoader';
+import { VocabularyWord } from '@/types/vocabulary';
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn()
+};
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+describe('useVocabularyDataLoader initialWords index handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const wordsA: VocabularyWord[] = [
+    { word: 'a', meaning: '', example: '', category: 'c', count: 1 },
+    { word: 'b', meaning: '', example: '', category: 'c', count: 1 },
+    { word: 'c', meaning: '', example: '', category: 'c', count: 1 }
+  ];
+
+  it('keeps current word if still present', () => {
+    let storedList: VocabularyWord[] = wordsA;
+    const setWordList = vi.fn((update: any) => {
+      storedList = typeof update === 'function' ? update(storedList) : update;
+    });
+    const setHasData = vi.fn();
+    let indexProp = 0;
+    const setCurrentIndex = vi.fn((i: number) => {
+      indexProp = i;
+    });
+
+    const { rerender } = renderHook(({ words }: { words: VocabularyWord[] }) =>
+      useVocabularyDataLoader(
+        setWordList,
+        setHasData,
+        setCurrentIndex,
+        indexProp,
+        'v',
+        vi.fn(),
+        words
+      ),
+      { initialProps: { words: wordsA } }
+    );
+
+    // simulate moving to index 1
+    indexProp = 1;
+    rerender({ words: wordsA });
+    setCurrentIndex.mockClear();
+    setWordList.mockClear();
+
+    const updated: VocabularyWord[] = [
+      { word: 'b', meaning: '', example: '', category: 'c', count: 1 },
+      { word: 'c', meaning: '', example: '', category: 'c', count: 1 },
+      { word: 'd', meaning: '', example: '', category: 'c', count: 1 }
+    ];
+
+    rerender({ words: updated });
+
+    expect(setCurrentIndex).toHaveBeenCalledWith(0);
+    expect(setWordList).toHaveBeenCalled();
+    expect(storedList).toEqual(updated);
+    expect(setHasData).toHaveBeenCalledWith(true);
+  });
+
+  it('advances when current word removed', () => {
+    let storedList: VocabularyWord[] = wordsA;
+    const setWordList = vi.fn((update: any) => {
+      storedList = typeof update === 'function' ? update(storedList) : update;
+    });
+    const setHasData = vi.fn();
+    let indexProp = 0;
+    const setCurrentIndex = vi.fn((i: number) => {
+      indexProp = i;
+    });
+
+    const { rerender } = renderHook(({ words }: { words: VocabularyWord[] }) =>
+      useVocabularyDataLoader(
+        setWordList,
+        setHasData,
+        setCurrentIndex,
+        indexProp,
+        'v',
+        vi.fn(),
+        words
+      ),
+      { initialProps: { words: wordsA } }
+    );
+
+    // simulate moving to index 1 (word 'b')
+    indexProp = 1;
+    rerender({ words: wordsA });
+    setCurrentIndex.mockClear();
+    setWordList.mockClear();
+
+    const updated: VocabularyWord[] = [
+      { word: 'a', meaning: '', example: '', category: 'c', count: 1 },
+      { word: 'c', meaning: '', example: '', category: 'c', count: 1 }
+    ];
+
+    rerender({ words: updated });
+
+    expect(setCurrentIndex).toHaveBeenCalledWith(1);
+    expect(setWordList).toHaveBeenCalled();
+    expect(storedList).toEqual(updated);
+    expect(setHasData).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
+++ b/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
@@ -76,7 +76,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
     const setCurrentIndex = vi.fn();
 
     renderHook(() =>
-      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 'v', vi.fn())
+      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 0, 'v', vi.fn())
     );
 
     expect(setWordList).toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
     const setCurrentIndex = vi.fn();
 
     renderHook(() =>
-      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 'v', vi.fn())
+      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 0, 'v', vi.fn())
     );
 
     expect(setCurrentIndex).toHaveBeenCalledWith(1);
@@ -146,7 +146,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
     const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
 
     renderHook(() =>
-      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 'v', vi.fn())
+      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 0, 'v', vi.fn())
     );
 
     expect(setCurrentIndex).toHaveBeenCalledWith(0);


### PR DESCRIPTION
## Summary
- keep current playback position when `initialWords` changes by tracking previous index and searching for current word
- update unified controller to pass current index into data loader
- cover index preservation and removal scenarios with new tests

## Testing
- `npx vitest run tests/useVocabularyDataLoaderInitialWordsIndex.test.ts tests/useVocabularyDataLoaderNextAllowedTime.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a1203ebe0c832fb6da1138e06e7c7d