### PR TITLE
Refine learning progress stats

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -14,10 +14,10 @@ interface LearningProgressPanelProps {
   dailySelection: DailySelection | null;
   progressStats: {
     total: number;
-    learned: number;
+    learning: number;
     new: number;
     due: number;
-    learnedCompleted: number;
+    learned: number;
   };
   onGenerateDaily: (severity: SeverityLevel) => void;
   learnerId: string;
@@ -30,7 +30,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
   learnerId
 }) => {
   const learnedPercentage = progressStats.total > 0
-    ? (progressStats.learned / progressStats.total) * 100
+    ? ((progressStats.learning + progressStats.learned) / progressStats.total) * 100
     : 0;
   const [open, setOpen] = useState(false);
   const { totalHours } = useLearnerHours(learnerId);
@@ -52,7 +52,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         {/* Progress Stats */}
         <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
           <div className="text-center">
-            <div className="text-2xl font-bold text-gray-600">{progressStats.learnedCompleted}</div>
+            <div className="text-2xl font-bold text-gray-600">{progressStats.learned}</div>
             <div className="text-sm text-gray-600">Learned</div>
           </div>
           <div className="text-center">
@@ -81,7 +81,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
             <div className="text-sm text-gray-600">Due Review</div>
           </div>
           <div className="text-center">
-            <div className="text-2xl font-bold text-green-600">{progressStats.learned}</div>
+            <div className="text-2xl font-bold text-green-600">{progressStats.learning}</div>
             <div className="text-sm text-gray-600">Learning</div>
           </div>
           <div className="text-center">

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -10,10 +10,10 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
   const [todayWords, setTodayWords] = useState<VocabularyWord[]>([]);
   const [progressStats, setProgressStats] = useState({
     total: 0,
-    learned: 0,
+    learning: 0,
     new: 0,
     due: 0,
-    learnedCompleted: 0
+    learned: 0
   });
 
   const refreshStats = useCallback(() => {

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -353,10 +353,10 @@ export class LearningProgressService {
 
     return {
       total: all.length,
-      learned: all.filter(p => p.isLearned).length,
+      learning: all.filter(p => p.isLearned && p.status !== 'learned').length,
       new: all.filter(p => !p.isLearned).length,
       due: all.filter(p => p.isLearned && p.nextReviewDate <= today).length,
-      learnedCompleted: all.filter(p => p.status === 'learned').length
+      learned: all.filter(p => p.status === 'learned').length
     };
   }
 

--- a/tests/LearningProgressPanel.test.tsx
+++ b/tests/LearningProgressPanel.test.tsx
@@ -8,8 +8,8 @@ import { LearningProgressPanel } from '@/components/LearningProgressPanel';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 describe('LearningProgressPanel', () => {
-  it('renders learnedCompleted stat', () => {
-    const progressStats = { total: 10, learned: 5, new: 3, due: 2, learnedCompleted: 4 };
+  it('renders learned stat', () => {
+    const progressStats = { total: 10, learning: 5, new: 3, due: 2, learned: 4 };
 
     render(
       <TooltipProvider>
@@ -29,7 +29,7 @@ describe('LearningProgressPanel', () => {
   });
 
   it('shows review schedule tooltip when interacting with due review count', async () => {
-    const progressStats = { total: 10, learned: 5, new: 3, due: 2, learnedCompleted: 4 };
+    const progressStats = { total: 10, learning: 5, new: 3, due: 2, learned: 4 };
     const user = userEvent.setup();
 
     render(

--- a/tests/learningProgress.test.ts
+++ b/tests/learningProgress.test.ts
@@ -298,7 +298,7 @@ describe('LearningProgressService', () => {
   });
 
   describe('Statistics', () => {
-    it('should calculate progress stats correctly', () => {
+    it('excludes learned words from learning count and balances totals', () => {
       const today = new Date().toISOString().split('T')[0];
       const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
       const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
@@ -316,10 +316,11 @@ describe('LearningProgressService', () => {
       const stats = service.getProgressStats();
 
       expect(stats.total).toBe(5);
-      expect(stats.learned).toBe(3);
+      expect(stats.learning).toBe(2);
+      expect(stats.learned).toBe(1);
       expect(stats.new).toBe(2);
       expect(stats.due).toBe(2);
-      expect(stats.learnedCompleted).toBe(1);
+      expect(stats.learning + stats.learned + stats.new).toBe(stats.total);
     });
 
     it('should include words with next review date today in due list', () => {

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -46,10 +46,10 @@ describe('useLearningProgress due reviews', () => {
     localStorage.clear();
     vi.spyOn(learningProgressService, 'getProgressStats').mockReturnValue({
       total: 0,
-      learned: 0,
+      learning: 0,
       new: 0,
       due: 0,
-      learnedCompleted: 0
+      learned: 0
     });
     vi.spyOn(learningProgressService, 'getTodaySelection').mockReturnValue(selection);
     vi.spyOn(learningProgressService, 'forceGenerateDailySelection').mockReturnValue(selection);

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -7,8 +7,8 @@ import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
 
 describe('useLearningProgress', () => {
-  it('provides learnedCompleted stat from service', () => {
-    const mockStats = { total: 1, learned: 1, new: 0, due: 0, learnedCompleted: 1 };
+  it('provides learned stat from service', () => {
+    const mockStats = { total: 1, learning: 0, new: 0, due: 0, learned: 1 };
     const spy = vi.spyOn(learningProgressService, 'getProgressStats').mockReturnValue(mockStats);
 
     const { result } = renderHook(() => useLearningProgress([]));
@@ -17,7 +17,7 @@ describe('useLearningProgress', () => {
       result.current.refreshStats();
     });
 
-    expect(result.current.progressStats.learnedCompleted).toBe(1);
+    expect(result.current.progressStats.learned).toBe(1);
     spy.mockRestore();
   });
 });

--- a/tests/vocabularyAppDueReviews.test.tsx
+++ b/tests/vocabularyAppDueReviews.test.tsx
@@ -49,7 +49,7 @@ vi.mock('@/hooks/useLearningProgress', () => ({
       totalCount: 1,
       severity: 'light'
     },
-    progressStats: { total: 0, learned: 0, new: 0, due: 1, learnedCompleted: 0 },
+    progressStats: { total: 0, learning: 0, new: 0, due: 1, learned: 0 },
     generateDailyWords: vi.fn(),
     markWordAsPlayed: vi.fn(),
     getDueReviewWords: () => [


### PR DESCRIPTION
## Summary
- Distinguish between `learning` and fully `learned` words in progress stats
- Update hooks and panel to consume new stats and show correct badges
- Add regression test for stats aggregation and panel rendering

## Testing
- `npm test tests/learningProgress.test.ts tests/LearningProgressPanel.test.tsx tests/useLearningProgressDueReviews.test.tsx tests/useLearningProgressStats.test.tsx tests/vocabularyAppDueReviews.test.tsx`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a124db60fc832fb6ce0aa2e6d42b2f