### PR TITLE
Use daily selection for due reviews

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -24,7 +24,6 @@ const VocabularyAppWithLearning: React.FC = () => {
     progressStats,
     generateDailyWords,
     markWordAsPlayed,
-    getDueReviewWords,
     getLearnedWords,
     markWordLearned: markCurrentWordLearned,
     markWordAsNew,
@@ -108,11 +107,13 @@ const VocabularyAppWithLearning: React.FC = () => {
                 </div>
               )}
 
-              {progressStats.due > 0 && (
+              {dailySelection.reviewWords.length > 0 && (
                 <div className="space-y-2">
-                  <h4 className="font-medium text-red-600">Today's Due Review ({progressStats.due})</h4>
+                  <h4 className="font-medium text-red-600">
+                    Today's Due Review ({dailySelection.reviewWords.length})
+                  </h4>
                   <div className="space-y-1 max-h-60 overflow-y-auto">
-                    {getDueReviewWords().map((word, index) => (
+                    {dailySelection.reviewWords.map((word, index) => (
                       <div
                         key={index}
                         className="text-sm p-2 bg-red-50 rounded border"

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -65,10 +65,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     setTodayWords(words);
   }, [dailySelection, allWords]);
 
-  const getDueReviewWords = useCallback(() => {
-    return learningProgressService.getDueReviewWords();
-  }, []);
-
   const getLearnedWords = useCallback(() => {
     return learningProgressService.getLearnedWords();
   }, []);
@@ -114,7 +110,6 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     markWordAsPlayed,
     getWordProgress,
     refreshStats,
-    getDueReviewWords,
     getLearnedWords,
     markWordLearned,
     markWordAsNew,

--- a/tests/vocabularyAppDueReviews.test.tsx
+++ b/tests/vocabularyAppDueReviews.test.tsx
@@ -3,9 +3,10 @@
  */
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { VocabularyWord } from '@/types/vocabulary';
 import VocabularyAppWithLearning from '@/components/VocabularyAppWithLearning';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 // make expect available for jest-dom extensions
 (globalThis as unknown as { expect: typeof expect }).expect = expect;
@@ -30,45 +31,63 @@ vi.mock('@/components/vocabulary-app/VocabularyAppContainerNew', () => ({
   }
 }));
 
-vi.mock('@/hooks/useLearningProgress', () => ({
-  useLearningProgress: () => ({
-    dailySelection: {
-      newWords: [],
-      reviewWords: [
-        {
-          word: 'apple',
-          category: 'fruit',
-          isLearned: true,
-          reviewCount: 1,
-          lastPlayedDate: '',
-          status: 'due',
-          nextReviewDate: '2024-01-01',
-          createdDate: ''
-        }
-      ],
-      totalCount: 1,
-      severity: 'light'
-    },
-    progressStats: { total: 0, learning: 0, new: 0, due: 1, learned: 0 },
-    generateDailyWords: vi.fn(),
-    markWordAsPlayed: vi.fn(),
-    getDueReviewWords: () => [
-      {
-        word: 'apple',
-        category: 'fruit',
-        reviewCount: 1,
-        nextReviewDate: '2024-01-01'
-      }
-    ],
-    getLearnedWords: () => [],
-    markWordLearned: vi.fn(),
-    markWordAsNew: vi.fn(),
-    todayWords: [
-      { word: 'apple', meaning: '', example: '', category: 'fruit' },
-      { word: 'banana', meaning: '', example: '', category: 'fruit' }
-    ] as VocabularyWord[]
-  })
-}));
+vi.mock('@/hooks/useLearningProgress', () => {
+  const React = require('react');
+  return {
+    useLearningProgress: () => {
+      const [dailySelection, setDailySelection] = React.useState({
+        newWords: [],
+        reviewWords: [
+          {
+            word: 'apple',
+            category: 'fruit',
+            isLearned: true,
+            reviewCount: 1,
+            lastPlayedDate: '',
+            status: 'due',
+            nextReviewDate: '2024-01-01',
+            createdDate: ''
+          },
+          {
+            word: 'banana',
+            category: 'fruit',
+            isLearned: true,
+            reviewCount: 1,
+            lastPlayedDate: '',
+            status: 'due',
+            nextReviewDate: '2024-01-02',
+            createdDate: ''
+          }
+        ],
+        totalCount: 2,
+        severity: 'moderate'
+      });
+
+      return {
+        dailySelection,
+        progressStats: { total: 0, learning: 0, new: 0, due: dailySelection.reviewWords.length, learned: 0 },
+        generateDailyWords: vi.fn((severity: string) => {
+          if (severity === 'light') {
+            setDailySelection(prev => ({
+              ...prev,
+              reviewWords: prev.reviewWords.slice(0, 1),
+              totalCount: prev.newWords.length + 1,
+              severity: 'light'
+            }));
+          }
+        }),
+        markWordAsPlayed: vi.fn(),
+        getLearnedWords: () => [],
+        markWordLearned: vi.fn(),
+        markWordAsNew: vi.fn(),
+        todayWords: [
+          { word: 'apple', meaning: '', example: '', category: 'fruit' },
+          { word: 'banana', meaning: '', example: '', category: 'fruit' }
+        ] as VocabularyWord[]
+      };
+    }
+  };
+});
 
 vi.mock('@/services/vocabularyService', () => ({
   vocabularyService: {
@@ -99,21 +118,49 @@ beforeEach(async () => {
 
 describe('VocabularyAppWithLearning due reviews', () => {
   it('includes due review words in initial playback without user action', () => {
-    render(<VocabularyAppWithLearning />);
+    render(
+      <TooltipProvider>
+        <VocabularyAppWithLearning />
+      </TooltipProvider>
+    );
     expect(initialWordsSpy).toHaveBeenCalled();
     const words = initialWordsSpy.mock.calls[0][0] as VocabularyWord[];
     expect(words.map(w => w.word)).toContain('apple');
     expect(screen.queryByText('Play Due Reviews')).not.toBeInTheDocument();
   });
 
-  it('renders next review date for due items', () => {
-    render(<VocabularyAppWithLearning />);
+  it("shrinks due review count and list when lighter intensity is selected", async () => {
+    render(
+      <TooltipProvider>
+        <VocabularyAppWithLearning />
+      </TooltipProvider>
+    );
+    const progressButton = screen.getAllByRole('button', {
+      name: /Learning Progress/i
+    })[0];
+    fireEvent.click(progressButton);
     const summaryButton = screen.getAllByRole('button', {
       name: /Word Summary/i
     })[0];
     fireEvent.click(summaryButton);
+
     expect(
-      screen.getByText('Next review: 2024-01-01')
+      screen.getByText("Today's Due Review (2)")
     ).toBeInTheDocument();
+    expect(screen.getByText('apple')).toBeInTheDocument();
+    expect(screen.getByText('banana')).toBeInTheDocument();
+
+    const lightButton = screen.getByRole('button', {
+      name: /Light \(15-25\)/i
+    });
+    fireEvent.click(lightButton);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Today's Due Review (1)")
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByText('apple')).toBeInTheDocument();
+    expect(screen.queryByText('banana')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- derive due review summary from `dailySelection.reviewWords`
- remove `getDueReviewWords` from `useLearningProgress`
- test that due review list shrinks with lighter intensity

## Testing
- `npm test -- --run tests/vocabularyAppDueReviews.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a164a3fb20832fa6c82b9c5f18798b