### PR TITLE
feat: apply speech volume immediately when muting

### DIFF
--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -252,6 +252,11 @@ class RealSpeechService {
   setMuted(muted: boolean): void {
     if (this.currentUtterance) {
       this.currentUtterance.volume = muted ? 0 : 1;
+
+      if (window.speechSynthesis?.speaking) {
+        window.speechSynthesis.pause();
+        window.speechSynthesis.resume();
+      }
     }
   }
 

--- a/tests/realSpeechServiceMute.test.ts
+++ b/tests/realSpeechServiceMute.test.ts
@@ -1,22 +1,34 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { realSpeechService } from '../src/services/speech/realSpeechService';
 
 describe('realSpeechService mute control', () => {
   beforeEach(() => {
     (realSpeechService as any).currentUtterance = null;
+    (window as any).speechSynthesis = {
+      speaking: false,
+      pause: vi.fn(),
+      resume: vi.fn(),
+    };
   });
 
-  it('adjusts volume on active utterance when muted state changes', () => {
+  it('adjusts volume and applies changes when muted state changes', () => {
     const fakeUtterance = { volume: 1 } as unknown as SpeechSynthesisUtterance;
     (realSpeechService as any).currentUtterance = fakeUtterance;
 
+    // Not speaking yet - no pause/resume
     realSpeechService.setMuted(true);
     expect(fakeUtterance.volume).toBe(0);
+    expect(window.speechSynthesis.pause).not.toHaveBeenCalled();
+    expect(window.speechSynthesis.resume).not.toHaveBeenCalled();
 
+    // When speaking, pause/resume should be triggered
+    (window.speechSynthesis as any).speaking = true;
     realSpeechService.setMuted(false);
     expect(fakeUtterance.volume).toBe(1);
+    expect(window.speechSynthesis.pause).toHaveBeenCalledTimes(1);
+    expect(window.speechSynthesis.resume).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- force the speech engine to pause/resume when mute toggles so volume updates without cancelling
- test volume changes and pause/resume calls

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: JS heap out of memory)*
- `npm run lint` *(fails: 92 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a21b16bc832f8ad2215a9609cbd6