### PR TITLE
Prevent mute toggle from retriggering playback

### DIFF
--- a/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
@@ -54,7 +54,8 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
     } else if (currentWord && paused) {
       console.log(`[SIMPLE-VOCABULARY] Word ready but paused: ${currentWord.word}`);
     }
-  }, [currentWord, muted, paused, playWord]);
+    // deliberately exclude `muted` so mute toggles don't retrigger playback
+  }, [currentWord, paused, playWord]);
 
   // Handle pause state changes with immediate effect
   useEffect(() => {
@@ -89,10 +90,7 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
     console.log(`[SIMPLE-VOCABULARY] ✓ Toggling mute: ${newMuted}`);
     setMuted(newMuted);
     unifiedSpeechController.setMuted(newMuted);
-    if (!newMuted && !paused && currentWord) {
-      playWord(currentWord);
-    }
-  }, [muted, paused, currentWord, playWord]);
+  }, [muted]);
 
   const togglePause = useCallback(() => {
     const newPaused = !paused;

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -252,10 +252,15 @@ class RealSpeechService {
   setMuted(muted: boolean): void {
     if (this.currentUtterance) {
       this.currentUtterance.volume = muted ? 0 : 1;
-
+      // Force the speech engine to apply the new volume immediately by
+      // briefly pausing and resuming. The resume is deferred to the next
+      // task to ensure the volume change takes effect before speaking
+      // continues.
       if (window.speechSynthesis?.speaking) {
         window.speechSynthesis.pause();
-        window.speechSynthesis.resume();
+        setTimeout(() => {
+          window.speechSynthesis.resume();
+        }, 0);
       }
     }
   }

--- a/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
+++ b/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { VocabularyWord } from '../src/types/vocabulary';
+
+vi.mock('../src/hooks/vocabulary-playback/useVoiceSelection', () => ({
+  useVoiceSelection: () => ({
+    selectedVoice: { label: 'US', region: 'US', gender: 'female', index: 0 },
+    cycleVoice: vi.fn(),
+    voices: []
+  })
+}));
+
+vi.mock('../src/services/speech/unifiedSpeechController', () => ({
+  unifiedSpeechController: {
+    setMuted: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  }
+}));
+
+vi.mock('../src/hooks/vocabulary-playback/useSimpleWordPlayback', () => {
+  const playWordMock = vi.fn();
+  return {
+    useSimpleWordPlayback: () => ({
+      playWord: playWordMock,
+      isSpeaking: false
+    }),
+    playWordMock
+  };
+});
+
+import { useSimpleVocabularyPlayback } from '../src/hooks/vocabulary-playback/useSimpleVocabularyPlayback';
+import { unifiedSpeechController } from '../src/services/speech/unifiedSpeechController';
+import { playWordMock } from '../src/hooks/vocabulary-playback/useSimpleWordPlayback';
+
+describe('useSimpleVocabularyPlayback mute toggling', () => {
+  const setMutedMock = vi.mocked(unifiedSpeechController.setMuted);
+
+  beforeEach(() => {
+    playWordMock.mockClear();
+    setMutedMock.mockClear();
+  });
+
+  it('continues through words while muted and does not replay on unmute', () => {
+    const words: VocabularyWord[] = [
+      { word: 'alpha', meaning: '', example: '', category: 'c' },
+      { word: 'beta', meaning: '', example: '', category: 'c' }
+    ];
+
+    const { result } = renderHook(() => useSimpleVocabularyPlayback(words));
+
+    expect(playWordMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.toggleMute();
+    });
+    expect(setMutedMock).toHaveBeenLastCalledWith(true);
+    expect(playWordMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.goToNext();
+    });
+    expect(playWordMock).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.toggleMute();
+    });
+    expect(setMutedMock).toHaveBeenLastCalledWith(false);
+    expect(playWordMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid replaying the current word when unmuting and remove muted dependency from auto-play
- apply speech volume changes immediately by pausing/resuming with a short delay
- add tests for mute volume handling and mute toggle playback flow

## Testing
- `npx vitest run tests/useSimpleVocabularyPlaybackMuteToggle.test.ts`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a2c04a4790832f9151103f62c1000b