### PR TITLE
feat: add reviewed word action

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import VocabularyAppContainerNew from './vocabulary-app/VocabularyAppContainerNew';
 import { LearningProgressPanel } from './LearningProgressPanel';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
@@ -23,7 +23,7 @@ const VocabularyAppWithLearning: React.FC = () => {
     dailySelection,
     progressStats,
     generateDailyWords,
-    markWordAsPlayed,
+    markWordReviewed,
     getLearnedWords,
     markWordLearned: markCurrentWordLearned,
     markWordAsNew,
@@ -45,24 +45,6 @@ const VocabularyAppWithLearning: React.FC = () => {
     
     setAllWords(allWordsFromService);
   }, []);
-
-  // Track when words are played (integrate with existing word navigation)
-  const previousWordRef = useRef<VocabularyWord | null>(null);
-  useEffect(() => {
-    previousWordRef.current = vocabularyService.getCurrentWord();
-
-    const handleWordChange = () => {
-      if (previousWordRef.current) {
-        markWordAsPlayed(previousWordRef.current.word);
-      }
-      previousWordRef.current = vocabularyService.getCurrentWord();
-    };
-
-    vocabularyService.addVocabularyChangeListener(handleWordChange);
-    return () => {
-      vocabularyService.removeVocabularyChangeListener(handleWordChange);
-    };
-  }, [markWordAsPlayed]);
 
   const learnedWords = getLearnedWords();
 
@@ -181,6 +163,7 @@ const VocabularyAppWithLearning: React.FC = () => {
           onMarkWordLearned={(word) => {
             markCurrentWordLearned(word);
           }}
+          onMarkWordReviewed={markWordReviewed}
           additionalContent={learningSection}
         />
       </div>

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -15,11 +15,12 @@ import { VocabularyWord } from '@/types/vocabulary';
 
 interface VocabularyAppContainerNewProps {
   onMarkWordLearned?: (word: string) => void;
+  onMarkWordReviewed?: (word: string) => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, onMarkWordReviewed, initialWords, additionalContent }) => {
   // Use stable state management
   const {
     currentWord,
@@ -89,6 +90,14 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ o
     isPaused,
     currentWord: debugData
   }), [isMuted, selectedVoiceName, isPaused, debugData]);
+
+  const previousWordRef = React.useRef<VocabularyWord | null>(null);
+  React.useEffect(() => {
+    if (previousWordRef.current && currentWord && previousWordRef.current.word !== currentWord.word) {
+      onMarkWordReviewed?.(previousWordRef.current.word);
+    }
+    previousWordRef.current = currentWord;
+  }, [currentWord?.word, onMarkWordReviewed]);
 
   if (!hasData && !vocabularyService.hasData()) {
     return (

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -37,6 +37,12 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     refreshStats();
   }, [refreshStats]);
 
+  const markWordReviewed = useCallback((word: string) => {
+    if (window.confirm(`Mark "${word}" as reviewed?`)) {
+      markWordAsPlayed(word);
+    }
+  }, [markWordAsPlayed]);
+
   const getWordProgress = useCallback((word: string) => {
     return learningProgressService.getWordProgress(word);
   }, []);
@@ -108,6 +114,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     progressStats,
     generateDailyWords,
     markWordAsPlayed,
+    markWordReviewed,
     getWordProgress,
     refreshStats,
     getLearnedWords,

--- a/tests/vocabularyAppDueReviews.test.tsx
+++ b/tests/vocabularyAppDueReviews.test.tsx
@@ -20,6 +20,8 @@ vi.mock('@/components/vocabulary-app/VocabularyAppContainerNew', () => ({
   }: {
     initialWords?: VocabularyWord[];
     additionalContent?: React.ReactNode;
+    onMarkWordLearned?: (word: string) => void;
+    onMarkWordReviewed?: (word: string) => void;
   }) => {
     initialWordsSpy(initialWords);
     return (
@@ -77,6 +79,7 @@ vi.mock('@/hooks/useLearningProgress', () => {
           }
         }),
         markWordAsPlayed: vi.fn(),
+        markWordReviewed: vi.fn(),
         getLearnedWords: () => [],
         markWordLearned: vi.fn(),
         markWordAsNew: vi.fn(),


### PR DESCRIPTION
## Summary
- add hook helper to confirm and mark words as reviewed
- notify parent container on word change to trigger review confirmation
- wire learning container to reviewed action and update tests

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npx vitest tests/vocabularyAppDueReviews.test.tsx --run`
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf3969b0832fb66cecfc07901c93