### PR TITLE
Allow silent speech to restart muted word

### DIFF
--- a/src/components/vocabulary-app/useVocabularyAppHandlers.ts
+++ b/src/components/vocabulary-app/useVocabularyAppHandlers.ts
@@ -34,13 +34,14 @@ export function useVocabularyAppHandlers({
     const wasMuted = isMuted;
     handleToggleMute();
 
-    if (wasMuted && currentWord) {
+    if (!wasMuted) {
+      resetLastSpokenWord();
+      speakCurrentWord(true);
+    } else if (currentWord) {
       setTimeout(() => {
         resetLastSpokenWord();
         speakCurrentWord(true);
       }, 800);
-    } else if (!wasMuted) {
-      resetLastSpokenWord();
     }
   }, [isMuted, currentWord, handleToggleMute, resetLastSpokenWord, speakCurrentWord, clearAllTimeouts]);
 

--- a/src/hooks/speech/useSpeechPlayback.tsx
+++ b/src/hooks/speech/useSpeechPlayback.tsx
@@ -29,8 +29,8 @@ export const useSpeechPlayback = () => {
   // Function to speak text, returns a Promise
   const speakText = useCallback((text: string): Promise<string> => {
     return new Promise((resolve, reject) => {
-      if (isMuted || !text) {
-        console.log("Speech is muted or text is empty");
+      if (!text) {
+        console.log("Text is empty");
         resolve('');
         return;
       }
@@ -48,11 +48,7 @@ export const useSpeechPlayback = () => {
         console.log("Speech already in progress, queuing request");
         // Resolve after a delay to allow current speech to finish
         setTimeout(() => {
-          if (!isMuted) {
-            speakText(text).then(resolve).catch(reject);
-          } else {
-            resolve('');
-          }
+          speakText(text).then(resolve).catch(reject);
         }, 800);
         return;
       }
@@ -80,7 +76,7 @@ export const useSpeechPlayback = () => {
             'US';
 
           // Fix the Promise type issue by explicitly handling the return value from speak()
-          speak(text, voiceRegion, pauseRequestedRef)
+          speak(text, voiceRegion, pauseRequestedRef, { muted: isMuted })
             .then((result) => {
               console.log('Speech synthesis completed:', result);
               retryAttemptsRef.current = 0; // Reset retry counter on success

--- a/src/hooks/useWordSpeechSync.tsx
+++ b/src/hooks/useWordSpeechSync.tsx
@@ -88,12 +88,6 @@ export const useWordSpeechSync = (
     speechLockRef.current = true;
 
     try {
-      if (isMuted) {
-        console.log("Speech is muted, not actually speaking");
-        setWordFullySpoken(true);
-        speechLockRef.current = false;
-        return;
-      }
       isSpeakingRef.current = true;
       try {
         localStorage.setItem('currentDisplayedWord', wordToSpeak.word);
@@ -103,8 +97,8 @@ export const useWordSpeechSync = (
         meaning: wordToSpeak.meaning,
         example: wordToSpeak.example
       });
-      if ((isPaused && !forceSpeak) || isMuted) {
-        console.log("App was paused/muted while preparing, aborting");
+      if (isPaused && !forceSpeak) {
+        console.log("App was paused while preparing, aborting");
         isSpeakingRef.current = false;
         speechLockRef.current = false;
         return;

--- a/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
@@ -90,7 +90,12 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
     console.log(`[SIMPLE-VOCABULARY] ✓ Toggling mute: ${newMuted}`);
     setMuted(newMuted);
     unifiedSpeechController.setMuted(newMuted);
-  }, [muted]);
+
+    if (newMuted && currentWord) {
+      console.log('[SIMPLE-VOCABULARY] Restarting current word while muted');
+      playWord(currentWord);
+    }
+  }, [muted, currentWord, playWord]);
 
   const togglePause = useCallback(() => {
     const newPaused = !paused;

--- a/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
+++ b/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
@@ -44,7 +44,7 @@ describe('useSimpleVocabularyPlayback mute toggling', () => {
     setMutedMock.mockClear();
   });
 
-  it('continues through words while muted and does not replay on unmute', () => {
+  it('restarts current word on mute and resumes without extra audio on unmute', () => {
     const words: VocabularyWord[] = [
       { word: 'alpha', meaning: '', example: '', category: 'c' },
       { word: 'beta', meaning: '', example: '', category: 'c' }
@@ -53,22 +53,25 @@ describe('useSimpleVocabularyPlayback mute toggling', () => {
     const { result } = renderHook(() => useSimpleVocabularyPlayback(words));
 
     expect(playWordMock).toHaveBeenCalledTimes(1);
+    expect(playWordMock.mock.calls[0][0].word).toBe('alpha');
 
     act(() => {
       result.current.toggleMute();
     });
     expect(setMutedMock).toHaveBeenLastCalledWith(true);
-    expect(playWordMock).toHaveBeenCalledTimes(1);
+    expect(playWordMock).toHaveBeenCalledTimes(2);
+    expect(playWordMock.mock.calls[1][0].word).toBe('alpha');
 
     act(() => {
       result.current.goToNext();
     });
-    expect(playWordMock).toHaveBeenCalledTimes(2);
+    expect(playWordMock).toHaveBeenCalledTimes(3);
+    expect(playWordMock.mock.calls[2][0].word).toBe('beta');
 
     act(() => {
       result.current.toggleMute();
     });
     expect(setMutedMock).toHaveBeenLastCalledWith(false);
-    expect(playWordMock).toHaveBeenCalledTimes(2);
+    expect(playWordMock).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary
- allow speech to run silently by removing muted early exit and passing `muted` option
- always speak current word even when muted and restart word when toggling mute
- restart current word in simple vocabulary playback and add regression test

## Testing
- `npm test tests/useSimpleVocabularyPlaybackMuteToggle.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9ee3d74832f831c5329f1e2628f