### PR TITLE
Store learning time data in localStorage only

### DIFF
--- a/src/hooks/useLearnerHours.ts
+++ b/src/hooks/useLearnerHours.ts
@@ -31,19 +31,6 @@ export function useLearnerHours(learnerId: string) {
 
   useEffect(() => {
     load();
-    const fetchTotal = async () => {
-      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
-      try {
-        const res = await fetch(`/api/learning-time/total/${encodeURIComponent(learnerId)}`);
-        if (res.ok) {
-          const data = await res.json();
-          if (typeof data.totalHours === 'number') {
-            setTotalHours(data.totalHours);
-          }
-        }
-      } catch { /* ignore */ }
-    };
-    void fetchTotal();
     const handler = (e: StorageEvent) => {
       if (e.key === getStorageKey(learnerId)) {
         load();

--- a/tests/learningTimeService.test.ts
+++ b/tests/learningTimeService.test.ts
@@ -6,15 +6,15 @@ import { learningTimeService } from '@/services/learningTimeService';
 
 const learnerId = 'learner1';
 
-describe('learningTimeService sync', () => {
+describe('learningTimeService', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
-    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }) as unknown as typeof fetch;
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
     localStorage.clear();
   });
 
-  it('stores duration locally and posts to API', async () => {
+  it('stores duration locally without network calls', () => {
     learningTimeService.startSession(learnerId);
     // advance time by 5 minutes
     vi.setSystemTime(new Date('2024-01-01T00:05:00Z'));
@@ -24,14 +24,7 @@ describe('learningTimeService sync', () => {
     const stored = JSON.parse(localStorage.getItem('learningTime_' + learnerId) || '{}');
     expect(stored['2024-01-01']).toBe(5 * 60 * 1000);
 
-    expect(fetch).toHaveBeenCalledTimes(2);
-    const mockFetch = fetch as unknown as vi.Mock;
-    const [, postCall] = mockFetch.mock.calls;
-    const [url, options] = postCall;
-    expect(url).toBe('/api/learning-time');
-    expect(options.method).toBe('POST');
-    const body = JSON.parse(options.body);
-    expect(body).toMatchObject({ learnerId, date: '2024-01-01', duration: 5 * 60 * 1000 });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/learningTimeTotalRoute.test.ts
+++ b/tests/learningTimeTotalRoute.test.ts
@@ -1,9 +1,8 @@
+/**
+ * @vitest-environment jsdom
+ */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import handler from '@/server/learningTime';
-import { promises as fs } from 'fs';
-import path from 'path';
-
-const DB_PATH = path.join(process.cwd(), 'learning-time.json');
 
 interface Req {
   method: string;
@@ -20,18 +19,18 @@ interface Res {
 }
 
 describe('learning time total route', () => {
-  beforeEach(async () => {
-    const data = {
-      learner1: {
+  beforeEach(() => {
+    localStorage.setItem(
+      'learningTime_learner1',
+      JSON.stringify({
         '2024-01-01': 60 * 60 * 1000,
         '2024-01-02': 30 * 60 * 1000,
-      },
-    };
-    await fs.writeFile(DB_PATH, JSON.stringify(data));
+      })
+    );
   });
 
-  afterEach(async () => {
-    await fs.unlink(DB_PATH).catch(() => {});
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('returns cumulative hours for learner', async () => {


### PR DESCRIPTION
## Summary
- Drop network sync from learningTimeService and rely entirely on localStorage
- Remove API fetch from useLearnerHours and listen only to storage events
- Replace server/learningTime file persistence with localStorage and update tests accordingly

## Testing
- `npm test -- --run` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb042914832f97bbc27b3eec1785