### PR TITLE
Embed default vocabulary data for synchronous loading

### DIFF
--- a/src/data/defaultVocabulary.json
+++ b/src/data/defaultVocabulary.json
@@ -1,0 +1,22856 @@
+{
+  "phrasal verbs": [
+    {
+      "word": "to be under house arrest",
+      "meaning": "to be legally forced to stay inside one's home instead of going to prison",
+      "example": "He was under house arrest while awaiting the final verdict.",
+      "translation": "bị quản thúc tại nhà",
+      "count": 0
+    },
+    {
+      "word": "Knuckle down",
+      "meaning": "to start working or studying seriously with full effort",
+      "example": "You'll need to knuckle down if you want to pass the final exams.",
+      "translation": "bắt tay vào làm việc nghiêm túc",
+      "count": 0
+    },
+    {
+      "word": "To get around to",
+      "meaning": "to finally do something that you have intended to do for a long time",
+      "example": "I finally got around to reading that book you lent me.",
+      "translation": "cuối cùng cũng làm được điều gì đó",
+      "count": 0
+    },
+    {
+      "word": "To cook the books",
+      "meaning": "to dishonestly change financial records to make them appear better than they are",
+      "example": "The accountant was fired for cooking the books to hide the losses.",
+      "translation": "gian lận sổ sách kế toán",
+      "count": 0
+    },
+    {
+      "word": "Burn the midnight oil",
+      "meaning": "to work or study late into the night",
+      "example": "She burned the midnight oil to finish the project on time.",
+      "translation": "thức khuya làm việc hoặc học bài",
+      "count": 0
+    },
+    {
+      "word": "Count on somebody [transitive]",
+      "meaning": "to rely on someone to do what they say or expect",
+      "example": "You can count on Tom to get the job done well.",
+      "translation": "dựa vào ai đó",
+      "count": 0
+    },
+    {
+      "word": "Take after somebody [transitive]",
+      "meaning": "to resemble a family member in appearance or behavior",
+      "example": "She really takes after her mother in both looks and attitude.",
+      "translation": "giống ai đó trong gia đình",
+      "count": 0
+    },
+    {
+      "word": "sneak out [intransitive]",
+      "meaning": "to leave a place quietly and secretly to avoid being noticed",
+      "example": "He tried to sneak out of the meeting without anyone seeing him.",
+      "translation": "lẻn ra ngoài",
+      "count": 0
+    },
+    {
+      "word": "barge in [intransitive]",
+      "meaning": "to enter a place or conversation rudely and unexpectedly",
+      "example": "He barged in without knocking and interrupted our discussion.",
+      "translation": "xông vào, chen ngang",
+      "count": 0
+    },
+    {
+      "word": "calm down [intransitive] / calm down somebody [transitive]",
+      "meaning": "to become or make someone become more relaxed and less upset",
+      "example": "It took a few minutes to calm her down after the argument.",
+      "translation": "bình tĩnh lại; làm ai đó bình tĩnh",
+      "count": 0
+    },
+    {
+      "word": "fall out (with somebody) [transitive]",
+      "meaning": "to stop being friendly with someone after having a disagreement",
+      "example": "After their heated discussion, they fell out and stopped talking.",
+      "translation": "cãi nhau, nghỉ chơi",
+      "count": 0
+    },
+    {
+      "word": "to bring up someone [transitive]",
+      "meaning": "to raise a child or help them grow into an adult",
+      "example": "He was brought up by his aunt after his parents passed away.",
+      "translation": "nuôi dưỡng",
+      "count": 0
+    },
+    {
+      "word": "be fed up [intransitive]",
+      "meaning": "to feel annoyed or tired because of repeated or unpleasant experiences",
+      "example": "She's fed up with working late every day without appreciation.",
+      "translation": "chán ngấy",
+      "count": 0
+    },
+    {
+      "word": "be in bad taste",
+      "meaning": "to be offensive or disrespectful, especially in sensitive situations",
+      "example": "His comment about the tragedy was definitely in bad taste.",
+      "translation": "phản cảm, thiếu tế nhị",
+      "count": 0
+    },
+    {
+      "word": "be in the public eye",
+      "meaning": "to be frequently seen or discussed in the media",
+      "example": "Public figures must accept that they are always in the public eye.",
+      "translation": "bị chú ý bởi công chúng",
+      "count": 0
+    },
+    {
+      "word": "turn down something/somebody [transitive]",
+      "meaning": "to refuse or reject an offer, request, or proposal",
+      "example": "She turned down the scholarship because she wanted to stay close to home.",
+      "translation": "từ chối",
+      "count": 0
+    },
+    {
+      "word": "dwell on something [transitive]",
+      "meaning": "to spend too much time thinking or talking about something negative",
+      "example": "Instead of dwelling on his failures, he focused on future goals.",
+      "translation": "suy nghĩ tiêu cực mãi về",
+      "count": 0
+    },
+    {
+      "word": "look forward to something [transitive]",
+      "meaning": "to be excited or happy about something that is going to happen",
+      "example": "I’m looking forward to seeing my family this weekend.",
+      "translation": "mong đợi",
+      "count": 0
+    },
+    {
+      "word": "look down on somebody [transitive]",
+      "meaning": "to think that you are better or more important than someone else",
+      "example": "He tends to look down on people who don’t share his opinions.",
+      "translation": "xem thường",
+      "count": 0
+    },
+    {
+      "word": "boss around somebody [transitive]",
+      "meaning": "to keep telling someone what to do in an overly controlling way",
+      "example": "Stop bossing your little brother around all the time.",
+      "translation": "ra lệnh một cách hách dịch",
+      "count": 0
+    },
+    {
+      "word": "stand up to somebody [transitive]",
+      "meaning": "to confront someone and refuse to be treated unfairly by them",
+      "example": "She finally stood up to her boss and demanded respect.",
+      "translation": "đối đầu, chống lại",
+      "count": 0
+    },
+    {
+      "word": "back up somebody [transitive]",
+      "meaning": "to support or defend someone in a difficult situation",
+      "example": "Her friends backed her up when she spoke out against the manager.",
+      "translation": "hỗ trợ, ủng hộ",
+      "count": 0
+    },
+    {
+      "word": "look up something [transitive]",
+      "meaning": "to search for information in a source like a dictionary or online",
+      "example": "I had to look up the recipe online before cooking.",
+      "translation": "tra cứu",
+      "count": 0
+    },
+    {
+      "word": "think through something [transitive]",
+      "meaning": "to carefully consider all aspects before making a decision",
+      "example": "He needs to think through the plan before presenting it.",
+      "translation": "suy nghĩ thấu đáo",
+      "count": 0
+    },
+    {
+      "word": "break down [intransitive]",
+      "meaning": "to stop working due to mechanical failure",
+      "example": "My old laptop broke down during the presentation.",
+      "translation": "hư hỏng (máy móc)",
+      "count": 0
+    },
+    {
+      "word": "freak out [intransitive]",
+      "meaning": "to become extremely upset or lose control due to fear or anger",
+      "example": "He freaked out when he lost his phone.",
+      "translation": "hoảng loạn, nổi giận",
+      "count": 0
+    },
+    {
+      "word": "turn up [intransitive]",
+      "meaning": "to arrive or appear unexpectedly or after being missing",
+      "example": "She turned up late to the meeting without explanation.",
+      "translation": "xuất hiện, đến nơi",
+      "count": 0
+    },
+    {
+      "word": "get on / get on something [transitive/intransitive]",
+      "meaning": "to board a vehicle such as a bus, plane, or bicycle",
+      "example": "We got on the train just before it left the station.",
+      "translation": "lên xe, tàu, máy bay",
+      "count": 0
+    },
+    {
+      "word": "sell out [intransitive]",
+      "meaning": "to have no more items available for sale because everything has been bought",
+      "example": "The concert tickets sold out in just ten minutes.",
+      "translation": "bán hết",
+      "count": 0
+    },
+    {
+      "word": "join in / join in something [transitive/intransitive]",
+      "meaning": "to participate in an activity that others are already doing",
+      "example": "He joined in the game even though he arrived late.",
+      "translation": "tham gia vào",
+      "count": 0
+    },
+    {
+      "word": "pass out [intransitive]",
+      "meaning": "to suddenly become unconscious",
+      "example": "He passed out from exhaustion after the marathon.",
+      "translation": "ngất xỉu",
+      "count": 0
+    },
+    {
+      "word": "carry on (doing something) [transitive/intransitive]",
+      "meaning": "to continue an activity that was already in progress",
+      "example": "Despite the noise, she carried on reading her book.",
+      "translation": "tiếp tục",
+      "count": 0
+    },
+    {
+      "word": "blow away somebody [transitive]",
+      "meaning": "to greatly impress or amaze someone",
+      "example": "Her performance blew everyone away at the talent show.",
+      "translation": "làm kinh ngạc",
+      "count": 0
+    },
+    {
+      "word": "bring out something [transitive]",
+      "meaning": "to make a new product, book, or album available to the public",
+      "example": "They brought out a new smartphone model last week.",
+      "translation": "phát hành, tung ra",
+      "count": 0
+    },
+    {
+      "word": "go off [intransitive]",
+      "meaning": "to begin making a sound (like an alarm) or to explode suddenly",
+      "example": "The fire alarm went off in the middle of the night.",
+      "translation": "reo lên, nổ tung",
+      "count": 0
+    },
+    {
+      "word": "sleep in [intransitive]",
+      "meaning": "to wake up later than planned or necessary",
+      "example": "I accidentally slept in and missed the first meeting.",
+      "translation": "ngủ nướng",
+      "count": 0
+    },
+    {
+      "word": "hang out (with somebody) [transitive]",
+      "meaning": "to spend time relaxing with someone or at a place",
+      "example": "They often hang out at the coffee shop near campus.",
+      "translation": "đi chơi, tụ tập",
+      "count": 0
+    },
+    {
+      "word": "rip off somebody [transitive]",
+      "meaning": "to charge someone too much or cheat them financially",
+      "example": "Tourists are often ripped off at local markets.",
+      "translation": "lừa gạt tiền",
+      "count": 0
+    },
+    {
+      "word": "watch out (for something) [transitive]",
+      "meaning": "to be cautious or careful of possible danger or problems",
+      "example": "Watch out for slippery floors after it rains.",
+      "translation": "cẩn thận, coi chừng",
+      "count": 0
+    },
+    {
+      "word": "run out of something [transitive]",
+      "meaning": "to no longer have something because it has been used up",
+      "example": "We ran out of coffee during the meeting.",
+      "translation": "hết, cạn kiệt",
+      "count": 0
+    },
+    {
+      "word": "talk (someone) into something [transitive]",
+      "meaning": "to convince or persuade someone to do something",
+      "example": "She talked me into applying for the internship.",
+      "translation": "thuyết phục",
+      "count": 0
+    },
+    {
+      "word": "run into somebody [transitive]",
+      "meaning": "to meet someone unexpectedly by chance",
+      "example": "I ran into my old professor at the bookstore.",
+      "translation": "tình cờ gặp",
+      "count": 0
+    },
+    {
+      "word": "throw up [intransitive]",
+      "meaning": "to vomit suddenly",
+      "example": "He felt dizzy and threw up after the rollercoaster ride.",
+      "translation": "nôn mửa",
+      "count": 0
+    },
+    {
+      "word": "break up / break up with somebody [transitive/intransitive]",
+      "meaning": "to end a romantic relationship",
+      "example": "They broke up after five years together.",
+      "translation": "chia tay",
+      "count": 0
+    },
+    {
+      "word": "show off [intransitive]",
+      "meaning": "to act in a way that draws attention or admiration to oneself",
+      "example": "He always shows off his expensive gadgets.",
+      "translation": "khoe khoang",
+      "count": 0
+    },
+    {
+      "word": "split up / split up with somebody [transitive/intransitive]",
+      "meaning": "to end a relationship or marriage",
+      "example": "The couple decided to split up after years of disagreement.",
+      "translation": "chia tay",
+      "count": 0
+    },
+    {
+      "word": "move in (with somebody) [transitive]",
+      "meaning": "to begin living in a new house or with someone",
+      "example": "They moved in together after getting engaged.",
+      "translation": "chuyển đến sống chung",
+      "count": 0
+    },
+    {
+      "word": "hit on somebody [transitive]",
+      "meaning": "to flirt with someone in a romantic or sexual way",
+      "example": "He was hitting on her all night at the party.",
+      "translation": "tán tỉnh",
+      "count": 0
+    },
+    {
+      "word": "keep on 'doing' something [transitive]",
+      "meaning": "to continue doing something persistently, often annoyingly",
+      "example": "She kept on talking even after the class had ended.",
+      "translation": "tiếp tục (làm gì đó)",
+      "count": 0
+    },
+    {
+      "word": "joke around [intransitive]",
+      "meaning": "to act playfully or not take things seriously",
+      "example": "He was just joking around and didn’t mean any harm.",
+      "translation": "đùa giỡn",
+      "count": 0
+    },
+    {
+      "word": "move out [intransitive]",
+      "meaning": "to leave a house or apartment permanently",
+      "example": "She moved out last week and found her own place.",
+      "translation": "chuyển đi",
+      "count": 0
+    },
+    {
+      "word": "get over something or someone [transitive]",
+      "meaning": "to recover from emotional pain or stop being upset about something",
+      "example": "It took her months to get over the breakup.",
+      "translation": "vượt qua (cảm xúc)",
+      "count": 0
+    },
+    {
+      "word": "get together [intransitive]",
+      "meaning": "to meet or gather with someone for a purpose, often social",
+      "example": "Let’s get together this weekend for a barbecue.",
+      "translation": "gặp gỡ, tụ tập",
+      "count": 0
+    },
+    {
+      "word": "put off something [transitive]",
+      "meaning": "to delay or postpone something to a later time",
+      "example": "They had to put off the meeting until next week.",
+      "translation": "hoãn lại",
+      "count": 0
+    },
+    {
+      "word": "put on something [transitive]",
+      "meaning": "to start wearing clothes or to gain weight",
+      "example": "She put on a warm jacket before going outside.",
+      "translation": "mặc vào; tăng cân",
+      "count": 0
+    },
+    {
+      "word": "get back into something [transitive]",
+      "meaning": "to return to a previous activity or habit",
+      "example": "He's getting back into painting after a long break.",
+      "translation": "quay lại với điều gì đó",
+      "count": 0
+    },
+    {
+      "word": "give up / give up something [transitive/intransitive]",
+      "meaning": "to stop a habit or regular activity",
+      "example": "She's decided to give up drinking coffee for a month.",
+      "translation": "từ bỏ",
+      "count": 0
+    },
+    {
+      "word": "cut down on something [transitive]",
+      "meaning": "to reduce the use or intake of something",
+      "example": "I'm trying to cut down on sugar this month.",
+      "translation": "cắt giảm",
+      "count": 0
+    },
+    {
+      "word": "eat out [intransitive]",
+      "meaning": "to have a meal at a restaurant instead of at home",
+      "example": "We usually eat out on the weekends.",
+      "translation": "ăn ngoài",
+      "count": 0
+    },
+    {
+      "word": "save up [intransative]",
+      "meaning": "to put aside money for a purpose",
+      "example": "He's saving up to buy a new laptop.",
+      "translation": "tiết kiệm tiền",
+      "count": 0
+    },
+    {
+      "word": "throw out something [transitive]",
+      "meaning": "to dispose of or discard something",
+      "example": "I threw out the old magazines to make space.",
+      "translation": "vứt bỏ",
+      "count": 0
+    },
+    {
+      "word": "figure out something [transitive]",
+      "meaning": "to understand or solve something",
+      "example": "We need to figure out why the system keeps crashing.",
+      "translation": "tìm ra",
+      "count": 0
+    },
+    {
+      "word": "set up something [transitive]",
+      "meaning": "to establish a business or organization",
+      "example": "They set up a new startup focused on education.",
+      "translation": "thành lập",
+      "count": 0
+    },
+    {
+      "word": "call around [intransitive]",
+      "meaning": "to visit someone's house casually",
+      "example": "My aunt called around yesterday to say hello.",
+      "translation": "ghé qua",
+      "count": 0
+    },
+    {
+      "word": "look after something or someone [transitive]",
+      "meaning": "to take care of someone or something",
+      "example": "Can you look after my dog while I’m away?",
+      "translation": "chăm sóc",
+      "count": 0
+    },
+    {
+      "word": "end up [intransitive]",
+      "meaning": "to reach a final or unexpected situation",
+      "example": "We ended up going to a different restaurant.",
+      "translation": "kết cục là",
+      "count": 0
+    },
+    {
+      "word": "keep up [intransitive]",
+      "meaning": "to maintain the same pace or level",
+      "example": "I couldn’t keep up with the fast runners.",
+      "translation": "theo kịp",
+      "count": 0
+    },
+    {
+      "word": "wait up [intransitive]",
+      "meaning": "to stay awake until someone arrives",
+      "example": "She waited up for her son to get home.",
+      "translation": "thức chờ",
+      "count": 0
+    },
+    {
+      "word": "get back [intransitive]",
+      "meaning": "to return to a place",
+      "example": "What time did you get back from work?",
+      "translation": "quay lại",
+      "count": 0
+    },
+    {
+      "word": "wander off [intransitive]",
+      "meaning": "to move away from a place without permission or direction",
+      "example": "The toddler wandered off while we were distracted.",
+      "translation": "đi lang thang",
+      "count": 0
+    },
+    {
+      "word": "mess up something [transitive]",
+      "meaning": "to make something untidy or dirty",
+      "example": "He messed up the kitchen while cooking.",
+      "translation": "làm bừa bộn",
+      "count": 0
+    },
+    {
+      "word": "give back something [transitive]",
+      "meaning": "to return something that was borrowed",
+      "example": "Don't forget to give back the book you borrowed.",
+      "translation": "trả lại",
+      "count": 0
+    },
+    {
+      "word": "miss out [intransitive]",
+      "meaning": "to not experience or take part in something",
+      "example": "She missed out on the concert because of work.",
+      "translation": "bỏ lỡ",
+      "count": 0
+    },
+    {
+      "word": "catch up [intransitive]",
+      "meaning": "to reconnect and update with someone after a while",
+      "example": "We finally caught up over lunch last weekend.",
+      "translation": "nói chuyện lại",
+      "count": 0
+    },
+    {
+      "word": "meet up ",
+      "meaning": "to get together with someone to spend time",
+      "example": "Let’s meet up next weekend for coffee.",
+      "translation": "gặp nhau",
+      "count": 0
+    },
+    {
+      "word": "feel up to something ",
+      "meaning": "to feel capable or ready to do something",
+      "example": "I don’t feel up to going out tonight.",
+      "translation": "cảm thấy đủ sức để làm gì",
+      "count": 0
+    },
+    {
+      "word": "fall through ",
+      "meaning": "to not happen as planned",
+      "example": "Our holiday plans fell through at the last minute.",
+      "translation": "thất bại, không xảy ra",
+      "count": 0
+    },
+    {
+      "word": "give away something ",
+      "meaning": "to donate or hand something out for free",
+      "example": "He gave away his old books to the local library.",
+      "translation": "tặng, phát miễn phí",
+      "count": 0
+    },
+    {
+      "word": "take up something ",
+      "meaning": "to begin a new activity or hobby",
+      "example": "She recently took up painting as a hobby.",
+      "translation": "bắt đầu làm gì (thói quen mới)",
+      "count": 0
+    },
+    {
+      "word": "stick at something ",
+      "meaning": "to continue doing something even when it’s hard",
+      "example": "He stuck at learning piano despite the challenges.",
+      "translation": "kiên trì làm điều gì",
+      "count": 0
+    },
+    {
+      "word": "drop out ",
+      "meaning": "to leave school, college, or an activity before completing it",
+      "example": "She dropped out of college to start her own business.",
+      "translation": "bỏ học, bỏ dở giữa chừng",
+      "count": 0
+    },
+    {
+      "word": "last ",
+      "meaning": "to continue for a period of time",
+      "example": "The movie lasted over three hours.",
+      "translation": "kéo dài",
+      "count": 0
+    },
+    {
+      "word": "zone out ",
+      "meaning": "to stop focusing and become distracted",
+      "example": "He zoned out during the long meeting.",
+      "translation": "mất tập trung",
+      "count": 0
+    },
+    {
+      "word": "take down something ",
+      "meaning": "to write or record information",
+      "example": "She took down the instructions carefully.",
+      "translation": "ghi chép lại",
+      "count": 0
+    },
+    {
+      "word": "fall behind ",
+      "meaning": "to not keep up with progress or schedule",
+      "example": "He fell behind in his schoolwork after being sick.",
+      "translation": "tụt lại phía sau",
+      "count": 0
+    },
+    {
+      "word": "drift off ",
+      "meaning": "to slowly fall asleep",
+      "example": "I drifted off while watching the movie.",
+      "translation": "ngủ gật",
+      "count": 0
+    },
+    {
+      "word": "knuckle down ",
+      "meaning": "to start working hard on something seriously",
+      "example": "It’s time to knuckle down and finish this report.",
+      "translation": "bắt tay vào làm việc chăm chỉ",
+      "count": 0
+    },
+    {
+      "word": "bring back something ",
+      "meaning": "to return something or carry it from another place",
+      "example": "He brought back souvenirs from Japan.",
+      "translation": "mang về",
+      "count": 0
+    },
+    {
+      "word": "grow on somebody ",
+      "meaning": "to become more liked over time",
+      "example": "At first I disliked the song, but it grew on me.",
+      "translation": "dần dần yêu thích",
+      "count": 0
+    },
+    {
+      "word": "grow up ",
+      "meaning": "to become older and more mature",
+      "example": "She grew up in a small village by the sea.",
+      "translation": "trưởng thành",
+      "count": 0
+    },
+    {
+      "word": "sort out something ",
+      "meaning": "to fix a problem or organize something",
+      "example": "We need to sort out the issues before launching.",
+      "translation": "giải quyết, sắp xếp",
+      "count": 0
+    },
+    {
+      "word": "look for something or somebody ",
+      "meaning": "to try to find something or someone",
+      "example": "I’m looking for my lost keys.",
+      "translation": "tìm kiếm",
+      "count": 0
+    },
+    {
+      "word": "fill in for somebody ",
+      "meaning": "to temporarily take someone’s place",
+      "example": "Can you fill in for me at the meeting tomorrow?",
+      "translation": "làm thay ai đó",
+      "count": 0
+    },
+    {
+      "word": "get by ",
+      "meaning": "to manage with what you have, especially money",
+      "example": "We’re not rich, but we get by just fine.",
+      "translation": "xoay sở",
+      "count": 0
+    },
+    {
+      "word": "pay back something or somebody ",
+      "meaning": "to return borrowed money",
+      "example": "I’ll pay you back next week after payday.",
+      "translation": "trả lại tiền",
+      "count": 0
+    },
+    {
+      "word": "set up somebody (with somebody) ",
+      "meaning": "to arrange a romantic meeting between two people",
+      "example": "She set me up with her cousin last weekend.",
+      "translation": "mai mối",
+      "count": 0
+    },
+    {
+      "word": "get on (with somebody) [intransitive]",
+      "meaning": "to have a friendly or harmonious relationship with someone",
+      "example": "She gets on really well with her coworkers at the new job.",
+      "translation": "hòa hợp với ai đó",
+      "count": 0
+    },
+    {
+      "word": "work out [intransitive]",
+      "meaning": "to result in a successful or satisfactory way",
+      "example": "Everything worked out in the end despite the initial problems.",
+      "translation": "diễn ra tốt đẹp",
+      "count": 0
+    },
+    {
+      "word": "move on [intransitive]",
+      "meaning": "to let go of the past and begin a new stage in life",
+      "example": "After the breakup, she decided it was time to move on.",
+      "translation": "tiến về phía trước",
+      "count": 0
+    },
+    {
+      "word": "cheer up / cheer up somebody [transitive/intransitive]",
+      "meaning": "to become or make someone feel happier",
+      "example": "He bought her flowers to cheer her up after a tough week.",
+      "translation": "làm vui lên",
+      "count": 0
+    },
+    {
+      "word": "fall for somebody [transitive]",
+      "meaning": "to develop romantic feelings for someone",
+      "example": "He fell for her the moment they met at the conference.",
+      "translation": "phải lòng ai đó",
+      "count": 0
+    },
+    {
+      "word": "ask out somebody [transitive]",
+      "meaning": "to invite someone on a date",
+      "example": "He finally asked her out after weeks of hesitation.",
+      "translation": "mời ai đó đi chơi",
+      "count": 0
+    },
+    {
+      "word": "chat up somebody [transitive]",
+      "meaning": "to start a flirtatious conversation with someone",
+      "example": "He tried to chat her up at the party, but she wasn’t interested.",
+      "translation": "tán tỉnh ai đó",
+      "count": 0
+    },
+    {
+      "word": "back out [intransitive]",
+      "meaning": "to withdraw from an agreement or commitment",
+      "example": "She backed out of the project just days before the deadline.",
+      "translation": "rút lui",
+      "count": 0
+    },
+    {
+      "word": "come up with something [transitive]",
+      "meaning": "to think of or create a new idea or plan",
+      "example": "They came up with a creative solution to reduce costs.",
+      "translation": "nghĩ ra điều gì",
+      "count": 0
+    },
+    {
+      "word": "bring back something",
+      "meaning": "to return with something from another place",
+      "example": "He brought back souvenirs from his trip to Japan.",
+      "translation": "mang về",
+      "count": 0
+    },
+    {
+      "word": "fall behind",
+      "meaning": "to lag behind in progress or performance",
+      "example": "He fell behind in his studies after missing several classes.",
+      "translation": "tụt lại phía sau",
+      "count": 0
+    },
+    {
+      "word": "puzzle over something",
+      "meaning": "to think hard about something confusing",
+      "example": "She puzzled over the strange message for hours.",
+      "translation": "suy nghĩ về điều khó hiểu",
+      "count": 0
+    },
+    {
+      "word": "be comprised of",
+      "meaning": "to consist of specific parts or elements",
+      "example": "The team is comprised of developers and designers.",
+      "translation": "bao gồm",
+      "count": 0
+    },
+    {
+      "word": "To set someone up ",
+      "meaning": "to arrange a date between two people",
+      "example": "She set up her cousin with a colleague from work.",
+      "translation": "mai mối ai đó",
+      "count": 0
+    },
+    {
+      "word": "Get one’s big break ",
+      "meaning": "to get an opportunity for success or fame",
+      "example": "He got his big break when a producer discovered his video.",
+      "translation": "cơ hội đột phá",
+      "count": 0
+    },
+    {
+      "word": "Office politics (noun)",
+      "meaning": "rivalry for influence or power within a workplace",
+      "example": "She found it exhausting dealing with office politics every day.",
+      "translation": "chính trị nơi công sở",
+      "count": 0
+    },
+    {
+      "word": "Pick holes in something",
+      "meaning": "to find and point out flaws or weaknesses",
+      "example": "Instead of supporting her idea, they kept picking holes in it.",
+      "translation": "bới móc lỗi",
+      "count": 0
+    },
+    {
+      "word": "Get your foot in the door",
+      "meaning": "to gain a starting opportunity in a field or company",
+      "example": "He took the internship just to get his foot in the door.",
+      "translation": "bắt đầu tạo dựng chỗ đứng",
+      "count": 0
+    },
+    {
+      "word": "See eye to eye",
+      "meaning": "to share the same opinion or viewpoint",
+      "example": "We rarely see eye to eye on political issues.",
+      "translation": "đồng quan điểm",
+      "count": 0
+    },
+    {
+      "word": "Pay under the table",
+      "meaning": "to pay someone secretly to avoid legal obligations",
+      "example": "They hired workers and paid them under the table.",
+      "translation": "trả lương chui",
+      "count": 0
+    },
+    {
+      "word": "Talk shop",
+      "meaning": "to talk about work outside the workplace",
+      "example": "They ended up talking shop during the entire dinner.",
+      "translation": "nói chuyện công việc",
+      "count": 0
+    },
+    {
+      "word": "Put something on the back burner",
+      "meaning": "to delay something less urgent to focus on other things",
+      "example": "She put her travel plans on the back burner to finish her project.",
+      "translation": "tạm gác lại",
+      "count": 0
+    },
+    {
+      "word": "Throw in the towel",
+      "meaning": "to stop trying or admit defeat",
+      "example": "After many failed attempts, he threw in the towel.",
+      "translation": "bỏ cuộc",
+      "count": 0
+    },
+    {
+      "word": "Go the extra mile",
+      "meaning": "to make a special effort beyond what is required",
+      "example": "She always goes the extra mile to help her team succeed.",
+      "translation": "nỗ lực hơn mong đợi",
+      "count": 0
+    },
+    {
+      "word": "Think outside of the box",
+      "meaning": "to use creative or unconventional thinking",
+      "example": "The company values employees who think outside of the box.",
+      "translation": "suy nghĩ đột phá",
+      "count": 0
+    },
+    {
+    "word": "Get off on the wrong foot",
+    "meaning": "To start something, especially a relationship, in a bad or awkward way.",
+    "example": "Our meeting got off on the wrong foot because of a scheduling mistake.",
+    "translation": "Bắt đầu mối quan hệ một cách không suôn sẻ",
+    "count": 0
+    },
+    {
+    "word": "Stand your ground",
+    "meaning": "To maintain your beliefs or position firmly even when others oppose you.",
+    "example": "Despite criticism, she stood her ground on the issue.",
+    "translation": "Giữ vững lập trường",
+    "count": 0
+    },
+    {
+    "word": "Run around like a headless chicken",
+    "meaning": "To act in a panicked, confused, or unorganized way.",
+    "example": "Everyone was running around like headless chickens before the event started.",
+    "translation": "Chạy loạn xạ, hành xử thiếu tổ chức",
+    "count": 0
+    },
+    {
+    "word": "Cut to the chase",
+    "meaning": "To skip the details and get straight to the main point.",
+    "example": "Let’s cut to the chase—what do you need from me?",
+    "translation": "Vào thẳng vấn đề",
+    "count": 0
+    },
+    {
+    "word": "Be a blessing in disguise",
+    "meaning": "Something that seems bad at first but results in something good.",
+    "example": "Losing that job was a blessing in disguise—it led me to a better one.",
+    "translation": "Phúc họa đan xen",
+    "count": 0
+    },
+    {
+    "word": "Cost an arm and a leg",
+    "meaning": "To be very expensive.",
+    "example": "That designer bag costs an arm and a leg!",
+    "translation": "Rất đắt đỏ",
+    "count": 0
+    },
+    {
+    "word": "Learn the ropes",
+    "meaning": "To learn how to do a particular job or task.",
+    "example": "She’s still learning the ropes at her new job.",
+    "translation": "Học việc, học cách làm việc",
+    "count": 0
+    },
+    {
+    "word": "Cook the books",
+    "meaning": "To dishonestly change financial records.",
+    "example": "They were accused of cooking the books to hide losses.",
+    "translation": "Gian lận sổ sách kế toán",
+    "count": 0
+    },
+    {
+    "word": "Make a cold call",
+    "meaning": "To contact someone you don't know to sell something or promote a service.",
+    "example": "He makes 20 cold calls a day to find new customers.",
+    "translation": "Gọi điện thoại tiếp thị",
+    "count": 0
+    },
+    {
+    "word": "Get the green light",
+    "meaning": "To receive permission to proceed.",
+    "example": "We got the green light to begin the project.",
+    "translation": "Được bật đèn xanh, được cho phép",
+    "count": 0
+    },
+    {
+    "word": "Twist somebody’s arm",
+    "meaning": "To strongly persuade someone to do something they are reluctant to do.",
+    "example": "She twisted my arm to get me to join the team.",
+    "translation": "Thuyết phục ai đó làm điều họ không muốn",
+    "count": 0
+    },
+    {
+    "word": "Run on a shoestring",
+    "meaning": "To operate with a very small budget.",
+    "example": "The charity runs on a shoestring but manages to help many.",
+    "translation": "Chạy với ngân sách eo hẹp",
+    "count": 0
+    },
+    {
+    "word": "Be snowed under",
+    "meaning": "To be overwhelmed with too much work.",
+    "example": "I'm snowed under with assignments this week.",
+    "translation": "Ngập trong công việc",
+    "count": 0
+    },
+    {
+    "word": "Be in the red / black",
+    "meaning": "To be operating at a financial loss (in the red) or profit (in the black).",
+    "example": "Thanks to good sales, we’re finally in the black.",
+    "translation": "Lỗ (in the red) / Lãi (in the black)",
+    "count": 0
+    },
+    {
+      "word": "Miss the boat",
+      "meaning": "To fail to seize an opportunity or take timely action.",
+      "example": "I missed the boat on that investment opportunity, and now the company has tripled in value.",
+      "translation": "Bỏ lỡ cơ hội",
+      "count": 0
+    },
+    {
+      "word": "Jump the gun",
+      "meaning": "To act before the appropriate or expected time.",
+      "example": "They jumped the gun by announcing the product before it was ready.",
+      "translation": "Hấp tấp, vội vàng",
+      "count": 0
+    },
+    {
+      "word": "Be in the loop",
+      "meaning": "To be informed or included in communication regarding decisions or developments.",
+      "example": "She wants to be in the loop for all project updates going forward.",
+      "translation": "Nắm bắt thông tin",
+      "count": 0
+    },
+    {
+      "word": "Move the goalposts",
+      "meaning": "To change the rules or conditions unfairly during a process.",
+      "example": "They moved the goalposts by changing the targets halfway through the project.",
+      "translation": "Thay đổi tiêu chuẩn/luật chơi",
+      "count": 0
+    },
+    {
+      "word": "Be put on the map",
+      "meaning": "To become widely known or important.",
+      "example": "The new innovation put the startup on the map in the tech world.",
+      "translation": "Được biết đến rộng rãi",
+      "count": 0
+    },
+    {
+      "word": "Do the donkey work",
+      "meaning": "To do the hard, boring parts of a task.",
+      "example": "The junior team handled the donkey work before the main event.",
+      "translation": "Làm việc nặng nhọc",
+      "count": 0
+    },
+    {
+      "word": "Jump on the bandwagon",
+      "meaning": "To join a trend or activity that is currently popular.",
+      "example": "Several competitors jumped on the bandwagon after our product succeeded.",
+      "translation": "Theo trào lưu",
+      "count": 0
+    },
+    {
+      "word": "Hold the fort",
+      "meaning": "To take responsibility temporarily in someone’s absence.",
+      "example": "She held the fort while the manager was away on leave.",
+      "translation": "Tạm thời quản lý",
+      "count": 0
+    },
+    {
+      "word": "Pay dividends",
+      "meaning": "To bring benefits or positive returns, often over time.",
+      "example": "Their training investments paid dividends in productivity.",
+      "translation": "Mang lại lợi ích",
+      "count": 0
+    },
+    {
+      "word": "Hold all the aces",
+      "meaning": "To be in a position of power or advantage.",
+      "example": "With the key patents, they held all the aces in negotiation.",
+      "translation": "Nắm mọi lợi thế",
+      "count": 0
+    },
+    {
+      "word": "Cash in your chips",
+      "meaning": "to leave a role or situation, typically to retire or quit permanently",
+      "example": "He finally cashed in his chips after 30 years in the industry.",
+      "translation": "nghỉ việc, về hưu",
+      "count": 0
+    },
+    {
+      "word": "Take something on board",
+      "meaning": "to acknowledge and consider feedback or suggestions",
+      "example": "We took their advice on board and adjusted our approach.",
+      "translation": "tiếp thu",
+      "count": 0
+    },
+    {
+      "word": "Call it a day",
+      "meaning": "to stop working for the time being or end an activity",
+      "example": "We’ve done enough; let’s call it a day.",
+      "translation": "kết thúc công việc",
+      "count": 0
+    },
+    {
+      "word": "add up to (/æd ʌp tə/)",
+      "meaning": "to result in or lead to a specific outcome",
+      "example": "Their actions don’t add up to real change.",
+      "translation": "tương đương với",
+      "count": 0
+    },
+    {
+      "word": "add up to (/æd ʌp tə/)",
+      "meaning": "to amount to a total figure when combined",
+      "example": "All his monthly bills add up to over $1,000.",
+      "translation": "tổng cộng lên tới",
+      "count": 0
+    },
+    {
+      "word": "answer back (/ˈɑːnsər bæk/)",
+      "meaning": "to speak disrespectfully to someone in authority",
+      "example": "He got detention for answering back in class.",
+      "translation": "cãi lại",
+      "count": 0
+    },
+    {
+      "word": "ask out (/æsk aʊt/)",
+      "meaning": "to invite someone on a date",
+      "example": "He finally asked her out after weeks of hesitation.",
+      "translation": "rủ đi chơi",
+      "count": 0
+    },
+    {
+      "word": "back down (/bæk daʊn/)",
+      "meaning": "to withdraw from a stance due to opposition",
+      "example": "She refused to back down despite criticism.",
+      "translation": "rút lại ý kiến",
+      "count": 0
+    },
+    {
+      "word": "back up (/bæk ʌp/)",
+      "meaning": "to support someone by agreeing with them",
+      "example": "Her colleague backed her up during the argument.",
+      "translation": "ủng hộ",
+      "count": 0
+    },
+    {
+      "word": "back up (/bæk ʌp/)",
+      "meaning": "to create a duplicate copy of digital data",
+      "example": "Always back up your files before updating.",
+      "translation": "sao lưu dữ liệu",
+      "count": 0
+    },
+    {
+      "word": "black out (/blæk aʊt/)",
+      "meaning": "to darken a place by turning off the lights",
+      "example": "The area blacked out during the power cut.",
+      "translation": "làm tối om",
+      "count": 0
+    },
+    {
+      "word": "black out (/blæk aʊt/)",
+      "meaning": "to faint or lose consciousness suddenly",
+      "example": "He blacked out after standing in the heat too long.",
+      "translation": "ngất lịm",
+      "count": 0
+    },
+    {
+      "word": "bring about (/brɪŋ əˈbaʊt/)",
+      "meaning": "to cause a specific event or change",
+      "example": "The reforms brought about major improvements.",
+      "translation": "gây ra",
+      "count": 0
+    },
+    {
+      "word": "bring out (/brɪŋ aʊt/)",
+      "meaning": "to highlight a particular trait or feature",
+      "example": "The new lighting brings out the colors nicely.",
+      "translation": "làm nổi bật",
+      "count": 0
+    },
+    {
+      "word": "bring out (/brɪŋ aʊt/)",
+      "meaning": "to launch a new product",
+      "example": "They’re bringing out a limited edition sneaker.",
+      "translation": "phát hành",
+      "count": 0
+    },
+    {
+      "word": "bring together (/brɪŋ təˈɡeðər/)",
+      "meaning": "to unite people for a shared activity or goal",
+      "example": "The charity event brought the community together.",
+      "translation": "kết nối",
+      "count": 0
+    },
+    {
+      "word": "brush up (on) (/brʌʃ ʌp/)",
+      "meaning": "to refresh or improve one’s knowledge of something",
+      "example": "She brushed up on her French before the trip.",
+      "translation": "ôn lại",
+      "count": 0
+    },
+    {
+      "word": "build up (/bɪld ʌp/)",
+      "meaning": "to gradually increase or develop over time",
+      "example": "They built up their business from scratch.",
+      "translation": "phát triển",
+      "count": 0
+    },
+    {
+      "word": "build up (/bɪld ʌp/)",
+      "meaning": "to grow in size, quantity, or strength",
+      "example": "Traffic built up quickly during rush hour.",
+      "translation": "tăng lên",
+      "count": 0
+    },
+    {
+      "word": "build up (/bɪld ʌp/)",
+      "meaning": "to improve someone’s health or physical condition",
+      "example": "She’s trying to build up her strength after surgery.",
+      "translation": "lớn lên, phát triển",
+      "count": 0
+    },
+    {
+      "word": "bump into ",
+      "meaning": "to collide with something by accident",
+      "example": "I wasn't watching where I was going and bumped into a table.",
+      "translation": "va phải",
+      "count": 0
+    },
+    {
+      "word": "blend in ",
+      "meaning": "to appear similar and go unnoticed in a particular setting",
+      "example": "He dyed his hair to help blend in with the crowd.",
+      "translation": "hòa nhập",
+      "count": 0
+    },
+    {
+      "word": "blurt out ",
+      "meaning": "to say something suddenly without thinking",
+      "example": "Without thinking, he blurted out the answer.",
+      "translation": "thốt ra",
+      "count": 0
+    },
+    {
+      "word": "board up ",
+      "meaning": "to cover windows or doors with wooden panels",
+      "example": "They boarded up the windows before the hurricane hit.",
+      "translation": "bịt kín",
+      "count": 0
+    },
+    {
+      "word": "break down ",
+      "meaning": "to separate something into smaller components",
+      "example": "Let me break the budget down into weekly expenses.",
+      "translation": "đập bé",
+      "count": 0
+    },
+    {
+      "word": "break up ",
+      "meaning": "to end an event or gathering",
+      "example": "The party broke up around midnight.",
+      "translation": "kết thúc",
+      "count": 0
+    },
+    {
+      "word": "break up ",
+      "meaning": "to end a romantic relationship",
+      "example": "They broke up after five years together.",
+      "translation": "chia tay",
+      "count": 0
+    },
+    {
+      "word": "brighten up ",
+      "meaning": "to become sunnier or more pleasant in weather",
+      "example": "It was raining in the morning but it brightened up in the afternoon.",
+      "translation": "trở nên tốt hơn",
+      "count": 0
+    },
+    {
+      "word": "brighten up ",
+      "meaning": "to start feeling or looking more cheerful",
+      "example": "Her mood brightened up after hearing the good news.",
+      "translation": "trở nên rạng rõ hơn",
+      "count": 0
+    },
+    {
+      "word": "brighten up ",
+      "meaning": "to add color or light to something",
+      "example": "The new curtains really brighten up the room.",
+      "translation": "trở nên đẹp/hấp dẫn hơn",
+      "count": 0
+    },
+    {
+      "word": "bump into ",
+      "meaning": "to meet someone unexpectedly",
+      "example": "I bumped into my old teacher at the supermarket.",
+      "translation": "tình cờ gặp",
+      "count": 0
+    },
+    {
+      "word": "buy off ",
+      "meaning": "to give someone money to avoid their opposition",
+      "example": "They tried to buy off the inspector to ignore the violations.",
+      "translation": "đút lót",
+      "count": 0
+    },
+    {
+      "word": "buy out ",
+      "meaning": "to purchase someone's share in a business",
+      "example": "He bought out his partner to become the sole owner.",
+      "translation": "mua lại",
+      "count": 0
+    },
+    {
+      "word": "buy up ",
+      "meaning": "to purchase all available items of something",
+      "example": "Investors bought up the land before prices soared.",
+      "translation": "mua hết, mua sạch",
+      "count": 0
+    },
+    {
+      "word": "cancel out ",
+      "meaning": "to neutralize the effect of something",
+      "example": "The benefits were cancelled out by the high costs.",
+      "translation": "triệt tiêu",
+      "count": 0
+    },
+    {
+      "word": "carry over ",
+      "meaning": "to transfer into a later time period",
+      "example": "Unused vacation days can carry over to the next year.",
+      "translation": "kéo dài, chuyển sang",
+      "count": 0
+    },
+    {
+      "word": "catch on ",
+      "meaning": "to become trendy or popular",
+      "example": "That fashion trend caught on quickly among teenagers.",
+      "translation": "trở thành mốt",
+      "count": 0
+    },
+    {
+      "word": "catch on ",
+      "meaning": "to begin to understand something",
+      "example": "It took me a while to catch on to the new software.",
+      "translation": "hiểu",
+      "count": 0
+    },
+    {
+      "word": "centre around ",
+      "meaning": "to focus or revolve around someone or something",
+      "example": "The discussion centered around budget cuts.",
+      "translation": "xoay quanh",
+      "count": 0
+    },
+    {
+      "word": "chance upon",
+      "meaning": "to discover or encounter something unexpectedly.",
+      "example": "We stumbled upon a delightful little restaurant during our walk.",
+      "translation": "tình cờ tìm thấy",
+      "count": 0
+    },
+    {
+      "word": "change into (1)",
+      "meaning": "to rearrange objects so they are in new positions.",
+      "example": "As a prank, my friends moved everything in my room to new places.",
+      "translation": "di chuyển đồ vật",
+      "count": 0
+    },
+    {
+      "word": "change into (2)",
+      "meaning": "to transform from one form, state, or condition into another.",
+      "example": "The movie depicted a man turning into a werewolf during the full moon.",
+      "translation": "biến đổi thành",
+      "count": 0
+    },
+    {
+      "word": "change out of (1)",
+      "meaning": "to remove your clothes and put on a different set.",
+      "example": "Let me slip into something more comfortable.",
+      "translation": "thay (quần áo) ra",
+      "count": 0
+    },
+    {
+      "word": "change out of (2)",
+      "meaning": "to take off the clothes you're wearing and change into others.",
+      "example": "Come inside and get out of those wet clothes.",
+      "translation": "thay (quần áo) ra",
+      "count": 0
+    },
+    {
+      "word": "check out (1)",
+      "meaning": "to inspect something to ensure it is accurate or acceptable.",
+      "example": "I've been testing the camera by taking lots of pictures.",
+      "translation": "kiểm tra, rà soát",
+      "count": 0
+    },
+    {
+      "word": "check out (2)",
+      "meaning": "to verify that something is true.",
+      "example": "Their explanation didn’t seem to match up with the facts.",
+      "translation": "đúng sự thật",
+      "count": 0
+    },
+    {
+      "word": "clock up",
+      "meaning": "to reach a particular amount or total.",
+      "example": "He has served in the police force for 34 years.",
+      "translation": "đạt mức",
+      "count": 0
+    },
+    {
+      "word": "close up",
+      "meaning": "to secure and shut a building or store.",
+      "example": "The shopkeeper locked up for the night.",
+      "translation": "khóa lại, đóng lại",
+      "count": 0
+    },
+    {
+      "word": "club together",
+      "meaning": "to pool money with others to buy something collectively.",
+      "example": "We all chipped in to buy her a thoughtful gift.",
+      "translation": "góp tiền",
+      "count": 0
+    },
+    {
+      "word": "come across",
+      "meaning": "to unexpectedly meet someone or find something.",
+      "example": "I found a mention of my grandfather in an old novel.",
+      "translation": "tình cờ gặp",
+      "count": 0
+    },
+    {
+      "word": "come (a)round (to)",
+      "meaning": "to change your mind due to someone's influence.",
+      "example": "At first, I didn’t agree, but I’ve warmed up to the idea now.",
+      "translation": "thay đổi quan điểm",
+      "count": 0
+    },
+    {
+      "word": "come between",
+      "meaning": "to cause conflict or separation between people.",
+      "example": "I’d never let any issue interfere with our friendship.",
+      "translation": "gây mâu thuẫn",
+      "count": 0
+    },
+    {
+      "word": "come off",
+      "meaning": "to be removed from a surface through cleaning or rubbing.",
+      "example": "The stain eventually came out after several washes.",
+      "translation": "bị xóa, biến khỏi",
+      "count": 0
+    },
+    {
+      "word": "come out (1)",
+      "meaning": "to be interpreted in a certain way.",
+      "example": "That didn’t sound right—let me reword it.",
+      "translation": "được hiểu",
+      "count": 0
+    },
+    {
+      "word": "come out (2)",
+      "meaning": "to be released for public access.",
+      "example": "The new magazine hits the shelves every Thursday.",
+      "translation": "được phát hành",
+      "count": 0
+    },
+    {
+      "word": "come out (3)",
+      "meaning": "to become visible or apparent.",
+      "example": "The differences only become clear when both teams meet.",
+      "translation": "được lộ",
+      "count": 0
+    },
+    {
+      "word": "come out (4)",
+      "meaning": "to become publicly known.",
+      "example": "He mentioned the truth would come out in court.",
+      "translation": "được công khai",
+      "count": 0
+    },
+    {
+      "word": "come out (5)",
+      "meaning": "to result in a particular outcome.",
+      "example": "Everything turned out fine in the end.",
+      "translation": "kết quả",
+      "count": 0
+    },
+    {
+      "word": "come round",
+      "meaning": "to regain consciousness after fainting or surgery.",
+      "example": "I felt groggy when I woke up from the operation.",
+      "translation": "tỉnh lại",
+      "count": 0
+    },
+{
+      "word": "come across /kʌm əˈkrɒs/",
+      "meaning": "to find someone or something unexpectedly",
+      "example": "While reading an old journal, I came across my grandmother’s photo.",
+      "translation": "tình cờ gặp",
+      "count": 0
+    },
+    {
+      "word": "come around (to) /kʌm əˈraʊnd/",
+      "meaning": "to change your mind after being convinced",
+      "example": "She wasn’t sure about the plan, but she eventually came around to it.",
+      "translation": "thay đổi quan điểm",
+      "count": 0
+    },
+    {
+      "word": "come between /kʌm bɪˈtwiːn/",
+      "meaning": "to cause conflict or distance in a relationship",
+      "example": "Nothing will ever come between us and our friendship.",
+      "translation": "gây mâu thuẫn",
+      "count": 0
+    },
+    {
+      "word": "come out (of) /kʌm aʊt/",
+      "meaning": "to be removed from something by washing or rubbing",
+      "example": "I spilled ink on my shirt, but it came out after a few washes.",
+      "translation": "bị xóa, biến khỏi",
+      "count": 0
+    },
+    {
+      "word": "come out (clear) /kʌm aʊt/",
+      "meaning": "to be expressed or understood in a certain way",
+      "example": "His comment didn’t come out the way he intended.",
+      "translation": "được hiểu",
+      "count": 0
+    },
+    {
+      "word": "come up (with) /kʌm ʌp/",
+      "meaning": "to invent or suggest a solution or idea",
+      "example": "She came up with a brilliant idea to solve the issue.",
+      "translation": "nghĩ ra",
+      "count": 0
+    },
+    {
+      "word": "cordon off /ˈkɔːdn ɒf/",
+      "meaning": "to block access to an area using a barrier",
+      "example": "They cordoned off the accident site for investigation.",
+      "translation": "chặn đường",
+      "count": 0
+    },
+    {
+      "word": "crack down (on) /kræk daʊn ɒn/",
+      "meaning": "to enforce laws or rules more strictly",
+      "example": "Authorities are cracking down on illegal parking in the city.",
+      "translation": "trừng trị",
+      "count": 0
+    },
+    {
+      "word": "creep up (on) /kriːp ʌp ɒn/",
+      "meaning": "to approach quietly and slowly",
+      "example": "He crept up on his friend and scared her as a prank.",
+      "translation": "lén tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "cut back (on) /kʌt bæk ɒn/",
+      "meaning": "to reduce the amount of something",
+      "example": "They’ve decided to cut back on overtime to reduce expenses.",
+      "translation": "cắt giảm",
+      "count": 0
+    },
+    {
+      "word": "cut out /kʌt aʊt/",
+      "meaning": "to stop doing or using something completely",
+      "example": "I’ve cut out sugar to improve my diet.",
+      "translation": "cắt giảm",
+      "count": 0
+    },
+    {
+      "word": "die out /daɪ aʊt/",
+      "meaning": "to gradually disappear or stop existing",
+      "example": "Dial-up Internet has almost completely died out.",
+      "translation": "biến mất hoàn toàn",
+      "count": 0
+    },
+    {
+      "word": "dig up /dɪg ʌp/",
+      "meaning": "to search for and find something",
+      "example": "She dug up some old emails to prove her point.",
+      "translation": "tìm kiếm kỹ",
+      "count": 0
+    },
+    {
+      "word": "cool down /kuːl daʊn/",
+      "meaning": "to become less hot or make something cooler",
+      "example": "Let’s wait for the engine to cool down before touching it.",
+      "translation": "hạ nhiệt",
+      "count": 0
+    },
+    {
+      "word": "come round /kʌm raʊnd/",
+      "meaning": "to visit someone at their home",
+      "example": "He came round last night to discuss the project.",
+      "translation": "ghé thăm",
+      "count": 0
+    },
+    {
+      "word": "come round /kʌm raʊnd/",
+      "meaning": "to happen again, usually on a regular basis",
+      "example": "My birthday always seems to come round so quickly.",
+      "translation": "tái diễn",
+      "count": 0
+    },
+    {
+      "word": "check out /tʃek aʊt/",
+      "meaning": "to investigate or look over something carefully",
+      "example": "You should check out the new café downtown.",
+      "translation": "kiểm tra, rà soát",
+      "count": 0
+    },
+    {
+      "word": "chase up /tʃeɪs ʌp/",
+      "meaning": "to follow up or remind someone to complete a task",
+      "example": "I’ll chase up the supplier to confirm the delivery date.",
+      "translation": "đuổi theo",
+      "count": 0
+    },
+    {
+      "word": "crowd around /kraʊd əˈraʊnd/",
+      "meaning": "to gather closely around someone or something",
+      "example": "People crowded around the performer in the street.",
+      "translation": "tụ tập quanh",
+      "count": 0
+    },
+    {
+      "word": "check in /tʃek ɪn/",
+      "meaning": "to register at a hotel or airport upon arrival",
+      "example": "We checked in at the airport three hours before departure.",
+      "translation": "đăng ký",
+      "count": 0
+    },
+    {
+      "word": "dig up /dɪg ʌp/",
+      "meaning": "to extract something from the ground by digging",
+      "example": "They managed to dig up some ancient pottery during the excavation.",
+      "translation": "khai quật",
+      "count": 0
+    },
+    {
+      "word": "dive in /daɪv ɪn/",
+      "meaning": "to start doing something eagerly and with enthusiasm",
+      "example": "As soon as dinner was served, everyone dived in.",
+      "translation": "bắt đầu làm một cách say mê",
+      "count": 0
+    },
+    {
+      "word": "do away with /du əˈweɪ wɪð/",
+      "meaning": "to eliminate or abolish something",
+      "example": "The school decided to do away with uniforms next year.",
+      "translation": "loại bỏ",
+      "count": 0
+    },
+    {
+      "word": "do up /du ʌp/",
+      "meaning": "to fasten clothing or similar items",
+      "example": "Make sure to do up your shirt before the meeting.",
+      "translation": "cài",
+      "count": 0
+    },
+    {
+      "word": "drum up /drʌm ʌp/",
+      "meaning": "to encourage interest or support for something",
+      "example": "The campaign team is trying to drum up more support before the election.",
+      "translation": "lôi kéo khách hàng cho",
+      "count": 0
+    },
+    {
+      "word": "dry up (1) /draɪ ʌp/",
+      "meaning": "to lose all moisture and become completely dry",
+      "example": "After weeks without rain, the pond eventually dried up.",
+      "translation": "cạn khô, ráo nước",
+      "count": 0
+    },
+    {
+      "word": "dry up (2) /draɪ ʌp/",
+      "meaning": "to no longer be available or exist",
+      "example": "Funding for the program dried up after the first year.",
+      "translation": "hết",
+      "count": 0
+    },
+    {
+      "word": "end up /ɛnd ʌp/",
+      "meaning": "to finally be in a particular state or place",
+      "example": "He ended up working in a completely different field than he studied.",
+      "translation": "có kết cục/ kết thúc",
+      "count": 0
+    },
+    {
+      "word": "face up to /feɪs ʌp tə/",
+      "meaning": "to confront or accept a difficult situation",
+      "example": "You need to face up to your responsibilities.",
+      "translation": "đương đầu, đối mặt",
+      "count": 0
+    },
+    {
+      "word": "fade away /feɪd əˈweɪ/",
+      "meaning": "to gradually disappear or become less noticeable",
+      "example": "His memories of childhood began to fade away over time.",
+      "translation": "dần biến mất",
+      "count": 0
+    },
+    {
+      "word": "fall behind /fɔːl bɪˈhaɪnd/",
+      "meaning": "to not keep up with progress or pace compared to others",
+      "example": "She fell behind in her studies after missing a few weeks of class.",
+      "translation": "tụt hậu",
+      "count": 0
+    },
+    {
+      "word": "fall behind /fɔːl bɪˈhaɪnd/",
+      "meaning": "to lag physically behind others while moving",
+      "example": "He fell behind the group during the hike because of his injury.",
+      "translation": "tụt lại phía sau",
+      "count": 0
+    },
+    {
+      "word": "figure out /ˈfɪɡər aʊt/",
+      "meaning": "to understand something or find an answer to a problem",
+      "example": "It took them hours to figure out how the machine works.",
+      "translation": "hiểu được, tìm ra",
+      "count": 0
+    },
+    {
+      "word": "fix up /fɪks ʌp/",
+      "meaning": "to repair or improve something",
+      "example": "They fixed up the old house before moving in.",
+      "translation": "sửa chữa, phục hồi",
+      "count": 0
+    },
+    {
+      "word": "follow up /ˈfɑːləʊ ʌp/",
+      "meaning": "to continue checking on someone's health after treatment",
+      "example": "She was advised to come in next month for a follow-up appointment.",
+      "translation": "theo dõi sức khỏe",
+      "count": 0
+    },
+    {
+      "word": "follow up /ˈfɑːləʊ ʌp/",
+      "meaning": "to investigate or act further on something",
+      "example": "Detectives are following up new tips from the public.",
+      "translation": "điều tra thêm",
+      "count": 0
+    },
+    {
+      "word": "get across /ɡet əˈkrɒs/",
+      "meaning": "to communicate an idea clearly",
+      "example": "She used visuals to get her point across effectively.",
+      "translation": "truyền đạt",
+      "count": 0
+    },
+    {
+      "word": "get (a)round /ɡet əˈraʊnd/",
+      "meaning": "to become widely known or spread",
+      "example": "Word got around quickly about the company’s sudden closure.",
+      "translation": "trở nên phổ biến",
+      "count": 0
+    },
+    {
+      "word": "get down /ɡet daʊn/",
+      "meaning": "to cause someone to feel depressed or discouraged",
+      "example": "The constant rain is really getting me down.",
+      "translation": "làm buồn/ thất vọng",
+      "count": 0
+    },
+    {
+      "word": "get in /ɡet ɪn/",
+      "meaning": "to be elected to a political position",
+      "example": "She got in with a narrow majority of votes.",
+      "translation": "được bầu chọn",
+      "count": 0
+    },
+    {
+      "word": "get into /ɡet ˈɪntuː/",
+      "meaning": "to become involved in something negative",
+      "example": "He got into trouble after joining the wrong crowd.",
+      "translation": "dính phải, vướng vào",
+      "count": 0
+    },
+    {
+      "word": "get into /ɡet ˈɪntuː/",
+      "meaning": "when a vehicle arrives at a place",
+      "example": "The train gets into London at 7 PM.",
+      "translation": "đến nơi",
+      "count": 0
+    },
+    {
+      "word": "get into /ɡet ˈɪntuː/",
+      "meaning": "to start becoming interested or engaged in something",
+      "example": "She really got into painting during the summer.",
+      "translation": "bắt đầu thích",
+      "count": 0
+    },
+    {
+      "word": "get off /ɡet ɒf/",
+      "meaning": "to send something, like a letter or package",
+      "example": "I'll send out those invitations tomorrow.",
+      "translation": "gửi",
+      "count": 0
+    },
+    {
+      "word": "get over /ɡet ˈəʊvər/",
+      "meaning": "to overcome or find a solution to a problem",
+      "example": "We still have a few major challenges to overcome before opening.",
+      "translation": "giải quyết",
+      "count": 0
+    },
+    {
+      "word": "get over /ɡet ˈəʊvər/",
+      "meaning": "to recover emotionally after a bad experience or relationship",
+      "example": "Recovering from something like that could take weeks.",
+      "translation": "vượt qua (chuyện buồn)",
+      "count": 0
+    },
+    {
+      "word": "get through /ɡet θruː/",
+      "meaning": "to complete a task or go through something difficult",
+      "example": "I’ve got a huge workload to get through today.",
+      "translation": "hoàn thành",
+      "count": 0
+    },
+    {
+      "word": "get through /ɡet θruː/",
+      "meaning": "to survive or handle a difficult experience",
+      "example": "I still can’t believe how we managed to survive that.",
+      "translation": "sống sót, vượt qua",
+      "count": 0
+    },
+    {
+      "word": "get through /ɡet θruː/",
+      "meaning": "to consume or use up something",
+      "example": "We use up a liter of milk every single day.",
+      "translation": "dùng, sử dụng",
+      "count": 0
+    },
+    {
+      "word": "get through (to) /ɡet θruː/",
+      "meaning": "to successfully connect a call",
+      "example": "I tried phoning him, but I couldn’t get through.",
+      "translation": "nối máy",
+      "count": 0
+    },
+    {
+      "word": "get through (to) /ɡet θruː/",
+      "meaning": "to make someone understand what you're saying",
+      "example": "The teacher struggles to get his message across to some students.",
+      "translation": "truyền đạt, giải thích",
+      "count": 0
+    },
+    {
+      "word": "give in /ɡɪv ɪn/",
+      "meaning": "to stop resisting a temptation or desire",
+      "example": "Eventually, I gave in and had some cake.",
+      "translation": "thỏa hiệp",
+      "count": 0
+    },
+    {
+      "word": "give in /ɡɪv ɪn/",
+      "meaning": "to stop resisting and accept defeat",
+      "example": "Eventually, I gave in and admitted she was right.",
+      "translation": "chịu thua",
+      "count": 0
+    },
+    {
+      "word": "go astray /ɡəʊ əˈstreɪ/",
+      "meaning": "to become lost or end up in the wrong place",
+      "example": "We got lost but managed to find our way again.",
+      "translation": "bị lạc đường",
+      "count": 0
+    },
+    {
+      "word": "go down (well/badly) (with sb) /ɡəʊ daʊn/",
+      "meaning": "to be received in a particular way",
+      "example": "The rent increase wasn’t well received by the tenants.",
+      "translation": "(không) được đón nhận (bởi ai)",
+      "count": 0
+    },
+    {
+      "word": "go in for /ɡəʊ ɪn fər/",
+      "meaning": "to choose a subject or profession",
+      "example": "I’m planning to pursue a career in dentistry.",
+      "translation": "theo đuổi ngành/nghề",
+      "count": 0
+    },
+    {
+      "word": "go in for /ɡəʊ ɪn fər/",
+      "meaning": "to enjoy a specific activity",
+      "example": "My father never really enjoyed attending parties.",
+      "translation": "thích, hưởng ứng",
+      "count": 0
+    },
+    {
+      "word": "go off /ɡəʊ ɒf/",
+      "meaning": "to explode or be triggered",
+      "example": "A bomb exploded at the mall yesterday.",
+      "translation": "phát nổ",
+      "count": 0
+    },
+    {
+      "word": "go off /ɡəʊ ɒf/",
+      "meaning": "for food or drink to spoil",
+      "example": "This milk smells like it’s gone bad to me.",
+      "translation": "bị ôi thiu",
+      "count": 0
+    },
+    {
+      "word": "go off /ɡəʊ ɒf/",
+      "meaning": "to leave a place for a reason",
+      "example": "Pete just stepped out to buy chewing gum.",
+      "translation": "rời đi",
+      "count": 0
+    },
+    {
+      "word": "go off /ɡəʊ ɒf/",
+      "meaning": "to stop liking something or someone",
+      "example": "For some reason, I’m no longer into peanuts.",
+      "translation": "không còn ưa thích",
+      "count": 0
+    },
+    {
+      "word": "go together /ɡəʊ təˈɡeðər/",
+      "meaning": "to often exist at the same time",
+      "example": "Why are poverty and crime so often linked?",
+      "translation": "đi liền với nhau",
+      "count": 0
+    },
+    {
+      "word": "go together /ɡəʊ təˈɡeðər/",
+      "meaning": "to match well in appearance or combination",
+      "example": "Do this top and this skirt match?",
+      "translation": "phù hợp",
+      "count": 0
+    },
+    {
+      "word": "grow on /ɡrəʊ ɒn/",
+      "meaning": "to gradually become more liked or appreciated",
+      "example": "I didn’t like that painting at first, but it’s growing on me.",
+      "translation": "khiến ai bắt đầu thích",
+      "count": 0
+    },
+    {
+      "word": "hang out /hæŋ aʊt/",
+      "meaning": "to lean out of a window so part of your body is outside",
+      "example": "Don’t hang out of the window or you’ll fall!",
+      "translation": "thò đầu/ người ra khỏi (cửa sổ)",
+      "count": 0
+    },
+    {
+      "word": "hang out /hæŋ aʊt/",
+      "meaning": "to spend time relaxing with others",
+      "example": "We often just hang out at each other’s houses.",
+      "translation": "hẹn hò, đi chơi",
+      "count": 0
+    },
+    {
+      "word": "head off /hed ɒf/",
+      "meaning": "to block someone from going somewhere",
+      "example": "One police officer chased the robber while the other went to head him off.",
+      "translation": "chặn đường",
+      "count": 0
+    },
+    {
+      "word": "head off /hed ɒf/",
+      "meaning": "to prevent something bad from happening",
+      "example": "The UN has sent emergency aid into the area to head off a catastrophe.",
+      "translation": "ngăn chặn",
+      "count": 0
+    },
+    {
+      "word": "heat up /hiːt ʌp/",
+      "meaning": "to make something hot or become hot",
+      "example": "Heat up the baby’s milk, would you?",
+      "translation": "(làm) nóng lên",
+      "count": 0
+    },
+    {
+      "word": "hit back /hɪt bæk/",
+      "meaning": "to retaliate verbally against criticism",
+      "example": "The Minister hit back at his critics.",
+      "translation": "phản pháo",
+      "count": 0
+    },
+    {
+      "word": "hit back /hɪt bæk/",
+      "meaning": "to strike or harm someone in return",
+      "example": "If someone hits you, think before you hit back next time.",
+      "translation": "trả đòn",
+      "count": 0
+    },
+    {
+      "word": "knock/pull/tear down /nɒk pʊl teə daʊn/",
+      "meaning": "to demolish a structure such as a building",
+      "example": "I see they’ve finally knocked the old factory down.",
+      "translation": "đổ bỏ, phá hủy",
+      "count": 0
+    },
+    {
+      "word": "lash out /læʃ aʊt/",
+      "meaning": "to strongly criticize or attack someone verbally",
+      "example": "They lashed out at the council’s move to stop free parking.",
+      "translation": "chỉ trích, đả kích",
+      "count": 0
+    },
+    {
+      "word": "lash out /læʃ aʊt/",
+      "meaning": "to suddenly try to hit or attack violently",
+      "example": "Occasionally the patients will lash out at the nurses.",
+      "translation": "tấn công",
+      "count": 0
+    },
+    {
+      "word": "lay off /leɪ ɒf/",
+      "meaning": "to dismiss someone from a job due to lack of work",
+      "example": "They’ve had to cut back production and lay off workers.",
+      "translation": "sa thải",
+      "count": 0
+    },
+    {
+      "word": "lay off /leɪ ɒf/",
+      "meaning": "to stop doing or using something for a period",
+      "example": "Lay off teasing your brother, Julie!",
+      "translation": "ngừng",
+      "count": 0
+    },
+    {
+      "word": "laze around /leɪz əˈraʊnd/",
+      "meaning": "to relax and do nothing productive",
+      "example": "I’m just planning to laze around this weekend.",
+      "translation": "nghỉ xả hơi",
+      "count": 0
+    },
+    {
+      "word": "let on /let ɒn/",
+      "meaning": "to reveal something that was meant to be a secret",
+      "example": "He knows more than he lets on.",
+      "translation": "tiết lộ",
+      "count": 0
+    },
+    {
+      "word": "lie ahead /laɪ əˈhed/",
+      "meaning": "to be something that is going to happen in the future",
+      "example": "A bright future lies ahead of him.",
+      "translation": "trước mắt, ở tương lai",
+      "count": 0
+    },
+    {
+      "word": "liven up /ˈlaɪvn ʌp/",
+      "meaning": "to enhance something’s appearance or taste",
+      "example": "You can liven up a plain shirt with a colourful scarf.",
+      "translation": "làm đẹp hơn",
+      "count": 0
+    },
+    {
+      "word": "liven up /ˈlaɪvn ʌp/",
+      "meaning": "to make something more fun or exciting",
+      "example": "What we needed was some music to liven things up.",
+      "translation": "làm thú vị hơn, cải thiện",
+      "count": 0
+    },
+    {
+      "word": "hit upon /hɪt əˈpɒn/",
+      "meaning": "to discover something unexpectedly",
+      "example": "She was scared he might hit upon the truth.",
+      "translation": "tình cờ phát hiện",
+      "count": 0
+    },
+    {
+      "word": "hit upon /hɪt əˈpɒn/",
+      "meaning": "to suddenly come up with an idea",
+      "example": "They hit upon the idea of celebrating the occasion with a concert.",
+      "translation": "chợt nghĩ ra",
+      "count": 0
+    },
+    {
+      "word": "hold back /həʊld bæk/",
+      "meaning": "to prevent someone or something from moving forward",
+      "example": "The police held back the crowd.",
+      "translation": "giữ lại",
+      "count": 0
+    },
+    {
+      "word": "keep up /kiːp ʌp/",
+      "meaning": "to continue doing something",
+      "example": "I don’t think I can afford to keep up my piano lessons.",
+      "translation": "tiếp tục",
+      "count": 0
+    },
+    {
+      "word": "keep up /kiːp ʌp/",
+      "meaning": "to move at the same pace as someone or something",
+      "example": "Dan walks so fast that it’s not easy to keep up with him.",
+      "translation": "theo kịp",
+      "count": 0
+    },
+    {
+      "word": "key in /kiː ɪn/",
+      "meaning": "to enter data into a computer using a keyboard",
+      "example": "All you have to do is key your details in and the computer does the rest.",
+      "translation": "nhập liệu, đánh máy",
+      "count": 0
+    },
+    {
+      "word": "kick off (with) /kɪk ɒf (/wɪð/)",
+      "meaning": "to begin something",
+      "example": "I’d like to kick off with a quick look at last month’s sales figures.",
+      "translation": "bắt đầu",
+      "count": 0
+    },
+    {
+      "word": "kill off /kɪl ɒf/",
+      "meaning": "to eliminate or destroy living things completely",
+      "example": "The pollution killed off all the fish in the lake.",
+      "translation": "tàn sát",
+      "count": 0
+    },
+    {
+      "word": "knock off /nɒk ɒf/",
+      "meaning": "to stop working, usually at the end of the day",
+      "example": "Do you want to knock off early tonight?",
+      "translation": "ngừng làm việc",
+      "count": 0
+    },
+    {
+      "word": "lock up /lɒk ʌp/",
+      "meaning": "to lock all doors and windows of a building",
+      "example": "I must have forgotten to lock up when I left this morning.",
+      "translation": "khóa toàn bộ cửa",
+      "count": 0
+    },
+    {
+      "word": "lock up /lɒk ʌp/",
+      "meaning": "to imprison someone",
+      "example": "They should lock him up for a very long time, if you ask me.",
+      "translation": "tống giam",
+      "count": 0
+    },
+    {
+      "word": "make into /meɪk ˈɪntuː/",
+      "meaning": "to transform something into something else",
+      "example": "It’s as if my parents are trying to make me into the ideal student, so I’m under a lot of pressure.",
+      "translation": "biến đổi thành",
+      "count": 0
+    },
+    {
+      "word": "make out /meɪk aʊt/",
+      "meaning": "to be able to see, hear, or understand something with difficulty",
+      "example": "Can you make out a face here in the photograph?",
+      "translation": "nhận ra, xác định",
+      "count": 0
+    },
+    {
+      "word": "make over /meɪk ˈəʊvər/",
+      "meaning": "to improve the appearance of someone or something",
+      "example": "They made over three contestants on the show. When they’d finished, they looked completely different.",
+      "translation": "chỉnh trang, thay đổi diện mạo",
+      "count": 0
+    },
+    {
+      "word": "make up /meɪk ʌp/",
+      "meaning": "to work extra hours to compensate for lost time",
+      "example": "Sorry I’m late; I’ll make up the time this evening.",
+      "translation": "bù vào",
+      "count": 0
+    },
+    {
+      "word": "meet up /miːt ʌp/",
+      "meaning": "to get together with someone",
+      "example": "Why don’t we meet up when I’m in Berlin, since it’s not far from you?",
+      "translation": "gặp gỡ",
+      "count": 0
+    },
+    {
+      "word": "mess about/around /mes əˈbaʊt əˈraʊnd/",
+      "meaning": "to behave in a silly or playful way",
+      "example": "Mrs Evans asked the children to stop messing around.",
+      "translation": "hành xử ngớ ngẩn",
+      "count": 0
+    },
+    {
+      "word": "step aside /step əˈsaɪd/",
+      "meaning": "to move out of the way to let someone pass",
+      "example": "We stepped aside to let someone in a wheelchair through.",
+      "translation": "nhường đường",
+      "count": 0
+    },
+    {
+      "word": "stop off /stɒp ɒf/",
+      "meaning": "to make a short visit somewhere during a journey",
+      "example": "We can stop off at the bakery on the way to school.",
+      "translation": "nghỉ giữa đường",
+      "count": 0
+    },
+    {
+      "word": "store up /stɔːr ʌp/",
+      "meaning": "to cause problems in the future by not dealing with them now",
+      "example": "If you ignore it, you’re just storing up problems for the future.",
+      "translation": "tích lũy, dồn nén",
+      "count": 0
+    },
+    {
+      "word": "store up /stɔːr ʌp/",
+      "meaning": "to collect a large supply of something for future use",
+      "example": "Squirrels store up nuts for the winter.",
+      "translation": "tích trữ",
+      "count": 0
+    },
+    {
+      "word": "summon up /ˈsʌmən ʌp/",
+      "meaning": "to find the courage or strength to do something difficult",
+      "example": "He couldn’t summon up the strength to carry on fighting.",
+      "translation": "dồn hết can đảm/ sức lực để làm gì",
+      "count": 0
+    },
+    {
+      "word": "swot up (on) /swɒt ʌp/ (/ɒn/)",
+      "meaning": "to study intensively for a test or exam",
+      "example": "I’ve got to swot up on the French Revolution for tomorrow’s test.",
+      "translation": "học gạo",
+      "count": 0
+    },
+    {
+      "word": "take after /teɪk ˈɑːftər/",
+      "meaning": "to resemble an older family member in appearance or behavior",
+      "example": "Doesn’t she take after her mother?",
+      "translation": "giống",
+      "count": 0
+    },
+    {
+      "word": "take apart /teɪk əˈpɑːt/",
+      "meaning": "to disassemble something into its component parts",
+      "example": "I took my computer apart completely, but I still didn’t find the problem.",
+      "translation": "tách rời, tách nhỏ",
+      "count": 0
+    },
+    {
+      "word": "take away /teɪk əˈweɪ/",
+      "meaning": "to subtract one number or quantity from another",
+      "example": "If you take three away from five, you’re left with two.",
+      "translation": "trừ, bớt đi",
+      "count": 0
+    },
+    {
+      "word": "take down /teɪk daʊn/",
+      "meaning": "to dismantle a large structure",
+      "example": "After the play, we had to take down all the scenery.",
+      "translation": "tháo dỡ",
+      "count": 0
+    },
+    {
+      "word": "take in /teɪk ɪn/",
+      "meaning": "to write down information or statements",
+      "example": "The police took down my details.",
+      "translation": "ghi chép lại",
+      "count": 0
+    },
+    {
+      "word": "take in /teɪk ɪn/",
+      "meaning": "to accept something as true or real",
+      "example": "He still hasn’t really taken in his father’s death.",
+      "translation": "chấp nhận",
+      "count": 0
+    },
+    {
+      "word": "take in /teɪk ɪn/",
+      "meaning": "to include or encompass something",
+      "example": "The tour takes in some incredible scenery.",
+      "translation": "bao gồm",
+      "count": 0
+    },
+    {
+      "word": "take off /teɪk ɒf/",
+      "meaning": "to quickly become successful or popular",
+      "example": "The new design took off immediately.",
+      "translation": "phát lên",
+      "count": 0
+    },
+    {
+      "word": "take on /teɪk ɒn/",
+      "meaning": "to accept a task or responsibility",
+      "example": "I can’t take on any more work at the moment.",
+      "translation": "nhận nhiệm vụ",
+      "count": 0
+    },
+    {
+      "word": "take out /teɪk aʊt/",
+      "meaning": "to invite someone out and pay for them",
+      "example": "On my birthday, he took me out for dinner.",
+      "translation": "đưa đi chơi",
+      "count": 0
+    },
+    {
+      "word": "take over /teɪk ˈəʊvər/",
+      "meaning": "to begin doing something in place of someone else",
+      "example": "When my dad retired, I took over the business.",
+      "translation": "tiếp quản",
+      "count": 0
+    },
+    {
+      "word": "take over /teɪk ˈəʊvər/",
+      "meaning": "to assume control of something",
+      "example": "Whenever we start organising something, you always want to take over.",
+      "translation": "nắm quyền kiểm soát",
+      "count": 0
+    },
+    {
+      "word": "take to /teɪk tə/",
+      "meaning": "to develop a liking for something or someone",
+      "example": "I didn’t take to living here straight away.",
+      "translation": "bắt đầu thích",
+      "count": 0
+    },
+    {
+      "word": "take to /teɪk tə/",
+      "meaning": "to start a new habit",
+      "example": "I’ve taken to getting up much earlier.",
+      "translation": "bắt đầu thói quen",
+      "count": 0
+    },
+    {
+      "word": "talk down to /tɔːk daʊn tə/",
+      "meaning": "to speak in a condescending way",
+      "example": "I hate the way Belinda talks down to people.",
+      "translation": "lên giọng kể cả",
+      "count": 0
+    },
+    {
+      "word": "talk over /tɔːk ˈəʊvər/",
+      "meaning": "to discuss a plan or issue",
+      "example": "Let’s talk it over tonight.",
+      "translation": "thảo luận",
+      "count": 0
+    },
+    {
+      "word": "talk round /tɔːk raʊnd/",
+      "meaning": "to persuade someone to agree",
+      "example": "I can talk her round.",
+      "translation": "thuyết phục được",
+      "count": 0
+    },
+    {
+      "word": "test out /test aʊt/",
+      "meaning": "to try a machine or product to see if it works well",
+      "example": "I’m taking my new model aeroplane to the park to test it out.",
+      "translation": "thử nghiệm",
+      "count": 0
+    },
+    {
+      "word": "think over /θɪŋk ˈəʊvər/",
+      "meaning": "to carefully consider an idea or decision",
+      "example": "Let’s think over his proposal before we see him again.",
+      "translation": "cân nhắc kỹ",
+      "count": 0
+    },
+    {
+      "word": "think through /θɪŋk θruː/",
+      "meaning": "to analyze something in a detailed way",
+      "example": "Have you thought things through?",
+      "translation": "xem xét",
+      "count": 0
+    },
+    {
+      "word": "think up /θɪŋk ʌp/",
+      "meaning": "to invent or imagine something, especially as an excuse",
+      "example": "She’d have to think up a good reason for being late.",
+      "translation": "bịa ra",
+      "count": 0
+    },
+    {
+      "word": "throw out /θrəʊ aʊt/",
+      "meaning": "to expel someone from a group or place",
+      "example": "Charlie was thrown out of the Scouts.",
+      "translation": "đuổi, tống cổ",
+      "count": 0
+    },
+    {
+      "word": "throw out /θrəʊ aʊt/",
+      "meaning": "to discard unwanted items",
+      "example": "We’re throwing these things out.",
+      "translation": "vứt bỏ",
+      "count": 0
+    },
+    {
+      "word": "throw up /θrəʊ ʌp/",
+      "meaning": "to cause dust or particles to rise into the air",
+      "example": "As the helicopter landed, it threw up a lot of dust.",
+      "translation": "làm bắn tung lên",
+      "count": 0
+    },
+    {
+      "word": "throw up /θrəʊ ʌp/",
+      "meaning": "to unexpectedly cause or reveal something new",
+      "example": "The new rules have thrown up a few problems.",
+      "translation": "tạo ra bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "tide over /taɪd ˈəʊvər/",
+      "meaning": "to help someone get through a difficult time, often by giving money",
+      "example": "Ed lent me £50 to tide me over until payday.",
+      "translation": "giúp vượt qua khó khăn",
+      "count": 0
+    },
+    {
+      "word": "tip up /tɪp ʌp/",
+      "meaning": "to lift or tilt one end of something upward due to weight on the other end",
+      "example": "The bench began to tip up and he sat on it.",
+      "translation": "nghiêng",
+      "count": 0
+    },
+    {
+      "word": "tip up /tɪp ʌp/",
+      "meaning": "to turn something upside down to empty its contents",
+      "example": "He picked the box up and emptied everything onto the table.",
+      "translation": "lật úp",
+      "count": 0
+    },
+    {
+      "word": "touch up /tʌtʃ ʌp/",
+      "meaning": "to make slight improvements to the appearance of something",
+      "example": "Touch up the paintwork before you try to sell the house.",
+      "translation": "trau chuốt, sửa sang",
+      "count": 0
+    },
+    {
+      "word": "try out /traɪ aʊt/",
+      "meaning": "to test something to see how well it works",
+      "example": "We’re trying out the new system.",
+      "translation": "dùng thử",
+      "count": 0
+    },
+    {
+      "word": "turn into /tɜːn ˈɪntuː/",
+      "meaning": "to transform into something else",
+      "example": "The sofa turns into a bed, so you can stay with us, if you like.",
+      "translation": "chuyển thành",
+      "count": 0
+    },
+    {
+      "word": "turn into /tɜːn ˈɪntuː/",
+      "meaning": "to convert or change something into a different form",
+      "example": "They’ve turned the old factory into luxury flats.",
+      "translation": "biến thành",
+      "count": 0
+    },
+    {
+      "word": "use up /juːz ʌp/",
+      "meaning": "to consume all of something",
+      "example": "Did you use the butter up when you were making cakes?",
+      "translation": "dùng hết, dùng cạn sạch",
+      "count": 0
+    },
+    {
+      "word": "walk out /wɔːk aʊt/",
+      "meaning": "to leave an event early due to anger or boredom",
+      "example": "I walked out halfway through the film.",
+      "translation": "rời đi (vì giận)",
+      "count": 0
+    },
+    {
+      "word": "walk out /wɔːk aʊt/",
+      "meaning": "to suddenly abandon a relationship, job, or responsibility",
+      "example": "You can’t just walk out like this!",
+      "translation": "dứt ngọt bỏ đi, rời khỏi",
+      "count": 0
+    },
+    {
+      "word": "ward off /wɔːd ɒf/",
+      "meaning": "to take action to prevent harm or danger",
+      "example": "Sheila carried a knife to ward off attacks.",
+      "translation": "phòng ngừa",
+      "count": 0
+    },
+    {
+      "word": "warm up /wɔːm ʌp/",
+      "meaning": "to do light exercises to prepare for a physical activity",
+      "example": "It’s very important to warm up before you exercise.",
+      "translation": "khởi động",
+      "count": 0
+    },
+    {
+      "word": "waste away /weɪst ə weɪ/",
+      "meaning": "to become very thin and weak due to illness or neglect",
+      "example": "He hadn’t eaten properly for weeks and was starting to waste away.",
+      "translation": "dần trở nên gầy gò",
+      "count": 0
+    },
+    {
+      "word": "water down /ˈwɔːtə daʊn/",
+      "meaning": "to dilute a liquid by adding water",
+      "example": "If it’s too strong, water it down.",
+      "translation": "pha loãng",
+      "count": 0
+    },
+    {
+      "word": "water down /ˈwɔːtə daʊn/",
+      "meaning": "to make something less powerful, detailed, or offensive",
+      "example": "The editor watered my article down.",
+      "translation": "làm dịu",
+      "count": 0
+    },
+    {
+      "word": "wear down /weə daʊn/",
+      "meaning": "to gradually reduce someone's energy or confidence",
+      "example": "This constant criticism at work is really wearing me down.",
+      "translation": "làm hao mòn",
+      "count": 0
+    },
+    {
+      "word": "wear down /weə daʊn/",
+      "meaning": "to erode or thin out something with use or friction",
+      "example": "These shoes are uncomfortable because the heel has worn down.",
+      "translation": "hư mòn",
+      "count": 0
+    },
+    {
+      "word": "wear out /weə aʊt/",
+      "meaning": "to use something until it is no longer usable",
+      "example": "On my walking holiday, I wore out three pairs of boots.",
+      "translation": "làm món cũ, hư hỏng",
+      "count": 0
+    },
+    {
+      "word": "weigh down /weɪ daʊn/",
+      "meaning": "to burden someone mentally or emotionally",
+      "example": "The entire industry has been weighed down by economic uncertainty.",
+      "translation": "đè nén, gây lo âu",
+      "count": 0
+    },
+    {
+      "word": "weigh down /weɪ daʊn/",
+      "meaning": "to physically burden someone or something with weight",
+      "example": "The waiters were weighed down by huge trays of food.",
+      "translation": "đè nặng lên",
+      "count": 0
+    },
+    {
+      "word": "while away /waɪl ə weɪ/",
+      "meaning": "to spend time in a relaxed and leisurely way",
+      "example": "We whiled away the Saturday afternoon sitting by the lake.",
+      "translation": "giết thời gian",
+      "count": 0
+    },
+    {
+      "word": "wind down /waɪnd daʊn/",
+      "meaning": "to gradually come to an end",
+      "example": "The party started to wind down around 2 a.m.",
+      "translation": "dần tàn, dần chấm dứt",
+      "count": 0
+    },
+    {
+      "word": "wind down /waɪnd daʊn/",
+      "meaning": "to slowly reduce business activity before stopping",
+      "example": "The factory will wind down production before closing next year.",
+      "translation": "dần đóng cửa",
+      "count": 0
+    },
+    {
+      "word": "wind down /waɪnd daʊn/",
+      "meaning": "to relax after stress or excitement",
+      "example": "It’s hard to wind down after doing such a stressful job all day.",
+      "translation": "thả giãn, xả hơi",
+      "count": 0
+    },
+    {
+      "word": "write off /raɪt ɒf/",
+      "meaning": "to damage a vehicle so badly that it is no longer worth fixing",
+      "example": "My uncle wrote his car off in an accident last weekend.",
+      "translation": "làm hỏng nặng",
+      "count": 0
+    },
+    {
+      "word": "write off /raɪt ɒf/",
+      "meaning": "to give up on someone or something as a failure",
+      "example": "He felt hopeless; his teachers had written him off.",
+      "translation": "từ bỏ, xóa sổ",
+      "count": 0
+    },
+    {
+      "word": "throw the book at sb",
+      "meaning": "to punish someone very harshly",
+      "example": "They’ll really throw the book at him this time.",
+      "translation": "trừng phạt ai đó thật nghiêm khắc",
+      "count": 0
+    },
+    {
+      "word": "tidy sum/amount",
+      "meaning": "a large amount of money",
+      "example": "I’ve managed to put away a tidy sum this year.",
+      "translation": "khoản lớn",
+      "count": 0
+    },
+    {
+      "word": "touch wood",
+      "meaning": "said to prevent bad luck after talking about good luck",
+      "example": "I’ll find a new job before too long, touch wood.",
+      "translation": "phỉ phui, trộm vía",
+      "count": 0
+    },
+    {
+      "word": "turn over a new leaf",
+      "meaning": "to make a fresh start and behave better",
+      "example": "Ralph seems to have turned over a new leaf this term.",
+      "translation": "có một khởi đầu mới",
+      "count": 0
+    },
+    {
+      "word": "under sb’s thumb",
+      "meaning": "completely under someone else's control",
+      "example": "I became self-employed because I was sick of being under someone’s thumb.",
+      "translation": "không thoát khỏi bàn tay của ai",
+      "count": 0
+    },
+    {
+      "word": "up in arms about",
+      "meaning": "angry and vocally protesting against something",
+      "example": "Everyone in the office is up in arms about having to work next weekend.",
+      "translation": "buồn bực, tức giận vì điều gì",
+      "count": 0
+    },
+    {
+      "word": "variety is the spice of life",
+      "meaning": "having different experiences makes life more interesting",
+      "example": "I do a million different things at work, but I suppose variety is the spice of life.",
+      "translation": "sự đa dạng là gia vị cuộc sống",
+      "count": 0
+    },
+    {
+      "word": "your flesh and blood",
+      "meaning": "a person related to you by blood",
+      "example": "My family is very important to me because, after all, they’re my flesh and blood.",
+      "translation": "họ hàng thân thuộc",
+      "count": 0
+    },
+    {
+      "word": "out of the blue",
+      "meaning": "very unexpectedly",
+      "example": "Then, suddenly, out of the blue, she said she wanted a divorce.",
+      "translation": "hoàn toàn bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "out of this world",
+      "meaning": "extremely good or impressive",
+      "example": "The food at that restaurant is out of this world!",
+      "translation": "tuyệt vời, không thể nào tốt hơn được",
+      "count": 0
+    },
+    {
+      "word": "over the top",
+      "meaning": "excessive or more than necessary",
+      "example": "Don’t think spending 500 euros on a dress was a bit over the top?",
+      "translation": "quá mức, vượt xa",
+      "count": 0
+    },
+    {
+      "word": "pride of place",
+      "meaning": "the most prominent or important position",
+      "example": "This stamp’s extremely rare, and takes pride of place in my stamp collection.",
+      "translation": "vị trí cao quý",
+      "count": 0
+    },
+    {
+      "word": "pull a few strings",
+      "meaning": "to use influential contacts to gain an advantage",
+      "example": "I don’t think it’s fair to pull strings in order to get a job.",
+      "translation": "nhờ vả mối quan hệ",
+      "count": 0
+    },
+    {
+      "word": "put sth in perspective",
+      "meaning": "to compare with something else to make it easier to understand the importance",
+      "example": "My illness has certainly put everything else in perspective.",
+      "translation": "nhận xét, đánh giá đúng vị trí",
+      "count": 0
+    },
+    {
+      "word": "put two and two together",
+      "meaning": "to figure something out based on what you’ve seen or heard",
+      "example": "He didn’t tell us he was retiring, but we could all put two and two together.",
+      "translation": "đoán trước sự việc",
+      "count": 0
+    },
+    {
+      "word": "put your feet up",
+      "meaning": "to sit back and relax",
+      "example": "Put your feet up and I’ll make dinner.",
+      "translation": "thư giãn",
+      "count": 0
+    },
+    {
+      "word": "quick/slow on the uptake",
+      "meaning": "quick/slow to understand something",
+      "example": "I’m sure Chad understood what you were suggesting; he’s very quick on the uptake.",
+      "translation": "hiểu nhanh/chậm",
+      "count": 0
+    },
+    {
+      "word": "recharge your batteries",
+      "meaning": "to rest and regain energy",
+      "example": "Why don’t you take a week off work to recharge your batteries?",
+      "translation": "sạc pin, nạp năng lượng",
+      "count": 0
+    },
+    {
+      "word": "red tape",
+      "meaning": "excessive bureaucracy or official procedures",
+      "example": "Is there a lot of red tape involved in getting a passport?",
+      "translation": "thủ tục giấy tờ",
+      "count": 0
+    },
+    {
+      "word": "reinvent the wheel",
+      "meaning": "to waste time doing something that has already been done effectively",
+      "example": "Just use the same document you used last time, because there’s no point reinventing the wheel.",
+      "translation": "phí công tái tạo",
+      "count": 0
+    },
+        {
+      "word": "ring a bell",
+      "meaning": "to sound familiar without being completely remembered",
+      "example": "The name rings a bell but I’m not sure if I’ve ever met her.",
+      "translation": "nghe hơi quen",
+      "count": 0
+    },
+    {
+      "word": "round the bend",
+      "meaning": "to be mentally unstable or extremely annoyed",
+      "example": "That noise is driving me round the bend.",
+      "translation": "điên rồi",
+      "count": 0
+    },
+    {
+      "word": "satellite town",
+      "meaning": "a small city near a larger one, relying on it for services or employment",
+      "example": "Brentwood is a satellite town just outside London.",
+      "translation": "thành phố vệ tinh",
+      "count": 0
+    },
+    {
+      "word": "sb is only human",
+      "meaning": "used to excuse someone’s mistake because everyone makes them",
+      "example": "I’m sorry I made a mistake, but I’m only human.",
+      "translation": "ai đó cũng chỉ là người thôi",
+      "count": 0
+    },
+    {
+      "word": "see eye to eye (with sb)",
+      "meaning": "to completely agree with someone",
+      "example": "Imogen and I have never really seen eye to eye.",
+      "translation": "đồng tình với ai",
+      "count": 0
+    },
+    {
+      "word": "set your heart on",
+      "meaning": "to want something very strongly",
+      "example": "I had set my heart on getting married on the beach, but the bad weather meant we couldn’t.",
+      "translation": "mong muốn điều gì đó xảy ra",
+      "count": 0
+    },
+    {
+      "word": "six of one (and) half a dozen of the other",
+      "meaning": "when two things are equally good or bad",
+      "example": "It’s six of one and half a dozen of the other, really.",
+      "translation": "kẻ tám lạng, người nửa cân",
+      "count": 0
+    },
+    {
+      "word": "speak volumes",
+      "meaning": "to reveal a lot without using words",
+      "example": "What he said to Mandy speaks volumes about the way he treats his staff.",
+      "translation": "biểu lộ sự thật mà không cần nói ra",
+      "count": 0
+    },
+    {
+      "word": "split hairs",
+      "meaning": "to make unnecessary distinctions in details",
+      "example": "Whether you call them ‘terrorists’ or ‘freedom fighters’ is just splitting hairs – the point is that they’re killing people!",
+      "translation": "cãi nhau vì những điều không quan trọng",
+      "count": 0
+    },
+    {
+      "word": "steal the show",
+      "meaning": "to attract the most attention or praise",
+      "example": "There was one comedian who really stole the show. She was fantastic!",
+      "translation": "chiếm sóng, đột phá",
+      "count": 0
+    },
+    {
+      "word": "stick to your guns",
+      "meaning": "to keep your position even under pressure",
+      "example": "I admire Kelly for the way she always sticks to her guns.",
+      "translation": "giữ vững niềm tin",
+      "count": 0
+    },
+    {
+      "word": "stop dead in your tracks",
+      "meaning": "to stop suddenly and completely",
+      "example": "When I heard the gunshot, I stopped dead in my tracks.",
+      "translation": "dừng đột ngột",
+      "count": 0
+    },
+    {
+      "word": "take a short cut (to)",
+      "meaning": "to go via a faster or shorter path",
+      "example": "I walked to school and I used to take a short cut along the canal.",
+      "translation": "đi đường tắt",
+      "count": 0
+    },
+    {
+      "word": "take stock (of)",
+      "meaning": "to evaluate the current situation before acting",
+      "example": "Let’s take a couple of days to take stock of the situation and then we’ll make a decision.",
+      "translation": "dành nhiều thời gian để nghĩ bước tiếp theo",
+      "count": 0
+    },
+    {
+      "word": "take the law into your own hands",
+      "meaning": "to deal with problems by yourself instead of using the legal system",
+      "example": "I know you’re angry, but that’s no reason to take the law into your own hands.",
+      "translation": "tự thi hành luật rừng",
+      "count": 0
+    },
+    {
+      "word": "take the scenic route",
+      "meaning": "to choose a longer but more pleasant path",
+      "example": "We’re not lost – we’re just taking the scenic route.",
+      "translation": "đi đường vòng để ngắm cảnh",
+      "count": 0
+    },
+    {
+      "word": "tell tales",
+      "meaning": "to report someone’s bad behavior, often unfairly",
+      "example": "Toby, stop telling tales about your classmates.",
+      "translation": "mách lẻo, đặt điều",
+      "count": 0
+    },
+    {
+      "word": "the edge over",
+      "meaning": "a slight advantage over someone else",
+      "example": "Our product’s got the edge over the competition because it’s so lightweight.",
+      "translation": "lợi thế hơn so với ai",
+      "count": 0
+    },
+    {
+      "word": "the luck of the draw",
+      "meaning": "something that depends purely on chance",
+      "example": "I never wanted to become a butcher, but I guess that’s the luck of the draw.",
+      "translation": "hên xui",
+      "count": 0
+    },
+    {
+      "word": "the other day",
+      "meaning": "a short time ago",
+      "example": "There was an interesting item on the news the other day.",
+      "translation": "một hôm, gần đây",
+      "count": 0
+    },
+    {
+      "word": "the powers that be",
+      "meaning": "people who hold the authority in a situation",
+      "example": "I don’t know if the powers that be will agree to that.",
+      "translation": "người nắm quyền",
+      "count": 0
+    },
+    {
+      "word": "the tools of the trade",
+      "meaning": "essential skills and equipment for a job",
+      "example": "A good bedside manner is one of the tools of the trade for a doctor.",
+      "translation": "các công cụ, đồ nghề",
+      "count": 0
+    },
+    {
+      "word": "live and let live",
+      "meaning": "to accept others’ differences and let them be",
+      "example": "I don’t agree with what he’s doing, but live and let live, I say.",
+      "translation": "sống để mà dễ sống",
+      "count": 0
+    },
+    {
+      "word": "lock, stock and barrel",
+      "meaning": "including everything completely",
+      "example": "They’ve sold all their possessions, lock, stock and barrel.",
+      "translation": "tất thảy",
+      "count": 0
+    },
+    {
+      "word": "lose your bearings",
+      "meaning": "to become confused about where you are or what to do",
+      "example": "I lost my bearings for a moment, but then realised where I was.",
+      "translation": "hoang mang, mất phương hướng",
+      "count": 0
+    },
+    {
+      "word": "make a beeline for",
+      "meaning": "to move quickly and directly toward someone or something",
+      "example": "As soon as we arrived at the hotel, Molly made a beeline for the manager to complain.",
+      "translation": "tiến thẳng về phía ai/cái gì",
+      "count": 0
+    },
+    {
+      "word": "make yourself at home",
+      "meaning": "to behave as if you are in your own house, feeling comfortable and relaxed",
+      "example": "Charles will be down in a moment, so please make yourselves at home.",
+      "translation": "cư xử như ở nhà",
+      "count": 0
+    },
+    {
+      "word": "never/don’t look a gift horse in the mouth",
+      "meaning": "to not criticize or question something you received for free",
+      "example": "The flat wasn’t in very good condition, but we were staying there rent-free, and you should never look a gift horse in the mouth, should you?",
+      "translation": "đừng xét nét quà tặng",
+      "count": 0
+    },
+    {
+      "word": "no rhyme or reason",
+      "meaning": "with no clear explanation or logical pattern",
+      "example": "There seems to be no rhyme or reason for the decision.",
+      "translation": "chẳng ra sao, vô lý",
+      "count": 0
+    },
+    {
+      "word": "not have a leg to stand on",
+      "meaning": "to lack proof or a valid argument in a discussion",
+      "example": "George tried to argue that the world was flat, but of course he didn’t have a leg to stand on.",
+      "translation": "không thể nào chứng minh mình đúng",
+      "count": 0
+    },
+    {
+      "word": "not see the wood for the trees",
+      "meaning": "to focus too much on details and miss the overall picture",
+      "example": "Many people can’t see the wood for the trees when talking about joining the eurozone; they just think about what’s on the notes and coins and don’t think about the economic benefits.",
+      "translation": "chỉ thấy cây mà không thấy rừng",
+      "count": 0
+    },
+    {
+      "word": "off the beaten track",
+      "meaning": "in a place not often visited or well known",
+      "example": "We like to get off the beaten track when we go on holiday.",
+      "translation": "nơi ít người biết đến",
+      "count": 0
+    },
+    {
+      "word": "on good terms (with)",
+      "meaning": "having a positive relationship with someone",
+      "example": "When I left the job, I was still on good terms with everyone in the office.",
+      "translation": "có mối quan hệ tốt với",
+      "count": 0
+    },
+    {
+      "word": "on the spur of the moment",
+      "meaning": "doing something suddenly without thinking it through",
+      "example": "We booked the holiday on the spur of the moment. We hadn’t been planning to take a break at all this summer.",
+      "translation": "nổi hứng làm gì",
+      "count": 0
+    },
+    {
+      "word": "on the street",
+      "meaning": "without a home to live in",
+      "example": "Life is hard on the street.",
+      "translation": "vô gia cư",
+      "count": 0
+    },
+    {
+      "word": "on the town",
+      "meaning": "enjoying nightlife in a city",
+      "example": "Did you go out on the town on your birthday?",
+      "translation": "đi chơi tận hưởng",
+      "count": 0
+    },
+    {
+      "word": "once in a blue moon",
+      "meaning": "very infrequently or rarely",
+      "example": "To be honest, I only go to museums once in a blue moon. I just don’t have time usually.",
+      "translation": "hiếm khi",
+      "count": 0
+    },
+    {
+      "word": "over the moon",
+      "meaning": "very delighted or joyful",
+      "example": "She was over the moon about her results.",
+      "translation": "cực kỳ vui sướng",
+      "count": 0
+    },
+    {
+      "word": "part and parcel",
+      "meaning": "an unavoidable and necessary part of something",
+      "example": "Working irregular hours is all part and parcel of being a journalist.",
+      "translation": "phần không thể thiếu",
+      "count": 0
+    },
+    {
+      "word": "pass the buck",
+      "meaning": "to avoid responsibility by blaming someone else",
+      "example": "The minister tried to pass the buck by blaming his civil servants for the mistake.",
+      "translation": "đùn đẩy trách nhiệm",
+      "count": 0
+    },
+    {
+      "word": "play it by ear",
+      "meaning": "to decide how to deal with a situation as it happens",
+      "example": "We can’t make a decision yet. Let’s just play it by ear.",
+      "translation": "tùy cơ ứng biến",
+      "count": 0
+    },
+    {
+      "word": "pride yourself on",
+      "meaning": "to feel pleased about a skill or quality you have",
+      "example": "Emily prides herself on her skills as a negotiator.",
+      "translation": "tự hào về điều gì",
+      "count": 0
+    },
+    {
+      "word": "pull a fast one",
+      "meaning": "to deceive or trick someone",
+      "example": "You paid £200 for that? He really pulled a fast one on you!",
+      "translation": "lừa đảo",
+      "count": 0
+    },
+    {
+      "word": "put your cards on the table",
+      "meaning": "to speak openly and honestly about your intentions",
+      "example": "I’m going to lay my cards on the table and offer you an extra £1,000. But that’s my final offer!",
+      "translation": "thẳng thắn nói rõ",
+      "count": 0
+    },
+    {
+      "word": "put your feet up",
+      "meaning": "to rest and relax, especially after working",
+      "example": "Put your feet up for half an hour – you look absolutely exhausted.",
+      "translation": "nghỉ ngơi, thư giãn",
+      "count": 0
+    },
+    {
+      "word": "put your money where your mouth is",
+      "meaning": "to support what you say by actions or financial commitment",
+      "example": "If you’re really serious about quitting your job, it’s time to put your money where your mouth is and hand in your resignation.",
+      "translation": "thể hiện niềm tin bằng hành động",
+      "count": 0
+    },
+    {
+      "word": "put yourself in someone else’s shoes",
+      "meaning": "to imagine yourself in another person’s position",
+      "example": "Try to put yourself in her shoes – how would you feel if your boss spoke to you like that?",
+      "translation": "đặt mình vào vị trí người khác",
+      "count": 0
+    },
+    {
+      "word": "read between the lines",
+      "meaning": "to understand an implicit message not directly expressed",
+      "example": "He didn’t seem too upset, but I suppose you have to read between the lines.",
+      "translation": "đọc giữa các dòng",
+      "count": 0
+    },
+    {
+      "word": "red herring",
+      "meaning": "a misleading clue or distraction from the main issue",
+      "example": "His remarks about the Prime Minister were just a red herring to distract attention from the main issue.",
+      "translation": "đánh lạc hướng",
+      "count": 0
+    },
+    {
+      "word": "red-letter day",
+      "meaning": "a very special or memorable day",
+      "example": "It was a red-letter day when we moved into our new house.",
+      "translation": "ngày đáng nhớ",
+      "count": 0
+    },
+    {
+      "word": "reinvent the wheel",
+      "meaning": "to waste effort doing something that has already been done successfully",
+      "example": "Just use the same document you used last time, because there’s no point reinventing the wheel.",
+      "translation": "phí công tái tạo",
+      "count": 0
+    },
+    {
+      "word": "ring a bell",
+      "meaning": "to sound familiar or remind you of something",
+      "example": "The name rings a bell, but I’m not sure if I’ve ever met her.",
+      "translation": "nghe quen quen",
+      "count": 0
+    },
+    {
+      "word": "do sth on a whim",
+      "meaning": "to do something spontaneously without planning",
+      "example": "Wendy decided on a whim to redecorate the whole house.",
+      "translation": "làm chuyện gì một cách ngẫu hứng",
+      "count": 0
+    },
+    {
+      "word": "down on your luck",
+      "meaning": "to experience a prolonged period of bad fortune or hardship",
+      "example": "The man was obviously down on his luck, so I gave him a little money.",
+      "translation": "gặp khó khăn",
+      "count": 0
+    },
+    {
+      "word": "draw the line (at)",
+      "meaning": "to set a limit beyond which you will not go",
+      "example": "I don’t mind you borrowing money, but I draw the line at you taking it without asking.",
+      "translation": "không đồng ý hoàn toàn",
+      "count": 0
+    },
+    {
+      "word": "fly off the handle",
+      "meaning": "to become very angry suddenly and without warning",
+      "example": "Whatever she says, don’t fly off the handle. Stay calm!",
+      "translation": "nổi khùng",
+      "count": 0
+    },
+    {
+      "word": "zealous (adjective)",
+      "meaning": "filled with intense enthusiasm or passion",
+      "example": "Last spring, a zealous political activist lived in a tree to ensure it wouldn't be cut down.",
+      "translation": "nhiệt huyết",
+      "count": 0
+    },
+    {
+      "word": "follow your nose",
+      "meaning": "to go straight ahead without turning",
+      "example": "Once you go past the traffic lights, just follow your nose.",
+      "translation": "cứ đi thẳng đường rẽ",
+      "count": 0
+    },
+    {
+      "word": "zenith (noun)",
+      "meaning": "the highest point or most successful period",
+      "example": "The zenith of Bert's career was when he sang on stage at the Grand Old Opry.",
+      "translation": "đỉnh cao",
+      "count": 0
+    },
+    {
+      "word": "step aside",
+      "meaning": "to leave a position so someone else can take over",
+      "example": "The chairman stepped aside to allow a younger person to take over.",
+      "translation": "về hưu",
+      "count": 0
+    },
+    {
+      "word": "for the time being",
+      "meaning": "temporarily, for now",
+      "example": "I’m staying in rented accommodation for the time being, but hope to buy a place early next year.",
+      "translation": "trong lúc này",
+      "count": 0
+    },
+    {
+      "word": "smarten up",
+      "meaning": "to improve the appearance of something",
+      "example": "This room needs smartening up.",
+      "translation": "cải thiện bề ngoài, cải tạo",
+      "count": 0
+    },
+    {
+      "word": "from time to time",
+      "meaning": "occasionally, not frequently",
+      "example": "We see Brian from time to time, but not regularly.",
+      "translation": "đôi khi",
+      "count": 0
+    },
+    {
+      "word": "gain/get/have/take the upper hand",
+      "meaning": "to gain control or a favorable position over someone",
+      "example": "It looked like Ivor was going to win the game, but I soon got the upper hand.",
+      "translation": "đoạt quyền kiểm soát hoặc lợi ích hơn",
+      "count": 0
+    },
+    {
+      "word": "get on like a house on fire",
+      "meaning": "to get along very well and become friends quickly",
+      "example": "George and Isabelle seem to be getting on like a house on fire, don’t they?",
+      "translation": "có quan hệ hòa thuận",
+      "count": 0
+    },
+    {
+      "word": "get sth off your chest",
+      "meaning": "to share something that has been worrying you",
+      "example": "It feels such a relief to have got this off my chest.",
+      "translation": "giãi bày tâm sự",
+      "count": 0
+    },
+    {
+      "word": "get the wrong end of the stick",
+      "meaning": "to misunderstand something completely",
+      "example": "Don said he was going to France and I got the wrong end of the stick and thought he was moving there forever.",
+      "translation": "hiểu lầm",
+      "count": 0
+    },
+    {
+      "word": "get/catch sb’s drift",
+      "meaning": "to understand the general meaning of what someone is saying",
+      "example": "Doreen and I have been having some problems recently, if you catch my drift.",
+      "translation": "nắm được ý chính",
+      "count": 0
+    },
+    {
+      "word": "give sb a taste/dose of their own medicine",
+      "meaning": "to treat someone the same unpleasant way they treat others",
+      "example": "He got me into trouble, so I’m going to give him a taste of his own medicine!",
+      "translation": "trả đũa",
+      "count": 0
+    },
+    {
+      "word": "give sb your word",
+      "meaning": "to make a sincere promise",
+      "example": "I give you my word I won’t tell anyone.",
+      "translation": "hứa hẹn với ai",
+      "count": 0
+    },
+    {
+      "word": "give sth a miss",
+      "meaning": "to decide not to do something you usually do",
+      "example": "I think I’ll give the office party a miss this year.",
+      "translation": "không làm việc gì",
+      "count": 0
+    },
+    {
+      "word": "go halves",
+      "meaning": "to share the cost of something equally",
+      "example": "Let’s go halves on the meal, shall we?",
+      "translation": "mỗi người trả phần mình",
+      "count": 0
+    },
+    {
+      "word": "go to your head",
+      "meaning": "to let success make you arrogant or proud",
+      "example": "I hope getting that scholarship doesn’t go to Carol’s head.",
+      "translation": "kiêu căng, ngạo mạn",
+      "count": 0
+    },
+    {
+      "word": "grin and bear it",
+      "meaning": "to endure something unpleasant without complaining",
+      "example": "Alan just has to grin and bear it because he needs a bad review.",
+      "translation": "ngậm bồ hòn làm ngọt",
+      "count": 0
+    },
+    {
+      "word": "have a change of heart",
+      "meaning": "to change your opinion or decision about something",
+      "example": "Y. Williams had a change of heart and decided not to go to university after all.",
+      "translation": "đổi ý",
+      "count": 0
+    },
+    {
+      "word": "have green fingers",
+      "meaning": "to be naturally skilled at gardening and growing plants",
+      "example": "My wife’s always had green fingers, whereas I don’t know anything about growing plants.",
+      "translation": "có tài trồng cây",
+      "count": 0
+    },
+    {
+      "word": "have time on your hands",
+      "meaning": "to have more free time than needed or expected",
+      "example": "Julie has a lot more time on her hands now that her children have all left home.",
+      "translation": "dư thời gian",
+      "count": 0
+    },
+    {
+      "word": "have your wits about you",
+      "meaning": "to be alert and capable of making quick, smart decisions",
+      "example": "You’ve got to have your wits about you when dealing with pushy salespeople.",
+      "translation": "thông thái",
+      "count": 0
+    },
+    {
+      "word": "hear (sth) on/through the grapevine",
+      "meaning": "to hear news or gossip from informal sources",
+      "example": "I heard through the grapevine you might be getting married soon.",
+      "translation": "nghe từ nguồn tin không chính thức",
+      "count": 0
+    },
+    {
+      "word": "be born with a silver spoon in your mouth",
+      "meaning": "to be born into a wealthy or privileged family",
+      "example": "I’ve always had to work hard because I wasn’t born with a silver spoon in my mouth.",
+      "translation": "sinh ra đã ngậm thìa vàng, sinh ra ở vạch đích",
+      "count": 0
+    },
+    {
+      "word": "be on the same wavelength",
+      "meaning": "to share the same thoughts, feelings, or ideas as someone else",
+      "example": "It was a difficult meeting because David and I didn’t seem to be on the same wavelength.",
+      "translation": "cùng tần số, cùng quan điểm",
+      "count": 0
+    },
+    {
+      "word": "blot on the landscape",
+      "meaning": "something unattractive that spoils a view or location",
+      "example": "Many people in the town think that the old factory is a blot on the landscape.",
+      "translation": "phá hủy phong cảnh",
+      "count": 0
+    },
+    {
+      "word": "break even",
+      "meaning": "to neither make a profit nor suffer a loss",
+      "example": "We didn’t make a profit last year, but we did break even.",
+      "translation": "hòa vốn",
+      "count": 0
+    },
+    {
+      "word": "break the mould",
+      "meaning": "to do something in a completely new or different way",
+      "example": "Her innovative approach really broke the mould in design.",
+      "translation": "phá cách",
+      "count": 0
+    },
+    {
+      "word": "bury your head in the sand",
+      "meaning": "to avoid dealing with a problem by pretending it doesn't exist",
+      "example": "You can’t just bury your head in the sand and expect things to improve.",
+      "translation": "làm đà điểu, trốn tránh sự thật",
+      "count": 0
+    },
+    {
+      "word": "change your tune",
+      "meaning": "to shift your opinion or attitude",
+      "example": "He changed his tune quickly after hearing the full story.",
+      "translation": "đổi ý",
+      "count": 0
+    },
+    {
+      "word": "clean as a whistle",
+      "meaning": "completely honest and without wrongdoing",
+      "example": "His background check came back clean as a whistle.",
+      "translation": "trong sạch",
+      "count": 0
+    },
+    {
+      "word": "clean as a whistle (exterior)",
+      "meaning": "spotlessly clean or tidy",
+      "example": "The kitchen was as clean as a whistle after she finished cleaning.",
+      "translation": "sạch bong",
+      "count": 0
+    },
+    {
+      "word": "come clean (about sth)",
+      "meaning": "to confess something you’ve been hiding",
+      "example": "He finally came clean about breaking the vase.",
+      "translation": "nói sự thật",
+      "count": 0
+    },
+    {
+      "word": "come rain or shine",
+      "meaning": "no matter what the circumstances are",
+      "example": "She goes jogging every day, come rain or shine.",
+      "translation": "dù thế nào đi chăng nữa",
+      "count": 0
+    },
+    {
+      "word": "commuter belt",
+      "meaning": "suburban area where many people travel into a nearby city for work",
+      "example": "The commuter belt around London has grown significantly.",
+      "translation": "khu vực vành đai thành phố",
+      "count": 0
+    },
+    {
+      "word": "concrete jungle",
+      "meaning": "a crowded urban area with many ugly buildings",
+      "example": "He grew up in a concrete jungle with barely any green spaces.",
+      "translation": "rừng bê tông, khu vực nhà cửa san sát",
+      "count": 0
+    },
+    {
+      "word": "couch potato",
+      "meaning": "someone who watches a lot of television and doesn't exercise",
+      "example": "Ever since he retired, he’s turned into a couch potato.",
+      "translation": "người hay xem tivi và lười vận động",
+      "count": 0
+    },
+    {
+      "word": "cry over spilt milk",
+      "meaning": "to be upset about something that cannot be undone",
+      "example": "It’s no use crying over spilt milk—just buy a new one.",
+      "translation": "tiếc rẻ con gà quạ tha",
+      "count": 0
+    },
+    {
+      "word": "set up /set ʌp/",
+      "meaning": "to assemble or place something in position",
+      "example": "They set up a shelter in the woods.",
+      "translation": "xây dựng",
+      "count": 0
+    },
+    {
+      "word": "shout down /ʃaʊt daʊn/",
+      "meaning": "to prevent someone from speaking by yelling",
+      "example": "Angry protesters shouted him down before he could speak.",
+      "translation": "la ó, hét lớn",
+      "count": 0
+    },
+    {
+      "word": "shrivel up /ˈʃrɪvəl ʌp/",
+      "meaning": "to lose strength or volume and become smaller",
+      "example": "The leaves shriveled up during the drought.",
+      "translation": "giảm sút",
+      "count": 0
+    },
+    {
+      "word": "single out /ˈsɪŋɡl aʊt/",
+      "meaning": "to choose one individual for special attention",
+      "example": "He was singled out for his bravery.",
+      "translation": "chọn ra",
+      "count": 0
+    },
+    {
+      "word": "size up /saɪz ʌp/",
+      "meaning": "to evaluate a person or situation",
+      "example": "She sized up the competition before the match.",
+      "translation": "đánh giá",
+      "count": 0
+    },
+    {
+      "word": "slip away /slɪp əˈweɪ/",
+      "meaning": "to leave without being noticed",
+      "example": "She slipped away during the break.",
+      "translation": "lẻn đi",
+      "count": 0
+    },
+    {
+      "word": "slip up /slɪp ʌp/",
+      "meaning": "to make a careless error",
+      "example": "He slipped up and entered the wrong password.",
+      "translation": "sơ suất",
+      "count": 0
+    },
+    {
+      "word": "smart up /smɑːt ʌp/",
+      "meaning": "to improve your appearance or outfit",
+      "example": "You need to smarten up before meeting the client.",
+      "translation": "làm đẹp lên",
+      "count": 0
+    },
+    {
+      "word": "snow under /ˈsnəʊ ˈʌndər/",
+      "meaning": "to be overwhelmed with tasks or work",
+      "example": "We’re snowed under with deadlines this week.",
+      "translation": "ngập trong việc",
+      "count": 0
+    },
+    {
+      "word": "sound out /saʊnd aʊt/",
+      "meaning": "to ask questions to find out someone's views",
+      "example": "They sounded out the staff about the new policy.",
+      "translation": "dò hỏi ý kiến",
+      "count": 0
+    },
+    {
+      "word": "speak out /spiːk aʊt/",
+      "meaning": "to express your opinion publicly and clearly",
+      "example": "She spoke out against injustice at the rally.",
+      "translation": "lên tiếng, nói rõ",
+      "count": 0
+    },
+	    {
+      "word": "spread out /spred aʊt/",
+      "meaning": "to move apart from each other within a group",
+      "example": "The hikers spread out across the trail to explore.",
+      "translation": "tản ra",
+      "count": 0
+    },
+    {
+      "word": "spring up /sprɪŋ ʌp/",
+      "meaning": "to appear or grow suddenly",
+      "example": "Small shops have sprung up everywhere in town.",
+      "translation": "đột ngột xuất hiện",
+      "count": 0
+    },
+    {
+      "word": "stand out /stænd aʊt/",
+      "meaning": "to be noticeably different or easy to recognize",
+      "example": "Her red coat made her stand out in the photo.",
+      "translation": "nổi bật",
+      "count": 0
+    },
+    {
+      "word": "stand up to /stænd ʌp tə/",
+      "meaning": "to resist or confront someone firmly",
+      "example": "She stood up to the bullies without hesitation.",
+      "translation": "đứng lên chống lại",
+      "count": 0
+    },
+    {
+      "word": "step aside /step əˈsaɪd/",
+      "meaning": "to leave a role to let someone else take over",
+      "example": "The CEO stepped aside to allow new leadership.",
+      "translation": "từ chức",
+      "count": 0
+    },
+    {
+      "word": "step down /step daʊn/",
+      "meaning": "to resign from a position of responsibility",
+      "example": "He decided to step down after the merger.",
+      "translation": "từ bỏ chức vụ",
+      "count": 0
+    },
+    {
+      "word": "step up /step ʌp/",
+      "meaning": "to increase intensity or take more action",
+      "example": "We stepped up production to meet demand.",
+      "translation": "tăng cường",
+      "count": 0
+    },
+    {
+      "word": "stick out /stɪk aʊt/",
+      "meaning": "to extend beyond the surface or edge",
+      "example": "Her elbow stuck out of the window.",
+      "translation": "nhô ra",
+      "count": 0
+    },
+    {
+      "word": "storm out /stɔːm aʊt/",
+      "meaning": "to leave angrily and abruptly",
+      "example": "She stormed out after the argument.",
+      "translation": "bỏ đi",
+      "count": 0
+    },
+    {
+      "word": "sum up /sʌm ʌp/",
+      "meaning": "to give a brief account or conclusion",
+      "example": "He summed up his thoughts at the end of the meeting.",
+      "translation": "tóm tắt",
+      "count": 0
+    },
+    {
+      "word": "switch off /swɪtʃ ɒf/",
+      "meaning": "to stop paying attention or stop a device",
+      "example": "I switched off after the first 10 minutes of the lecture.",
+      "translation": "ngừng tập trung",
+      "count": 0
+    },
+    {
+      "word": "tag along /tæɡ əˈlɒŋ/",
+      "meaning": "to go somewhere with someone without being invited",
+      "example": "I tagged along with them to the fair.",
+      "translation": "theo sau",
+      "count": 0
+    },
+    {
+      "word": "tail off /teɪl ɒf/",
+      "meaning": "to decrease in intensity or amount gradually",
+      "example": "His speech tailed off as he lost confidence.",
+      "translation": "giảm dần",
+      "count": 0
+    },
+    {
+      "word": "talk down /tɔːk daʊn/",
+      "meaning": "to speak to someone as if they are less intelligent",
+      "example": "He constantly talks down to junior staff.",
+      "translation": "nói giọng hạ thấp",
+      "count": 0
+    },
+    {
+      "word": "talk into /tɔːk ˈɪntə/",
+      "meaning": "to persuade someone to do something",
+      "example": "They talked me into signing up for the race.",
+      "translation": "thuyết phục ai làm gì",
+      "count": 0
+    },
+    {
+      "word": "talk out of /tɔːk ˈaʊt əv/",
+      "meaning": "to persuade someone not to do something",
+      "example": "She talked me out of quitting the job.",
+      "translation": "thuyết phục ai không làm gì",
+      "count": 0
+    },
+    {
+      "word": "tear down /teər daʊn/",
+      "meaning": "to demolish or destroy a structure",
+      "example": "The old stadium was torn down last year.",
+      "translation": "phá hủy",
+      "count": 0
+    },
+    {
+      "word": "think over /θɪŋk ˈəʊvə/",
+      "meaning": "to consider something thoroughly",
+      "example": "I'll need time to think over your suggestion.",
+      "translation": "cân nhắc kỹ",
+      "count": 0
+    },
+    {
+      "word": "throw away /θrəʊ əˈweɪ/",
+      "meaning": "to dispose of something no longer needed",
+      "example": "She threw away the broken headphones.",
+      "translation": "vứt bỏ",
+      "count": 0
+    },
+    {
+      "word": "throw out /θrəʊ aʊt/",
+      "meaning": "to remove or reject someone or something forcefully",
+      "example": "The club threw him out for bad behavior.",
+      "translation": "đuổi ra",
+      "count": 0
+    },
+    {
+      "word": "tick off /tɪk ɒf/",
+      "meaning": "to scold or reprimand",
+      "example": "The manager ticked off the employee for being late.",
+      "translation": "trách mắng",
+      "count": 0
+    },
+    {
+      "word": "tip off /tɪp ɒf/",
+      "meaning": "to secretly inform or alert someone",
+      "example": "A neighbor tipped off the police about the robbery.",
+      "translation": "báo tin",
+      "count": 0
+    },
+    {
+      "word": "top off /tɒp ɒf/",
+      "meaning": "to complete something in a special way",
+      "example": "We topped off the night with fireworks.",
+      "translation": "hoàn thành",
+      "count": 0
+    },
+    {
+      "word": "tune in /tjuːn ɪn/",
+      "meaning": "to watch or listen to a broadcast",
+      "example": "Tune in to the show at 9 PM sharp.",
+      "translation": "điều chỉnh",
+      "count": 0
+    },
+    {
+      "word": "turn away /tɜːn əˈweɪ/",
+      "meaning": "to deny someone entry or access",
+      "example": "They turned away visitors at the gate.",
+      "translation": "từ chối cho vào",
+      "count": 0
+    },
+    {
+      "word": "turn out /tɜːn aʊt/",
+      "meaning": "to end up being or happening in a particular way",
+      "example": "The concert turned out better than expected.",
+      "translation": "hóa ra là",
+      "count": 0
+    },
+    {
+      "word": "use up /juːz ʌp/",
+      "meaning": "to consume all of something",
+      "example": "She used up all the paper printing drafts.",
+      "translation": "sử dụng hết",
+      "count": 0
+    },
+    {
+      "word": "walk out /wɔːk aʊt/",
+      "meaning": "to leave a place suddenly, especially in protest",
+      "example": "Several employees walked out over the new contract terms.",
+      "translation": "rời đi bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "wear out /weər aʊt/",
+      "meaning": "to become extremely tired or damaged from use",
+      "example": "I was worn out after the long hike.",
+      "translation": "mệt mỏi rã rời",
+      "count": 0
+    },
+    {
+      "word": "mess about/around /mes əˈbaʊt əˈraʊnd/",
+      "meaning": "to spend time doing unimportant or relaxing things",
+      "example": "We spent the afternoon messing around by the river.",
+      "translation": "thư giãn",
+      "count": 0
+    },
+    {
+      "word": "mess up /mes ʌp/",
+      "meaning": "to make a mistake or do something incorrectly",
+      "example": "He messed up the recipe by adding too much salt.",
+      "translation": "gây lỗi, làm sai",
+      "count": 0
+    },
+    {
+      "word": "mix up /mɪks ʌp/",
+      "meaning": "to confuse or jumble items or information",
+      "example": "The files got mixed up on my desk.",
+      "translation": "trộn lẫn",
+      "count": 0
+    },
+    {
+      "word": "mount up /maʊnt ʌp/",
+      "meaning": "to increase greatly in number or amount",
+      "example": "Our expenses quickly mounted up this month.",
+      "translation": "tăng vọt",
+      "count": 0
+    },
+    {
+      "word": "move in (with) /muːv ɪn (wɪð)/",
+      "meaning": "to begin living in a new home or with someone else",
+      "example": "She moved in with her sister last weekend.",
+      "translation": "chuyển tới (nơi ở mới)",
+      "count": 0
+    },
+    {
+      "word": "move on /muːv ɒn/",
+      "meaning": "to leave a place and go somewhere else",
+      "example": "After the project ended, we moved on to another city.",
+      "translation": "rời đi",
+      "count": 0
+    },
+    {
+      "word": "move out /muːv aʊt/",
+      "meaning": "to leave your place of residence permanently",
+      "example": "They finally moved out of their apartment last month.",
+      "translation": "rời khỏi (nơi ở cũ)",
+      "count": 0
+    },
+    {
+      "word": "move over /muːv ˈəʊvər/",
+      "meaning": "to shift aside to make space",
+      "example": "Please move over so I can sit down.",
+      "translation": "dịch sang",
+      "count": 0
+    },
+    {
+      "word": "mull over /mʌl ˈəʊvər/",
+      "meaning": "to think deeply about something",
+      "example": "He’s still mulling over the job offer.",
+      "translation": "nghiền ngẫm",
+      "count": 0
+    },
+    {
+      "word": "open up /ˈəʊpən ʌp/",
+      "meaning": "to become accessible or available for use or activity",
+      "example": "New markets have opened up overseas.",
+      "translation": "mở cửa",
+      "count": 0
+    },
+    {
+      "word": "opt out (of) /ɒpt aʊt (əv)/",
+      "meaning": "to choose not to participate in something",
+      "example": "She opted out of the company retreat this year.",
+      "translation": "chọn không tham gia",
+      "count": 0
+    },
+    {
+      "word": "paper over /ˈpeɪpər ˈəʊvər/",
+      "meaning": "to hide a problem instead of solving it",
+      "example": "They tried to paper over their differences during the interview.",
+      "translation": "che giấu",
+      "count": 0
+    },
+    {
+      "word": "pass away/on /pɑːs əˈweɪ/",
+      "meaning": "to die in a gentle or respectful way",
+      "example": "Her grandfather passed away last night.",
+      "translation": "qua đời",
+      "count": 0
+    },
+    {
+      "word": "patch up /pætʃ ʌp/",
+      "meaning": "to fix a disagreement and restore good relations",
+      "example": "They patched up their friendship after a long talk.",
+      "translation": "hàn gắn",
+      "count": 0
+    },
+    {
+      "word": "pay back /peɪ bæk/",
+      "meaning": "to return money that was borrowed",
+      "example": "Don’t worry, I’ll pay you back tomorrow.",
+      "translation": "hoàn trả",
+      "count": 0
+    },
+    {
+      "word": "pay out /peɪ aʊt/",
+      "meaning": "to spend a large amount of money",
+      "example": "The company paid out bonuses to all staff.",
+      "translation": "trả",
+      "count": 0
+    },
+    {
+      "word": "phase out /feɪz aʊt/",
+      "meaning": "to gradually stop using or producing something",
+      "example": "The old version of the app is being phased out.",
+      "translation": "loại bỏ dần",
+      "count": 0
+    },
+    {
+      "word": "pick on /pɪk ɒn/",
+      "meaning": "to repeatedly treat someone unfairly",
+      "example": "The older kids picked on him every day.",
+      "translation": "trêu chọc",
+      "count": 0
+    },
+    {
+      "word": "pick out /pɪk aʊt/",
+      "meaning": "to choose or identify someone or something",
+      "example": "She picked out the best dress in the shop.",
+      "translation": "đón",
+      "count": 0
+    },
+    {
+      "word": "pick up /pɪk ʌp/",
+      "meaning": "to gradually collect or learn something",
+      "example": "I picked up some Spanish while traveling.",
+      "translation": "lắp ghép thông tin",
+      "count": 0
+    },
+    {
+      "word": "piece together /piːs təˈɡeðər/",
+      "meaning": "to learn the truth by linking separate bits of information",
+      "example": "Police are piecing together what happened that night.",
+      "translation": "chất đống",
+      "count": 0
+    },
+    {
+      "word": "pile up /paɪl ʌp/",
+      "meaning": "to accumulate or increase in number or amount, often causing stress or difficulty",
+      "example": "The assignments began to pile up right before the exams.",
+      "translation": "gây khó chịu",
+      "count": 0
+    },
+    {
+      "word": "play up /pleɪ ʌp/",
+      "meaning": "to behave badly or cause problems",
+      "example": "My knee has been playing up again recently.",
+      "translation": "quyết tâm tiến hành",
+      "count": 0
+    }
+  ],
+  "idioms": [
+    {
+      "word": "keep a straight face",
+      "meaning": "to stay serious and not laugh",
+      "example": "She struggled to keep a straight face during the prank.",
+      "translation": "giữ vẻ mặt nghiêm túc",
+      "count": 0
+    },
+    {
+      "word": "keep sb posted",
+      "meaning": "to give someone regular updates or information",
+      "example": "I’ll keep you posted on any changes to the schedule.",
+      "translation": "thường xuyên cập nhật thông tin",
+      "count": 0
+    },
+    {
+      "word": "keep sth under your hat",
+      "meaning": "to keep something secret or confidential",
+      "example": "Keep this under your hat, but I'm planning a surprise party.",
+      "translation": "giữ bí mật",
+      "count": 0
+    },
+    {
+      "word": "keep up with the Joneses",
+      "meaning": "to try to match your neighbors in spending or lifestyle",
+      "example": "She bought a luxury car just to keep up with the Joneses.",
+      "translation": "đu đòi",
+      "count": 0
+    },
+    {
+      "word": "keep your hair on",
+      "meaning": "used to tell someone to stay calm and not get angry",
+      "example": "Keep your hair on! It’s just a mistake.",
+      "translation": "bình tĩnh nào",
+      "count": 0
+    },
+    {
+      "word": "kick yourself",
+      "meaning": "to feel bad about a mistake or missed opportunity",
+      "example": "I could have kicked myself for not applying sooner.",
+      "translation": "dằn vặt bản thân",
+      "count": 0
+    },
+    {
+      "word": "knee-high to a grasshopper",
+      "meaning": "very young or small",
+      "example": "I’ve known her since I was knee-high to a grasshopper.",
+      "translation": "lúc còn nhỏ xíu",
+      "count": 0
+    },
+    {
+      "word": "know sth inside out",
+      "meaning": "to know something very thoroughly",
+      "example": "He knows the system inside out.",
+      "translation": "biết tường tận",
+      "count": 0
+    },
+    {
+      "word": "know what’s what",
+      "meaning": "to be well-informed about a subject or situation",
+      "example": "She’s been in the business long enough to know what’s what.",
+      "translation": "hiểu rõ cái gì ra cái gì",
+      "count": 0
+    },
+    {
+      "word": "last word in sth",
+      "meaning": "the most recent and best example of something",
+      "example": "This phone is the last word in mobile technology.",
+      "translation": "kiểu mới nhất, thành tựu mới nhất",
+      "count": 0
+    },
+    {
+      "word": "lay/put your cards on the table",
+      "meaning": "to be open and honest about your plans or intentions",
+      "example": "He laid all his cards on the table during negotiations.",
+      "translation": "thẳng thắn nói hết ra",
+      "count": 0
+    },
+    {
+      "word": "let nature take its course",
+      "meaning": "to allow events to unfold naturally without interference",
+      "example": "Let’s not interfere and let nature take its course.",
+      "translation": "hãy cứ để tự nhiên đi",
+      "count": 0
+    },
+    {
+      "word": "let off steam",
+      "meaning": "to release anger or frustration",
+      "example": "He went for a run to let off steam after the argument.",
+      "translation": "xả hơi, xả giận",
+      "count": 0
+    },
+    {
+      "word": "let sleeping dogs lie",
+      "meaning": "to avoid mentioning a problem so as not to cause trouble",
+      "example": "Let’s not bring it up—better to let sleeping dogs lie.",
+      "translation": "chuyện đã qua hãy để cho qua đi",
+      "count": 0
+    },
+    {
+      "word": "let your hair down",
+      "meaning": "to relax and enjoy oneself",
+      "example": "After the exams, everyone let their hair down and partied.",
+      "translation": "xõa đi",
+      "count": 0
+    },
+    {
+      "word": "life and soul of the party",
+      "meaning": "a person who is lively and entertaining at social events",
+      "example": "He’s always the life and soul of the party.",
+      "translation": "linh hồn của bữa tiệc",
+      "count": 0
+    },
+    {
+      "word": "like two peas in a pod",
+      "meaning": "very similar in appearance or behavior",
+      "example": "Those twins are like two peas in a pod.",
+      "translation": "giống như hai giọt nước",
+      "count": 0
+    },
+    {
+      "word": "line your pocket(s)",
+      "meaning": "to earn money dishonestly or unfairly",
+      "example": "The contractor was found guilty of lining his pockets.",
+      "translation": "vì tiền mà bất chấp, mờ mắt vì tiền",
+      "count": 0
+    },
+    {
+      "word": "Your guess is as good as mine",
+      "meaning": "used to say that you don't know the answer either",
+      "example": "I have no clue where he went—your guess is as good as mine.",
+      "translation": "tôi cũng không biết",
+      "count": 0
+    },
+    {
+      "word": "Speak of the devil",
+      "meaning": "used when someone being talked about appears",
+      "example": "Speak of the devil—there he is now!",
+      "translation": "vừa nhắc đã tới",
+      "count": 0
+    },
+    {
+      "word": "Not a spark of decency",
+      "meaning": "completely lacking manners or respect",
+      "example": "He interrupted the whole meeting—what a lack of decency.",
+      "translation": "không có một chút lịch sự nào",
+      "count": 0
+    },
+    {
+      "word": "In the heat of the moment",
+      "meaning": "while strongly affected by emotion or stress",
+      "example": "He said some harsh things in the heat of the moment.",
+      "translation": "trong lúc mất bình tĩnh",
+      "count": 0
+    },
+    {
+      "word": "Hear it on the grapevine",
+      "meaning": "to hear gossip or unofficial information",
+      "example": "I heard on the grapevine that they might cancel the event.",
+      "translation": "nghe phong thanh",
+      "count": 0
+    },
+   {
+      "word": "Devil’s Advocate",
+      "meaning": "someone who supports a contrary or unpopular view to spark debate.",
+      "example": "I wasn’t serious — just playing devil’s advocate to see how you'd respond.",
+      "translation": "người cố ý phản biện để tranh luận",
+      "count": 0
+    },
+    {
+      "word": "Under his thumb",
+      "meaning": "completely controlled by someone.",
+      "example": "She won’t make a move without asking him — she’s totally under his thumb.",
+      "translation": "bị kiểm soát hoàn toàn",
+      "count": 0
+    },
+    {
+      "word": "By fits and starts",
+      "meaning": "happening irregularly or inconsistently.",
+      "example": "His progress on the book came by fits and starts, never steady.",
+      "translation": "lúc được lúc không",
+      "count": 0
+    },
+    {
+      "word": "Out of the way",
+      "meaning": "unusual or uncommon.",
+      "example": "She always comes up with the most out-of-the-way solutions.",
+      "translation": "kỳ lạ, không thông thường",
+      "count": 0
+    },
+    {
+      "word": "Be in a tight corner",
+      "meaning": "facing a difficult or troubling situation.",
+      "example": "After missing the deadline, he found himself in a tight corner with his manager.",
+      "translation": "rơi vào tình huống khó khăn",
+      "count": 0
+    },
+    {
+      "word": "Keep one’s fingers crossed",
+      "meaning": "hope strongly for a good outcome.",
+      "example": "I’ve got an interview today — keep your fingers crossed for me!",
+      "translation": "cầu mong điều tốt đẹp xảy ra",
+      "count": 0
+    },
+    {
+      "word": "The gift of the gab",
+      "meaning": "the ability to speak easily and persuasively.",
+      "example": "He talked his way into the job — he really has the gift of the gab.",
+      "translation": "khả năng ăn nói lưu loát",
+      "count": 0
+    },
+    {
+      "word": "Cost an arm and a leg",
+      "meaning": "be extremely expensive.",
+      "example": "Their wedding cost an arm and a leg, but it was worth every penny.",
+      "translation": "rất đắt đỏ",
+      "count": 0
+    },
+    {
+      "word": "Smell a rat",
+      "meaning": "suspect that something is wrong or dishonest.",
+      "example": "When he refused to show the documents, I began to smell a rat.",
+      "translation": "nghi ngờ có điều khuất tất",
+      "count": 0
+    },
+    {
+      "word": "By hook or by crook",
+      "meaning": "using any method necessary, fair or unfair.",
+      "example": "He promised to win the deal by hook or by crook.",
+      "translation": "bằng mọi cách",
+      "count": 0
+    },
+    {
+      "word": "Spread like a wildfire",
+      "meaning": "circulate or expand very quickly.",
+      "example": "Rumors about their breakup spread like wildfire.",
+      "translation": "lan truyền nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "Out of gear",
+      "meaning": "stopped or disrupted from functioning properly.",
+      "example": "The sudden announcement threw the whole operation out of gear.",
+      "translation": "lệch nhịp, rối loạn",
+      "count": 0
+    },
+    {
+      "word": "Die in harness",
+      "meaning": "continue working until death.",
+      "example": "He remained a teacher until the end — he died in harness.",
+      "translation": "chết khi vẫn đang làm việc",
+      "count": 0
+    },
+    {
+      "word": "To be snowed under",
+      "meaning": "be overwhelmed with work or tasks.",
+      "example": "She’s snowed under with deadlines at the moment.",
+      "translation": "bận ngập đầu",
+      "count": 0
+    },
+    {
+      "word": "To get the sack",
+      "meaning": "be dismissed from a job.",
+      "example": "He got the sack for repeated tardiness.",
+      "translation": "bị sa thải",
+      "count": 0
+    },
+    {
+      "word": "Don’t give up a day’s job",
+      "meaning": "not be good enough at something to do it professionally.",
+      "example": "Your singing’s fun, but don’t give up your day job just yet!",
+      "translation": "chưa đủ giỏi để theo nghề",
+      "count": 0
+    },
+    {
+      "word": "To balance the books",
+      "meaning": "ensure expenses and income are equal.",
+      "example": "The accountant worked late to balance the books before the audit.",
+      "translation": "cân bằng sổ sách tài chính",
+      "count": 0
+    },
+    {
+      "word": "A ball park figure",
+      "meaning": "an approximate estimate.",
+      "example": "Just give me a ballpark figure for the cost, not the exact amount.",
+      "translation": "con số ước lượng",
+      "count": 0
+    },
+    {
+      "word": "Yellow press",
+      "meaning": "media that emphasizes sensationalism over facts.",
+      "example": "The yellow press blew the story out of proportion.",
+      "translation": "báo lá cải",
+      "count": 0
+    },
+    {
+      "word": "A nine day’s Wonder",
+      "meaning": "something popular for a short time and then forgotten.",
+      "example": "The viral challenge was a nine day’s wonder.",
+      "translation": "sớm nở chóng tàn",
+      "count": 0
+    },
+    {
+      "word": "One swallow does not make a summer",
+      "meaning": "drawing conclusions from a single instance is unreliable",
+      "example": "Just because the first meeting went well doesn't mean the deal will succeed — one swallow doesn’t make a summer.",
+      "translation": "một cánh én không làm nên mùa xuân",
+      "count": 0
+    },
+    {
+      "word": "To move heaven and earth",
+      "meaning": "to try everything possible to achieve something",
+      "example": "She moved heaven and earth to get her son into that school.",
+      "translation": "cố gắng hết sức",
+      "count": 0
+    },
+    {
+      "word": "A miss is as good as a mile",
+      "meaning": "a failure is still a failure, even if it's close",
+      "example": "He was just one vote short, but a miss is as good as a mile.",
+      "translation": "sai một ly đi một dặm",
+      "count": 0
+    },
+    {
+      "word": "Lock, stock and barrel",
+      "meaning": "everything included, completely",
+      "example": "They sold the business lock, stock and barrel.",
+      "translation": "toàn bộ",
+      "count": 0
+    },
+    {
+      "word": "Make hay while the sun shines",
+      "meaning": "take advantage of favorable conditions",
+      "example": "You should invest now — make hay while the sun shines.",
+      "translation": "tranh thủ lúc thuận lợi",
+      "count": 0
+    },
+    {
+      "word": "All that glitters are not gold",
+      "meaning": "things that look valuable might not be",
+      "example": "The apartment seemed nice online, but all that glitters is not gold.",
+      "translation": "chớ thấy sáng loáng mà tưởng là vàng",
+      "count": 0
+    },
+    {
+      "word": "To jump from a frying pan into fire",
+      "meaning": "to move from a bad situation to a worse one",
+      "example": "She left one toxic job only to jump into another — from the frying pan into the fire.",
+      "translation": "tránh vỏ dưa gặp vỏ dừa",
+      "count": 0
+    },
+    {
+      "word": "Foul play",
+      "meaning": "dishonest or criminal behavior",
+      "example": "The police suspected foul play after finding the door broken.",
+      "translation": "hành vi gian lận",
+      "count": 0
+    },
+    {
+      "word": "A fish out of water",
+      "meaning": "a person who feels uncomfortable in a situation",
+      "example": "I felt like a fish out of water at the tech conference.",
+      "translation": "như cá mắc cạn",
+      "count": 0
+    },
+    {
+      "word": "A burnt child dreads the fire",
+      "meaning": "people avoid repeating painful experiences",
+      "example": "After the accident, he refused to drive again — a burnt child dreads the fire.",
+      "translation": "trẻ bị bỏng sợ lửa",
+      "count": 0
+    },
+    {
+      "word": "To set the Thames on fire",
+      "meaning": "to do something amazing or outstanding",
+      "example": "He’s talented, but I doubt he'll set the Thames on fire.",
+      "translation": "làm điều phi thường",
+      "count": 0
+    },
+    {
+      "word": "A white elephant",
+      "meaning": "an expensive but useless possession",
+      "example": "That stadium became a white elephant after the tournament.",
+      "translation": "của nợ đắt tiền",
+      "count": 0
+    },
+    {
+      "word": "To throw dust in one’s eyes",
+      "meaning": "to deceive someone",
+      "example": "The manager tried to throw dust in our eyes with fake reports.",
+      "translation": "đánh lừa",
+      "count": 0
+    },
+    {
+      "word": "Every dog has his day",
+      "meaning": "everyone gets a chance eventually",
+      "example": "He finally got promoted — every dog has his day.",
+      "translation": "ai rồi cũng có thời",
+      "count": 0
+    },
+    {
+      "word": "Give a dog a bad name and hang him",
+      "meaning": "condemn someone based on reputation alone",
+      "example": "They kept blaming her — give a dog a bad name and hang him.",
+      "translation": "một lần mất tín vạn lần mất tin",
+      "count": 0
+    },
+    {
+      "word": "Devil’s Playthings",
+      "meaning": "something seen as morally corrupting, like cards",
+      "example": "Some elders still consider poker the devil’s playthings.",
+      "translation": "trò chơi xấu xa",
+      "count": 0
+    },
+    {
+      "word": "Go to the devil",
+      "meaning": "to go away in anger",
+      "example": "He told his boss to go to the devil and quit.",
+      "translation": "cút đi",
+      "count": 0
+    },
+    {
+      "word": "To step into dead man’s shoes",
+      "meaning": "to replace someone, often after death",
+      "example": "She stepped into her late father’s shoes as company CEO.",
+      "translation": "thế chỗ người đã khuất",
+      "count": 0
+    },
+    {
+      "word": "Halcyon Days",
+      "meaning": "a time of peace and happiness",
+      "example": "I always remember my college years as halcyon days.",
+      "translation": "ngày tháng yên bình",
+      "count": 0
+    },
+    {
+      "word": "Evil days",
+      "meaning": "a period marked by hardship",
+      "example": "He fell into evil days after losing his job.",
+      "translation": "ngày tháng khó khăn",
+      "count": 0
+    },
+    {
+      "word": "Cut and dried",
+      "meaning": "decided or fixed beforehand",
+      "example": "The rules were cut and dried — no exceptions.",
+      "translation": "rõ ràng, định sẵn",
+      "count": 0
+    },
+    {
+      "word": "Too many cooks spoil the broth",
+      "meaning": "too many people involved causes problems",
+      "example": "The project failed — too many cooks spoiled the broth.",
+      "translation": "lắm thầy thối ma",
+      "count": 0
+    },
+    {
+      "word": "To commit to memory",
+      "meaning": "to memorize something thoroughly",
+      "example": "He committed every line of the speech to memory.",
+      "translation": "học thuộc lòng",
+      "count": 0
+    },
+    {
+      "word": "To throw cold water upon anything",
+      "meaning": "to discourage or criticize enthusiasm",
+      "example": "His negative comments threw cold water on our excitement.",
+      "translation": "làm cụt hứng",
+      "count": 0
+    },
+    {
+      "word": "A cock and bull story",
+      "meaning": "an unbelievable or silly tale",
+      "example": "He made up a cock and bull story about traffic delays.",
+      "translation": "chuyện bịa đặt",
+      "count": 0
+    },
+    {
+      "word": "Close fisted",
+      "meaning": "Unwilling to share or spend money generously.",
+      "example": "He’s so close-fisted that he never contributes to group gifts.",
+      "translation": "Keo kiệt",
+      "count": 0
+    },
+    {
+      "word": "To square the circle",
+      "meaning": "To try to accomplish something logically or practically impossible.",
+      "example": "They were attempting to square the circle by merging two incompatible systems.",
+      "translation": "Cố làm điều không thể",
+      "count": 0
+    },
+    {
+      "word": "Ball is in your court",
+      "meaning": "It’s your responsibility to take the next step.",
+      "example": "I've done my part, now the ball is in your court.",
+      "translation": "Quyết định ở bạn",
+      "count": 0
+    },
+    {
+      "word": "To pick and choose",
+      "meaning": "To select carefully from a group of options.",
+      "example": "You can't always pick and choose your assignments at work.",
+      "translation": "Chọn lựa kỹ càng",
+      "count": 0
+    },
+    {
+      "word": "She is no chicken",
+      "meaning": "She is older and experienced.",
+      "example": "She is no chicken, but she’s still full of energy and wisdom.",
+      "translation": "Không còn trẻ nữa",
+      "count": 0
+    },
+    {
+      "word": "To Catch one’s eye",
+      "meaning": "To draw someone’s attention visually.",
+      "example": "That painting caught my eye the moment I entered the room.",
+      "translation": "Làm ai chú ý",
+      "count": 0
+    },
+    {
+      "word": "Care killed the cat",
+      "meaning": "Worrying too much can be harmful.",
+      "example": "Stop stressing over every little thing — care killed the cat.",
+      "translation": "Lo nghĩ quá có hại",
+      "count": 0
+    },
+    {
+      "word": "To burn the candle at both ends",
+      "meaning": "To overwork by staying up late and rising early.",
+      "example": "He’s exhausted from burning the candle at both ends.",
+      "translation": "Làm việc kiệt sức",
+      "count": 0
+    },
+    {
+      "word": "Good wine needs no bush",
+      "meaning": "Something of quality doesn't need advertising.",
+      "example": "His skills speak for themselves — good wine needs no bush.",
+      "translation": "Tốt không cần khoe",
+      "count": 0
+    },
+    {
+      "word": "To kick the bucket",
+      "meaning": "To pass away or die.",
+      "example": "He kicked the bucket peacefully in his sleep.",
+      "translation": "Chết",
+      "count": 0
+    },
+    {
+      "word": "If the cap fits, wear it",
+      "meaning": "Accept criticism if it applies to you.",
+      "example": "If you think that’s unfair, well, if the cap fits, wear it.",
+      "translation": "Có tật giật mình",
+      "count": 0
+    },
+    {
+      "word": "To make bricks without straw",
+      "meaning": "To attempt a task without necessary resources.",
+      "example": "I can’t design a website without the assets — it's like making bricks without straw.",
+      "translation": "Làm việc thiếu điều kiện",
+      "count": 0
+    },
+    {
+      "word": "One’s bread and butter",
+      "meaning": "Main source of income.",
+      "example": "Freelance writing is her bread and butter.",
+      "translation": "Kế sinh nhai",
+      "count": 0
+    },
+    {
+      "word": "A Bolt from the Blue",
+      "meaning": "An unexpected event or surprise.",
+      "example": "Her resignation was a bolt from the blue.",
+      "translation": "Bất ngờ xảy ra",
+      "count": 0
+    },
+    {
+      "word": "At First Blush",
+      "meaning": "Upon initial impression.",
+      "example": "At first blush, the idea looked promising.",
+      "translation": "Mới nhìn qua",
+      "count": 0
+    },
+    {
+      "word": "A wet blanket",
+      "meaning": "Someone who spoils the fun.",
+      "example": "Don’t be such a wet blanket during the party.",
+      "translation": "Người làm cụt hứng",
+      "count": 0
+    },
+    {
+      "word": "In Cold Blood",
+      "meaning": "Without emotion or pity.",
+      "example": "The crime was committed in cold blood.",
+      "translation": "Máu lạnh",
+      "count": 0
+    },
+    {
+      "word": "To bite the dust",
+      "meaning": "To fail or die.",
+      "example": "Several startups bit the dust during the recession.",
+      "translation": "Thất bại hoặc chết",
+      "count": 0
+    },
+    {
+      "word": "To hit below the belt",
+      "meaning": "To act unfairly or cruelly.",
+      "example": "Bringing up his past like that was hitting below the belt.",
+      "translation": "Chơi xấu",
+      "count": 0
+    },
+    {
+      "word": "Behind the scenes",
+      "meaning": "Out of public view.",
+      "example": "Much of the planning happened behind the scenes.",
+      "translation": "Hậu trường",
+      "count": 0
+    },
+    {
+      "word": "To cause bad blood",
+      "meaning": "To create animosity.",
+      "example": "That argument caused bad blood between them.",
+      "translation": "Gây thù hằn",
+      "count": 0
+    },
+    {
+      "word": "To backbite a person",
+      "meaning": "To talk badly about someone behind their back.",
+      "example": "She was hurt to find they had been backbiting her.",
+      "translation": "Nói xấu sau lưng",
+      "count": 0
+    },
+    {
+      "word": "Bag and baggage",
+      "meaning": "With all belongings.",
+      "example": "They arrived at the station bag and baggage.",
+      "translation": "Mang theo tất cả",
+      "count": 0
+    },
+    {
+      "word": "To have no backbone",
+      "meaning": "Lacking courage or resolve.",
+      "example": "He has no backbone to stand up for himself.",
+      "translation": "Thiếu bản lĩnh",
+      "count": 0
+    },
+    {
+      "word": "To keep the ball rolling",
+      "meaning": "To maintain progress or activity.",
+      "example": "Let's keep the ball rolling with our weekly meetings.",
+      "translation": "Tiếp tục công việc",
+      "count": 0
+    },
+   {
+      "word": "To take up arms",
+      "meaning": "to get ready to fight or resist",
+      "example": "They took up arms to fight for their rights.",
+      "translation": "cầm vũ khí",
+      "count": 0
+    },
+    {
+      "word": "The other side of the coin",
+      "meaning": "the opposite or contrasting view of a situation",
+      "example": "The project may improve productivity, but the other side of the coin is employee burnout.",
+      "translation": "mặt khác của vấn đề",
+      "count": 0
+    },
+    {
+      "word": "Rock the boat",
+      "meaning": "to cause trouble or disrupt a stable situation",
+      "example": "Don't rock the boat when everything is going smoothly.",
+      "translation": "làm xáo trộn",
+      "count": 0
+    },
+    {
+      "word": "A cash cow",
+      "meaning": "a product or business that consistently generates a lot of money",
+      "example": "That old TV series remains a cash cow for the network.",
+      "translation": "nguồn thu lợi nhuận lớn",
+      "count": 0
+    },
+    {
+      "word": "Plenty more fish in the sea (Idiom, noun)",
+      "meaning": "there are many other possible romantic partners",
+      "example": "Don't be sad, there are plenty more fish in the sea.",
+      "translation": "còn nhiều người khác ngoài kia",
+      "count": 0
+    },
+    {
+      "word": "Single and ready to mingle (adjective)",
+      "meaning": "being single and open to dating",
+      "example": "He's single and ready to mingle after his breakup.",
+      "translation": "độc thân và sẵn sàng hẹn hò",
+      "count": 0
+    },
+    {
+      "word": "It’s better to have loved and lost than never to have loved at all (common expression)",
+      "meaning": "it's better to experience love even if it ends than to never love",
+      "example": "She reminded him it’s better to have loved and lost than never to have loved.",
+      "translation": "thà yêu rồi mất còn hơn không bao giờ được yêu",
+      "count": 0
+    },
+    {
+      "word": "Mouths to feed (idiom, noun)",
+      "meaning": "people who rely on you for food and care",
+      "example": "He works two jobs to support all those mouths to feed.",
+      "translation": "miệng ăn cần nuôi",
+      "count": 0
+    },
+    {
+      "word": "To loosen the purse strings (idiom, verb)",
+      "meaning": "to start spending more money than usual",
+      "example": "He finally loosened the purse strings and treated the family to a vacation.",
+      "translation": "nới lỏng hầu bao",
+      "count": 0
+    },
+    {
+      "word": "To tighten one’s belt (idiom, verb)",
+      "meaning": "to reduce spending due to financial difficulties",
+      "example": "With rising prices, many households had to tighten their belts.",
+      "translation": "thắt lưng buộc bụng",
+      "count": 0
+    },
+    {
+      "word": "Impulse purchase (noun)",
+      "meaning": "an unplanned or spontaneous buying decision",
+      "example": "She made an impulse purchase of a dress she didn’t really need.",
+      "translation": "mua sắm bốc đồng",
+      "count": 0
+    },
+    {
+      "word": "Breadwinner (noun)",
+      "meaning": "the main income earner in a household",
+      "example": "He became the sole breadwinner after his partner lost her job.",
+      "translation": "trụ cột tài chính trong gia đình",
+      "count": 0
+    },
+    {
+      "word": "Consumerism (noun)",
+      "meaning": "a focus on acquiring goods and services",
+      "example": "Modern consumerism drives people to constantly buy the latest gadgets.",
+      "translation": "chủ nghĩa tiêu dùng",
+      "count": 0
+    },
+    {
+      "word": "Investment (noun)",
+      "meaning": "the act of putting resources into something for future benefit",
+      "example": "Buying that apartment turned out to be a great investment.",
+      "translation": "đầu tư",
+      "count": 0
+    },
+    {
+      "word": "Make ends meet (idiom, verb)",
+      "meaning": "to earn just enough to cover expenses",
+      "example": "Many workers struggle to make ends meet despite working full time.",
+      "translation": "đủ sống",
+      "count": 0
+    },
+    {
+      "word": "To splash the cash (informal idiom, verb)",
+      "meaning": "to spend money freely or extravagantly",
+      "example": "They splashed the cash on a luxury car after winning the lottery.",
+      "translation": "vung tiền",
+      "count": 0
+    },
+    {
+      "word": "Plot (noun)",
+      "meaning": "the main events of a story or movie",
+      "example": "The movie had a gripping plot with many twists.",
+      "translation": "cốt truyện",
+      "count": 0
+    },
+    {
+      "word": "Soundtrack (noun)",
+      "meaning": "the music accompanying a movie or show",
+      "example": "The soundtrack made the emotional scenes even more powerful.",
+      "translation": "nhạc phim",
+      "count": 0
+    },
+    {
+      "word": "Character (noun)",
+      "meaning": "a person in a book, play, or movie",
+      "example": "Her favorite character was the brave and witty sidekick.",
+      "translation": "nhân vật",
+      "count": 0
+    },
+    {
+      "word": "Cinematography (noun)",
+      "meaning": "the visual aspects of filming movies",
+      "example": "The cinematography in that movie was absolutely stunning.",
+      "translation": "nghệ thuật quay phim",
+      "count": 0
+    },
+    {
+      "word": "Scene (noun)",
+      "meaning": "a single segment of a movie or play",
+      "example": "The final scene of the movie brought tears to the audience.",
+      "translation": "cảnh phim",
+      "count": 0
+    },
+    {
+      "word": "Cast (noun)",
+      "meaning": "all the actors in a movie or play",
+      "example": "The cast did a great job bringing the story to life.",
+      "translation": "dàn diễn viên",
+      "count": 0
+    },
+    {
+      "word": "Box Office (noun)",
+      "meaning": "the revenue generated from ticket sales",
+      "example": "The film was a surprise hit at the box office.",
+      "translation": "doanh thu phòng vé",
+      "count": 0
+    },
+    {
+      "word": "Existing Universe (noun)",
+      "meaning": "a fictional world already established in previous media",
+      "example": "The new movie expands the existing universe with new characters.",
+      "translation": "vũ trụ điện ảnh có sẵn",
+      "count": 0
+    },
+    {
+      "word": "Groundbreaking (adjective)",
+      "meaning": "introducing new and original ideas or methods",
+      "example": "The director’s approach was groundbreaking and influenced many others.",
+      "translation": "đột phá",
+      "count": 0
+    },
+    { 
+      "word": "To steal the show",
+      "meaning": "To unexpectedly become the center of attention due to excellence or charm.",
+      "example": "The little girl portraying the daughter truly stole the show with her captivating performance.",
+      "translation": "thu hút toàn bộ sự chú ý",
+      "count": 0
+    },
+    {
+      "word": "Lyrics (noun)",
+      "meaning": "The words that are sung in a musical piece.",
+      "example": "Learning English song lyrics has helped me expand my vocabulary.",
+      "translation": "lời bài hát",
+      "count": 0
+    },
+    {
+      "word": "Chorus (noun)",
+      "meaning": "The repeated part of a song that is usually the most catchy.",
+      "example": "Everyone sang along loudly during the chorus of the song.",
+      "translation": "điệp khúc",
+      "count": 0
+    },
+    {
+      "word": "Melody (noun)",
+      "meaning": "A sequence of musical notes that forms the main tune.",
+      "example": "The melody of that ballad is both simple and beautiful.",
+      "translation": "giai điệu",
+      "count": 0
+    },
+    {
+      "word": "Snob (noun)",
+      "meaning": "Someone who thinks their taste is superior to others, especially in art or culture.",
+      "example": "His attitude toward pop music makes him come off as a bit of a snob.",
+      "translation": "kẻ tự cao",
+      "count": 0
+    },
+    {
+      "word": "Taste in music (noun)",
+      "meaning": "The style or genre of music someone prefers.",
+      "example": "Her taste in music includes everything from jazz to electronic.",
+      "translation": "gu âm nhạc",
+      "count": 0
+    },
+    {
+      "word": "Soothing (adjective)",
+      "meaning": "Creating a calming or relaxing effect.",
+      "example": "The soft piano music was incredibly soothing after a long day.",
+      "translation": "êm dịu",
+      "count": 0
+    },
+    {
+      "word": "Mainstream (noun/adjective)",
+      "meaning": "Widely accepted and popular, often lacking originality.",
+      "example": "He prefers indie artists over mainstream pop stars.",
+      "translation": "dòng chính, phổ biến",
+      "count": 0
+    },
+    {
+      "word": "Out of tune (adjective)",
+      "meaning": "Not in the correct musical pitch.",
+      "example": "She was clearly out of tune during the audition.",
+      "translation": "lệch tông",
+      "count": 0
+    },
+    {
+      "word": "Go on tour",
+      "meaning": "To travel and perform at different venues as a musician or artist.",
+      "example": "The band plans to go on tour across Europe next spring.",
+      "translation": "đi lưu diễn",
+      "count": 0
+    },
+    {
+      "word": "Following (noun)",
+      "meaning": "A group of fans or supporters of a person or idea.",
+      "example": "The band gained a loyal following after their first album.",
+      "translation": "lượng người hâm mộ",
+      "count": 0
+    },
+    {
+      "word": "At one with nature (adjective)",
+      "meaning": "Feeling deeply connected and harmonious with the natural world.",
+      "example": "He feels at one with nature while hiking in the mountains.",
+      "translation": "hòa mình với thiên nhiên",
+      "count": 0
+    },
+    {
+      "word": "Desolate (adjective)",
+      "meaning": "Empty, lifeless, and often bleak in appearance.",
+      "example": "The village looked desolate after the storm hit.",
+      "translation": "hoang vắng",
+      "count": 0
+    },
+    {
+      "word": "Pristine (adjective)",
+      "meaning": "Unspoiled and in perfect condition.",
+      "example": "We hiked through a pristine forest untouched by humans.",
+      "translation": "nguyên sơ",
+      "count": 0
+    },
+    {
+      "word": "Wilderness (noun)",
+      "meaning": "A remote, uninhabited area of natural land.",
+      "example": "They spent weeks exploring the Alaskan wilderness.",
+      "translation": "vùng hoang dã",
+      "count": 0
+    },
+    {
+      "word": "To blossom (verb)",
+      "meaning": "To produce flowers; to grow or develop positively.",
+      "example": "The trees began to blossom as spring arrived.",
+      "translation": "nở hoa",
+      "count": 0
+    },
+    {
+      "word": "Savanna (noun)",
+      "meaning": "A grassy plain in tropical regions with few trees.",
+      "example": "Lions roam freely across the African savanna.",
+      "translation": "thảo nguyên",
+      "count": 0
+    },
+    {
+      "word": "Deciduous (adjective)",
+      "meaning": "Describes trees that shed leaves annually.",
+      "example": "Deciduous trees turn vibrant colors in autumn.",
+      "translation": "rụng lá theo mùa",
+      "count": 0
+    },
+    {
+      "word": "Conservation (noun)",
+      "meaning": "The act of protecting and preserving the environment.",
+      "example": "Many groups focus on wildlife conservation efforts.",
+      "translation": "bảo tồn",
+      "count": 0
+    },
+    {
+      "word": "To coexist (verb)",
+      "meaning": "To live or exist together peacefully.",
+      "example": "Humans must learn to coexist with wildlife.",
+      "translation": "cùng tồn tại",
+      "count": 0
+    },
+    {
+      "word": "A green thumb (noun)",
+      "meaning": "A talent for gardening or growing plants well.",
+      "example": "My grandmother truly has a green thumb.",
+      "translation": "có tài trồng cây",
+      "count": 0
+    },
+    {
+      "word": "Human interest story (noun)",
+      "meaning": "A news piece focused on personal or emotional aspects of someone’s life.",
+      "example": "The article about the local teacher was a touching human interest story.",
+      "translation": "câu chuyện nhân văn",
+      "count": 0
+    },
+    {
+      "word": "Tabloid (noun)",
+      "meaning": "A newspaper with sensational stories and simplified language.",
+      "example": "He prefers serious journalism over tabloids.",
+      "translation": "báo lá cải",
+      "count": 0
+    },
+    {
+      "word": "Coverage (noun)",
+      "meaning": "Media attention given to an event or topic.",
+      "example": "The election received wall-to-wall news coverage.",
+      "translation": "sự đưa tin",
+      "count": 0
+    },
+    {
+      "word": "Exposé (noun)",
+      "meaning": "A report revealing shocking or hidden facts.",
+      "example": "The exposé uncovered corruption within the company.",
+      "translation": "bài phanh phui",
+      "count": 0
+    },
+    {
+      "word": "Impartial (adjective)",
+      "meaning": "Not showing favoritism or bias toward any side.",
+      "example": "Journalists should stay impartial when reporting to ensure fairness.",
+      "translation": "khách quan",
+      "count": 0
+    },
+    {
+      "word": "Proprietor (noun)",
+      "meaning": "A person who owns a business or publication.",
+      "example": "The proprietor of the magazine has strong opinions that influence its content.",
+      "translation": "chủ sở hữu",
+      "count": 0
+    },
+    {
+      "word": "Keep up to speed (idiom, verb)",
+      "meaning": "To stay informed about recent developments.",
+      "example": "I check the news app daily to keep up to speed with global events.",
+      "translation": "cập nhật thông tin",
+      "count": 0
+    },
+    {
+      "word": "Doom and gloom (idiom, noun)",
+      "meaning": "A feeling or atmosphere of negativity and pessimism.",
+      "example": "She avoids watching the news because it’s always full of doom and gloom.",
+      "translation": "tình trạng ảm đạm, u ám",
+      "count": 0
+    },
+    {
+      "word": "Headline (noun)",
+      "meaning": "The title or summary of a news article.",
+      "example": "The headline caught my attention right away.",
+      "translation": "tiêu đề",
+      "count": 0
+    },
+    {
+      "word": "Clickbait (noun)",
+      "meaning": "Content designed to attract clicks through sensational titles.",
+      "example": "That article was clearly just clickbait with no real news.",
+      "translation": "tiêu đề giật gân",
+      "count": 0
+    },
+    {
+      "word": "Have a short fuse (idiom, verb)",
+      "meaning": "To get angry quickly or easily.",
+      "example": "My boss has a short fuse, so we try not to upset him.",
+      "translation": "dễ nổi nóng",
+      "count": 0
+    },
+    {
+      "word": "Two-faced (adjective)",
+      "meaning": "Pretending to be nice while acting differently behind someone’s back.",
+      "example": "She seemed friendly, but turned out to be two-faced.",
+      "translation": "hai mặt",
+      "count": 0
+    },
+    {
+      "word": "Bend over backwards to help (idiom, verb)",
+      "meaning": "To make a big effort to help someone.",
+      "example": "He bent over backwards to help his friend move house.",
+      "translation": "hết lòng giúp đỡ",
+      "count": 0
+    },
+    {
+      "word": "Self-deprecating (adjective)",
+      "meaning": "Modest or critical about oneself in a humorous way.",
+      "example": "Her self-deprecating jokes made everyone laugh.",
+      "translation": "tự giễu",
+      "count": 0
+    },
+    {
+      "word": "Set in one’s ways (adjective)",
+      "meaning": "Unwilling to change habits or opinions.",
+      "example": "My grandfather is very set in his ways and won’t try new food.",
+      "translation": "bảo thủ",
+      "count": 0
+    },
+    {
+      "word": "Comfortable in one’s own skin (idiom, adjective)",
+      "meaning": "Being confident and accepting of oneself.",
+      "example": "She became comfortable in her own skin after many years of self-growth.",
+      "translation": "tự tin với bản thân",
+      "count": 0
+    },
+    {
+      "word": "Absent-minded (adjective)",
+      "meaning": "Frequently forgetful or distracted.",
+      "example": "He’s so absent-minded, he left his keys in the fridge.",
+      "translation": "đãng trí",
+      "count": 0
+    },
+    {
+      "word": "On the ball (idiom, adjective)",
+      "meaning": "Being alert and quick to react.",
+      "example": "We need someone who’s really on the ball for this position.",
+      "translation": "nhanh nhạy",
+      "count": 0
+    },
+    {
+      "word": "A people person (noun)",
+      "meaning": "Someone who enjoys socializing and engaging with others.",
+      "example": "She’s a people person and makes friends easily.",
+      "translation": "người hướng ngoại",
+      "count": 0
+    },
+    {
+      "word": "Nature versus nurture (noun)",
+      "meaning": "The debate on whether traits come from genetics or environment.",
+      "example": "The nature versus nurture discussion continues in psychology.",
+      "translation": "bẩm sinh hay giáo dục",
+      "count": 0
+    },
+    {
+      "word": "Companionship (noun)",
+      "meaning": "A close friendship or presence of someone.",
+      "example": "Many elderly people value the companionship of pets.",
+      "translation": "tình bạn đồng hành",
+      "count": 0
+    },
+    {
+      "word": "Purebred (adjective)",
+      "meaning": "Bred from parents of the same breed.",
+      "example": "They bought a purebred puppy from a certified breeder.",
+      "translation": "thuần chủng",
+      "count": 0
+    },
+    {
+      "word": "Affectionate (adjective)",
+      "meaning": "Showing love or fondness openly.",
+      "example": "He’s very affectionate towards his family and pets.",
+      "translation": "thể hiện tình cảm",
+      "count": 0
+    },
+    {
+      "word": "Possessive (adjective)",
+      "meaning": "Not wanting to share someone’s attention or affection.",
+      "example": "Her boyfriend became too possessive and controlling.",
+      "translation": "chiếm hữu",
+      "count": 0
+    },
+    {
+      "word": "Unconditional love (noun)",
+      "meaning": "Love that is given freely without expecting anything in return.",
+      "example": "A mother’s unconditional love is one of life’s greatest gifts.",
+      "translation": "tình yêu vô điều kiện",
+      "count": 0
+    },
+    {
+      "word": "To shed (verb)",
+      "meaning": "To lose fur, feathers, or skin naturally.",
+      "example": "Their dog sheds a lot during summer.",
+      "translation": "rụng lông",
+      "count": 0
+    },
+    {
+      "word": "A dog/cat person (noun)",
+      "meaning": "Someone who prefers one pet over the other.",
+      "example": "He’s clearly a dog person, always playing with his Labrador.",
+      "translation": "người thích chó/mèo",
+      "count": 0
+    },
+   {
+      "word": "Groom (verb)",
+      "meaning": "To take care of an animal’s appearance and cleanliness.",
+      "example": "Monkeys naturally groom each other, but domestic pets like dogs need grooming from their owners.",
+      "translation": "chải chuốt, chăm sóc lông",
+      "count": 0
+    },
+    {
+      "word": "Breed (noun)",
+      "meaning": "A particular kind of animal developed through selective mating.",
+      "example": "Many people consider owning a rare breed of dog as a status statement.",
+      "translation": "giống loài",
+      "count": 0
+    },
+    {
+      "word": "Splurge (verb)",
+      "meaning": "To spend a lot of money extravagantly.",
+      "example": "I rarely shop, but when I do, I tend to splurge on things I don’t really need.",
+      "translation": "vung tiền",
+      "count": 0
+    },
+    {
+      "word": "Retail therapy (noun)",
+      "meaning": "Shopping as a way to improve one’s mood.",
+      "example": "When she’s upset, my sister turns to retail therapy to cheer herself up.",
+      "translation": "liệu pháp mua sắm",
+      "count": 0
+    },
+    {
+      "word": "Peruse (verb)",
+      "meaning": "To browse through items in a relaxed, unhurried way.",
+      "example": "Some people enjoy perusing shelves without intending to buy anything.",
+      "translation": "xem lướt qua",
+      "count": 0
+    },
+    {
+      "word": "Shopaholic (noun)",
+      "meaning": "A person who is addicted to shopping.",
+      "example": "Being a shopaholic, she can't resist buying things even when unnecessary.",
+      "translation": "người nghiện mua sắm",
+      "count": 0
+    },
+    {
+      "word": "To shop around",
+      "meaning": "To compare prices and options before making a purchase.",
+      "example": "I always shop around before buying electronics to get the best deal.",
+      "translation": "so sánh giá cả",
+      "count": 0
+    },
+    {
+      "word": "Same-day delivery (noun)",
+      "meaning": "Delivery of a purchased item within the same day.",
+      "example": "Online retailers attract customers by offering same-day delivery.",
+      "translation": "giao hàng trong ngày",
+      "count": 0
+    },
+    {
+      "word": "Spoiled for choice (adjective)",
+      "meaning": "Having too many good options to choose from.",
+      "example": "Online platforms leave customers spoiled for choice with endless options.",
+      "translation": "quá nhiều sự lựa chọn",
+      "count": 0
+    },
+    {
+      "word": "Independent store (noun)",
+      "meaning": "A small business not part of a large retail chain.",
+      "example": "I enjoy visiting independent stores when traveling to new cities.",
+      "translation": "cửa hàng độc lập",
+      "count": 0
+    },
+    {
+      "word": "On a tight budget (adjective)",
+      "meaning": "Having limited money to spend.",
+      "example": "When I’m on a tight budget, I only buy essentials.",
+      "translation": "ngân sách eo hẹp",
+      "count": 0
+    },
+    {
+      "word": "Sales Assistant (noun)",
+      "meaning": "A person who helps customers in a store.",
+      "example": "Sales assistants sometimes overwhelm me when I just want to browse.",
+      "translation": "nhân viên bán hàng",
+      "count": 0
+    },
+    {
+      "word": "Trolls (noun)",
+      "meaning": "People who post offensive or upsetting content online.",
+      "example": "Social media platforms struggle to manage internet trolls.",
+      "translation": "kẻ phá rối trên mạng",
+      "count": 0
+    },
+    {
+      "word": "Derogatory (adjective)",
+      "meaning": "Disrespectful or insulting in tone or intent.",
+      "example": "He received backlash for making derogatory comments online.",
+      "translation": "xúc phạm, miệt thị",
+      "count": 0
+    },
+    {
+      "word": "Influencer (noun)",
+      "meaning": "Someone who affects public opinion through social media presence.",
+      "example": "Many influencers earn a living through product endorsements.",
+      "translation": "người ảnh hưởng",
+      "count": 0
+    },
+    {
+      "word": "Instagrammable (adjective)",
+      "meaning": "Visually appealing and suitable for posting on social media.",
+      "example": "The restaurant’s dishes are incredibly instagrammable.",
+      "translation": "đẹp để đăng Instagram",
+      "count": 0
+    },
+    {
+      "word": "News feed (noun)",
+      "meaning": "A stream of updates and content shown on a user’s homepage.",
+      "example": "I often get lost scrolling through my news feed for hours.",
+      "translation": "bảng tin",
+      "count": 0
+    },
+    {
+      "word": "To monetize (verb)",
+      "meaning": "To generate income from an activity or content.",
+      "example": "He found a way to monetize his YouTube channel effectively.",
+      "translation": "kiếm tiền từ",
+      "count": 0
+    },
+    {
+      "word": "Meme (noun)",
+      "meaning": "A humorous image or text shared widely online.",
+      "example": "That meme went viral in just a few hours.",
+      "translation": "ảnh chế",
+      "count": 0
+    },
+    {
+      "word": "To vlog (verb)",
+      "meaning": "To create and post video content about daily life or interests.",
+      "example": "She vlogs about her travels around Southeast Asia.",
+      "translation": "quay video nhật ký",
+      "count": 0
+    },
+    {
+      "word": "Filter (noun)",
+      "meaning": "A digital effect that alters images or videos.",
+      "example": "The filter made her selfie look flawless.",
+      "translation": "bộ lọc ảnh",
+      "count": 0
+    },
+    {
+      "word": "Go viral (verb)",
+      "meaning": "To spread rapidly and widely online.",
+      "example": "The funny video went viral overnight.",
+      "translation": "lan truyền mạnh",
+      "count": 0
+    },
+    {
+      "word": "Astronaut (noun)",
+      "meaning": "A person trained to travel in space.",
+      "example": "Becoming an astronaut requires years of training.",
+      "translation": "phi hành gia",
+      "count": 0
+    },
+    {
+      "word": "Extraterrestrial life (noun)",
+      "meaning": "Life that originates outside of Earth.",
+      "example": "Scientists are still searching for extraterrestrial life.",
+      "translation": "sự sống ngoài hành tinh",
+      "count": 0
+    },
+    {
+      "word": "The commercial exploitation of space (phrasal noun)",
+      "meaning": "The act of profiting from activities in space.",
+      "example": "Companies are racing toward the commercial exploitation of space through tourism and mining.",
+      "translation": "khai thác thương mại không gian",
+      "count": 0
+    },
+   {
+      "word": "The militarization of space (phrasal noun)",
+      "meaning": "The deployment of weapons and military systems into outer space.",
+      "example": "Experts warn that the militarization of space could spark a new kind of arms race.",
+      "translation": "quân sự hóa không gian",
+      "count": 0
+    },
+    {
+      "word": "Deep space (noun)",
+      "meaning": "Regions of space that are far from Earth and the Moon.",
+      "example": "Exploring deep space will likely be the next big leap for human civilization.",
+      "translation": "vũ trụ sâu",
+      "count": 0
+    },
+    {
+      "word": "Cryogenic (adjective)",
+      "meaning": "Relating to very low temperatures, often used to preserve bodies or objects.",
+      "example": "In many science fiction stories, cryogenic sleep helps astronauts endure long missions.",
+      "translation": "thuộc nhiệt độ cực thấp",
+      "count": 0
+    },
+    {
+      "word": "Light-year (noun)",
+      "meaning": "A unit of distance showing how far light travels in one year.",
+      "example": "The closest star to Earth is around four light-years away.",
+      "translation": "năm ánh sáng",
+      "count": 0
+    },
+    {
+      "word": "Astronomy (noun)",
+      "meaning": "The scientific study of planets, stars, and outer space.",
+      "example": "Astronomy requires both theoretical knowledge and observational skills.",
+      "translation": "thiên văn học",
+      "count": 0
+    },
+    {
+      "word": "In orbit (adjective)",
+      "meaning": "Circulating around a planet or celestial body in space.",
+      "example": "Thousands of satellites are currently in orbit around Earth.",
+      "translation": "đang quay quanh quỹ đạo",
+      "count": 0
+    },
+    {
+      "word": "Awe-inspiring (adjective)",
+      "meaning": "So impressive that it causes deep admiration or amazement.",
+      "example": "Seeing a full solar eclipse in person is absolutely awe-inspiring.",
+      "translation": "gây kinh ngạc",
+      "count": 0
+    },
+    {
+      "word": "Camaraderie (noun)",
+      "meaning": "A strong sense of friendship and loyalty among people in a group.",
+      "example": "There was clear camaraderie among the teammates after their victory.",
+      "translation": "tình bạn thân thiết",
+      "count": 0
+    },
+    {
+      "word": "Go toe to toe (idiom, verb)",
+      "meaning": "To challenge someone directly and forcefully.",
+      "example": "The underdog team went toe to toe with the reigning champions and nearly won.",
+      "translation": "đối đầu trực diện",
+      "count": 0
+    },
+    {
+      "word": "To leave it all out on the field (idiom, verb)",
+      "meaning": "To give maximum effort with nothing held back.",
+      "example": "She left it all out on the field and had no regrets about the result.",
+      "translation": "dốc hết sức",
+      "count": 0
+    },
+    {
+      "word": "Spectator sport (noun)",
+      "meaning": "A sport that is enjoyable to watch live or on TV.",
+      "example": "Tennis has grown into a major global spectator sport.",
+      "translation": "môn thể thao thu hút người xem",
+      "count": 0
+    },
+    {
+      "word": "Take up (verb)",
+      "meaning": "To begin learning or doing a new activity.",
+      "example": "I decided to take up painting as a way to relax after work.",
+      "translation": "bắt đầu một hoạt động",
+      "count": 0
+    },
+    {
+      "word": "Practice religiously",
+      "meaning": "To do something consistently and with full dedication.",
+      "example": "He practices religiously every morning before school to improve his skills.",
+      "translation": "luyện tập nghiêm túc",
+      "count": 0
+    },
+    {
+      "word": "Contact sport (noun)",
+      "meaning": "A sport involving physical contact between players.",
+      "example": "Rugby is a high-intensity contact sport that demands strength and stamina.",
+      "translation": "môn thể thao có va chạm",
+      "count": 0
+    },
+    {
+      "word": "Exhilarating (adjective)",
+      "meaning": "Causing great excitement and joy.",
+      "example": "The rollercoaster ride was exhilarating from start to finish.",
+      "translation": "gây phấn khích",
+      "count": 0
+    },
+    {
+      "word": "Go down to the wire (idiom, verb)",
+      "meaning": "To continue until the last possible moment before a decision or outcome is clear.",
+      "example": "The championship went down to the wire with a last-minute goal.",
+      "translation": "kéo dài đến phút chót",
+      "count": 0
+    },
+    {
+      "word": "Get a standing ovation",
+      "meaning": "To receive enthusiastic applause where everyone stands up.",
+      "example": "The actress got a standing ovation for her powerful performance.",
+      "translation": "được đứng dậy vỗ tay khen ngợi",
+      "count": 0
+    },
+    {
+      "word": "Breakthrough (noun)",
+      "meaning": "A significant and sudden discovery or progress.",
+      "example": "The scientist’s breakthrough changed how we treat the disease.",
+      "translation": "đột phá",
+      "count": 0
+    },
+    {
+      "word": "In layman’s terms (adverbial phrase)",
+      "meaning": "Explained in simple, easy-to-understand language.",
+      "example": "Can you explain quantum computing in layman’s terms?",
+      "translation": "ngôn ngữ dễ hiểu",
+      "count": 0
+    },
+    {
+      "word": "Artificial Intelligence (noun)",
+      "meaning": "Technology that simulates human thinking in machines.",
+      "example": "Artificial intelligence is transforming industries like healthcare and finance.",
+      "translation": "trí tuệ nhân tạo",
+      "count": 0
+    },
+    {
+      "word": "Luddite (noun, adjective)",
+      "meaning": "A person who resists or dislikes new technology.",
+      "example": "Despite being a Luddite, she eventually learned to use a smartphone.",
+      "translation": "người ghét công nghệ",
+      "count": 0
+    },
+    {
+      "word": "Cookies (noun)",
+      "meaning": "Small data files used by websites to track user activity.",
+      "example": "Websites now ask for permission before storing cookies on your device.",
+      "translation": "tập tin cookie",
+      "count": 0
+    },
+    {
+      "word": "Obsolete (adjective)",
+      "meaning": "No longer useful or effective due to being outdated.",
+      "example": "DVDs have become nearly obsolete in the age of streaming.",
+      "translation": "lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "Game changer (noun)",
+      "meaning": "An event or idea that brings a major shift.",
+      "example": "The vaccine was a game changer in the fight against the pandemic.",
+      "translation": "yếu tố thay đổi cuộc chơi",
+      "count": 0
+    },
+    {
+      "word": "Cryptocurrency (noun)",
+      "meaning": "Digital money that exists only online and uses encryption.",
+      "example": "Cryptocurrency has become a popular investment despite its volatility.",
+      "translation": "tiền điện tử",
+      "count": 0
+    },
+    {
+      "word": "Cybersecurity (noun)",
+      "meaning": "The practice of safeguarding systems and data from online threats and attacks.",
+      "example": "Cybersecurity is crucial for protecting personal and national information from hackers.",
+      "translation": "an ninh mạng",
+      "count": 0
+    },
+    {
+      "word": "User-friendly (adjective)",
+      "meaning": "Easy for people to use, even without technical expertise.",
+      "example": "Any software aiming for mass adoption needs to be user-friendly.",
+      "translation": "thân thiện với người dùng",
+      "count": 0
+    },
+    {
+      "word": "Infrastructure (noun)",
+      "meaning": "The basic systems and structures that support a functioning society, like roads and utilities.",
+      "example": "The city expanded its infrastructure to improve public transport and reduce congestion.",
+      "translation": "cơ sở hạ tầng",
+      "count": 0
+    },
+    {
+      "word": "Bumper to bumper (idiom, adjective)",
+      "meaning": "Describes traffic that is very dense and barely moving.",
+      "example": "The streets were bumper to bumper during the morning commute.",
+      "translation": "kẹt xe nối đuôi nhau",
+      "count": 0
+    },
+    {
+      "word": "Bottleneck (noun)",
+      "meaning": "A point of congestion where traffic flow is restricted.",
+      "example": "The construction site created a major bottleneck on the highway.",
+      "translation": "điểm nghẽn giao thông",
+      "count": 0
+    },
+    {
+      "word": "Boy racer (noun)",
+      "meaning": "A young male who drives recklessly and at high speeds.",
+      "example": "Boy racers are often responsible for dangerous driving incidents.",
+      "translation": "tay lái trẻ bốc đồng",
+      "count": 0
+    },
+    {
+      "word": "Road rage (noun)",
+      "meaning": "Aggressive or angry behavior by drivers during traffic incidents.",
+      "example": "He lost his temper and yelled at another driver in a case of road rage.",
+      "translation": "cơn giận khi lái xe",
+      "count": 0
+    },
+    {
+      "word": "Exhaust fumes (noun)",
+      "meaning": "Polluted gases emitted from a vehicle’s exhaust system.",
+      "example": "Reducing exhaust fumes is essential for urban air quality.",
+      "translation": "khí thải xe",
+      "count": 0
+    },
+    {
+      "word": "Carpool (verb)",
+      "meaning": "To share a ride with others heading in the same direction.",
+      "example": "Many coworkers carpool to reduce fuel costs and emissions.",
+      "translation": "đi chung xe",
+      "count": 0
+    },
+    {
+      "word": "Season ticket (noun)",
+      "meaning": "A long-term pass for transportation services, usually at a discounted rate.",
+      "example": "I bought a season ticket to save money on my daily commute.",
+      "translation": "vé dài hạn",
+      "count": 0
+    },
+    {
+      "word": "Backseat driver (noun)",
+      "meaning": "Someone who gives unwanted advice to the actual driver.",
+      "example": "It's hard to focus with a backseat driver criticizing every move.",
+      "translation": "người ngồi sau hay chỉ đạo",
+      "count": 0
+    },
+    {
+      "word": "Self-driving cars",
+      "meaning": "Vehicles that navigate and operate without human control.",
+      "example": "Self-driving cars could transform the way we travel in the near future.",
+      "translation": "xe tự lái",
+      "count": 0
+    },
+    {
+      "word": "All-inclusive (adjective)",
+      "meaning": "Covering all costs for food, drinks, and activities in one price.",
+      "example": "They booked an all-inclusive vacation to avoid any extra expenses.",
+      "translation": "bao trọn gói",
+      "count": 0
+    },
+    {
+      "word": "Excursion (noun)",
+      "meaning": "A short journey taken for leisure or interest.",
+      "example": "We went on a guided excursion to the waterfalls.",
+      "translation": "chuyến tham quan",
+      "count": 0
+    },
+    {
+      "word": "Eat like pigs",
+      "meaning": "To eat a lot, often in a messy or indulgent way.",
+      "example": "During the buffet, we completely ate like pigs.",
+      "translation": "ăn ngấu nghiến",
+      "count": 0
+    },
+    {
+      "word": "Paradise (noun)",
+      "meaning": "An ideal or beautiful place that feels like heaven.",
+      "example": "The beach was a true paradise with crystal clear water.",
+      "translation": "thiên đường",
+      "count": 0
+    },
+    {
+      "word": "Get one’s bearings",
+      "meaning": "To become familiar with a new place or situation.",
+      "example": "I took a quick walk around the city to get my bearings.",
+      "translation": "định hướng vị trí",
+      "count": 0
+    },
+    {
+      "word": "To drink it in",
+      "meaning": "To fully enjoy or appreciate something beautiful or meaningful.",
+      "example": "She stood on the balcony and drank in the sunset view.",
+      "translation": "thưởng ngoạn",
+      "count": 0
+    },
+    {
+      "word": "Must-see (adjective)",
+      "meaning": "Describes something worth visiting or watching.",
+      "example": "The Colosseum is a must-see if you're in Rome.",
+      "translation": "đáng xem",
+      "count": 0
+    },
+    {
+      "word": "Show someone the sights",
+      "meaning": "To act as a guide for someone visiting a place.",
+      "example": "He showed his cousin the sights when she visited from abroad.",
+      "translation": "dẫn đi tham quan",
+      "count": 0
+    },
+    {
+      "word": "Attentive (adjective)",
+      "meaning": "Being very alert and responsive to the needs of others.",
+      "example": "The hotel staff were attentive and made our stay comfortable.",
+      "translation": "chu đáo",
+      "count": 0
+    },
+    {
+      "word": "Highlight (noun)",
+      "meaning": "The most exciting or enjoyable part of an event.",
+      "example": "The boat trip was the highlight of our holiday.",
+      "translation": "điểm nhấn",
+      "count": 0
+    },
+    {
+      "word": "Hurricane (noun)",
+      "meaning": "A violent storm with strong winds and heavy rain.",
+      "example": "Residents were evacuated ahead of the approaching hurricane.",
+      "translation": "bão lớn",
+      "count": 0
+    },
+    {
+      "word": "Freezing (adjective)",
+      "meaning": "Extremely cold; near or below 0°C.",
+      "example": "It was freezing outside, so I wore multiple layers.",
+      "translation": "lạnh cóng",
+      "count": 0
+    },
+    {
+      "word": "To get soaked (verb)",
+      "meaning": "To become completely wet, typically from rain.",
+      "example": "I forgot my umbrella and got soaked walking home.",
+      "translation": "ướt sũng",
+      "count": 0
+    },
+    {
+        "word": "Like a drowned rat (adjective)",
+        "meaning": "extremely wet and looking miserable, often due to heavy rain",
+        "example": "We got caught in the downpour and ended up looking like drowned rats.",
+        "translation": "ướt như chuột lột",
+        "count": 0
+    },
+    {
+        "word": "Heatwave (noun)",
+        "meaning": "a stretch of exceptionally high temperatures for the time of year",
+        "example": "A severe heatwave last summer caused multiple wildfires across the region.",
+        "translation": "đợt nắng nóng",
+        "count": 0
+    },
+    {
+        "word": "Humidity (noun)",
+        "meaning": "the amount of moisture in the air, making it feel hot and sticky",
+        "example": "The humidity in the jungle made every step feel exhausting.",
+        "translation": "độ ẩm",
+        "count": 0
+    },
+    {
+        "word": "Overcast (adjective)",
+        "meaning": "covered with clouds, lacking sunshine",
+        "example": "The skies remained overcast throughout our trip to the mountains.",
+        "translation": "u ám",
+        "count": 0
+    },
+    {
+        "word": "Forecast (noun)",
+        "meaning": "a prediction about future weather conditions",
+        "example": "According to the forecast, the rain will stop by evening.",
+        "translation": "dự báo",
+        "count": 0
+    },
+    {
+        "word": "A spell (noun)",
+        "meaning": "a short period of a specific type of weather",
+        "example": "We enjoyed a brief sunny spell before the rain returned.",
+        "translation": "một đợt",
+        "count": 0
+    },
+    {
+        "word": "Chucking it down (idiom, verb, informal)",
+        "meaning": "raining extremely heavily",
+        "example": "We had to cancel the match because it was chucking it down all morning.",
+        "translation": "mưa như trút nước",
+        "count": 0
+    },
+    {
+        "word": "Repetitive (adjective)",
+        "meaning": "involving repeating actions that become dull or uninteresting",
+        "example": "Her job at the factory felt repetitive and uninspiring.",
+        "translation": "lặp đi lặp lại",
+        "count": 0
+    },
+    {
+        "word": "To punch in (verb)",
+        "meaning": "to record the start of a work shift",
+        "example": "He punched in late and received a warning from his supervisor.",
+        "translation": "chấm công vào",
+        "count": 0
+    },
+    {
+        "word": "To unplug (verb)",
+        "meaning": "to disconnect from work or technology to relax",
+        "example": "She takes weekends off to completely unplug from work.",
+        "translation": "ngắt kết nối, thư giãn",
+        "count": 0
+    },
+    {
+        "word": "To learn the ropes (idiom, verb)",
+        "meaning": "to become familiar with how something is done",
+        "example": "He spent the first week learning the ropes at his new job.",
+        "translation": "học việc",
+        "count": 0
+    },
+    {
+        "word": "Snowed under (adjective)",
+        "meaning": "having more work than can be easily handled",
+        "example": "I'm snowed under with deadlines this week.",
+        "translation": "bị ngập trong công việc",
+        "count": 0
+    },
+    {
+        "word": "To pour one’s heart and soul into something (idiom, verb)",
+        "meaning": "to give full dedication and effort to something",
+        "example": "She poured her heart and soul into creating the nonprofit.",
+        "translation": "dốc hết tâm huyết",
+        "count": 0
+    },
+    {
+        "word": "The daily grind (noun)",
+        "meaning": "a monotonous routine, especially work-related",
+        "example": "He’s trying to escape the daily grind by starting his own business.",
+        "translation": "công việc hằng ngày nhàm chán",
+        "count": 0
+    },
+    {
+        "word": "A cog in the machine (noun)",
+        "meaning": "a small part of a larger system, often feeling unimportant",
+        "example": "She didn’t want to be just another cog in the machine.",
+        "translation": "một phần nhỏ trong hệ thống lớn",
+        "count": 0
+    },
+    {
+        "word": "Be a big fish in a small pond",
+        "meaning": "to be important in a small or limited group",
+        "example": "He left the big city to become a big fish in a small pond back home.",
+        "translation": "cá lớn trong ao nhỏ",
+        "count": 0
+    },
+    {
+        "word": "before your time",
+        "meaning": "something that existed before you were born or involved",
+        "example": "That old cinema was torn down before your time.",
+        "translation": "trước khi bạn được sinh ra",
+        "count": 0
+    },
+    {
+        "word": "below/under par",
+        "meaning": "worse than expected or usual",
+        "example": "His recent performance has been under par due to illness.",
+        "translation": "dưới mức bình thường",
+        "count": 0
+    },
+    {
+        "word": "big mouth",
+        "meaning": "a person who often reveals secrets or talks too much",
+        "example": "She’s such a big mouth—nothing stays private around her.",
+        "translation": "nhiều chuyện",
+        "count": 0
+    },
+    {
+        "word": "home sweet home",
+        "meaning": "used to express affection for one’s home",
+        "example": "After traveling for weeks, it felt great to be back to home sweet home.",
+        "translation": "không đâu bằng nhà",
+        "count": 0
+    },
+    {
+        "word": "in/for donkey’s years",
+        "meaning": "a very long period of time",
+        "example": "I haven’t played tennis in donkey’s years.",
+        "translation": "rất lâu",
+        "count": 0
+    },
+    {
+        "word": "in sb’s bad/good books",
+        "meaning": "in someone's favor or disfavor",
+        "example": "He’s in her bad books for missing the meeting.",
+        "translation": "mất lòng hoặc được lòng ai đó",
+        "count": 0
+    },
+    {
+        "word": "in the dark (about)",
+        "meaning": "not knowing something important or being kept uninformed",
+        "example": "We were kept in the dark about the budget cuts.",
+        "translation": "không biết gì",
+        "count": 0
+    },
+    {
+        "word": "in the middle of nowhere",
+        "meaning": "in a very remote or isolated place",
+        "example": "Their cabin is located in the middle of nowhere, far from any town.",
+        "translation": "ở nơi hẻo lánh",
+        "count": 0
+    },
+    {
+        "word": "in the nick of time",
+        "meaning": "just in time to prevent something from happening",
+        "example": "They reached the airport in the nick of time for their flight.",
+        "translation": "vừa kịp lúc",
+        "count": 0
+    },
+    {
+      "word": "in the sticks",
+      "meaning": "in a remote or rural area far from urban life",
+      "example": "They moved to a farmhouse way out in the sticks.",
+      "translation": "nơi hẻo lánh",
+      "count": 0
+    },
+    {
+      "word": "it’s as broad as it’s long",
+      "meaning": "used when two options are equally acceptable or undesirable",
+      "example": "We’ll get there either way—it’s as broad as it’s long.",
+      "translation": "cũng thế cả thôi",
+      "count": 0
+    },
+    {
+      "word": "a drop in the ocean",
+      "meaning": "a small amount that makes little impact in a large context",
+      "example": "Donating one dollar feels like a drop in the ocean compared to the total needed.",
+      "translation": "muối bỏ bể",
+      "count": 0
+    },
+    {
+      "word": "a home from home",
+      "meaning": "a place where you feel as comfortable as at home",
+      "example": "This cozy inn felt like a home from home during our travels.",
+      "translation": "ngôi nhà thứ hai",
+      "count": 0
+    },
+    {
+      "word": "a leopard can’t change its spots",
+      "meaning": "someone's true nature cannot be changed",
+      "example": "No matter what he says, a leopard can’t change its spots.",
+      "translation": "giang sơn dễ đổi, bản tính khó dời",
+      "count": 0
+    },
+    {
+      "word": "a sight for sore eyes",
+      "meaning": "someone or something you’re delighted to see",
+      "example": "After weeks abroad, her smile was a sight for sore eyes.",
+      "translation": "cảnh đẹp ý vui",
+      "count": 0
+    },
+    {
+      "word": "a stitch in time (saves nine)",
+      "meaning": "fixing a problem early prevents it from getting worse",
+      "example": "You should repair that leak now—a stitch in time saves nine.",
+      "translation": "một mũi khâu lúc này hơn chín mũi khâu sau",
+      "count": 0
+    },
+    {
+      "word": "a stone’s throw (away/from)",
+      "meaning": "a very short distance away",
+      "example": "The hotel is just a stone’s throw from the beach.",
+      "translation": "rất gần",
+      "count": 0
+    },
+    {
+      "word": "Achilles’ heel",
+      "meaning": "a weakness in someone or something otherwise strong",
+      "example": "Her Achilles’ heel is her tendency to overthink.",
+      "translation": "gót chân Achilles, điểm yếu",
+      "count": 0
+    },
+    {
+      "word": "add fuel to the fire",
+      "meaning": "to make an already tense situation worse",
+      "example": "Criticizing him in public only added fuel to the fire.",
+      "translation": "đổ thêm dầu vào lửa",
+      "count": 0
+    },
+    {
+      "word": "all in good time",
+      "meaning": "be patient, things will happen when ready",
+      "example": "You’ll hear the results soon— all in good time.",
+      "translation": "kiên nhẫn, lặng lẽ",
+      "count": 0
+    },
+    {
+      "word": "all mod cons",
+      "meaning": "modern appliances and facilities in a home",
+      "example": "The apartment has all mod cons, including a smart fridge.",
+      "translation": "tất cả tiện nghi hiện đại",
+      "count": 0
+    },
+    {
+      "word": "an act of God",
+      "meaning": "a natural disaster that is beyond human control",
+      "example": "The damage was caused by an act of God—no one could prevent it.",
+      "translation": "thảm họa thiên nhiên",
+      "count": 0
+    },
+    {
+      "word": "as the crow flies",
+      "meaning": "in a straight line, without taking roads into account",
+      "example": "It’s 20 miles as the crow flies, but longer by road.",
+      "translation": "theo đường chim bay",
+      "count": 0
+    },
+    {
+      "word": "at a loose end",
+      "meaning": "with nothing planned or to occupy your time",
+      "example": "I was at a loose end, so I decided to visit an old friend.",
+      "translation": "vô công rồi nghề",
+      "count": 0
+    },
+    {
+      "word": "at the drop of a hat",
+      "meaning": "without hesitation or delay",
+      "example": "She’s always ready to travel at the drop of a hat.",
+      "translation": "ngay lập tức",
+      "count": 0
+    },
+    {
+      "word": "for good",
+      "meaning": "permanently, without the intention of changing",
+      "example": "He moved abroad for good after graduating.",
+      "translation": "mãi mãi",
+      "count": 0
+    }
+
+    ],
+    "topic vocab": [
+      {
+      "word": "Abrupt (adjective)",
+      "meaning": "happening suddenly without warning",
+      "example": "His departure was so abrupt that no one had time to say goodbye.",
+      "translation": "đột ngột",
+      "count": 0
+    },
+    {
+      "word": "yearn (v) /jɜːn/",
+      "meaning": "to strongly desire something that is hard to get",
+      "example": "They yearned for a simpler life in the countryside.",
+      "translation": "ao ước",
+      "count": 0
+    },
+    {
+      "word": "absorbing (adj) /əbˈzɔːbɪŋ/",
+      "meaning": "so interesting that it captures your full attention",
+      "example": "The documentary was incredibly absorbing from start to finish.",
+      "translation": "hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "casual (adj) /ˈkæʒuəl/",
+      "meaning": "relaxed, not formal or serious",
+      "example": "His casual tone made the meeting feel informal.",
+      "translation": "tự nhiên, không trịnh trọng",
+      "count": 0
+    },
+    {
+      "word": "exhilarating (adj) /ɪɡˈzɪləreɪtɪŋ/",
+      "meaning": "causing excitement and great happiness",
+      "example": "Skydiving was the most exhilarating experience of my life.",
+      "translation": "gây hứng khởi, hồi hộp",
+      "count": 0
+    },
+    {
+      "word": "fatigue (n) /fəˈtiːɡ/",
+      "meaning": "extreme physical or mental tiredness",
+      "example": "Working non-stop for hours left her in a state of fatigue.",
+      "translation": "mệt nhọc",
+      "count": 0
+    },
+    {
+      "word": "idle (adj) /ˈaɪdl/",
+      "meaning": "not doing any work or avoiding activity",
+      "example": "The kids were idle all day during summer vacation.",
+      "translation": "lười biếng, vô công rồi nghề",
+      "count": 0
+    },
+    {
+      "word": "idle (adj) /ˈaɪdl/",
+      "meaning": "not in use or not active",
+      "example": "The machines sat idle after the plant was shut down.",
+      "translation": "ăn không ngồi rồi",
+      "count": 0
+    },
+    {
+      "word": "impractical (adj) /ɪmˈpræktɪkl/",
+      "meaning": "not sensible or realistic for practical use",
+      "example": "The plan was deemed impractical due to its high costs.",
+      "translation": "không thực tế",
+      "count": 0
+    },
+    {
+      "word": "indispensable (adj) /ˌɪndɪˈspensəbl/",
+      "meaning": "absolutely necessary, cannot be done without",
+      "example": "Water is indispensable for all forms of life.",
+      "translation": "không thể thiếu",
+      "count": 0
+    },
+    {
+      "word": "indulge (v) /ɪnˈdʌldʒ/",
+      "meaning": "to treat yourself to something you enjoy",
+      "example": "She indulged in a long spa day after finishing her exams.",
+      "translation": "nuông chiều, thỏa mãn",
+      "count": 0
+    },
+    {
+      "word": "lifestyle (n) /ˈlaɪfstaɪl/",
+      "meaning": "the typical way a person lives and behaves",
+      "example": "He changed his lifestyle completely after the diagnosis.",
+      "translation": "lối sống",
+      "count": 0
+    },
+    {
+      "word": "leave (n) /liːv/",
+      "meaning": "a break from work or duty, especially for rest",
+      "example": "She’ll be on maternity leave until next spring.",
+      "translation": "thời gian nghỉ phép",
+      "count": 0
+    },
+    {
+      "word": "outing (n) /ˈaʊtɪŋ/",
+      "meaning": "a brief trip taken for fun or leisure",
+      "example": "We went on a family outing to the countryside.",
+      "translation": "cuộc đi chơi ngắn",
+      "count": 0
+    },
+    {
+      "word": "pastime (n) /ˈpɑːstaɪm/",
+      "meaning": "an enjoyable activity done in your spare time",
+      "example": "Playing board games is one of my favorite pastimes.",
+      "translation": "trò tiêu khiển",
+      "count": 0
+    },
+    {
+      "word": "pursue (v) /pəˈsjuː/",
+      "meaning": "to actively work toward achieving something",
+      "example": "She plans to pursue a degree in psychology.",
+      "translation": "theo đuổi",
+      "count": 0
+    },
+    {
+      "word": "recreation (n) /ˌrekriˈeɪʃn/",
+      "meaning": "leisure activities that bring enjoyment",
+      "example": "Hiking is a popular form of recreation in this area.",
+      "translation": "sự giải trí, tiêu khiển",
+      "count": 0
+    },
+    {
+      "word": "respite (n) /ˈrespaɪt/",
+      "meaning": "a temporary pause from something tiring or unpleasant",
+      "example": "The rain gave us a welcome respite from the heat.",
+      "translation": "thời gian nghỉ ngơi",
+      "count": 0
+    },
+    {
+      "word": "sedentary (adj) /ˈsedntri/",
+      "meaning": "involving little movement or physical activity",
+      "example": "Too much sedentary behavior can impact your health.",
+      "translation": "tĩnh tại, ít vận động",
+      "count": 0
+    },
+    {
+      "word": "socialise (v) /ˈsəʊʃəlaɪz/",
+      "meaning": "to interact with others in a friendly way",
+      "example": "She loves to socialise at parties and events.",
+      "translation": "giao tiếp xã hội",
+      "count": 0
+    },
+    {
+      "word": "solitude (n) /ˈsɒlɪtjuːd/",
+      "meaning": "the peaceful state of being alone",
+      "example": "He enjoys reading in solitude after a long day.",
+      "translation": "trạng thái cô độc dễ chịu",
+      "count": 0
+    },
+    {
+      "word": "tedious (adj) /ˈtiːdiəs/",
+      "meaning": "dull and taking a long time to complete",
+      "example": "Filing these reports is such a tedious task.",
+      "translation": "chán ngắt",
+      "count": 0
+    },
+    {
+      "word": "trivial (adj) /ˈtrɪviəl/",
+      "meaning": "not important or worth serious attention",
+      "example": "They argued over something completely trivial.",
+      "translation": "tầm thường, vụn vặt",
+      "count": 0
+    },
+    {
+      "word": "unwind (v) /ʌnˈwaɪnd/",
+      "meaning": "to relax after stress or activity",
+      "example": "A warm bath helps me unwind after work.",
+      "translation": "thư giãn",
+      "count": 0
+    },
+    {
+      "word": "venue (n) /ˈvenjuː/",
+      "meaning": "a location where an event takes place",
+      "example": "They picked a beachfront venue for their wedding.",
+      "translation": "địa điểm",
+      "count": 0
+    },
+    {
+      "word": "decline (v) /dɪˈklaɪn/",
+      "meaning": "to decrease or weaken over time",
+      "example": "Interest in the product began to decline last year.",
+      "translation": "giảm, suy tàn",
+      "count": 0
+    },
+    {
+      "word": "dedicated (adj) /ˈdedɪkeɪtɪd/",
+      "meaning": "fully committed to a task or purpose",
+      "example": "He’s a dedicated athlete who trains daily.",
+      "translation": "tận tâm",
+      "count": 0
+    },
+    {
+      "word": "delight (v) /dɪˈlaɪt/",
+      "meaning": "to give someone great joy or satisfaction",
+      "example": "The surprise party delighted her.",
+      "translation": "làm vui sướng",
+      "count": 0
+    },
+    {
+      "word": "desire (v) /dɪˈzaɪər/",
+      "meaning": "to strongly wish for something",
+      "example": "They deeply desired a chance to prove themselves.",
+      "translation": "ao ước, khát khao",
+      "count": 0
+    },
+    {
+      "word": "desire (n) /dɪˈzaɪər/",
+      "meaning": "a strong feeling of wanting something",
+      "example": "Her desire to win pushed her to train harder.",
+      "translation": "niềm mơ ước, khao khát",
+      "count": 0
+    },
+    {
+      "word": "devote (v) /dɪˈvəʊt/",
+      "meaning": "to dedicate time or energy to something important",
+      "example": "She devotes weekends to volunteering.",
+      "translation": "cống hiến",
+      "count": 0
+    },
+    {
+      "word": "devote (v) /dɪˈvəʊt/",
+      "meaning": "to allocate something, like money, for a use",
+      "example": "They devoted more funds to education programs.",
+      "translation": "dành cho việc gì",
+      "count": 0
+    },
+    {
+      "word": "differentiate (v) /ˌdɪfəˈrenʃieɪt/",
+      "meaning": "to recognize or show how things are different",
+      "example": "Can you differentiate between the two versions?",
+      "translation": "phân biệt",
+      "count": 0
+    },
+    {
+      "word": "envy (v) /ˈenvi/",
+      "meaning": "to feel unhappy because you want what others have",
+      "example": "He envied her calm attitude in stressful situations.",
+      "translation": "ghen tị",
+      "count": 0
+    },
+    {
+      "word": "envy (n) /ˈenvi/",
+      "meaning": "the feeling of jealousy toward others’ success or things",
+      "example": "There was clear envy in her tone when she saw the car.",
+      "translation": "sự ghen tị",
+      "count": 0
+    },    
+    {
+      "word": "fancy (v) /ˈfænsi/",
+      "meaning": "to feel like doing or having something",
+      "example": "Do you fancy grabbing a coffee later?",
+      "translation": "thích, muốn",
+      "count": 0
+    },
+    {
+      "word": "fascination (n) /ˌfæsɪˈneɪʃn/",
+      "meaning": "a strong interest or attraction to something",
+      "example": "He’s had a lifelong fascination with space travel.",
+      "translation": "sự quyến rũ, hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "favour (n) /ˈfeɪvər/",
+      "meaning": "support or preference shown for something",
+      "example": "His favour clearly leaned toward the second option.",
+      "translation": "sự ủng hộ",
+      "count": 0
+    },
+    {
+      "word": "favour (v) /ˈfeɪvər/",
+      "meaning": "to give someone an advantage over others",
+      "example": "The manager was accused of favouring his relatives.",
+      "translation": "thiên vị",
+      "count": 0
+    },
+    {
+      "word": "favour (v) /ˈfeɪvər/",
+      "meaning": "to do something helpful for someone",
+      "example": "Would you mind doing me a favour and printing this?",
+      "translation": "sự giúp đỡ",
+      "count": 0
+    },
+    {
+      "word": "greedy (adj) /ˈɡriːdi/",
+      "meaning": "wanting more than what is reasonable or needed",
+      "example": "He got sick from being too greedy at the buffet.",
+      "translation": "tham lam",
+      "count": 0
+    },
+    {
+      "word": "impulse (n) /ˈɪmpʌls/",
+      "meaning": "a sudden urge to act without thinking",
+      "example": "She bought the shoes on impulse.",
+      "translation": "sự thôi thúc",
+      "count": 0
+    },
+    {
+      "word": "inclined (adj) /ɪnˈklaɪnd/",
+      "meaning": "having a tendency or preference to do something",
+      "example": "He’s inclined to believe her story.",
+      "translation": "có khuynh hướng",
+      "count": 0
+    },
+    {
+      "word": "liking (n) /ˈlaɪkɪŋ/",
+      "meaning": "a fondness or preference for something",
+      "example": "She has a liking for spicy dishes.",
+      "translation": "sự ưa thích",
+      "count": 0
+    },
+    {
+      "word": "mediocre (adj) /ˌmiːdiˈəʊkər/",
+      "meaning": "not very good; average in quality",
+      "example": "The movie was mediocre at best.",
+      "translation": "tầm thường",
+      "count": 0
+    },
+    {
+      "word": "motive (n) /ˈməʊtɪv/",
+      "meaning": "a reason for doing something",
+      "example": "The police are still trying to determine the motive.",
+      "translation": "động cơ",
+      "count": 0
+    },
+    {
+      "word": "mundane (adj) /mʌnˈdeɪn/",
+      "meaning": "lacking excitement; very ordinary",
+      "example": "He’s tired of his mundane job.",
+      "translation": "tẻ nhạt",
+      "count": 0
+    },
+    {
+      "word": "obsessed (adj) /əbˈsest/",
+      "meaning": "completely fixated or preoccupied with something",
+      "example": "She’s obsessed with fitness and health.",
+      "translation": "bị ám ảnh",
+      "count": 0
+    },
+    {
+      "word": "optional (adj) /ˈɒpʃənl/",
+      "meaning": "not required; left to individual choice",
+      "example": "The workshop is optional, but recommended.",
+      "translation": "tùy chọn",
+      "count": 0
+    },
+    {
+      "word": "passion (n) /ˈpæʃn/",
+      "meaning": "a strong enthusiasm or love for something",
+      "example": "She pursued her passion for photography.",
+      "translation": "niềm đam mê",
+      "count": 0
+    },
+    {
+      "word": "praise (v) /preɪz/",
+      "meaning": "to express approval or admiration",
+      "example": "He praised the team’s dedication.",
+      "translation": "khen ngợi",
+      "count": 0
+    },
+    {
+      "word": "praise (n) /preɪz/",
+      "meaning": "words expressing admiration or approval",
+      "example": "The project received a lot of praise.",
+      "translation": "lời khen",
+      "count": 0
+    },
+    {
+      "word": "resolve (v) /rɪˈzɒlv/",
+      "meaning": "to firmly decide to take action",
+      "example": "She resolved to quit smoking by the end of the month.",
+      "translation": "quyết tâm",
+      "count": 0
+    },
+    {
+      "word": "sacrifice (v) /ˈsækrɪfaɪs/",
+      "meaning": "to give up something for a greater good",
+      "example": "They sacrificed their vacation to finish the work.",
+      "translation": "hy sinh",
+      "count": 0
+    },
+    {
+      "word": "sacrifice (n) /ˈsækrɪfaɪs/",
+      "meaning": "something valuable that is given up",
+      "example": "Her sacrifice helped the family survive.",
+      "translation": "sự hy sinh",
+      "count": 0
+    },
+    {
+      "word": "strive (v) /straɪv/",
+      "meaning": "to put in a lot of effort to reach a goal",
+      "example": "He continues to strive for excellence.",
+      "translation": "phấn đấu",
+      "count": 0
+    },
+    {
+      "word": "taste (n) /teɪst/",
+      "meaning": "a person's preference or judgment in aesthetics",
+      "example": "She has great taste in interior design.",
+      "translation": "gu, khiếu thẩm mỹ",
+      "count": 0
+    },
+    {
+      "word": "tempting (adj) /ˈtemptɪŋ/",
+      "meaning": "appealing and hard to resist",
+      "example": "The dessert looked extremely tempting.",
+      "translation": "đầy cám dỗ",
+      "count": 0
+    },
+    {
+      "word": "urge (v) /ɜːdʒ/",
+      "meaning": "to strongly advise or encourage someone to do something",
+      "example": "Doctors urge patients to exercise regularly.",
+      "translation": "thúc giục",
+      "count": 0
+    },
+    {
+      "word": "welcome (v) /ˈwelkəm/",
+      "meaning": "to express acceptance or support for something",
+      "example": "We welcome any input that can help us improve.",
+      "translation": "hoan nghênh",
+      "count": 0
+    },
+    {
+      "word": "welcome (adj) /ˈwelkəm/",
+      "meaning": "feeling accepted or appreciated",
+      "example": "They made us feel very welcome at the party.",
+      "translation": "được chào đón",
+      "count": 0
+    },
+    {
+      "word": "worthwhile (adj) /ˌwɜːθˈwaɪl/",
+      "meaning": "valuable enough to justify the effort",
+      "example": "Volunteering is a worthwhile way to spend your time.",
+      "translation": "đáng giá",
+      "count": 0
+    },
+    {
+      "word": "adopt (v) /əˈdɒpt/",
+      "meaning": "to begin using a new idea or approach",
+      "example": "The school adopted a new learning strategy.",
+      "translation": "thực hiện",
+      "count": 0
+    },
+    {
+      "word": "adopt (v) /əˈdɒpt/",
+      "meaning": "to legally take a child into your family",
+      "example": "They adopted a baby girl last year.",
+      "translation": "nhận nuôi",
+      "count": 0
+    },
+    {
+      "word": "ancestor (n) /ˈænsestər/",
+      "meaning": "a family member from generations past",
+      "example": "Her ancestors were early settlers in the region.",
+      "translation": "tổ tiên",
+      "count": 0
+    },
+    {
+      "word": "citizen (n) /ˈsɪtɪzn/",
+      "meaning": "a person who belongs to a country and has legal rights there",
+      "example": "She became a French citizen after living there for years.",
+      "translation": "công dân",
+      "count": 0
+    },
+    {
+      "word": "companion (n) /kəmˈpænjən/",
+      "meaning": "someone who accompanies you or shares time with you",
+      "example": "His dog was his constant companion.",
+      "translation": "người đồng hành",
+      "count": 0
+    },
+    {
+      "word": "dependant (n) /dɪˈpendənt/",
+      "meaning": "someone who relies on another for financial support",
+      "example": "He has three young dependants at home.",
+      "translation": "người sống phụ thuộc",
+      "count": 0
+    },
+    {
+      "word": "descendant (n) /dɪˈsendənt/",
+      "meaning": "a person related to someone from an earlier generation",
+      "example": "She is a direct descendant of the poet.",
+      "translation": "hậu duệ",
+      "count": 0
+    },
+    {
+      "word": "empathetic (adj) /ˌempəˈθetɪk/",
+      "meaning": "able to understand and share another's feelings",
+      "example": "Her empathetic nature made her a great counselor.",
+      "translation": "thấu cảm",
+      "count": 0
+    },
+    {
+      "word": "extrovert (n) /ˈekstrəvɜːt/",
+      "meaning": "a person who enjoys social interaction and being around others",
+      "example": "Being an extrovert, he thrived at parties.",
+      "translation": "người hướng ngoại",
+      "count": 0
+    },
+    {
+      "word": "foster (v) /ˈfɒstər/",
+      "meaning": "to temporarily care for a child who is not biologically yours",
+      "example": "They fostered children while waiting to adopt.",
+      "translation": "nuôi dưỡng tạm thời",
+      "count": 0
+    },
+    {
+      "word": "guardian (n) /ˈɡɑːdiən/",
+      "meaning": "a person who legally cares for someone, especially a child",
+      "example": "Her uncle was appointed as her legal guardian.",
+      "translation": "người giám hộ",
+      "count": 0
+    },
+    {
+      "word": "introvert (n) /ˈɪntrəvɜːt/",
+      "meaning": "a person who prefers quiet and solitude over social interaction",
+      "example": "As an introvert, he found large gatherings draining.",
+      "translation": "người hướng nội",
+      "count": 0
+    },
+    {
+      "word": "partner (n) /ˈpɑːtnər/",
+      "meaning": "someone you team up with for an activity",
+      "example": "My dance partner and I practice twice a week.",
+      "translation": "đối tác",
+      "count": 0
+    },
+    {
+      "word": "partner (n) /ˈpɑːtnər/",
+      "meaning": "someone you have a romantic relationship with",
+      "example": "He lives with his partner in the countryside.",
+      "translation": "bạn đời",
+      "count": 0
+    },
+    {
+      "word": "peer (n) /pɪər/",
+      "meaning": "someone of similar age, status, or background",
+      "example": "He struggled to fit in with his peers at school.",
+      "translation": "người đồng lứa",
+      "count": 0
+    },
+    {
+      "word": "predecessor (n) /ˈpriːdəsesər/",
+      "meaning": "a person who held a job or position before someone else",
+      "example": "Her predecessor left the department in good shape.",
+      "translation": "người tiền nhiệm",
+      "count": 0
+    },
+    {
+      "word": "sibling (n) /ˈsɪblɪŋ/",
+      "meaning": "a brother or sister",
+      "example": "He often argued with his younger sibling.",
+      "translation": "anh/chị/em ruột",
+      "count": 0
+    },
+    {
+      "word": "spouse (n) /spaʊs/",
+      "meaning": "a person's husband or wife",
+      "example": "Each spouse needs to sign the form.",
+      "translation": "vợ hoặc chồng",
+      "count": 0
+    },
+    {
+      "word": "stepmother/son/etc (n) /ˈstepˌmʌðər/",
+      "meaning": "a relative by marriage, not by birth",
+      "example": "He had a difficult relationship with his stepfather.",
+      "translation": "mẹ kế, con riêng...",
+      "count": 0
+    },
+    {
+      "word": "successor (n) /səkˈsesər/",
+      "meaning": "a person who follows another in a position or job",
+      "example": "The board appointed her as the CEO’s successor.",
+      "translation": "người kế nhiệm",
+      "count": 0
+    },
+    {
+      "word": "sympathise (v) /ˈsɪmpəθaɪz/",
+      "meaning": "to show concern or understanding for someone’s situation",
+      "example": "I sympathise with their difficult position.",
+      "translation": "đồng cảm",
+      "count": 0
+    },
+    {
+      "word": "addiction (n) /əˈdɪkʃn/",
+      "meaning": "a strong habit that is hard to give up",
+      "example": "He’s battling an addiction to social media.",
+      "translation": "nghiện",
+      "count": 0
+    },
+    {
+      "word": "adore (v) /əˈdɔːr/",
+      "meaning": "to deeply love or enjoy someone or something",
+      "example": "She absolutely adores her new puppy.",
+      "translation": "rất yêu thích",
+      "count": 0
+    },
+    {
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "a feeling of excitement or interest in something",
+      "example": "The appeal of starting a new hobby was hard to resist.",
+      "translation": "sự hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "an attractive quality that makes people like something",
+      "example": "The city’s appeal lies in its vibrant culture and nightlife.",
+      "translation": "tính hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "appeal (n) /əˈpiːl/",
+      "meaning": "a formal request to change a decision",
+      "example": "The lawyer submitted an appeal to the court.",
+      "translation": "lời kháng cáo",
+      "count": 0
+    },
+    {
+      "word": "arbitrary (adj) /ˈɑːbɪtrəri/",
+      "meaning": "based on random choice rather than reason",
+      "example": "The rule seemed completely arbitrary and unfair.",
+      "translation": "tùy tiện",
+      "count": 0
+    },
+    {
+      "word": "aspiration (n) /ˌæspəˈreɪʃn/",
+      "meaning": "a strong hope or ambition to achieve something",
+      "example": "He’s always had aspirations to become an artist.",
+      "translation": "khát vọng",
+      "count": 0
+    },
+    {
+      "word": "bear (v) /beər/",
+      "meaning": "to endure something unpleasant or painful",
+      "example": "I can’t bear listening to that song anymore.",
+      "translation": "chịu đựng",
+      "count": 0
+    },
+    {
+      "word": "compulsory (adj) /kəmˈpʌlsəri/",
+      "meaning": "required by law or a rule",
+      "example": "Wearing seatbelts is compulsory in most countries.",
+      "translation": "bắt buộc",
+      "count": 0
+    },
+    {
+      "word": "content (adj) /kənˈtent/",
+      "meaning": "feeling satisfied with your situation",
+      "example": "She looked content after finishing the project.",
+      "translation": "hài lòng",
+      "count": 0
+    },
+    {
+      "word": "craving (n) /ˈkreɪvɪŋ/",
+      "meaning": "a strong desire for something specific",
+      "example": "He had a craving for salty snacks.",
+      "translation": "sự thèm muốn",
+      "count": 0
+    },
+    {
+      "word": "decline (v) /dɪˈklaɪn/",
+      "meaning": "to politely say no to an invitation or offer",
+      "example": "She declined the invitation to the party.",
+      "translation": "từ chối",
+      "count": 0
+    },
+    {
+      "word": "dispute (n) /dɪˈspjuːt/",
+      "meaning": "a prolonged argument or disagreement",
+      "example": "The land dispute lasted for years.",
+      "translation": "tranh chấp",
+      "count": 0
+    },
+    {
+      "word": "distinguish (v) /dɪˈstɪŋɡwɪʃ/",
+      "meaning": "to recognize the differences between things",
+      "example": "It’s important to distinguish fact from opinion.",
+      "translation": "phân biệt",
+      "count": 0
+    },
+    {
+      "word": "diverse (adj) /daɪˈvɜːs/",
+      "meaning": "showing a variety of different types",
+      "example": "Our team is made up of people from diverse backgrounds.",
+      "translation": "đa dạng",
+      "count": 0
+    },
+    {
+      "word": "divorce (v) /dɪˈvɔːs/",
+      "meaning": "to legally end a marriage",
+      "example": "They divorced after 15 years of marriage.",
+      "translation": "ly hôn",
+      "count": 0
+    },
+    {
+      "word": "divorce (n) /dɪˈvɔːs/",
+      "meaning": "the official end of a marriage",
+      "example": "The divorce was finalized last month.",
+      "translation": "ly hôn",
+      "count": 0
+    },
+    {
+      "word": "equivalent (n) /ɪˈkwɪvələnt/",
+      "meaning": "something with the same function or value",
+      "example": "There’s no exact equivalent for that word in Spanish.",
+      "translation": "vật tương đương",
+      "count": 0
+    },
+    {
+      "word": "equivalent (adj) /ɪˈkwɪvələnt/",
+      "meaning": "having the same value or function",
+      "example": "Their roles are equivalent in the company structure.",
+      "translation": "tương đương",
+      "count": 0
+    },
+    {
+      "word": "exclude (v) /ɪkˈskluːd/",
+      "meaning": "to leave something or someone out",
+      "example": "They excluded several names from the final list.",
+      "translation": "loại trừ",
+      "count": 0
+    },
+    {
+      "word": "external (adj) /ɪkˈstɜːnl/",
+      "meaning": "originating from outside something",
+      "example": "The project requires input from external experts.",
+      "translation": "bên ngoài",
+      "count": 0
+    },
+    {
+      "word": "external (adj) /ɪkˈstɜːnl/",
+      "meaning": "located on the outside surface",
+      "example": "The external walls need repainting.",
+      "translation": "ở bên ngoài",
+      "count": 0
+    },
+    {
+      "word": "identify (v) /aɪˈdentɪfaɪ/",
+      "meaning": "to recognize someone or something",
+      "example": "She couldn’t identify the man in the lineup.",
+      "translation": "xác nhận, nhận diện",
+      "count": 0
+    },
+    {
+      "word": "identify with (v) /aɪˈdentɪfaɪ wɪð/",
+      "meaning": "to feel emotionally connected with someone",
+      "example": "I identified with the main character’s struggles.",
+      "translation": "thấu hiểu",
+      "count": 0
+    },
+    {
+      "word": "integral (adj) /ˈɪntɪɡrəl/",
+      "meaning": "essential to make something complete",
+      "example": "Trust is an integral part of any relationship.",
+      "translation": "cần thiết, không thể thiếu",
+      "count": 0
+    },
+    {
+      "word": "integrate (v) /ˈɪntɪɡreɪt/",
+      "meaning": "to become part of a group or society",
+      "example": "It took him a while to integrate into the new community.",
+      "translation": "hòa nhập",
+      "count": 0
+    },
+    {
+      "word": "interfere (v) /ˌɪntəˈfɪər/",
+      "meaning": "to get involved in a situation where you're not wanted",
+      "example": "Please stop interfering in matters that don't concern you.",
+      "translation": "xen vào, quấy rầy",
+      "count": 0
+    },
+    {
+      "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
+      "meaning": "positioned between basic and advanced levels",
+      "example": "He enrolled in an intermediate English class.",
+      "translation": "trung gian",
+      "count": 0
+    },
+    {
+      "word": "intermediate (adj) /ˌɪntəˈmiːdiət/",
+      "meaning": "having a skill level that is between beginner and advanced",
+      "example": "The school offers an intermediate Spanish course.",
+      "translation": "trung cấp",
+      "count": 0
+    },
+    {
+      "word": "internal (adj) /ɪnˈtɜːnl/",
+      "meaning": "located inside something like a system or structure",
+      "example": "Internal walls were removed to create an open space.",
+      "translation": "bên trong",
+      "count": 0
+    },
+    {
+      "word": "intervene (v) /ˌɪntəˈviːn/",
+      "meaning": "to step in to help improve or alter a situation",
+      "example": "A security guard intervened to break up the fight.",
+      "translation": "can thiệp",
+      "count": 0
+    },
+    {
+      "word": "intimate (adj) /ˈɪntɪmət/",
+      "meaning": "describing a deeply personal and close connection",
+      "example": "They maintained an intimate friendship for years.",
+      "translation": "thân mật",
+      "count": 0
+    },
+    {
+      "word": "intimate (adj) /ˈɪntɪmət/",
+      "meaning": "related to private or personal details",
+      "example": "He shared intimate stories from his past.",
+      "translation": "riêng tư",
+      "count": 0
+    },
+    {
+      "word": "involve (v) /ɪnˈvɒlv/",
+      "meaning": "to include something as part of an activity or event",
+      "example": "Renovating the house involves a lot of planning.",
+      "translation": "bao gồm",
+      "count": 0
+    },
+    {
+      "word": "involve (v) /ɪnˈvɒlv/",
+      "meaning": "to include someone in an activity or process",
+      "example": "The manager involved the whole team in the decision.",
+      "translation": "bao gồm ai đó tham gia",
+      "count": 0
+    },
+    {
+      "word": "joint (adj) /dʒɔɪnt/",
+      "meaning": "done or shared by two or more people",
+      "example": "They issued a joint statement after the meeting.",
+      "translation": "chung, cùng nhau",
+      "count": 0
+    },
+    {
+      "word": "liken (v) /ˈlaɪkən/",
+      "meaning": "to compare one thing to another",
+      "example": "He likened her voice to that of an angel.",
+      "translation": "so sánh với",
+      "count": 0
+    },
+    {
+      "word": "link (v) /lɪŋk/",
+      "meaning": "to create a connection between things",
+      "example": "The study links pollution to respiratory diseases.",
+      "translation": "liên kết",
+      "count": 0
+    },
+    {
+      "word": "link (n) /lɪŋk/",
+      "meaning": "a relationship or connection between two items",
+      "example": "They found a link between diet and performance.",
+      "translation": "mối liên hệ",
+      "count": 0
+    },
+    {
+      "word": "merge (v) /mɜːdʒ/",
+      "meaning": "to combine multiple things into one",
+      "example": "The two departments will merge next month.",
+      "translation": "sáp nhập",
+      "count": 0
+    },
+    {
+      "word": "mutual (adj) /ˈmjuːtʃuəl/",
+      "meaning": "shared or experienced equally by two or more parties",
+      "example": "There was mutual respect between the competitors.",
+      "translation": "lẫn nhau, chung",
+      "count": 0
+    },
+    {
+      "word": "negotiate (v) /nɪˈɡəʊʃieɪt/",
+      "meaning": "to try to reach an agreement through discussion",
+      "example": "They negotiated a new contract with the supplier.",
+      "translation": "đàm phán",
+      "count": 0
+    },
+    {
+      "word": "related (adj) /rɪˈleɪtɪd/",
+      "meaning": "connected or associated with something",
+      "example": "His health problems are related to stress.",
+      "translation": "liên quan",
+      "count": 0
+    },
+    {
+      "word": "relative (adj) /ˈrelətɪv/",
+      "meaning": "judged or measured in comparison with something else",
+      "example": "The cost is low relative to the benefits.",
+      "translation": "tương đối",
+      "count": 0
+    },
+    {
+      "word": "resemblance (n) /rɪˈzembləns/",
+      "meaning": "the state of being similar to someone or something",
+      "example": "She bears a strong resemblance to her grandmother.",
+      "translation": "sự tương đồng",
+      "count": 0
+    },
+    {
+      "word": "acquaintance (n) /əˈkweɪntəns/",
+      "meaning": "a person you know slightly, not a close friend",
+      "example": "I met him through a mutual acquaintance.",
+      "translation": "người quen",
+      "count": 0
+    },
+    {
+      "word": "installation (n) /ˌɪnstəˈleɪʃn/",
+      "meaning": "an arrangement of objects designed as a form of art",
+      "example": "The museum features a light and sound installation.",
+      "translation": "tác phẩm trưng bày",
+      "count": 0
+    },
+    {
+      "word": "lines (n pl) /laɪnz/",
+      "meaning": "the words spoken by an actor in a play or movie",
+      "example": "She forgot her lines during the audition.",
+      "translation": "lời thoại",
+      "count": 0
+    },
+    {
+      "word": "lyrics (n pl) /ˈlɪrɪks/",
+      "meaning": "the words of a song",
+      "example": "He wrote the lyrics for a hit single.",
+      "translation": "lời bài hát",
+      "count": 0
+    },
+    {
+      "word": "masterpiece (n) /ˈmɑːstəpiːs/",
+      "meaning": "a work of art considered outstanding or exceptional",
+      "example": "The painting is considered a Renaissance masterpiece.",
+      "translation": "kiệt tác",
+      "count": 0
+    },
+    {
+      "word": "paperback (n) /ˈpeɪəbæk/",
+      "meaning": "a book with a soft paper cover",
+      "example": "The novel is now available in paperback edition.",
+      "translation": "sách bìa mềm",
+      "count": 0
+    },
+    {
+      "word": "period (adj) /ˈpɪəriəd/",
+      "meaning": "representing a historical time style or fashion",
+      "example": "Are you wearing a period outfit for the play?",
+      "translation": "thuộc về thời kỳ nào đó",
+      "count": 0
+    },
+    {
+      "word": "period (n) /ˈpɪəriəd/",
+      "meaning": "a specific span of time in history",
+      "example": "We studied the Renaissance period in detail.",
+      "translation": "thời kỳ",
+      "count": 0
+    },
+    {
+      "word": "priceless (adj) /ˈpraɪsləs/",
+      "meaning": "extremely valuable and impossible to replace",
+      "example": "That necklace is absolutely priceless to her.",
+      "translation": "vô giá",
+      "count": 0
+    },
+    {
+      "word": "ritual (n) /ˈrɪtʃuəl/",
+      "meaning": "a repeated, structured set of actions",
+      "example": "His evening ritual includes meditation and journaling.",
+      "translation": "nghi lễ, nghi thức",
+      "count": 0
+    },
+    {
+      "word": "retrospective (adj) /ˌretrəˈspektɪv/",
+      "meaning": "looking back on or dealing with past events",
+      "example": "Her novel had a deeply retrospective tone.",
+      "translation": "hồi tưởng",
+      "count": 0
+    },
+    {
+      "word": "retrospective (n) /ˌretrəˈspektɪv/",
+      "meaning": "an art exhibition covering an artist’s body of work",
+      "example": "The gallery hosted a major Monet retrospective.",
+      "translation": "triển lãm hồi cố",
+      "count": 0
+    },
+    {
+      "word": "score (n) /skɔːr/",
+      "meaning": "music composed for a movie or performance",
+      "example": "The score gave the film a haunting atmosphere.",
+      "translation": "nhạc phim",
+      "count": 0
+    },
+    {
+      "word": "sketch (n) /sketʃ/",
+      "meaning": "a simple drawing made quickly",
+      "example": "He showed me a sketch of his invention idea.",
+      "translation": "bức phác thảo",
+      "count": 0
+    },
+    {
+      "word": "sketch (v) /sketʃ/",
+      "meaning": "to draw something quickly and roughly",
+      "example": "She sat on the beach sketching the waves.",
+      "translation": "phác thảo",
+      "count": 0
+    },
+    {
+      "word": "sketch (v) /sketʃ/",
+      "meaning": "to give a brief summary or description",
+      "example": "Let me sketch the plan before we start.",
+      "translation": "mô tả sơ lược",
+      "count": 0
+    },
+    {
+      "word": "work of art (n phr) /ˌwɜːk əv ˈɑːt/",
+      "meaning": "something crafted with exceptional skill or beauty",
+      "example": "That handmade quilt is a real work of art.",
+      "translation": "công trình nghệ thuật",
+      "count": 0
+    },
+    {
+      "word": "worthless (adj) /ˈwɜːθləs/",
+      "meaning": "having no value or usefulness",
+      "example": "The broken phone is now completely worthless.",
+      "translation": "vô giá trị",
+      "count": 0
+    },
+    {
+      "word": "adjacent (adj) /əˈdʒeɪsnt/",
+      "meaning": "located next to or very close to something",
+      "example": "The café is adjacent to the bookstore.",
+      "translation": "ở sát cạnh",
+      "count": 0
+    },
+    {
+      "word": "attach (v) /əˈtætʃ/",
+      "meaning": "to connect or fasten something to another",
+      "example": "You need to attach the cable before switching on.",
+      "translation": "gắn liền, đính",
+      "count": 0
+    },
+    {
+      "word": "bond (v) /bɒnd/",
+      "meaning": "to join or develop a strong connection",
+      "example": "They bonded during their travels across Asia.",
+      "translation": "gắn kết",
+      "count": 0
+    },
+    {
+      "word": "bond (n) /bɒnd/",
+      "meaning": "a strong emotional or social connection",
+      "example": "Their bond grew stronger after the accident.",
+      "translation": "mối liên kết",
+      "count": 0
+    },
+    {
+      "word": "coexist (v) /ˌkəʊɪɡˈzɪst/",
+      "meaning": "to exist peacefully alongside one another",
+      "example": "Different beliefs can coexist in harmony.",
+      "translation": "cùng tồn tại",
+      "count": 0
+    },
+    {
+      "word": "coherent (adj) /kəʊˈhɪərənt/",
+      "meaning": "clear and logically connected",
+      "example": "Your proposal was well-structured and coherent.",
+      "translation": "mạch lạc",
+      "count": 0
+    },
+    {
+      "word": "compatible (adj) /kəmˈpætəbl/",
+      "meaning": "able to function or get along together",
+      "example": "The software is compatible with both systems.",
+      "translation": "tương thích, hòa hợp",
+      "count": 0
+    },
+    {
+      "word": "compromise (n) /ˈkɒmprəmaɪz/",
+      "meaning": "a mutual agreement where both sides adjust demands",
+      "example": "They reached a compromise that suited everyone.",
+      "translation": "sự thỏa hiệp",
+      "count": 0
+    },
+    {
+      "word": "compromise (v) /ˈkɒmprəmaɪz/",
+      "meaning": "to give up part of your demands to reach agreement",
+      "example": "We compromised on the budget for the project.",
+      "translation": "thỏa hiệp",
+      "count": 0
+    },
+    {
+      "word": "conflict (n) /ˈkɒnflɪkt/",
+      "meaning": "a serious disagreement or argument",
+      "example": "The conflict between the two teams escalated quickly.",
+      "translation": "xung đột",
+      "count": 0
+    },
+    {
+      "word": "confront (v) /kənˈfrʌnt/",
+      "meaning": "to face someone aggressively or directly",
+      "example": "He confronted the stranger who followed him.",
+      "translation": "đối mặt",
+      "count": 0
+    },
+    {
+      "word": "confront (v) /kənˈfrʌnt/",
+      "meaning": "to address or tackle a problem directly",
+      "example": "It’s time to confront your fears.",
+      "translation": "đương đầu",
+      "count": 0
+    },
+    {
+      "word": "consistent (adj) /kənˈsɪstənt/",
+      "meaning": "always acting or performing the same way",
+      "example": "She is consistent in her study routine.",
+      "translation": "nhất quán",
+      "count": 0
+    },
+    {
+      "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
+      "meaning": "to state the opposite of what someone else said",
+      "example": "She always contradicts her colleagues during meetings.",
+      "translation": "mâu thuẫn, phủ nhận",
+      "count": 0
+    },
+    {
+      "word": "contradict (v) /ˌkɒntrəˈdɪkt/",
+      "meaning": "to prove something is incorrect or untrue",
+      "example": "The new data completely contradicts their claims.",
+      "translation": "bác bỏ",
+      "count": 0
+    },
+    {
+      "word": "contrasting (adj) /kənˈtrɑːstɪŋ/",
+      "meaning": "markedly different in character or style",
+      "example": "The room was decorated in contrasting shades of blue and orange.",
+      "translation": "đối lập",
+      "count": 0
+    },
+    {
+      "word": "cooperate (v) /kəʊˈɒpəreɪt/",
+      "meaning": "to act or work together towards a shared goal",
+      "example": "They cooperated on writing the final report.",
+      "translation": "hợp tác",
+      "count": 0
+    },
+    {
+      "word": "correspond (v) /ˌkɒrəˈspɒnd/",
+      "meaning": "to match or be similar in meaning, character, or function",
+      "example": "The description doesn’t correspond with the real item.",
+      "translation": "tương ứng, khớp",
+      "count": 0
+    },
+    {
+      "word": "dispute (v) /dɪˈspjuːt/",
+      "meaning": "to question the truth or accuracy of something",
+      "example": "They disputed the results of the election.",
+      "translation": "tranh cãi, phản bác",
+      "count": 0
+    },
+    {
+      "word": "dispute (n) /ˈdɪspjuːt/",
+      "meaning": "a serious disagreement or argument",
+      "example": "A dispute arose between the neighbors over property lines.",
+      "translation": "cuộc tranh cãi",
+      "count": 0
+    },
+    {
+      "word": "ideal (adj) /aɪˈdɪəl/",
+      "meaning": "perfect or most appropriate for a situation",
+      "example": "It’s the ideal time to plant these trees.",
+      "translation": "lý tưởng, tốt nhất",
+      "count": 0
+    },
+    {
+      "word": "ideal (n) /aɪˈdɪəl/",
+      "meaning": "a principle or value considered to be perfect",
+      "example": "Freedom and equality are democratic ideals.",
+      "translation": "lý tưởng",
+      "count": 0
+    },
+    {
+      "word": "inadequate (adj) /ɪnˈædɪkwət/",
+      "meaning": "not enough or not acceptable in quality or quantity",
+      "example": "Their response to the emergency was inadequate.",
+      "translation": "không đủ, không tương xứng",
+      "count": 0
+    },
+    {
+      "word": "invaluable (adj) /ɪnˈvæljuəbl/",
+      "meaning": "extremely helpful or important",
+      "example": "Her insights were invaluable to the investigation.",
+      "translation": "vô giá",
+      "count": 0
+    },
+    {
+      "word": "optimum (adj) /ˈɒptɪməm/",
+      "meaning": "most effective or favorable in a situation",
+      "example": "This temperature is optimum for seed growth.",
+      "translation": "tối ưu",
+      "count": 0
+    },
+    {
+      "word": "optimum (n) /ˈɒptɪməm/",
+      "meaning": "the best possible level or amount",
+      "example": "They worked at the optimum to meet the deadline.",
+      "translation": "mức tối ưu",
+      "count": 0
+    },
+    {
+      "word": "outclass (v) /ˌaʊtˈklɑːs/",
+      "meaning": "to perform much better than someone else",
+      "example": "She outclassed all the other runners in the race.",
+      "translation": "vượt trội",
+      "count": 0
+    },
+    {
+      "word": "prime (adj) /praɪm/",
+      "meaning": "most important, top-quality or central",
+      "example": "Security is our prime concern right now.",
+      "translation": "chính, chủ yếu, ưu tú",
+      "count": 0
+    },
+    {
+      "word": "redeeming feature (n phr) /rɪˈdiːmɪŋ ˈfiːtʃə/",
+      "meaning": "a good quality that makes something bad more acceptable",
+      "example": "The only redeeming feature of the film was the soundtrack.",
+      "translation": "điểm bù trừ",
+      "count": 0
+    },
+    {
+      "word": "refurbish (v) /ˌriːˈfɜːbɪʃ/",
+      "meaning": "to clean, repair and update something to improve it",
+      "example": "We decided to refurbish the guest house.",
+      "translation": "tân trang, cải tạo",
+      "count": 0
+    },
+    {
+      "word": "reinforce (v) /ˌriːɪnˈfɔːs/",
+      "meaning": "to strengthen something physically or emotionally",
+      "example": "The bridge was reinforced with steel beams.",
+      "translation": "gia cố",
+      "count": 0
+    },
+    {
+      "word": "renovate (v) /ˈrenəveɪt/",
+      "meaning": "to restore something old to good condition",
+      "example": "They spent a year renovating their old house.",
+      "translation": "nâng cấp, cải tạo",
+      "count": 0
+    },
+    {
+      "word": "rotten (adj) /ˈrɒtn/",
+      "meaning": "spoiled or decayed, especially food",
+      "example": "The fruit had gone rotten in the basket.",
+      "translation": "thối, hỏng",
+      "count": 0
+    },
+    {
+      "word": "rotten (adj) /ˈrɒtn/",
+      "meaning": "very bad in quality or behavior",
+      "example": "He made a rotten excuse to skip the event.",
+      "translation": "tệ hại",
+      "count": 0
+    },
+    {
+      "word": "rusty (adj) /ˈrʌsti/",
+      "meaning": "covered in rust from lack of use or exposure",
+      "example": "This old bike is completely rusty.",
+      "translation": "bị gỉ sét",
+      "count": 0
+    },
+    {
+      "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
+      "meaning": "meeting the basic requirements or expectations",
+      "example": "The report was satisfactory but not impressive.",
+      "translation": "đủ dùng",
+      "count": 0
+    },
+    {
+      "word": "satisfactory (adj) /ˌsætɪsˈfæktəri/",
+      "meaning": "pleasing or fulfilling",
+      "example": "Everyone found the outcome highly satisfactory.",
+      "translation": "hài lòng",
+      "count": 0
+    },
+    {
+      "word": "shambles (n) /ˈʃæmbəlz/",
+      "meaning": "a messy or chaotic situation",
+      "example": "The whole event was a complete shambles.",
+      "translation": "rối ren, hỗn loạn",
+      "count": 0
+    },
+    {
+      "word": "shoddy (adj) /ˈʃɒdi/",
+      "meaning": "poorly made or done with low standards",
+      "example": "Some parts of the road were repaired with shoddy workmanship.",
+      "translation": "chất lượng kém",
+      "count": 0
+    },
+    {
+      "word": "sound (adj) /saʊnd/",
+      "meaning": "based on solid reasoning or effective methods",
+      "example": "Before starting, you need a sound grasp of teaching basics.",
+      "translation": "hợp lý, đúng đắn",
+      "count": 0
+    },
+    {
+      "word": "sound (adj) /saʊnd/",
+      "meaning": "strong, secure, or in good condition",
+      "example": "Use foil to keep the bread sound and fresh.",
+      "translation": "toàn diện, vững chắc",
+      "count": 0
+    },
+    {
+      "word": "stale (adj) /steɪl/",
+      "meaning": "no longer fresh or good to eat",
+      "example": "Throw away that bread—it's gone stale.",
+      "translation": "ôi, thiu",
+      "count": 0
+    },
+    {
+      "word": "streamline (v) /ˈstriːmlaɪn/",
+      "meaning": "to simplify and make more efficient",
+      "example": "The company plans to streamline its operations.",
+      "translation": "tinh gọn",
+      "count": 0
+    },
+    {
+      "word": "strengthen (v) /ˈstreŋθn/",
+      "meaning": "to make something more secure or effective",
+      "example": "The bridge strengthens the link between the two cities.",
+      "translation": "gia cố, củng cố",
+      "count": 0
+    },
+    {
+      "word": "surpass (v) /səˈpɑːs/",
+      "meaning": "to exceed expectations or standards",
+      "example": "Winning the championship surpassed what we had hoped.",
+      "translation": "vượt qua",
+      "count": 0
+    },
+    {
+      "word": "ultimate (adj) /ˈʌltɪmət/",
+      "meaning": "occurring at the final stage or outcome",
+      "example": "The event influenced the ultimate verdict.",
+      "translation": "cuối cùng",
+      "count": 0
+    },
+    {
+      "word": "ultimate (adj) /ˈʌltɪmət/",
+      "meaning": "the best or most extreme possible",
+      "example": "This competition is the ultimate challenge.",
+      "translation": "tối thượng, tốt nhất",
+      "count": 0
+    },
+    {
+      "word": "worsen (v) /ˈwɜːsn/",
+      "meaning": "to become or make something more severe",
+      "example": "The bad weather continued to worsen.",
+      "translation": "làm trầm trọng hơn",
+      "count": 0
+    },
+    {
+      "word": "wreck (n) /rek/",
+      "meaning": "something that is badly destroyed or damaged",
+      "example": "The vehicle was a complete wreck after the crash.",
+      "translation": "đống đổ nát",
+      "count": 0
+    },
+    {
+      "word": "wreck (v) /rek/",
+      "meaning": "to cause great damage or ruin",
+      "example": "The explosion wrecked several nearby houses.",
+      "translation": "phá hủy",
+      "count": 0
+    },
+    {
+      "word": "abstract (adj) /ˈæbstrækt/",
+      "meaning": "relating to ideas rather than realistic images",
+      "example": "I’m not fond of abstract art pieces.",
+      "translation": "trừu tượng",
+      "count": 0
+    },
+    {
+      "word": "abstract (n) /ˈæbstrækt/",
+      "meaning": "a work of art representing ideas, not objects",
+      "example": "An abstract doesn't need to be understood literally.",
+      "translation": "tác phẩm trừu tượng",
+      "count": 0
+    },
+    {
+      "word": "auction (n) /ˈɔːkʃn/",
+      "meaning": "a public sale where the highest bidder wins",
+      "example": "They purchased the antique chair at auction.",
+      "translation": "buổi đấu giá",
+      "count": 0
+    },
+    {
+      "word": "audition (n) /ɔːˈdɪʃn/",
+      "meaning": "a short performance to test talent",
+      "example": "She has an audition for the lead role tomorrow.",
+      "translation": "buổi thử vai",
+      "count": 0
+    },
+    {
+      "word": "bestseller (n) /ˌbestˈselə/",
+      "meaning": "a book or product that sells in large numbers",
+      "example": "His debut novel became an instant bestseller.",
+      "translation": "sách bán chạy",
+      "count": 0
+    },
+    {
+      "word": "collector’s item (n phr) /kəˈlektəz ˈaɪtəm/",
+      "meaning": "a rare object highly valued by collectors",
+      "example": "This limited-edition coin is a collector’s item.",
+      "translation": "đồ hiếm",
+      "count": 0
+    },
+    {
+      "word": "curator (n) /kjʊˈreɪtə/",
+      "meaning": "someone responsible for a museum or exhibition",
+      "example": "Ask the curator if you have any questions about the painting.",
+      "translation": "bảo tàng viên",
+      "count": 0
+    },
+    {
+      "word": "fine art (n phr) /ˌfaɪn ˈɑːt/",
+      "meaning": "creative visual art like painting or sculpture",
+      "example": "He’s considering studying fine art at college.",
+      "translation": "mỹ thuật",
+      "count": 0
+    },
+    {
+      "word": "diagnosis (n)",
+      "meaning": "the identification of a disease based on symptoms",
+      "example": "Doctors confirmed the diagnosis of appendicitis through lab tests.",
+      "translation": "chẩn đoán",
+      "count": 0
+    },
+    {
+      "word": "inoculate (v)",
+      "meaning": "to protect from disease via vaccination",
+      "example": "Children should be inoculated before flu season begins.",
+      "translation": "tiêm phòng",
+      "count": 0
+    },
+    {
+      "word": "irritation (n)",
+      "meaning": "discomfort or inflammation in a body part",
+      "example": "His eyes showed signs of irritation after swimming.",
+      "translation": "kích ứng",
+      "count": 0
+    },
+    {
+      "word": "numb (adj)",
+      "meaning": "unable to feel due to cold or shock",
+      "example": "His hands went numb in the freezing air.",
+      "translation": "tê liệt",
+      "count": 0
+    },
+    {
+      "word": "numb (v)",
+      "meaning": "to cause someone to feel no emotion or sensation",
+      "example": "The trauma numbed him emotionally.",
+      "translation": "làm tê liệt",
+      "count": 0
+    },
+    {
+      "word": "nursing home (n phr)",
+      "meaning": "a place where elderly or sick people receive long-term care",
+      "example": "Her parents decided to move her grandmother into a nursing home.",
+      "translation": "viện dưỡng lão",
+      "count": 0
+    },
+    {
+      "word": "paralysis (n)",
+      "meaning": "a condition where a part of the body loses movement or feeling",
+      "example": "The injury caused temporary paralysis in his legs.",
+      "translation": "liệt",
+      "count": 0
+    },
+    {
+      "word": "plaster (v)",
+      "meaning": "to cover a wound or injury with a protective material",
+      "example": "The nurse plastered his knee after the fall.",
+      "translation": "băng dán vết thương",
+      "count": 0
+    },
+    {
+      "word": "plaster (n)",
+      "meaning": "a hard protective covering used to heal broken bones",
+      "example": "He had his foot in plaster after the accident.",
+      "translation": "thạch cao",
+      "count": 0
+    },
+    {
+      "word": "prescribe (v)",
+      "meaning": "to recommend a specific medicine or treatment",
+      "example": "The doctor prescribed medication to treat the infection.",
+      "translation": "kê đơn",
+      "count": 0
+    },
+    {
+      "word": "preventative medicine (n phr)",
+      "meaning": "medical practices focused on avoiding disease",
+      "example": "Regular check-ups are a part of preventative medicine.",
+      "translation": "y tế dự phòng",
+      "count": 0
+    },
+    {
+      "word": "prognosis (n)",
+      "meaning": "an expert opinion about how a disease will develop",
+      "example": "Doctors gave a positive prognosis after surgery.",
+      "translation": "tiên lượng",
+      "count": 0
+    },
+    {
+      "word": "sick leave (n phr)",
+      "meaning": "time off from work due to illness",
+      "example": "He used his sick leave to recover after surgery.",
+      "translation": "nghỉ ốm",
+      "count": 0
+    },
+    {
+      "word": "side effect (n phr)",
+      "meaning": "an unintended and often unpleasant result of medicine",
+      "example": "The medicine may cause drowsiness as a side effect.",
+      "translation": "tác dụng phụ",
+      "count": 0
+    },
+    {
+      "word": "syringe (n)",
+      "meaning": "a tool used to inject or withdraw fluids from the body",
+      "example": "The doctor filled the syringe with the vaccine.",
+      "translation": "ống tiêm",
+      "count": 0
+    },
+    {
+      "word": "vaccine (n)",
+      "meaning": "a substance used to protect against diseases",
+      "example": "Children receive the vaccine before entering school.",
+      "translation": "vắc xin",
+      "count": 0
+    },
+    {
+      "word": "ward (n)",
+      "meaning": "a hospital section with beds for patients",
+      "example": "She was taken to the orthopedic ward after surgery.",
+      "translation": "phòng bệnh",
+      "count": 0
+    },
+    {
+      "word": "aggression (n)",
+      "meaning": "hostile behavior or the intention to harm",
+      "example": "The dog showed aggression when strangers approached.",
+      "translation": "sự hung hăng",
+      "count": 0
+    },
+    {
+      "word": "authority (n)",
+      "meaning": "the power or right to give orders and make decisions",
+      "example": "She has the authority to approve new hires.",
+      "translation": "quyền hạn",
+      "count": 0
+    },
+    {
+      "word": "benign (adj)",
+      "meaning": "harmless or gentle in effect or character",
+      "example": "Thankfully, the tumor was benign and not dangerous.",
+      "translation": "lành tính",
+      "count": 0
+    },
+    {
+      "word": "bully (v)",
+      "meaning": "to intimidate or mistreat someone weaker",
+      "example": "He was caught bullying younger kids at school.",
+      "translation": "bắt nạt",
+      "count": 0
+    },
+    {
+      "word": "bully (n)",
+      "meaning": "a person who intimidates or harms others",
+      "example": "The school implemented strict rules against bullies.",
+      "translation": "kẻ bắt nạt",
+      "count": 0
+    },
+    {
+      "word": "command (v)",
+      "meaning": "to give an authoritative order",
+      "example": "The officer commanded the troops to retreat.",
+      "translation": "ra lệnh",
+      "count": 0
+    },
+    {
+      "word": "command (n)",
+      "meaning": "an order given with authority",
+      "example": "He followed the command without hesitation.",
+      "translation": "mệnh lệnh",
+      "count": 0
+    },
+    {
+      "word": "conquer (v)",
+      "meaning": "to take over by force or effort",
+      "example": "The army conquered the region in a week.",
+      "translation": "chinh phục",
+      "count": 0
+    },
+    {
+      "word": "conquer (v)",
+      "meaning": "to successfully deal with a challenge",
+      "example": "She conquered her fear of heights after training.",
+      "translation": "vượt qua",
+      "count": 0
+    },
+    {
+      "word": "consent (v)",
+      "meaning": "to give permission or approval",
+      "example": "The patient consented to the medical procedure.",
+      "translation": "đồng ý",
+      "count": 0
+    },
+    {
+      "word": "consent (n)",
+      "meaning": "official permission for something to happen",
+      "example": "They received consent to proceed with the plan.",
+      "translation": "sự đồng ý",
+      "count": 0
+    },
+    {
+      "word": "controversy (n)",
+      "meaning": "strong public disagreement or debate",
+      "example": "The new policy sparked major controversy.",
+      "translation": "tranh cãi",
+      "count": 0
+    },
+    {
+      "word": "dictator (n)",
+      "meaning": "a ruler with total power, often ruling by force",
+      "example": "The dictator controlled the country with no opposition.",
+      "translation": "nhà độc tài",
+      "count": 0
+    },
+    {
+      "word": "dominate (v)",
+      "meaning": "to have strong control or influence over someone or something",
+      "example": "Big tech companies dominate the digital market worldwide.",
+      "translation": "áp đảo",
+      "count": 0
+    },
+    {
+      "word": "eliminate (v)",
+      "meaning": "to remove or get rid of something completely",
+      "example": "The new update aims to eliminate all existing bugs in the system.",
+      "translation": "loại bỏ",
+      "count": 0
+    },
+    {
+      "word": "enforce (v)",
+      "meaning": "to ensure laws or rules are followed",
+      "example": "Local authorities enforce strict regulations on waste disposal.",
+      "translation": "thực thi",
+      "count": 0
+    },
+    {
+      "word": "entitled (adj)",
+      "meaning": "having the legal right or privilege to something",
+      "example": "Employees are entitled to annual bonuses under the company policy.",
+      "translation": "được quyền",
+      "count": 0
+    },
+    {
+      "word": "exempt (adj)",
+      "meaning": "not required to follow a certain rule or pay something",
+      "example": "Non-profit organizations are exempt from certain types of tax.",
+      "translation": "được miễn",
+      "count": 0
+    },
+    {
+      "word": "former (adj)",
+      "meaning": "having had a certain position or role in the past",
+      "example": "The former president is now advising young leaders.",
+      "translation": "trước đó",
+      "count": 0
+    },
+    {
+      "word": "impose (v)",
+      "meaning": "to enforce something such as a law, rule, or restriction on others",
+      "example": "The city council imposed a ban on smoking in public parks.",
+      "translation": "áp đặt",
+      "count": 0
+    },
+    {
+      "word": "aggression (n)",
+      "meaning": "a strong and hostile behavior or attitude towards others",
+      "example": "His sudden aggression shocked everyone in the room.",
+      "translation": "sự hung hăng",
+      "count": 0
+    },
+    {
+      "word": "authority (n)",
+      "meaning": "the power or right to control or command others",
+      "example": "Only the board has the authority to approve such changes.",
+      "translation": "quyền hạn",
+      "count": 0
+    },
+    {
+      "word": "benign (adj)",
+      "meaning": "gentle, kind, or not harmful",
+      "example": "The tumor was confirmed to be benign after tests.",
+      "translation": "lành tính",
+      "count": 0
+    },
+    {
+      "word": "bully (v)",
+      "meaning": "to intimidate or mistreat someone weaker",
+      "example": "She refused to let the older students bully her.",
+      "translation": "bắt nạt",
+      "count": 0
+    },
+    {
+      "word": "bully (n)",
+      "meaning": "someone who hurts or intimidates weaker people",
+      "example": "The school organized a campaign to stop the bully problem.",
+      "translation": "kẻ bắt nạt",
+      "count": 0
+    },
+    {
+      "word": "command (v)",
+      "meaning": "to give an order or directive",
+      "example": "The captain commanded the team to stay focused.",
+      "translation": "ra lệnh",
+      "count": 0
+    },
+    {
+      "word": "command (n)",
+      "meaning": "an order that must be followed",
+      "example": "He executed every command without hesitation.",
+      "translation": "mệnh lệnh",
+      "count": 0
+    },
+    {
+      "word": "conquer (v)",
+      "meaning": "to take control of a place or people using force",
+      "example": "The army set out to conquer new territories.",
+      "translation": "chinh phục",
+      "count": 0
+    },
+    {
+      "word": "conquer (v)",
+      "meaning": "to overcome difficulties, fears, or challenges",
+      "example": "She worked hard to conquer her fear of heights.",
+      "translation": "chinh phục",
+      "count": 0
+    },
+    {
+      "word": "consent (v)",
+      "meaning": "to give permission for something to happen",
+      "example": "The patient consented to the surgery after detailed explanation.",
+      "translation": "đồng ý",
+      "count": 0
+    },
+    {
+      "word": "consent (n)",
+      "meaning": "approval or permission for something",
+      "example": "We cannot proceed without your written consent.",
+      "translation": "sự đồng ý",
+      "count": 0
+    },
+    {
+      "word": "controversy (n)",
+      "meaning": "a public disagreement about something important",
+      "example": "The new education policy caused major controversy among parents.",
+      "translation": "tranh cãi",
+      "count": 0
+    },
+    {
+      "word": "dictator (n)",
+      "meaning": "a ruler with total power who often rules by force",
+      "example": "The dictator remained in power for over 20 years.",
+      "translation": "nhà độc tài",
+      "count": 0
+    },
+    {
+      "word": "dominate (v)",
+      "meaning": "to strongly influence or control something or someone",
+      "example": "This brand dominates the market in luxury goods.",
+      "translation": "áp đảo",
+      "count": 0
+    },
+    {
+      "word": "eliminate (v)",
+      "meaning": "to completely remove or end something",
+      "example": "The software update eliminated all previous bugs.",
+      "translation": "loại bỏ",
+      "count": 0
+    },
+    {
+      "word": "enforce (v)",
+      "meaning": "to ensure people obey a rule or law",
+      "example": "New safety rules were enforced at all construction sites.",
+      "translation": "thực thi",
+      "count": 0
+    },
+    {
+      "word": "entitled (adj)",
+      "meaning": "having the right or claim to something",
+      "example": "All customers are entitled to a full refund within 7 days.",
+      "translation": "được quyền",
+      "count": 0
+    },
+    {
+      "word": "exempt (adj)",
+      "meaning": "free from a rule, duty, or obligation",
+      "example": "Students under 18 are exempt from this tax.",
+      "translation": "được miễn",
+      "count": 0
+    },
+	  {
+      "word": "former (adj)",
+      "meaning": "used to describe someone or something that held a particular position or state in the past",
+      "example": "The former manager now works as an independent consultant.",
+      "translation": "trước đó",
+      "count": 0
+    },
+    {
+      "word": "impose (v)",
+      "meaning": "to officially enforce or apply something, such as a rule or penalty",
+      "example": "The council decided to impose a fine for illegal parking.",
+      "translation": "áp đặt",
+      "count": 0
+    },
+    {
+      "word": "inferior (adj)",
+      "meaning": "lower in quality or status compared to something else",
+      "example": "This brand is seen as inferior to its competitors in durability.",
+      "translation": "kém hơn",
+      "count": 0
+    },
+    {
+      "word": "intimidate (v)",
+      "meaning": "to make someone feel afraid in order to control them",
+      "example": "He tried to intimidate the witness into staying silent.",
+      "translation": "hăm dọa",
+      "count": 0
+    },
+    {
+      "word": "label (v)",
+      "meaning": "to unfairly categorize someone or something",
+      "example": "He was quickly labeled as lazy without real evidence.",
+      "translation": "gán mác",
+      "count": 0
+    },
+    {
+      "word": "label (n)",
+      "meaning": "a tag or sticker that provides information about an item",
+      "example": "Make sure you read the label before using the product.",
+      "translation": "nhãn, nhãn hiệu",
+      "count": 0
+    },
+    {
+      "word": "liberate (v)",
+      "meaning": "to set someone or something free from limitations or control",
+      "example": "Winning the case liberated them from years of restrictions.",
+      "translation": "giải phóng",
+      "count": 0
+    },
+    {
+      "word": "mainstream (n)",
+      "meaning": "ideas or activities accepted by most people as normal",
+      "example": "His views are far from what the mainstream supports.",
+      "translation": "xu hướng chính",
+      "count": 0
+    },
+    {
+      "word": "mainstream (adj)",
+      "meaning": "common and widely accepted by the general public",
+      "example": "She prefers indie films over mainstream ones.",
+      "translation": "chính thống",
+      "count": 0
+    },
+    {
+      "word": "master (v)",
+      "meaning": "to become highly skilled at something",
+      "example": "She mastered the software after weeks of practice.",
+      "translation": "nắm vững, tinh thông",
+      "count": 0
+    },
+    {
+      "word": "master (n)",
+      "meaning": "a person who has control over others, especially in the past",
+      "example": "The master gave orders that no one questioned.",
+      "translation": "chủ, thầy",
+      "count": 0
+    },
+    {
+      "word": "minister (n)",
+      "meaning": "a senior official in charge of a government department",
+      "example": "The Minister of Finance delivered the budget speech.",
+      "translation": "bộ trưởng",
+      "count": 0
+    },
+    {
+      "word": "monarch (n)",
+      "meaning": "a ruler such as a king or queen",
+      "example": "The monarch greeted the citizens from the palace balcony.",
+      "translation": "vua, chúa",
+      "count": 0
+    },
+    {
+      "word": "prohibit (v)",
+      "meaning": "to officially ban or forbid something",
+      "example": "The government prohibits alcohol sales after midnight.",
+      "translation": "cấm",
+      "count": 0
+    },
+    {
+      "word": "reign (v)",
+      "meaning": "to rule over a country as king or queen",
+      "example": "The queen reigned during a time of prosperity.",
+      "translation": "trị vì",
+      "count": 0
+    },
+    {
+      "word": "reign (n)",
+      "meaning": "the period when a monarch rules",
+      "example": "Her reign lasted over five decades.",
+      "translation": "triều đại",
+      "count": 0
+    },
+    {
+      "word": "reinforce (v)",
+      "meaning": "to strengthen an idea or belief",
+      "example": "The teacher used real-life examples to reinforce the lesson.",
+      "translation": "củng cố",
+      "count": 0
+    },
+    {
+      "word": "reluctant (adj)",
+      "meaning": "unwilling or hesitant to do something",
+      "example": "He was reluctant to accept the offer without thinking it over.",
+      "translation": "chần chừ, miễn cưỡng",
+      "count": 0
+    },
+    {
+      "word": "resist (v)",
+      "meaning": "to fight back or refuse to accept something",
+      "example": "The villagers resisted the invaders bravely.",
+      "translation": "chống cự, kháng cự",
+      "count": 0
+    },
+    {
+      "word": "resist (v)",
+      "meaning": "to stop yourself from doing something tempting",
+      "example": "I couldn’t resist trying the dessert.",
+      "translation": "cưỡng lại, kìm chế",
+      "count": 0
+    },
+    {
+      "word": "restrict (v)",
+      "meaning": "to limit or control something tightly",
+      "example": "They restricted access to the sensitive documents.",
+      "translation": "hạn chế",
+      "count": 0
+    },
+    {
+      "word": "society (n)",
+      "meaning": "a structured community of people living together",
+      "example": "Our society depends on laws and mutual respect.",
+      "translation": "xã hội",
+      "count": 0
+    },
+    {
+      "word": "subject (v)",
+      "meaning": "to cause someone to go through something unpleasant",
+      "example": "They were subjected to harsh living conditions.",
+      "translation": "bắt phải chịu",
+      "count": 0
+    },
+    {
+      "word": "subject (n)",
+      "meaning": "a topic or area that is studied or discussed",
+      "example": "Her favorite subject in school is chemistry.",
+      "translation": "chủ đề, đề tài",
+      "count": 0
+    },
+    {
+      "word": "subject (n)",
+      "meaning": "a person ruled by a monarch",
+      "example": "The king addressed his loyal subjects.",
+      "translation": "thần dân",
+      "count": 0
+    },
+    {
+      "word": "subjective (adj)",
+      "meaning": "based on personal opinions or feelings",
+      "example": "Art criticism is often very subjective.",
+      "translation": "chủ quan",
+      "count": 0
+    },
+    {
+      "word": "submit (v)",
+      "meaning": "to yield to someone else's authority or power",
+      "example": "They had no choice but to submit to the demands.",
+      "translation": "phục tùng, đầu hàng",
+      "count": 0
+    },
+    {
+      "word": "submit (v)",
+      "meaning": "to give something officially to someone in authority",
+      "example": "Be sure to submit your documents before the deadline.",
+      "translation": "nộp",
+      "count": 0
+    },
+    {
+      "word": "summon (v)",
+      "meaning": "to officially ask someone to appear, especially in court",
+      "example": "The lawyer was summoned to testify in the case.",
+      "translation": "triệu tập",
+      "count": 0
+    },
+    {
+      "word": "superior (adj)",
+      "meaning": "having higher quality or skill than something else",
+      "example": "This phone has superior battery life compared to mine.",
+      "translation": "vượt trội",
+      "count": 0
+    },
+    {
+      "word": "undermine (v)",
+      "meaning": "to gradually weaken or damage something",
+      "example": "Gossip can undermine trust between coworkers.",
+      "translation": "làm suy yếu",
+      "count": 0
+    },
+    {
+      "word": "unrest (n)",
+      "meaning": "violent or disruptive behavior by people protesting",
+      "example": "The strike led to widespread unrest in the city.",
+      "translation": "tình trạng bất ổn",
+      "count": 0
+    },
+    {
+      "word": "victimise (v)",
+      "meaning": "to treat someone unfairly and harmfully",
+      "example": "She felt victimised by the biased treatment at work.",
+      "translation": "ngược đãi",
+      "count": 0
+    },
+    {
+      "word": "vulnerable (adj)",
+      "meaning": "easily hurt physically or emotionally",
+      "example": "After the accident, he became more emotionally vulnerable.",
+      "translation": "dễ bị tổn thương",
+      "count": 0
+    },
+    {
+      "word": "abolish (v)",
+      "meaning": "to officially end a system or practice",
+      "example": "They plan to abolish outdated labor laws.",
+      "translation": "bãi bỏ",
+      "count": 0
+    },
+    {
+      "word": "advocate (v)",
+      "meaning": "to publicly support a cause or proposal",
+      "example": "She advocates better access to mental health services.",
+      "translation": "ủng hộ công khai",
+      "count": 0
+    },
+    {
+      "word": "alleviate (v)",
+      "meaning": "to reduce pain, difficulty, or hardship",
+      "example": "These efforts could alleviate poverty in rural areas.",
+      "translation": "giảm bớt",
+      "count": 0
+    },
+    {
+      "word": "aggravate (v)",
+      "meaning": "to make a problem or condition worse",
+      "example": "Lack of sleep can aggravate your illness.",
+      "translation": "làm trầm trọng thêm",
+      "count": 0
+    },
+    {
+      "word": "better (v)",
+      "meaning": "to surpass or improve on a previous result",
+      "example": "She bettered her performance in the final exam.",
+      "translation": "vượt qua, vượt trội",
+      "count": 0
+    },
+    {
+      "word": "better (adj)",
+      "meaning": "to make something improved or more effective",
+      "example": "They hope to better their customer service this year.",
+      "translation": "cải thiện",
+      "count": 0
+    },
+    {
+      "word": "blemish (n)",
+      "meaning": "a flaw that reduces appearance or quality",
+      "example": "The scratch left a blemish on the screen.",
+      "translation": "vết nhơ, vết xấu",
+      "count": 0
+    },
+    {
+      "word": "chaos (n)",
+      "meaning": "a state of total confusion and disorder",
+      "example": "There was chaos at the airport after the delay.",
+      "translation": "hỗn loạn",
+      "count": 0
+    },
+    {
+      "word": "cheapen (v)",
+      "meaning": "to reduce the value or dignity of something",
+      "example": "Those ads cheapen the company’s image.",
+      "translation": "làm mất giá trị",
+      "count": 0
+    },
+    {
+      "word": "contaminate (v)",
+      "meaning": "to pollute or make something unsafe",
+      "example": "Chemicals contaminated the river water.",
+      "translation": "làm ô nhiễm",
+      "count": 0
+    },
+    {
+      "word": "decay (v)",
+      "meaning": "to break down over time due to natural causes",
+      "example": "The abandoned barn slowly began to decay.",
+      "translation": "mục nát, suy tàn",
+      "count": 0
+    },
+    {
+      "word": "decay (n)",
+      "meaning": "gradual decline or breakdown of something",
+      "example": "The building showed clear signs of decay.",
+      "translation": "sự mục nát, suy tàn",
+      "count": 0
+    },
+    {
+      "word": "decline (v)",
+      "meaning": "to decrease in amount, quality, or strength",
+      "example": "His energy levels have declined recently.",
+      "translation": "giảm sút",
+      "count": 0
+    },
+    {
+      "word": "defective (adj)",
+      "meaning": "not functioning properly or made incorrectly",
+      "example": "They returned the defective appliance for a refund.",
+      "translation": "bị lỗi",
+      "count": 0
+    },
+    {
+      "word": "detrimental (adj)",
+      "meaning": "causing damage or harm",
+      "example": "The noise had a detrimental effect on her sleep.",
+      "translation": "có hại, bất lợi",
+      "count": 0
+    },
+    {
+      "word": "devastate (v)",
+      "meaning": "to cause severe damage or destruction",
+      "example": "The fire devastated several nearby homes.",
+      "translation": "tàn phá, phá hủy",
+      "count": 0
+    },
+    {
+      "word": "devastate (v)",
+      "meaning": "to deeply shock or upset someone",
+      "example": "Losing her pet devastated her emotionally.",
+      "translation": "tàn phá về tinh thần",
+      "count": 0
+    },
+    {
+      "word": "enhance (v)",
+      "meaning": "to improve something or increase its value",
+      "example": "They enhanced the app with new features.",
+      "translation": "nâng cao, cải thiện",
+      "count": 0
+    },
+    {
+      "word": "evaluate (v)",
+      "meaning": "to carefully assess something before forming a decision or opinion",
+      "example": "It's important to evaluate all options before choosing a strategy.",
+      "translation": "đánh giá",
+      "count": 0
+    },
+    {
+      "word": "exacerbate (v)",
+      "meaning": "to make a difficult situation even worse",
+      "example": "Adding more stress will only exacerbate the problem.",
+      "translation": "làm trầm trọng thêm",
+      "count": 0
+    },
+    {
+      "word": "exquisite (adj)",
+      "meaning": "extremely elegant, beautiful, or finely detailed",
+      "example": "The gallery displayed an exquisite collection of paintings.",
+      "translation": "tinh xảo",
+      "count": 0
+    },
+    {
+      "word": "first-rate (adj)",
+      "meaning": "of exceptional quality or performance",
+      "example": "They provide first-rate customer service at that hotel.",
+      "translation": "hàng đầu, xuất sắc",
+      "count": 0
+    },
+    {
+      "word": "flaw (n)",
+      "meaning": "a defect or weakness that reduces something’s value or effectiveness",
+      "example": "The design had a critical flaw that needed fixing.",
+      "translation": "lỗi, khuyết điểm",
+      "count": 0
+    },
+    {
+      "word": "bureaucracy (n)",
+      "meaning": "an overly complex and slow system of rules and administration",
+      "example": "We faced too much bureaucracy while applying for the license.",
+      "translation": "quan liêu",
+      "count": 0
+    },
+    {
+      "word": "charity (n)",
+      "meaning": "an organization that helps people in need, often funded by donations",
+      "example": "The charity raised money to support orphaned children.",
+      "translation": "tổ chức từ thiện",
+      "count": 0
+    },
+    {
+      "word": "class (n)",
+      "meaning": "a social division based on income, background, or education",
+      "example": "He comes from a working-class family.",
+      "translation": "giai cấp, tầng lớp",
+      "count": 0
+    },
+    {
+      "word": "community (n)",
+      "meaning": "a group of people living in the same area or sharing common interests",
+      "example": "The entire community came together for the festival.",
+      "translation": "cộng đồng",
+      "count": 0
+    },
+    {
+      "word": "convict (v)",
+      "meaning": "to legally declare someone guilty of a crime",
+      "example": "The court convicted him of armed robbery.",
+      "translation": "kết tội",
+      "count": 0
+    },
+    {
+      "word": "convict (n)",
+      "meaning": "a person who has been found guilty and is serving a sentence",
+      "example": "The convict escaped during a prison transfer.",
+      "translation": "tù nhân",
+      "count": 0
+    },
+    {
+      "word": "corruption (n)",
+      "meaning": "unethical or illegal acts by people in positions of power",
+      "example": "The journalist uncovered widespread political corruption.",
+      "translation": "sự tham nhũng",
+      "count": 0
+    },
+    {
+      "word": "deterrent (n)",
+      "meaning": "something that discourages people from doing something harmful",
+      "example": "Tough penalties act as a deterrent to criminals.",
+      "translation": "răn đe",
+      "count": 0
+    },
+    {
+      "word": "heritage (n)",
+      "meaning": "the cultural, historical, or natural legacy of a group or nation",
+      "example": "We must safeguard our national heritage for future generations.",
+      "translation": "di sản",
+      "count": 0
+    },
+    {
+      "word": "immigration (n)",
+      "meaning": "the process of entering and settling in a foreign country",
+      "example": "The country experienced a rise in immigration last year.",
+      "translation": "sự nhập cư",
+      "count": 0
+    },
+    {
+      "word": "industrial action (n phr)",
+      "meaning": "a protest by employees, often involving strikes, over working conditions",
+      "example": "Industrial action halted production at the factory.",
+      "translation": "trừng phạt lao động",
+      "count": 0
+    },
+    {
+      "word": "institution (n)",
+      "meaning": "a large and established organization such as a school, bank, or prison",
+      "example": "She was raised in a government institution.",
+      "translation": "cơ quan, tổ chức",
+      "count": 0
+    },
+    {
+      "word": "legislation (n)",
+      "meaning": "a collection of laws or legal rules",
+      "example": "New legislation aims to reduce carbon emissions.",
+      "translation": "pháp luật",
+      "count": 0
+    },
+    {
+      "word": "prejudice (n)",
+      "meaning": "a biased and often negative attitude toward a group without valid reason",
+      "example": "The film explores how prejudice affects social justice.",
+      "translation": "định kiến",
+      "count": 0
+    },
+    {
+      "word": "prison reform (n phr)",
+      "meaning": "changes made to improve how the prison system operates",
+      "example": "There’s growing support for prison reform to improve rehabilitation.",
+      "translation": "cải cách nhà tù",
+      "count": 0
+    },
+    {
+      "word": "privileged (adj)",
+      "meaning": "having special benefits or advantages not available to others",
+      "example": "She lived a privileged life in an upscale neighborhood.",
+      "translation": "được ưu tiên",
+      "count": 0
+    },
+    {
+      "word": "prosecute (v)",
+      "meaning": "to bring legal action against someone for a criminal act",
+      "example": "The company was prosecuted for violating safety laws.",
+      "translation": "khởi tố",
+      "count": 0
+    },
+    {
+      "word": "state (n)",
+      "meaning": "the government of a country or a particular condition something is in",
+      "example": "The state provides healthcare for its citizens.",
+      "translation": "nhà nước",
+      "count": 0
+    },
+    {
+      "word": "leverage",
+      "meaning": "the use of strategic influence or borrowed resources to gain advantage",
+      "example": "The company used its market leverage to secure better terms.",
+      "translation": "đòn bẩy, lợi thế chiến lược",
+      "count": 0
+    },
+    {
+      "word": "abandon",
+      "meaning": "to leave something behind permanently or stop supporting it",
+      "example": "The project was abandoned due to budget cuts.",
+      "translation": "bỏ rơi, từ bỏ",
+      "count": 0
+    },
+    {
+      "word": "abysmal",
+      "meaning": "extremely bad or appalling in quality",
+      "example": "Their performance in the competition was abysmal.",
+      "translation": "tồi tệ",
+      "count": 0
+    },
+    {
+      "word": "abominable",
+      "meaning": "causing strong disgust or hatred due to being very bad or unpleasant",
+      "example": "His behavior at the event was absolutely abominable.",
+      "translation": "đáng ghê tởm, kinh tởm",
+      "count": 0
+    },
+    {
+      "word": "assertive",
+      "meaning": "confidently expressing ideas or needs in a firm but respectful way",
+      "example": "Being assertive helps you communicate your needs clearly without aggression.",
+      "translation": "quả quyết, quyết đoán",
+      "count": 0
+    },
+    {
+      "word": "bias - biased",
+      "meaning": "a tendency to favor one side unfairly, often due to personal views or background",
+      "example": "The article was clearly biased against the candidate.",
+      "translation": "thiên vị, định kiến",
+      "count": 0
+    },
+    {
+      "word": "bottom line",
+      "meaning": "the final financial result after all calculations, especially profits or losses",
+      "example": "Improving efficiency will positively impact the bottom line.",
+      "translation": "kết quả tài chính cuối cùng",
+      "count": 0
+    },
+    {
+      "word": "bygone",
+      "meaning": "belonging to a time in the distant past",
+      "example": "The museum displayed artifacts from a bygone era.",
+      "translation": "quá khứ, xưa cũ",
+      "count": 0
+    },
+    {
+      "word": "chief claim to fame",
+      "meaning": "the main reason a person or place is well-known",
+      "example": "The town's chief claim to fame is its historic castle.",
+      "translation": "lý do chính khiến nổi tiếng",
+      "count": 0
+    },
+    {
+      "word": "Subjects: Statistics; Visual arts; Philosophy; Politics; Performing arts; Logic",
+      "meaning": "various academic fields within humanities, business, and sciences",
+      "example": "She focused on subjects like Statistics and Philosophy during her degree.",
+      "translation": "Thống kê; Mỹ thuật; Triết học; Chính trị học; Nghệ thuật biểu diễn; Logic",
+      "count": 0
+    },
+    {
+      "word": "abuzz",
+      "meaning": "full of lively noise, activity, or excitement",
+      "example": "The whole city was abuzz with excitement before the concert.",
+      "translation": "ồn ào, náo nhiệt",
+      "count": 0
+    },
+    {
+      "word": "abdomen - abdominal",
+      "meaning": "the area of the body between the chest and hips; related to this region",
+      "example": "He experienced severe abdominal pain after the meal.",
+      "translation": "bụng - thuộc về bụng",
+      "count": 0
+    },
+    {
+      "word": "BEING SPONTANEOUS",
+      "meaning": "freely expressing thoughts and ideas without pre-planning during speech",
+      "example": "She impressed the interviewer with her spontaneous and fluent responses.",
+      "translation": "ứng biến tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "In order to achieve a very high band in the IELTS speaking test, you need to show that you can use some ‘less common’ vocabulary, including idioms and less common collocations.",
+      "meaning": "using rare vocabulary and idiomatic expressions can demonstrate advanced speaking skills",
+      "example": "She used a few idioms naturally to raise her IELTS score.",
+      "translation": "từ vựng ít gặp, thành ngữ, cụm từ ít dùng",
+      "count": 0
+    },
+    {
+      "word": "He would → He'd, Why have → Why've, I will → I'll, Where did → Where'd, They are → They're",
+      "meaning": "shortened forms of common auxiliary verbs and pronouns used in informal English",
+      "example": "I'll call you later, and they'll come too.",
+      "translation": "dạng rút gọn phổ biến",
+      "count": 0
+    },
+    {
+      "word": "some ‘less common’ vocabulary, including idioms and less common collocations.",
+      "meaning": "expressions and phrases that are not used frequently but enrich language usage",
+      "example": "He impressed the examiner by using less common collocations effectively.",
+      "translation": "từ vựng, thành ngữ ít dùng",
+      "count": 0
+    },
+    {
+      "word": "appropriate [A]",
+      "meaning": "suitable for a particular time, place, or situation",
+      "example": "It’s appropriate to wear formal clothes to a wedding.",
+      "translation": "phù hợp",
+      "count": 0
+    },
+    {
+      "word": "detrimental [A]",
+      "meaning": "causing negative effects or harm",
+      "example": "Skipping meals regularly can be detrimental to your health.",
+      "translation": "gây hại",
+      "count": 0
+    },
+    {
+      "word": "nasty [A]",
+      "meaning": "unpleasant in nature or behavior",
+      "example": "He made a nasty comment that offended everyone.",
+      "translation": "khó chịu, xấu tính",
+      "count": 0
+    },
+    {
+      "word": "scenic [A]",
+      "meaning": "offering attractive or picturesque views",
+      "example": "We took the scenic route through the mountains.",
+      "translation": "có cảnh đẹp",
+      "count": 0
+    },
+    {
+      "word": "forbidden [A]",
+      "meaning": "not allowed by law or rule",
+      "example": "Taking photos is strictly forbidden inside the gallery.",
+      "translation": "bị cấm",
+      "count": 0
+    },
+    {
+      "word": "attractive [A]",
+      "meaning": "pleasing to look at or appealing in quality",
+      "example": "She has an attractive personality and appearance.",
+      "translation": "hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "vast [A]",
+      "meaning": "extremely large in size, amount, or range",
+      "example": "The desert stretched across a vast area of land.",
+      "translation": "rộng lớn",
+      "count": 0
+    },
+    {
+      "word": "dull [A]",
+      "meaning": "lacking interest or excitement",
+      "example": "The lecture was so dull that half the audience fell asleep.",
+      "translation": "nhàm chán",
+      "count": 0
+    },
+    {
+      "word": "hectic [A]",
+      "meaning": "very busy or full of activity and chaos",
+      "example": "Work has been hectic this week with tight deadlines.",
+      "translation": "bận rộn, sôi động",
+      "count": 0
+    },
+    {
+      "word": "inexpensive [A]",
+      "meaning": "affordable or costing little money",
+      "example": "They stayed in an inexpensive guesthouse near the beach.",
+      "translation": "rẻ, không đắt",
+      "count": 0
+    },
+    {
+      "word": "obligatory [A]",
+      "meaning": "something required by law or rules",
+      "example": "Wearing seatbelts is obligatory in most countries.",
+      "translation": "bắt buộc",
+      "count": 0
+    },
+    {
+      "word": "hazardous [A]",
+      "meaning": "dangerous or likely to cause harm",
+      "example": "Working in a chemical factory can be hazardous.",
+      "translation": "nguy hiểm",
+      "count": 0
+    },
+    {
+      "word": "tricky [A]",
+      "meaning": "complicated or difficult to handle",
+      "example": "That’s a tricky question that requires careful thought.",
+      "translation": "khó, phức tạp",
+      "count": 0
+    },
+    {
+      "word": "effortless [A]",
+      "meaning": "requiring little effort to accomplish",
+      "example": "She gave an effortless performance on stage.",
+      "translation": "dễ dàng",
+      "count": 0
+    },
+    {
+      "word": "pleasurable [A]",
+      "meaning": "providing enjoyment or satisfaction",
+      "example": "The evening with friends was truly pleasurable.",
+      "translation": "thú vị",
+      "count": 0
+    },
+    {
+      "word": "stimulating [A]",
+      "meaning": "mentally or physically exciting or motivating",
+      "example": "The discussion was both deep and stimulating.",
+      "translation": "kích thích, thú vị",
+      "count": 0
+    },
+    {
+      "word": "pricey [A]",
+      "meaning": "more expensive than expected or reasonable",
+      "example": "That restaurant is great but quite pricey.",
+      "translation": "đắt tiền",
+      "count": 0
+    },
+    {
+      "word": "spare [A]",
+      "meaning": "extra and available for use if needed",
+      "example": "I always keep a spare charger in my bag.",
+      "translation": "dự phòng",
+      "count": 0
+    },
+    {
+      "word": "well-known [A]",
+      "meaning": "familiar to many people; widely recognized",
+      "example": "He’s a well-known author in the region.",
+      "translation": "nổi tiếng",
+      "count": 0
+    },
+    {
+      "word": "rapid [A]",
+      "meaning": "happening quickly or in a short time",
+      "example": "The company saw rapid growth in just two years.",
+      "translation": "nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "preferred [A]",
+      "meaning": "chosen or favored over other options",
+      "example": "My preferred method of study is online learning.",
+      "translation": "ưa thích",
+      "count": 0
+    },
+    {
+      "word": "Checking understanding",
+      "meaning": "ways to confirm that you understood someone correctly",
+      "example": "When you say 'hometown', do you mean where I was born or where I live now?",
+      "translation": "kiểm tra sự hiểu",
+      "count": 0
+    },
+    {
+      "word": "amusing",
+      "meaning": "entertaining or funny in a light-hearted way",
+      "example": "The comedian told an amusing story about his childhood.",
+      "translation": "vui nhộn",
+      "count": 0
+    },
+    {
+      "word": "hilarious",
+      "meaning": "extremely funny or laugh-out-loud amusing",
+      "example": "That movie was absolutely hilarious.",
+      "translation": "rất buồn cười",
+      "count": 0
+    },
+    {
+      "word": "witty",
+      "meaning": "clever and amusing in speech or writing",
+      "example": "She gave a witty reply that made everyone laugh.",
+      "translation": "hóm hỉnh",
+      "count": 0
+    },
+    {
+      "word": "enjoyable, pleasant, pleasurable, nice",
+      "meaning": "giving pleasure or satisfaction",
+      "example": "We had an enjoyable evening at the concert.",
+      "translation": "dễ chịu, thú vị",
+      "count": 0
+    },
+    {
+      "word": "beneficial, helpful",
+      "meaning": "producing good or helpful results",
+      "example": "Regular exercise is beneficial for your health.",
+      "translation": "có lợi",
+      "count": 0
+    },
+    {
+      "word": "nutritious, wholesome",
+      "meaning": "containing substances needed for good health",
+      "example": "She always prepares nutritious meals for her children.",
+      "translation": "bổ dưỡng",
+      "count": 0
+    },
+    {
+      "word": "supportive, cooperative",
+      "meaning": "willing to help or work with others",
+      "example": "The team has a very supportive atmosphere.",
+      "translation": "hỗ trợ, hợp tác",
+      "count": 0
+    },
+    {
+      "word": "perfect, model",
+      "meaning": "an ideal or flawless version of something",
+      "example": "They live in a perfect home with a model garden.",
+      "translation": "hoàn hảo, mẫu mực",
+      "count": 0
+    },
+    {
+      "word": "major, significant, essential, vital (= very important)",
+      "meaning": "extremely important or necessary",
+      "example": "Clean water is vital for survival.",
+      "translation": "quan trọng",
+      "count": 0
+    },
+    {
+      "word": "smart, clever, brainy, bright",
+      "meaning": "showing intelligence or quick thinking",
+      "example": "He’s a bright student who always asks good questions.",
+      "translation": "thông minh",
+      "count": 0
+    },
+    {
+      "word": "intriguing, engaging, fascinating",
+      "meaning": "very interesting or capturing attention",
+      "example": "The plot of the book was truly fascinating.",
+      "translation": "hấp dẫn",
+      "count": 0
+    },
+    {
+      "word": "tardy, behind time, unpunctual",
+      "meaning": "not arriving or happening on time",
+      "example": "He got in trouble at school for being tardy every day.",
+      "translation": "đi trễ",
+      "count": 0
+    },
+    {
+      "word": "principal, major",
+      "meaning": "most important or main",
+      "example": "Tourism is one of the principal sources of income.",
+      "translation": "chính, chủ yếu",
+      "count": 0
+    },
+    {
+      "word": "unforgettable",
+      "meaning": "so remarkable that it cannot be forgotten",
+      "example": "Our trip to Japan was truly unforgettable.",
+      "translation": "không thể quên",
+      "count": 0
+    },
+    {
+      "word": "contemporary, present-day, up-to-date",
+      "meaning": "belonging to the current time period",
+      "example": "She prefers contemporary art over classical pieces.",
+      "translation": "hiện đại, đương đại",
+      "count": 0
+    },
+    {
+      "word": "undesirable, detrimental",
+      "meaning": "likely to cause harm or be unwanted",
+      "example": "The policy may have undesirable effects on the economy.",
+      "translation": "bất lợi",
+      "count": 0
+    },
+    {
+      "word": "outdated, unfashionable, out-of-style",
+      "meaning": "no longer modern or in style",
+      "example": "Those jeans look outdated compared to current trends.",
+      "translation": "lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "nutritious, wholesome I try to eat wholesome food.",
+      "meaning": "containing substances essential for health",
+      "example": "She prepares nutritious meals every day.",
+      "translation": "bổ dưỡng",
+      "count": 0
+    },
+    {
+      "word": "well-mannered",
+      "meaning": "polite and respectful in behavior",
+      "example": "He's a well-mannered child who always says thank you.",
+      "translation": "lễ phép",
+      "count": 0
+    },
+    {
+      "word": "hard-up, impoverished, penniless (= very poor)",
+      "meaning": "having very little or no money",
+      "example": "She grew up in an impoverished village.",
+      "translation": "nghèo khó",
+      "count": 0
+    },
+    {
+      "word": "widespread, prevalent, common",
+      "meaning": "existing or happening over a large area or among many people",
+      "example": "That belief is still widespread in rural areas.",
+      "translation": "phổ biến",
+      "count": 0
+    },
+    {
+      "word": "well-liked",
+      "meaning": "enjoyed or admired by many people",
+      "example": "She’s well-liked by her colleagues.",
+      "translation": "được yêu thích",
+      "count": 0
+    },
+    {
+      "word": "favourable, beneficial, constructive",
+      "meaning": "producing a good or helpful result",
+      "example": "The new policy had a favourable effect on employment.",
+      "translation": "tích cực",
+      "count": 0
+    },
+    {
+      "word": "punctual",
+      "meaning": "arriving or happening at the correct time",
+      "example": "He is always punctual for meetings.",
+      "translation": "đúng giờ",
+      "count": 0
+    },
+    {
+      "word": "wealthy, affluent",
+      "meaning": "having a lot of money or resources",
+      "example": "She comes from an affluent family.",
+      "translation": "giàu có",
+      "count": 0
+    },
+    {
+      "word": "secure",
+      "meaning": "safe and protected from danger or harm",
+      "example": "They live in a very secure neighborhood.",
+      "translation": "an toàn",
+      "count": 0
+    },
+    {
+      "word": "unusual, distinctive, characteristic, unique",
+      "meaning": "different from others in a special way",
+      "example": "Her style is very distinctive and artistic.",
+      "translation": "đặc biệt",
+      "count": 0
+    },
+    {
+      "word": "fruitful, prosperous",
+      "meaning": "producing good results or success",
+      "example": "They had a fruitful discussion that led to a solution.",
+      "translation": "thành công, hiệu quả",
+      "count": 0
+    },
+    {
+      "word": "conventional",
+      "meaning": "following traditional or commonly accepted ways",
+      "example": "He prefers conventional teaching methods.",
+      "translation": "truyền thống",
+      "count": 0
+    },
+    {
+      "word": "characteristic, popular",
+      "meaning": "typical or commonly associated with something",
+      "example": "Pho is a characteristic dish of Vietnam.",
+      "translation": "đặc trưng",
+      "count": 0
+    },
+    {
+      "word": "practical, convenient",
+      "meaning": "useful and easy to apply",
+      "example": "Online banking is a convenient option for many people.",
+      "translation": "tiện lợi, hữu ích",
+      "count": 0
+    },
+    {
+      "word": "favourable, beneficial, constructive",
+      "meaning": "having a positive or helpful effect",
+      "example": "Her feedback was very constructive.",
+      "translation": "có lợi",
+      "count": 0
+    },
+    {
+      "word": "A LAWNMOWER",
+      "meaning": "a machine used for cutting grass",
+      "example": "I used the lawnmower to trim the front yard.",
+      "translation": "máy cắt cỏ",
+      "count": 0
+    },
+    {
+      "word": "A REMOTE CONTROL",
+      "meaning": "a handheld device used to operate electronic equipment from a distance",
+      "example": "He lost the remote control for the TV again.",
+      "translation": "điều khiển từ xa",
+      "count": 0
+    },
+    {
+      "word": "GOGGLES",
+      "meaning": "protective eyewear used in specific conditions like swimming or lab work",
+      "example": "She put on her goggles before diving into the pool.",
+      "translation": "kính bảo hộ",
+      "count": 0
+    },
+    {
+      "word": "SALMON",
+      "meaning": "a type of fish known for its pink flesh, often eaten as food",
+      "example": "Grilled salmon is one of my favorite dishes.",
+      "translation": "cá hồi",
+      "count": 0
+    },
+    {
+      "word": "A FLIGHT ATTENDANT",
+      "meaning": "a person who assists passengers during a flight",
+      "example": "The flight attendant gave us safety instructions.",
+      "translation": "tiếp viên hàng không",
+      "count": 0
+    },
+    {
+      "word": "DYE",
+      "meaning": "a substance used to change the color of something",
+      "example": "She dyed her hair bright red last summer.",
+      "translation": "thuốc nhuộm",
+      "count": 0
+    },
+    {
+      "word": "EMBEZZLEMENT",
+      "meaning": "the act of illegally taking money that you were trusted to manage",
+      "example": "He was found guilty of embezzlement and sentenced to five years in prison.",
+      "translation": "tham ô",
+      "count": 0
+    },
+    {
+      "word": "ASTHMA",
+      "meaning": "a chronic condition that causes difficulty in breathing",
+      "example": "He uses an inhaler to manage his asthma.",
+      "translation": "hen suyễn",
+      "count": 0
+    },
+    {
+      "word": "AN OWL",
+      "meaning": "a nocturnal bird with large eyes and a flat face, known for its hooting sound",
+      "example": "The owl hooted softly in the quiet forest.",
+      "translation": "con cú",
+      "count": 0
+    },
+      {
+          "word": "You didn’t understand something",
+          "meaning": "phrases used to ask for clarification when a word is unclear or unfamiliar",
+          "example": "Sorry, I’m not sure what 'exaggerate' means. Could you explain it another way?",
+          "translation": "bạn không hiểu điều gì đó",
+          "count": 0
+      },
+      {
+          "word": "You didn’t hear something",
+          "meaning": "ways to ask the speaker to repeat something you didn’t catch",
+          "example": "Excuse me, could you repeat that? I didn’t quite catch it.",
+          "translation": "bạn không nghe rõ điều gì đó",
+          "count": 0
+      },
+      {
+          "word": "BUYING TIME",
+          "meaning": "techniques used to delay your response and gain time to think",
+          "example": "Hmm... that’s a good question. Let me think for a moment.",
+          "translation": "câu kéo thời gian",
+          "count": 0
+      },
+      {
+          "word": "Direct vs. indirect questions",
+          "meaning": "types of questions differing in how directly they are asked",
+          "example": "Direct: What time is it? Indirect: Could you tell me what time it is?",
+          "translation": "câu hỏi trực tiếp và gián tiếp",
+          "count": 0
+      },
+      {
+          "word": "Ask for time",
+          "meaning": "phrases to politely request more time to think before answering",
+          "example": "That’s a tricky one. Can I take a moment to think it over?",
+          "translation": "xin thời gian suy nghĩ",
+          "count": 0
+      },
+      {
+          "word": "Use conversation fillers",
+          "meaning": "short expressions to fill pauses and buy thinking time",
+          "example": "Well, I guess I’d say it depends on the situation.",
+          "translation": "dùng từ đệm trong hội thoại",
+          "count": 0
+      },
+      {
+          "word": "Combine techniques",
+          "meaning": "using multiple strategies like repeating, fillers, or asking for time",
+          "example": "Hmm… let me think. So you're asking about local food types?",
+          "translation": "kết hợp nhiều kỹ thuật",
+          "count": 0
+      },
+      {
+          "word": "CONNECTING IDEAS",
+          "meaning": "phrases used to organize and link parts of a spoken response",
+          "example": "Firstly, cities offer more jobs. Also, they have better infrastructure. However, they can be noisy.",
+          "translation": "kết nối ý tưởng",
+          "count": 0
+      },
+      {
+          "word": "On the whole",
+          "meaning": "used to express a general opinion or summary",
+          "example": "On the whole, I prefer working from home.",
+          "translation": "nhìn chung",
+          "count": 0
+      },
+      {
+          "word": "Regarding (transport)",
+          "meaning": "used to introduce the topic of transportation",
+          "example": "Regarding transport, buses are more eco-friendly.",
+          "translation": "liên quan đến (giao thông)",
+          "count": 0
+      },
+      {
+          "word": "On top of that, Also,",
+          "meaning": "phrases used to add more points to your response",
+          "example": "Also, public transport is cheaper. On top of that, it reduces pollution.",
+          "translation": "thêm vào đó",
+          "count": 0
+      },
+      {
+          "word": "On the other hand, However, Despite (those disadvantages),",
+          "meaning": "phrases used to show contrast or exception",
+          "example": "However, small towns offer peace and quiet.",
+          "translation": "mặt khác, tuy nhiên, mặc dù",
+          "count": 0
+      },
+      {
+          "word": "In fact,",
+          "meaning": "used to introduce something surprising or to emphasize",
+          "example": "In fact, I used to live in a very crowded city.",
+          "translation": "thực tế là",
+          "count": 0
+      },
+      {
+          "word": "In short,",
+          "meaning": "used to summarize what has been said",
+          "example": "In short, both have their pros and cons.",
+          "translation": "nói ngắn gọn",
+          "count": 0
+      },
+      {
+          "word": "well",
+          "meaning": "used to begin a statement or give yourself time to think",
+          "example": "Well, I think that depends on the context.",
+          "translation": "à thì",
+          "count": 0
+      },
+      {
+          "word": "so/therefore",
+          "meaning": "used to introduce a logical result or conclusion",
+          "example": "The weather was bad, so we canceled the trip.",
+          "translation": "vì vậy",
+          "count": 0
+      },
+      {
+          "word": "basically",
+          "meaning": "used to simplify or highlight the main idea",
+          "example": "Basically, I just want to be happy.",
+          "translation": "nói chung là",
+          "count": 0
+      },
+      {
+          "word": "however/yet",
+          "meaning": "used to express contrast between ideas",
+          "example": "It sounds interesting. However, it’s quite risky.",
+          "translation": "tuy nhiên",
+          "count": 0
+      },
+      {
+          "word": "though",
+          "meaning": "used at the end of a sentence to show contrast",
+          "example": "I liked the movie. It was a bit long, though.",
+          "translation": "mặc dù vậy",
+          "count": 0
+      },
+      {
+          "word": "in other words",
+          "meaning": "used to explain or rephrase something",
+          "example": "He's very frugal. In other words, he rarely spends money.",
+          "translation": "nói cách khác",
+          "count": 0
+      },
+      {
+          "word": "if we’re talking ...",
+          "meaning": "used to narrow down or clarify the topic",
+          "example": "If we’re talking food, I’d say Vietnamese cuisine is my favorite.",
+          "translation": "nếu nói về...",
+          "count": 0
+      },
+      {
+          "word": "as far as ... is concerned",
+          "meaning": "used to introduce your opinion on a specific topic",
+          "example": "As far as traffic is concerned, it's a big issue in major cities.",
+          "translation": "xét về mặt...",
+          "count": 0
+      },
+      {
+          "word": "eventually",
+          "meaning": "used to describe something that happens after a delay or effort",
+          "example": "After several tries, I eventually passed the test.",
+          "translation": "cuối cùng",
+          "count": 0
+      },
+      {
+          "word": "on top of that/what’s more",
+          "meaning": "used to add extra information that strengthens your point",
+          "example": "The food was expensive. On top of that, it wasn’t even tasty.",
+          "translation": "thêm vào đó",
+          "count": 0
+      },
+      {
+          "word": "anyway/anyhow",
+          "meaning": "used to return to a previous topic or close a discussion",
+          "example": "Anyway, let’s move on to the next question.",
+          "translation": "dù sao thì",
+          "count": 0
+      },
+      {
+          "word": "actually",
+          "meaning": "used to introduce a response that may be surprising or unexpected",
+          "example": "I thought he wouldn’t come, but actually he arrived early.",
+          "translation": "thực ra",
+          "count": 0
+      },
+      {
+          "word": "in fact",
+          "meaning": "used to clarify or correct a previous statement",
+          "example": "He said he didn’t like movies. In fact, he rarely watches TV at all.",
+          "translation": "thực tế là",
+          "count": 0
+      },
+      {
+          "word": "to cut a long story short",
+          "meaning": "used to summarize a story by only mentioning the main point",
+          "example": "To cut a long story short, we missed the flight and had to rebook.",
+          "translation": "nói ngắn gọn",
+          "count": 0
+      },
+      {
+          "word": "on the whole / in general",
+          "meaning": "used to express a broad or general opinion",
+          "example": "On the whole, people in this town are very welcoming.",
+          "translation": "nhìn chung",
+          "count": 0
+      },
+      {
+          "word": "overall",
+          "meaning": "used to give a general conclusion or final assessment",
+          "example": "Overall, the trip was a great success despite the weather.",
+          "translation": "tổng thể",
+          "count": 0
+      },
+      {
+          "word": "for example/for instance",
+          "meaning": "used to give a specific case or illustration",
+          "example": "Many cities have excellent public transport. For example, Tokyo's train system is highly efficient.",
+          "translation": "ví dụ",
+          "count": 0
+      },
+      {
+          "word": "alternatively",
+          "meaning": "used to offer another possibility or choice",
+          "example": "You can go by train. Alternatively, you can take a bus if it’s cheaper.",
+          "translation": "hoặc là",
+          "count": 0
+      },
+      {
+          "word": "Neolithic",
+          "meaning": "relating to the later Stone Age period when farming and settled life began",
+          "example": "The Neolithic era introduced farming and permanent homes.",
+          "translation": "thời kỳ đồ đá mới",
+          "count": 0
+      },
+      {
+          "word": "bluestones",
+          "meaning": "a type of rock used in ancient monuments like Stonehenge",
+          "example": "The bluestones at Stonehenge were brought from over 200 kilometers away.",
+          "translation": "đá xanh",
+          "count": 0
+      },
+      {
+          "word": "haul",
+          "meaning": "to drag or pull something with effort over a distance",
+          "example": "Workers had to haul the logs up the hill using ropes.",
+          "translation": "kéo, vận chuyển",
+          "count": 0
+      },
+      {
+          "word": "prehistoric",
+          "meaning": "relating to the time before written history",
+          "example": "Prehistoric humans left cave paintings as evidence of their lives.",
+          "translation": "thời tiền sử",
+          "count": 0
+      },
+      {
+          "word": "sophisticated",
+          "meaning": "highly developed or advanced in design, knowledge, or culture",
+          "example": "The ancient city had a sophisticated system of water distribution.",
+          "translation": "tinh vi",
+          "count": 0
+      },
+      {
+          "word": "boulders",
+          "meaning": "large, rounded rocks often shaped by erosion",
+          "example": "The path was blocked by massive boulders.",
+          "translation": "tảng đá lớn",
+          "count": 0
+      },
+      {
+          "word": "primitive",
+          "meaning": "simple and not developed; from an early stage of evolution",
+          "example": "Primitive tools were made of stone and animal bones.",
+          "translation": "nguyên thủy",
+          "count": 0
+      },
+      {
+          "word": "timber",
+          "meaning": "wood prepared for building or carpentry",
+          "example": "They built the shelter using timber from nearby trees.",
+          "translation": "gỗ xây dựng",
+          "count": 0
+      },
+      {
+          "word": "deer antlers",
+          "meaning": "branched horns that grow on deer and fall off annually",
+          "example": "Early humans crafted tools from deer antlers.",
+          "translation": "gạc hươu",
+          "count": 0
+      },
+      {
+          "word": "ditch",
+                "meaning": "a narrow channel dug in the ground to drain or mark boundaries",
+          "example": "Farmers dug a ditch around the field to keep animals out.",
+          "translation": "hào, rãnh",
+          "count": 0
+      },
+      {
+          "word": "bank",
+          "meaning": "a raised area of ground, especially along a river or ditch",
+          "example": "They stood on the river bank to watch the boats pass by.",
+          "translation": "bờ đất",
+          "count": 0
+      },
+      {
+          "word": "henge",
+          "meaning": "a prehistoric earthwork typically consisting of a circle of stones or posts",
+          "example": "Stonehenge is the most famous henge in Britain.",
+          "translation": "di tích vòng tròn cổ",
+          "count": 0
+      },
+      {
+          "word": "pits",
+          "meaning": "holes dug in the ground, often for storage or construction",
+          "example": "Archaeologists discovered storage pits under the ancient site.",
+          "translation": "hố đất",
+          "count": 0
+      },
+      {
+          "word": "scholars",
+          "meaning": "experts who study a particular subject deeply",
+          "example": "Many scholars have tried to interpret the function of Stonehenge.",
+          "translation": "học giả",
+          "count": 0
+      },
+      {
+          "word": "antiquarian",
+          "meaning": "a person who studies or collects ancient artifacts or antiques",
+          "example": "The antiquarian recorded detailed drawings of the site in his journal.",
+          "translation": "nhà nghiên cứu cổ vật",
+          "count": 0
+      },
+      {
+          "word": "indigenous",
+          "meaning": "native to a particular place or region",
+          "example": "These plants are indigenous to Southeast Asia.",
+          "translation": "bản địa",
+          "count": 0
+      },
+      {
+          "word": "astrological",
+          "meaning": "related to the belief in the influence of stars and planets on human affairs",
+          "example": "He studied the astrological alignment of the monument's stones.",
+          "translation": "thuộc chiêm tinh",
+          "count": 0
+      },
+      {
+          "word": "curative",
+          "meaning": "having healing or medicinal properties",
+          "example": "They believed the spring water had curative effects.",
+          "translation": "có tác dụng chữa bệnh",
+          "count": 0
+      },
+      {
+      "word": "New Stone Age",
+      "meaning": "a time marked by early farming, animal domestication, and polished stone tools",
+      "example": "During the New Stone Age, people began to grow crops and settle in villages.",
+      "translation": "Thời kỳ đồ đá mới",
+      "count": 0
+    },
+    {
+      "word": "Iron Age",
+      "meaning": "a historical era known for the use of iron for making tools and weapons",
+      "example": "Many ancient civilizations expanded during the Iron Age due to better tools.",
+      "translation": "Thời kỳ đồ sắt",
+      "count": 0
+    },
+    {
+      "word": "hypothesis",
+      "meaning": "a proposed idea to explain something, based on limited data",
+      "example": "One hypothesis suggests that the stones were transported by water.",
+      "translation": "giả thuyết",
+      "count": 0
+    },
+    {
+      "word": "consensus",
+      "meaning": "a shared agreement among a group of people",
+      "example": "There is a consensus that Stonehenge was used for ceremonial purposes.",
+      "translation": "sự đồng thuận",
+      "count": 0
+    },
+    {
+      "word": "megalithic",
+      "meaning": "relating to large stones used in ancient constructions",
+      "example": "The megalithic design of Stonehenge is still admired today.",
+      "translation": "liên quan đến đá lớn",
+      "count": 0
+    },
+    {
+      "word": "archaeologist",
+      "meaning": "a researcher who studies history through physical remains",
+      "example": "The archaeologist uncovered burial tools near the monument.",
+      "translation": "nhà khảo cổ học",
+      "count": 0
+    },
+    {
+      "word": "radiocarbon dating",
+      "meaning": "a scientific method to estimate the age of ancient organic material",
+      "example": "Radiocarbon dating revealed the stones are over 4,000 years old.",
+      "translation": "phương pháp định tuổi bằng carbon",
+      "count": 0
+    },
+    {
+      "word": "sceptical",
+      "meaning": "having doubts or questioning something",
+      "example": "Many remain sceptical about the new excavation findings.",
+      "translation": "hoài nghi",
+      "count": 0
+    },
+    {
+      "word": "artifacts",
+      "meaning": "historical objects created by humans",
+      "example": "Artifacts found at the site included tools and pottery shards.",
+      "translation": "hiện vật",
+      "count": 0
+    },
+    {
+      "word": "communal",
+      "meaning": "shared by a group or community",
+      "example": "The villagers worked together in a communal effort to build the site.",
+      "translation": "chung, cộng đồng",
+      "count": 0
+    },
+    {
+      "word": "descended",
+      "meaning": "originating from a particular ancestor",
+      "example": "The tribe is believed to have descended from early Neolithic settlers.",
+      "translation": "xuất thân từ",
+      "count": 0
+    },
+    {
+      "word": "dense cloud cover",
+      "meaning": "a thick blanket of clouds blocking visibility",
+      "example": "Dense cloud cover often limits sky visibility in this region.",
+      "translation": "mây dày đặc",
+      "count": 0
+    },
+    {
+      "word": "astronomical",
+      "meaning": "related to stars, planets, or space science",
+      "example": "Astronomical studies suggest the stones align with solstices.",
+      "translation": "thuộc thiên văn học",
+      "count": 0
+    },
+    {
+      "word": "monoliths",
+      "meaning": "very large single stone structures",
+      "example": "The builders transported massive monoliths across great distances.",
+      "translation": "khối đá đơn lớn",
+      "count": 0
+    },
+    {
+      "word": "ritual",
+      "meaning": "a series of formal actions performed for religious or cultural reasons",
+      "example": "They likely gathered there for seasonal rituals.",
+      "translation": "nghi lễ",
+      "count": 0
+    },
+    {
+      "word": "enigmatic",
+      "meaning": "hard to understand or explain; mysterious",
+      "example": "The purpose of the site remains enigmatic to this day.",
+      "translation": "bí ẩn",
+      "count": 0
+    },
+    {
+      "word": "celestial bodies",
+      "meaning": "natural objects like stars and planets visible in the sky",
+      "example": "The monument may have been aligned with celestial bodies.",
+      "translation": "thiên thể",
+      "count": 0
+    },
+    {
+      "word": "astronomical alignments",
+      "meaning": "positions of stars or planets matching specific locations on Earth",
+      "example": "Some stones correspond to key astronomical alignments.",
+      "translation": "sự sắp xếp thiên văn",
+      "count": 0
+    },
+    {
+      "word": "megalithic culture",
+      "meaning": "an ancient civilization known for using massive stones in construction",
+      "example": "The region once flourished under a megalithic culture.",
+      "translation": "văn hóa đá lớn",
+      "count": 0
+    },
+    {
+      "word": "astronomical observatory",
+      "meaning": "a place for studying stars and other space objects",
+      "example": "Researchers suggest the site may have served as an astronomical observatory.",
+      "translation": "đài thiên văn",
+      "count": 0
+    },
+    {
+      "word": "cultural significance",
+      "meaning": "the importance of something in a culture",
+      "example": "Stonehenge holds deep cultural significance in British heritage.",
+      "translation": "ý nghĩa văn hóa",
+      "count": 0
+    },
+    {
+      "word": "paradigm",
+      "meaning": "a standard example or model of something",
+      "example": "The discovery introduced a new paradigm in scientific thought.",
+      "translation": "mô hình, khuôn mẫu",
+      "count": 0
+    },
+    {
+      "word": "ubiquitous",
+      "meaning": "existing or being everywhere at once",
+      "example": "Smart devices have become ubiquitous in modern life.",
+      "translation": "phổ biến, có mặt khắp nơi",
+      "count": 0
+    },
+    {
+      "word": "dichotomy",
+      "meaning": "a contrast or division between two things",
+      "example": "There is a clear dichotomy between ancient beliefs and science.",
+      "translation": "sự phân đôi, đối lập",
+      "count": 0
+    },
+    {
+      "word": "conundrum",
+      "meaning": "a difficult or puzzling question or situation",
+      "example": "The origin of the stones remains a conundrum.",
+      "translation": "vấn đề nan giải",
+      "count": 0
+    },
+    {
+      "word": "cognitive dissonance",
+      "meaning": "a psychological conflict resulting from holding contradictory thoughts or beliefs at the same time",
+      "example": "She felt cognitive dissonance after spending money on something she believed was wasteful.",
+      "translation": "mâu thuẫn nhận thức",
+      "count": 0
+    },
+    {
+      "word": "conjectural (adjective)",
+      "meaning": "based on guesswork rather than solid proof; speculative",
+      "example": "Most explanations about the monument’s origin are purely conjectural.",
+      "translation": "dự đoán, không chắc chắn",
+      "count": 0
+    },
+    {
+      "word": "Brand awareness (noun)",
+      "meaning": "the level at which consumers recognize or recall a brand",
+      "example": "Social media marketing can rapidly boost brand awareness among young audiences.",
+      "translation": "nhận diện thương hiệu",
+      "count": 0
+    },
+    {
+      "word": "Manipulate (verb)",
+      "meaning": "to influence someone’s behavior secretly or unfairly",
+      "example": "The advertisement was designed to manipulate viewers into buying the product without realizing it.",
+      "translation": "thao túng",
+      "count": 0
+    },
+    {
+      "word": "Target audience (noun)",
+      "meaning": "the specific group a product or message is intended for",
+      "example": "Teenagers were identified as the target audience for the new fashion line.",
+      "translation": "đối tượng mục tiêu",
+      "count": 0
+    },
+    {
+      "word": "A call to action (noun)",
+      "meaning": "a prompt in marketing encouraging people to take a specific step",
+      "example": "Adding a strong call to action like 'Buy now' helps increase sales conversions.",
+      "translation": "lời kêu gọi hành động",
+      "count": 0
+    },
+    {
+      "word": "Commercial break (noun)",
+      "meaning": "a short interruption in a broadcast to air advertisements",
+      "example": "She used the commercial break to grab a drink from the kitchen.",
+      "translation": "quảng cáo giữa chương trình",
+      "count": 0
+    },
+    {
+      "word": "Word of mouth (noun)",
+      "meaning": "informal promotion by people talking about products with others",
+      "example": "The restaurant became popular thanks to positive word of mouth.",
+      "translation": "truyền miệng",
+      "count": 0
+    },
+    {
+      "word": "Product placement (noun)",
+      "meaning": "showing products in entertainment content to advertise them subtly",
+      "example": "The car featured prominently in the movie through strategic product placement.",
+      "translation": "quảng cáo chèn sản phẩm",
+      "count": 0
+    },
+    {
+      "word": "Jingle (noun)",
+      "meaning": "a catchy tune used in an advertisement to make it memorable",
+      "example": "That fast-food chain’s jingle is stuck in my head all day.",
+      "translation": "giai điệu quảng cáo",
+      "count": 0
+    },
+    {
+      "word": "Slogan (noun)",
+      "meaning": "a short, memorable phrase used in advertising to convey a brand message",
+      "example": "Nike’s slogan ‘Just Do It’ has become iconic worldwide.",
+      "translation": "khẩu hiệu",
+      "count": 0
+    },
+    {
+      "word": "(Celebrity) endorsement (noun)",
+      "meaning": "a famous person publicly supporting a product to boost sales",
+      "example": "The perfume sales increased after a celebrity endorsement by a pop star.",
+      "translation": "sự chứng thực từ người nổi tiếng",
+      "count": 0
+    },
+    {
+      "word": "Carnivore (noun)",
+      "meaning": "an animal whose primary diet consists of meat",
+      "example": "Lions are classic examples of carnivores that dominate their habitats.",
+      "translation": "động vật ăn thịt",
+      "count": 0
+    },
+    {
+      "word": "Herbivore (noun)",
+      "meaning": "an animal that only eats plants",
+      "example": "Giraffes, as herbivores, feed mostly on leaves and fruits.",
+      "translation": "động vật ăn cỏ",
+      "count": 0
+    },
+    {
+      "word": "Domesticated (adjective)",
+      "meaning": "tamed or trained to live with humans and serve specific purposes",
+      "example": "Domesticated cats rely on humans for food and shelter.",
+      "translation": "đã thuần hóa",
+      "count": 0
+    },
+    {
+      "word": "Poach (verb)",
+      "meaning": "to illegally hunt or capture animals",
+      "example": "Efforts to stop elephant poaching are increasing in Africa.",
+      "translation": "săn trộm",
+      "count": 0
+    },
+    {
+      "word": "Territory (noun)",
+      "meaning": "an area that an animal claims and defends as its own",
+      "example": "Wolves mark their territory with scent to warn other packs.",
+      "translation": "lãnh thổ",
+      "count": 0
+    },
+    {
+      "word": "Reproduce (verb)",
+      "meaning": "to produce offspring or new generations",
+      "example": "Frogs can reproduce quickly in wet environments.",
+      "translation": "sinh sản",
+      "count": 0
+    },
+    {
+      "word": "Apex Predator (noun)",
+      "meaning": "a top-level predator with no natural enemies",
+      "example": "Polar bears are apex predators in Arctic ecosystems.",
+      "translation": "động vật săn mồi đầu chuỗi",
+      "count": 0
+    },
+    {
+      "word": "Migrate (verb)",
+      "meaning": "to move from one region to another at certain times of the year",
+      "example": "Geese migrate south to avoid harsh winter conditions.",
+      "translation": "di cư",
+      "count": 0
+    },
+    {
+      "word": "Endangered (adjective)",
+      "meaning": "at risk of disappearing completely from the wild",
+      "example": "The panda is considered an endangered species needing protection.",
+      "translation": "bị đe dọa tuyệt chủng",
+      "count": 0
+    },
+    {
+      "word": "Aggressive (adjective)",
+      "meaning": "likely to attack or confront; hostile in behavior",
+      "example": "Some animals become aggressive if they feel threatened.",
+      "translation": "hung dữ",
+      "count": 0
+    },
+    {
+      "word": "Architect (noun)",
+      "meaning": "a professional who designs buildings or structures",
+      "example": "The architect created blueprints for a modern museum.",
+      "translation": "kiến trúc sư",
+      "count": 0
+    },
+    {
+      "word": "Controversial (adjective)",
+      "meaning": "causing strong disagreement or public debate",
+      "example": "The new skyscraper sparked controversial opinions among citizens.",
+      "translation": "gây tranh cãi",
+      "count": 0
+    },
+    {
+      "word": "Eyesore (noun)",
+      "meaning": "something very unpleasant to look at",
+      "example": "The abandoned factory became a city eyesore.",
+      "translation": "cảnh chướng mắt",
+      "count": 0
+    },
+    {
+      "word": "Demolish (verb)",
+      "meaning": "To completely tear down or destroy a structure, often to make way for something new.",
+      "example": "The old theater was demolished to build a modern shopping complex.",
+      "translation": "Phá hủy",
+      "count": 0
+    },
+    {
+      "word": "Planning Permission (noun)",
+      "meaning": "Official approval from authorities to build or modify a structure at a specific site.",
+      "example": "They had to wait six months to get planning permission for the new office building.",
+      "translation": "Giấy phép xây dựng",
+      "count": 0
+    },
+    {
+      "word": "Gothic (adjective)",
+      "meaning": "Describing an architectural style known for its pointed arches and detailed ornamentation, prominent in medieval Europe.",
+      "example": "The Gothic cathedral towered above the city with its intricate stone carvings.",
+      "translation": "Kiến trúc Gothic",
+      "count": 0
+    },
+    {
+      "word": "Modernist (adjective)",
+      "meaning": "Relating to a style of architecture using clean lines and geometric shapes, often minimal in design.",
+      "example": "The modernist museum features bold shapes and a sleek glass exterior.",
+      "translation": "Hiện đại (trong kiến trúc)",
+      "count": 0
+    },
+    {
+      "word": "Sticks out like a sore thumb (idiom, verb)",
+      "meaning": "To be noticeably different or mismatched with the surroundings, often unpleasantly.",
+      "example": "That neon sign sticks out like a sore thumb on a historic street.",
+      "translation": "Lạc lõng, không phù hợp",
+      "count": 0
+    },
+    {
+      "word": "Futuristic (noun)",
+      "meaning": "Involving designs or ideas that seem advanced or ahead of the present time.",
+      "example": "The futuristic building features vertical gardens and solar panel walls.",
+      "translation": "Tương lai (kiến trúc)",
+      "count": 0
+    },
+    {
+      "word": "Iconic (adjective)",
+      "meaning": "Widely recognized and symbolically significant, often admired across cultures.",
+      "example": "The Eiffel Tower is an iconic symbol of Paris.",
+      "translation": "Mang tính biểu tượng",
+      "count": 0
+    },
+    {
+      "word": "Abstract (adjective)",
+      "meaning": "Art that represents ideas or feelings through shapes and colors rather than realistic forms.",
+      "example": "She enjoys creating abstract paintings using only circles and lines.",
+      "translation": "Trừu tượng",
+      "count": 0
+    },
+    {
+      "word": "(A) Watercolour (adjective/noun)",
+      "meaning": "A type of painting using pigments mixed with water, producing soft and translucent effects.",
+      "example": "He painted a peaceful countryside scene in soft watercolours.",
+      "translation": "Màu nước / tranh màu nước",
+      "count": 0
+    },
+    {
+      "word": "Sculpture (noun)",
+      "meaning": "A three-dimensional piece of art made by shaping materials like stone, wood, or metal.",
+      "example": "The bronze sculpture in the park draws attention from every visitor.",
+      "translation": "Tượng điêu khắc",
+      "count": 0
+    },
+    {
+      "word": "A still life (noun)",
+      "meaning": "A painting or artwork showing inanimate objects, like flowers or bowls of fruit.",
+      "example": "She spent hours painting a still life of wine bottles and fruit.",
+      "translation": "Tĩnh vật",
+      "count": 0
+    },
+    {
+      "word": "Masterpiece (noun)",
+      "meaning": "An exceptional or highly praised work of art, often seen as the creator’s best.",
+      "example": "Many consider The Starry Night to be Van Gogh's masterpiece.",
+      "translation": "Kiệt tác",
+      "count": 0
+    },
+    {
+      "word": "To depict (verb)",
+      "meaning": "To represent something in a visual or artistic form.",
+      "example": "The mural depicts the struggles of everyday life in the city.",
+      "translation": "Miêu tả, khắc họa",
+      "count": 0
+    },
+    {
+      "word": "Impenetrable (adjective)",
+      "meaning": "Extremely difficult to understand or interpret.",
+      "example": "His explanation of the art was so impenetrable that no one followed.",
+      "translation": "Khó hiểu",
+      "count": 0
+    },
+    {
+      "word": "Interpretation (noun)",
+      "meaning": "The way someone understands or explains the meaning of something.",
+      "example": "Everyone had a different interpretation of the painting’s message.",
+      "translation": "Sự diễn giải",
+      "count": 0
+    },
+    {
+      "word": "Motor skills (noun)",
+      "meaning": "The ability to make precise movements with the hands and fingers.",
+      "example": "Clay sculpting helps children develop fine motor skills.",
+      "translation": "Kỹ năng vận động",
+      "count": 0
+    },
+    {
+      "word": "Innovative (adjective)",
+      "meaning": "Describes someone or something that introduces new ideas or methods.",
+      "example": "Her innovative designs won first place in the architecture contest.",
+      "translation": "Sáng tạo, đổi mới",
+      "count": 0
+    },
+    {
+      "word": "The center of attention (noun)",
+      "meaning": "A person or thing that everyone is watching or focusing on.",
+      "example": "The birthday girl was the center of attention all evening.",
+      "translation": "Tâm điểm chú ý",
+      "count": 0
+    },
+    {
+      "word": "To turn + age (verb)",
+      "meaning": "To reach a particular age in years.",
+      "example": "He just turned 30 and had a big celebration.",
+      "translation": "Tròn (bao nhiêu tuổi)",
+      "count": 0
+    },
+    {
+      "word": "The birthday boy/girl (noun)",
+      "meaning": "The person whose birthday is being celebrated.",
+      "example": "Everyone sang to the birthday girl before she blew out the candles.",
+      "translation": "Nhân vật chính trong tiệc sinh nhật",
+      "count": 0
+    },
+    {
+      "word": "Low-key (adjective)",
+      "meaning": "Quiet, modest, or restrained in style or celebration.",
+      "example": "They chose a low-key dinner instead of a big party.",
+      "translation": "Đơn giản, kín đáo",
+      "count": 0
+    },
+    {
+      "word": "To wrap (verb)",
+      "meaning": "To cover something in paper, especially as a gift.",
+      "example": "She carefully wrapped the book in red foil paper.",
+      "translation": "Gói quà",
+      "count": 0
+    },
+    {
+      "word": "A surprise party (noun)",
+      "meaning": "A party that is planned secretly for someone who doesn't know it will happen.",
+      "example": "They threw him a surprise party for his 21st birthday.",
+      "translation": "Tiệc bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "Get-together (noun)",
+      "meaning": "An informal meeting or small gathering of friends or family.",
+      "example": "We had a weekend get-together with old classmates.",
+      "translation": "Buổi tụ họp",
+      "count": 0
+    },
+    {
+      "word": "Decorate (verb)",
+      "meaning": "To make something more attractive by adding items or colors.",
+      "example": "They decorated the house with balloons for the party.",
+      "translation": "Trang trí",
+      "count": 0
+    },
+    {
+      "word": "Make a birthday wish",
+      "meaning": "to silently hope for something special before blowing out candles",
+      "example": "Every year, she made a secret birthday wish before extinguishing the flames.",
+      "translation": "ước sinh nhật",
+      "count": 0
+    },
+    {
+      "word": "Blow out the candles",
+      "meaning": "to extinguish candles on a cake using breath",
+      "example": "He leaned forward and blew out the candles in one breath.",
+      "translation": "thổi nến",
+      "count": 0
+    },
+    {
+      "word": "Value for money (noun)",
+      "meaning": "a good product or service compared to its cost",
+      "example": "This phone offers great value for money given its features.",
+      "translation": "đáng tiền",
+      "count": 0
+    },
+    {
+      "word": "Entrepreneur (noun)",
+      "meaning": "a person who builds and runs new businesses",
+      "example": "The entrepreneur pitched her new eco-friendly brand to investors.",
+      "translation": "doanh nhân",
+      "count": 0
+    },
+    {
+      "word": "The bottom line (noun)",
+      "meaning": "a company’s profit after deducting expenses",
+      "example": "Rising energy costs affected the company’s bottom line.",
+      "translation": "lợi nhuận ròng",
+      "count": 0
+    },
+    {
+      "word": "Generate revenue",
+      "meaning": "to earn income for a business through activities",
+      "example": "The app quickly generated revenue through subscriptions.",
+      "translation": "tạo doanh thu",
+      "count": 0
+    },
+    {
+      "word": "Cut-throat (adjective)",
+      "meaning": "extremely competitive and aggressive",
+      "example": "The cut-throat nature of the industry makes it hard to survive.",
+      "translation": "cạnh tranh khốc liệt",
+      "count": 0
+    },
+    {
+      "word": "Cut costs (verb)",
+      "meaning": "to reduce spending to save money",
+      "example": "They cut costs by switching to cheaper suppliers.",
+      "translation": "cắt giảm chi phí",
+      "count": 0
+    },
+    {
+      "word": "Rules and regulations (noun)",
+      "meaning": "official policies or restrictions one must follow",
+      "example": "Businesses must comply with environmental rules and regulations.",
+      "translation": "quy định và luật lệ",
+      "count": 0
+    },
+    {
+      "word": "Multinational corporation (noun)",
+      "meaning": "a business that operates in multiple countries",
+      "example": "Multinational corporations often adapt their strategies to local markets.",
+      "translation": "tập đoàn đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "A start-up / A start-up company (noun/adjective)",
+      "meaning": "a newly formed company, usually innovative or tech-based",
+      "example": "The start-up gained rapid traction among young users.",
+      "translation": "công ty khởi nghiệp",
+      "count": 0
+    },
+    {
+      "word": "Unique selling point (noun)",
+      "meaning": "a feature that sets a product apart from others",
+      "example": "Their unique selling point is 24-hour delivery.",
+      "translation": "điểm bán hàng độc nhất",
+      "count": 0
+    },
+    {
+      "word": "Lenient (adjective)",
+      "meaning": "not strict in enforcing rules or discipline",
+      "example": "The teacher was lenient with students who submitted work late.",
+      "translation": "nhân hậu, dễ tính",
+      "count": 0
+    },
+    {
+      "word": "Obedient (adjective)",
+      "meaning": "willing to follow rules or authority",
+      "example": "The obedient dog stayed by its owner’s side.",
+      "translation": "ngoan ngoãn",
+      "count": 0
+    },
+    {
+      "word": "To get away with something",
+      "meaning": "to avoid punishment after doing something wrong",
+      "example": "He got away with cheating on the exam without consequences.",
+      "translation": "thoát tội",
+      "count": 0
+    },
+    {
+      "word": "An only child (noun)",
+      "meaning": "a child without siblings",
+      "example": "Being an only child, she often played alone.",
+      "translation": "con một",
+      "count": 0
+    },
+    {
+      "word": "To raise someone to be",
+      "meaning": "to bring up a child to have certain qualities",
+      "example": "They raised him to be respectful and honest.",
+      "translation": "nuôi dưỡng thành người",
+      "count": 0
+    },
+    {
+      "word": "To drift apart",
+      "meaning": "to slowly lose closeness in a relationship",
+      "example": "We drifted apart after high school despite being best friends.",
+      "translation": "dần xa cách",
+      "count": 0
+    },
+    {
+      "word": "To look up to someone",
+      "meaning": "to admire and respect someone",
+      "example": "She looked up to her older sister as a role model.",
+      "translation": "ngưỡng mộ",
+      "count": 0
+    },
+    {
+      "word": "To follow in someone’s footsteps",
+      "meaning": "to pursue a similar path as someone else",
+      "example": "He followed in his father’s footsteps and became a teacher.",
+      "translation": "nối nghiệp",
+      "count": 0
+    },
+    {
+      "word": "To go through a ____ phase",
+      "meaning": "to be obsessed with something temporarily",
+      "example": "He went through a space phase when he was ten.",
+      "translation": "trải qua giai đoạn",
+      "count": 0
+    },
+    {
+      "word": "Upbringing (noun)",
+      "meaning": "the way a child is nurtured and taught at home",
+      "example": "Her strict upbringing influenced her disciplined lifestyle.",
+      "translation": "sự nuôi dạy",
+      "count": 0
+    },
+    {
+      "word": "Outfit (noun)",
+      "meaning": "a set of clothes worn together",
+      "example": "She packed her favorite outfit for the party.",
+      "translation": "trang phục",
+      "count": 0
+    },
+    {
+      "word": "To get dressed up",
+      "meaning": "to wear elegant or special clothing",
+      "example": "He got dressed up for the wedding ceremony.",
+      "translation": "ăn diện",
+      "count": 0
+    },
+    {
+      "word": "Presentable (adjective)",
+      "meaning": "neatly dressed and looking appropriate",
+      "example": "She always looks presentable for job interviews.",
+      "translation": "chỉnh tề",
+      "count": 0
+    },
+    {
+      "word": "To dress down",
+      "meaning": "to wear casual or less formal clothes",
+      "example": "On Fridays, employees are allowed to dress down.",
+      "translation": "ăn mặc giản dị",
+      "count": 0
+    },
+    {
+      "word": "A fashionista (noun)",
+      "meaning": "someone who closely follows fashion trends and styles",
+      "example": "Being a fashionista, she never wore the same outfit twice.",
+      "translation": "người sành thời trang",
+      "count": 0
+    },
+    {
+      "word": "Dress code (noun)",
+      "meaning": "rules about what clothing is acceptable in a setting",
+      "example": "The restaurant enforces a strict dress code for dinner service.",
+      "translation": "quy định trang phục",
+      "count": 0
+    },
+    {
+      "word": "Smart-casual (adjective)",
+      "meaning": "a mix of formal and relaxed clothing style",
+      "example": "He chose a smart-casual outfit with a blazer and sneakers.",
+      "translation": "trang phục lịch sự thoải mái",
+      "count": 0
+    },
+    {
+      "word": "Accessories (noun)",
+      "meaning": "small wearable items that complete an outfit",
+      "example": "Her earrings and handbag were the perfect accessories.",
+      "translation": "phụ kiện",
+      "count": 0
+    },
+    {
+      "word": "Metrosexual (noun, adjective)",
+      "meaning": "a man who enjoys fashion and self-care",
+      "example": "He’s a metrosexual who takes pride in his skincare routine.",
+      "translation": "người đàn ông chăm chút ngoại hình",
+      "count": 0
+    },
+    {
+      "word": "Leisure wear (noun)",
+      "meaning": "comfortable clothing worn during relaxing or exercise",
+      "example": "She spent the weekend lounging in her leisure wear.",
+      "translation": "đồ mặc nhà/thể thao",
+      "count": 0
+    },
+    {
+      "word": "Designer (adjective)",
+      "meaning": "made by a high-end or well-known brand",
+      "example": "She saved up to buy a designer handbag.",
+      "translation": "hàng hiệu",
+      "count": 0
+    },
+    {
+      "word": "Chew the fat (idiom, verb)",
+      "meaning": "to have a casual and lengthy chat",
+      "example": "We sat on the porch chewing the fat for hours.",
+      "translation": "tám chuyện",
+      "count": 0
+    },
+    {
+      "word": "Beat around the bush (idiom, verb)",
+      "meaning": "to avoid directly addressing a topic",
+      "example": "Stop beating around the bush and tell me the truth.",
+      "translation": "nói vòng vo",
+      "count": 0
+    },
+    {
+      "word": "Confrontational (adjective)",
+      "meaning": "inclined to argue or challenge others directly",
+      "example": "His confrontational tone made the meeting tense.",
+      "translation": "thích đối đầu",
+      "count": 0
+    },
+    {
+      "word": "In your face (idiom, adjective, informal)",
+      "meaning": "bold and uncomfortably direct in style or speech",
+      "example": "His in-your-face attitude annoyed some teammates.",
+      "translation": "thẳng thừng, gây khó chịu",
+      "count": 0
+    },
+    {
+      "word": "Passive-aggressive (adjective)",
+      "meaning": "showing hidden hostility through subtle actions",
+      "example": "She made a passive-aggressive comment about my lateness.",
+      "translation": "hung hăng thụ động",
+      "count": 0
+    },
+    {
+      "word": "Catch up (Verb)",
+      "meaning": "to reconnect and exchange updates after time apart",
+      "example": "We caught up over coffee after two years apart.",
+      "translation": "trò chuyện cập nhật",
+      "count": 0
+    },
+    {
+      "word": "Interpersonal relationships (noun)",
+      "meaning": "connections and interactions between people",
+      "example": "Strong interpersonal relationships are vital in teamwork.",
+      "translation": "mối quan hệ giữa người với người",
+      "count": 0
+    },
+    {
+      "word": "Body language (noun)",
+      "meaning": "communication through gestures and posture",
+      "example": "Her nervous body language gave her away.",
+      "translation": "ngôn ngữ cơ thể",
+      "count": 0
+    },
+    {
+      "word": "Drop someone a line (phrasal verb, informal)",
+      "meaning": "to send a quick message to someone",
+      "example": "Don’t forget to drop me a line when you arrive.",
+      "translation": "liên lạc bằng thư/tin nhắn",
+      "count": 0
+    },
+    {
+      "word": "Shoot someone a message (phrasal verb, informal)",
+      "meaning": "to send someone a casual message",
+      "example": "I'll shoot her a message to confirm our meeting.",
+      "translation": "nhắn tin nhanh",
+      "count": 0
+    },
+    {
+      "word": "Fussy eater (noun)",
+      "meaning": "someone picky about the food they eat",
+      "example": "My son’s a fussy eater and avoids vegetables.",
+      "translation": "người kén ăn",
+      "count": 0
+    },
+    {
+      "word": "Repertoire (noun)",
+      "meaning": "a set of abilities someone can perform",
+      "example": "His cooking repertoire includes Italian and Thai dishes.",
+      "translation": "kho kỹ năng",
+      "count": 0
+    },
+    {
+      "word": "Ready meal (noun)",
+      "meaning": "pre-cooked food needing only heating",
+      "example": "She grabbed a ready meal after her late shift.",
+      "translation": "đồ ăn sẵn",
+      "count": 0
+    },
+    {
+      "word": "Follow a recipe",
+      "meaning": "to cook by using written instructions",
+      "example": "He followed the recipe exactly to make the cake.",
+      "translation": "làm theo công thức",
+      "count": 0
+    },
+    {
+      "word": "Fry (verb)",
+      "meaning": "to cook food in hot oil or fat",
+      "example": "She fried the fish until it turned golden brown.",
+      "translation": "rán",
+      "count": 0
+    },
+    {
+      "word": "Chop (verb)",
+      "meaning": "to cut into small pieces using a knife",
+      "example": "Chop the onions finely for this dish.",
+      "translation": "thái, chặt",
+      "count": 0
+    },
+    {
+      "word": "Cuisine (noun)",
+      "meaning": "a style of cooking from a region or culture",
+      "example": "Vietnamese cuisine features many fresh herbs.",
+      "translation": "ẩm thực",
+      "count": 0
+    },
+    {
+      "word": "Specialty (noun)",
+      "meaning": "a dish or skill someone is especially good at",
+      "example": "Her specialty is homemade dumplings.",
+      "translation": "món tủ",
+      "count": 0
+    },
+    {
+      "word": "Boil (verb)",
+      "meaning": "to cook food in water that has reached its boiling point",
+      "example": "Boil the pasta for ten minutes until tender.",
+      "translation": "luộc",
+      "count": 0
+    },
+    {
+      "word": "Home-cooked meals (noun)",
+      "meaning": "food prepared and cooked at home, often considered comforting",
+      "example": "She prefers home-cooked meals to eating at restaurants.",
+      "translation": "bữa ăn nấu tại nhà",
+      "count": 0
+    },
+    {
+      "word": "Lock someone up and throw away the key",
+      "meaning": "to imprison someone for a very long time",
+      "example": "Some believe violent criminals should be locked up and the key thrown away.",
+      "translation": "bỏ tù ai đó mãi mãi",
+      "count": 0
+    },
+    {
+      "word": "Rehabilitate (verb)",
+      "meaning": "to help someone return to a normal, law-abiding life",
+      "example": "The prison system focuses more on punishment than rehabilitation.",
+      "translation": "cải tạo",
+      "count": 0
+    },
+    {
+      "word": "Premeditated (adjective)",
+      "meaning": "planned or thought out before being carried out",
+      "example": "He was found guilty of premeditated murder.",
+      "translation": "có chủ ý từ trước",
+      "count": 0
+    },
+    {
+      "word": "A crime of passion (noun)",
+      "meaning": "a spontaneous crime triggered by intense emotions",
+      "example": "The defense argued it was a crime of passion, not murder.",
+      "translation": "tội do cảm xúc nhất thời",
+      "count": 0
+    },
+    {
+      "word": "Commit + name of crime/negative action",
+      "meaning": "to carry out an illegal or harmful act",
+      "example": "He committed arson and fled the scene.",
+      "translation": "phạm tội",
+      "count": 0
+    },
+    {
+      "word": "Convicted (adjective/passive verb)",
+      "meaning": "formally declared guilty of a crime by a court",
+      "example": "She was convicted of fraud after a lengthy trial.",
+      "translation": "bị kết tội",
+      "count": 0
+    },
+    {
+      "word": "Organised crime (noun)",
+      "meaning": "criminal activities coordinated by structured groups",
+      "example": "The gang was involved in organised crime across several cities.",
+      "translation": "tội phạm có tổ chức",
+      "count": 0
+    },
+    {
+      "word": "Community service (noun)",
+      "meaning": "unpaid work done as punishment instead of prison",
+      "example": "He was sentenced to 100 hours of community service.",
+      "translation": "lao động công ích",
+      "count": 0
+    },
+    {
+      "word": "Deterrent (noun)",
+      "meaning": "something that prevents people from doing something bad",
+      "example": "Strict laws act as a deterrent to crime.",
+      "translation": "biện pháp răn đe",
+      "count": 0
+    },
+    {
+      "word": "Juvenile detention center (noun)",
+      "meaning": "a facility for housing young offenders",
+      "example": "Teen offenders are sent to a juvenile detention center.",
+      "translation": "trại giam thiếu niên",
+      "count": 0
+    },
+    {
+      "word": "Globalization (noun)",
+      "meaning": "the worldwide integration of economies, cultures, and markets",
+      "example": "Globalization has boosted trade and cultural exchange.",
+      "translation": "toàn cầu hóa",
+      "count": 0
+    },
+    {
+      "word": "Multicultural (adjective)",
+      "meaning": "including people of various cultural backgrounds",
+      "example": "Living in a multicultural city teaches tolerance and openness.",
+      "translation": "đa văn hóa",
+      "count": 0
+    },
+    {
+      "word": "Integrate (verb)",
+      "meaning": "to become part of a new community or culture",
+      "example": "Newcomers are encouraged to integrate into society.",
+      "translation": "hòa nhập",
+      "count": 0
+    },
+    {
+      "word": "Culture shock (noun)",
+      "meaning": "discomfort or confusion from being in a new culture",
+      "example": "She experienced culture shock during her first month abroad.",
+      "translation": "sốc văn hóa",
+      "count": 0
+    },
+    {
+      "word": "Values (noun)",
+      "meaning": "moral principles or standards of behavior",
+      "example": "Honesty and kindness are core values in our home.",
+      "translation": "giá trị",
+      "count": 0
+    },
+    {
+      "word": "Ritual (noun, adjective)",
+      "meaning": "a traditional or formal action performed regularly",
+      "example": "Every morning, he followed the same coffee ritual.",
+      "translation": "nghi thức",
+      "count": 0
+    },
+    {
+      "word": "Heritage (noun)",
+      "meaning": "cultural traditions passed down through generations",
+      "example": "They celebrate their national heritage every year.",
+      "translation": "di sản",
+      "count": 0
+    },
+    {
+      "word": "Stereotype (noun)",
+      "meaning": "a fixed and oversimplified idea about a group",
+      "example": "She fought against the stereotype of women in tech.",
+      "translation": "định kiến",
+      "count": 0
+    },
+    {
+      "word": "Vibrant (adjective)",
+      "meaning": "full of life, energy, and enthusiasm",
+      "example": "The market was vibrant with color and music.",
+      "translation": "sôi động",
+      "count": 0
+    },
+    {
+      "word": "Taboo (noun, adjective)",
+      "meaning": "a socially unacceptable or prohibited act",
+      "example": "Talking about money is still a taboo in some cultures.",
+      "translation": "điều cấm kỵ",
+      "count": 0
+    },
+    {
+      "word": "A morning person (noun)",
+      "meaning": "someone who feels energetic early in the day",
+      "example": "My dad’s a morning person and wakes up before sunrise.",
+      "translation": "người dậy sớm",
+      "count": 0
+    },
+    {
+      "word": "Get something out of the way",
+      "meaning": "to finish a task to stop worrying about it",
+      "example": "I prefer getting tough tasks out of the way early.",
+      "translation": "giải quyết xong việc gì",
+      "count": 0
+    },
+    {
+      "word": "Procrastinator (noun)",
+      "meaning": "someone who delays doing important tasks",
+      "example": "As a procrastinator, he always started assignments last minute.",
+      "translation": "người hay trì hoãn",
+      "count": 0
+    },
+    {
+      "word": "Fit something in",
+      "meaning": "to manage to find time for an activity",
+      "example": "I try to fit in a workout every evening.",
+      "translation": "sắp xếp thời gian cho việc gì",
+      "count": 0
+    },
+    {
+      "word": "(Take) a nap (noun)",
+      "meaning": "a short rest or sleep during the day",
+      "example": "He takes a quick nap during lunch break.",
+      "translation": "ngủ trưa",
+      "count": 0
+    },
+    {
+      "word": "Pull an all-nighter",
+      "meaning": "to stay awake all night to work or study",
+      "example": "He pulled an all-nighter to finish the report before the deadline.",
+      "translation": "thức trắng đêm",
+      "count": 0
+    },
+    {
+      "word": "Multitask (verb)",
+      "meaning": "to handle several tasks at once",
+      "example": "She multitasks effortlessly while managing calls and emails.",
+      "translation": "làm nhiều việc cùng lúc",
+      "count": 0
+    },
+    {
+      "word": "Prioritize (verb)",
+      "meaning": "to decide what tasks are most important and do them first",
+      "example": "I always prioritize urgent work to avoid last-minute stress.",
+      "translation": "ưu tiên",
+      "count": 0
+    },
+    {
+      "word": "Crawl out of bed",
+      "meaning": "to get up with difficulty, especially in the morning",
+      "example": "I could barely crawl out of bed after staying up so late.",
+      "translation": "lết ra khỏi giường",
+      "count": 0
+    },
+    {
+      "word": "Frame of mind (noun)",
+      "meaning": "a person’s mental or emotional state at a given time",
+      "example": "A short walk helps me get into a better frame of mind.",
+      "translation": "tâm trạng",
+      "count": 0
+    },
+    {
+      "word": "Disposable income (noun)",
+      "meaning": "money left after paying for essentials",
+      "example": "With more disposable income, people tend to spend on travel and gadgets.",
+      "translation": "thu nhập khả dụng",
+      "count": 0
+    },
+    {
+      "word": "Public Spending (noun)",
+      "meaning": "money used by the government for public services",
+      "example": "Public spending on healthcare is rising every year.",
+      "translation": "chi tiêu công",
+      "count": 0
+    },
+    {
+      "word": "(The) Unemployment rate (noun)",
+      "meaning": "the percentage of people without jobs",
+      "example": "The unemployment rate dropped after the new policy was introduced.",
+      "translation": "tỷ lệ thất nghiệp",
+      "count": 0
+    },
+    {
+      "word": "Stimulate the economy",
+      "meaning": "to encourage economic activity and growth",
+      "example": "Tax cuts are one way to stimulate the economy.",
+      "translation": "kích thích nền kinh tế",
+      "count": 0
+    },
+    {
+      "word": "Tax (noun, verb)",
+      "meaning": "money collected by the government from individuals or businesses",
+      "example": "The government increased the tax on luxury items.",
+      "translation": "thuế",
+      "count": 0
+    },
+    {
+      "word": "Recession (noun)",
+      "meaning": "a period of economic decline",
+      "example": "The country is trying to recover from a long recession.",
+      "translation": "suy thoái",
+      "count": 0
+    },
+    {
+      "word": "Tax avoidance (noun)",
+      "meaning": "legally minimizing the amount of tax paid",
+      "example": "Tax avoidance by large firms often sparks public criticism.",
+      "translation": "tránh thuế",
+      "count": 0
+    },
+    {
+      "word": "Live beyond one’s means",
+      "meaning": "to spend more money than one can afford",
+      "example": "Many people live beyond their means by overusing credit cards.",
+      "translation": "tiêu quá khả năng",
+      "count": 0
+    },
+    {
+      "word": "Live hand to mouth",
+      "meaning": "to survive on a very limited income",
+      "example": "They live hand to mouth, with no savings for emergencies.",
+      "translation": "sống chật vật",
+      "count": 0
+    },
+    {
+      "word": "Livelihood (noun)",
+      "meaning": "a job or way of earning money to live",
+      "example": "Fishing is the main livelihood of the coastal village.",
+      "translation": "kế sinh nhai",
+      "count": 0
+    },
+    {
+      "word": "Cram (verb)",
+      "meaning": "to study intensely over a short time period",
+      "example": "She crammed the night before the biology exam.",
+      "translation": "học nhồi nhét",
+      "count": 0
+    },
+    {
+      "word": "Theoretical Knowledge (noun)",
+      "meaning": "understanding concepts without practical experience",
+      "example": "Engineering students need both theoretical knowledge and hands-on training.",
+      "translation": "kiến thức lý thuyết",
+      "count": 0
+    },
+    {
+      "word": "Practical skills (noun)",
+      "meaning": "the ability to perform real-world tasks",
+      "example": "Internships help students develop practical skills.",
+      "translation": "kỹ năng thực tiễn",
+      "count": 0
+    },
+    {
+      "word": "Due date (noun)",
+      "meaning": "the deadline for submitting work",
+      "example": "She set reminders so she wouldn’t miss the due date.",
+      "translation": "hạn nộp",
+      "count": 0
+    },
+    {
+      "word": "Rote learning (noun)",
+      "meaning": "learning by repetition and memorization",
+      "example": "Rote learning is less effective than active understanding.",
+      "translation": "học vẹt",
+      "count": 0
+    },
+    {
+      "word": "Qualification (noun)",
+      "meaning": "a certificate showing education or skill level",
+      "example": "He earned qualifications in both IT and business.",
+      "translation": "bằng cấp",
+      "count": 0
+    },
+    {
+      "word": "Distance learning (noun)",
+      "meaning": "studying remotely, often online",
+      "example": "Many adults prefer distance learning due to flexible schedules.",
+      "translation": "học từ xa",
+      "count": 0
+    },
+    {
+      "word": "Burnout (noun)",
+      "meaning": "mental and physical exhaustion from stress",
+      "example": "She took a break from work to recover from burnout.",
+      "translation": "kiệt sức",
+      "count": 0
+    },
+    {
+      "word": "Stickler (noun)",
+      "meaning": "a person who insists on strict rules or details",
+      "example": "He’s a stickler for deadlines and expects the same from others.",
+      "translation": "người nghiêm khắc",
+      "count": 0
+    },
+    {
+      "word": "Corporal Punishment (noun)",
+      "meaning": "physical punishment as a form of discipline",
+      "example": "Corporal punishment is banned in many countries.",
+      "translation": "hình phạt thể xác",
+      "count": 0
+    },
+    {
+      "word": "Perks (noun)",
+      "meaning": "extra benefits provided by a job",
+      "example": "Free gym access is one of the job’s perks.",
+      "translation": "phúc lợi",
+      "count": 0
+    },
+    {
+      "word": "Corporate ladder (noun)",
+      "meaning": "the levels of positions within a company",
+      "example": "She’s determined to climb the corporate ladder.",
+      "translation": "nấc thang sự nghiệp",
+      "count": 0
+    },
+    {
+      "word": "Sellable skill (noun)",
+      "meaning": "a skill that is in demand by employers or clients",
+      "example": "Coding is one of the most valuable sellable skills in today’s job market.",
+      "translation": "kỹ năng có thể bán được",
+      "count": 0
+    },
+    {
+      "word": "Fulfilling (adjective)",
+      "meaning": "bringing satisfaction or a sense of purpose",
+      "example": "She finds her job as a teacher truly fulfilling.",
+      "translation": "mang lại sự hài lòng",
+      "count": 0
+    },
+    {
+      "word": "Work ethic (noun)",
+      "meaning": "a person’s approach to work and their level of dedication",
+      "example": "His strong work ethic helped him earn a quick promotion.",
+      "translation": "đạo đức nghề nghiệp",
+      "count": 0
+    },
+    {
+      "word": "Join the workforce (verb)",
+      "meaning": "to start working after completing school or being unemployed",
+      "example": "After graduating, she joined the workforce as a marketing assistant.",
+      "translation": "tham gia lực lượng lao động",
+      "count": 0
+    },
+    {
+      "word": "Get your foot in the door (idiom, verb)",
+      "meaning": "to gain an initial opportunity or entry into a company",
+      "example": "Internships are a great way to get your foot in the door.",
+      "translation": "mở đường vào làm việc",
+      "count": 0
+    },
+    {
+      "word": "Corporate culture (noun)",
+      "meaning": "the shared values and behaviors within a company",
+      "example": "A positive corporate culture can boost employee morale.",
+      "translation": "văn hóa doanh nghiệp",
+      "count": 0
+    },
+    {
+      "word": "Soft skills (noun)",
+      "meaning": "non-technical skills that relate to communication and teamwork",
+      "example": "Good soft skills are essential for leadership roles.",
+      "translation": "kỹ năng mềm",
+      "count": 0
+    },
+    {
+      "word": "Laid off (adjective/passive verb)",
+      "meaning": "having lost a job due to company downsizing or budget cuts",
+      "example": "Hundreds of workers were laid off during the pandemic.",
+      "translation": "bị sa thải",
+      "count": 0
+    },
+    {
+      "word": "Dopamine (noun)",
+      "meaning": "a brain chemical linked to feelings of pleasure and reward",
+      "example": "Winning a game triggers the release of dopamine in the brain.",
+      "translation": "dopamine",
+      "count": 0
+    },
+    {
+      "word": "Absorbing (adjective)",
+      "meaning": "completely engaging or holding attention",
+      "example": "The novel was so absorbing that she read it in one sitting.",
+      "translation": "lôi cuốn",
+      "count": 0
+    },
+    {
+      "word": "Extracurricular activities (noun)",
+      "meaning": "non-academic activities pursued outside of school hours",
+      "example": "Universities value students involved in extracurricular activities.",
+      "translation": "hoạt động ngoại khóa",
+      "count": 0
+    },
+    {
+      "word": "Unwind (verb)",
+      "meaning": "to relax and let go of stress",
+      "example": "She unwinds by listening to classical music before bed.",
+      "translation": "thư giãn",
+      "count": 0
+    },
+    {
+      "word": "Mind-numbingly dull (phrasal adjective)",
+      "meaning": "extremely boring or tedious",
+      "example": "The meeting was mind-numbingly dull and lasted over three hours.",
+      "translation": "chán đến tê liệt",
+      "count": 0
+    },
+    {
+      "word": "Binge-watch (verb)",
+      "meaning": "to watch many episodes of a show in one sitting",
+      "example": "He binge-watched the whole season over the weekend.",
+      "translation": "xem liên tục",
+      "count": 0
+    },
+    {
+      "word": "Amusement park (noun)",
+      "meaning": "a place with rides and games for entertainment",
+      "example": "We spent the whole day at the amusement park riding rollercoasters.",
+      "translation": "công viên giải trí",
+      "count": 0
+    },
+    {
+      "word": "Work-life balance (noun)",
+      "meaning": "the balance between time spent working and enjoying personal life",
+      "example": "Remote work helps many people improve their work-life balance.",
+      "translation": "cân bằng công việc và cuộc sống",
+      "count": 0
+    },
+    {
+      "word": "Board game (noun)",
+      "meaning": "a tabletop game involving counters or pieces moved on a board",
+      "example": "They enjoy playing board games as a family every weekend.",
+      "translation": "trò chơi bàn cờ",
+      "count": 0
+    },
+    {
+      "word": "Livestream (noun)",
+      "meaning": "a real-time video broadcast over the internet",
+      "example": "The musician held a livestream to interact with fans.",
+      "translation": "phát trực tiếp",
+      "count": 0
+    },
+    {
+      "word": "Dilemma (noun)",
+      "meaning": "a situation where a difficult decision must be made",
+      "example": "He faced a dilemma between accepting the job or continuing school.",
+      "translation": "tình huống khó xử",
+      "count": 0
+    },
+    {
+      "word": "Justice (noun)",
+      "meaning": "fairness in protection of rights and punishment of wrongs",
+      "example": "The victims are still waiting for justice to be served.",
+      "translation": "công lý",
+      "count": 0
+    },
+    {
+      "word": "Compassion (noun)",
+      "meaning": "sympathy and desire to help those who suffer",
+      "example": "Showing compassion can greatly impact someone's life.",
+      "translation": "lòng trắc ẩn",
+      "count": 0
+    },
+    {
+      "word": "Integrity (noun)",
+      "meaning": "honesty and strong moral principles",
+      "example": "She was respected for her integrity and fairness.",
+      "translation": "chính trực",
+      "count": 0
+    },
+    {
+      "word": "Morally bankrupt (adjective)",
+      "meaning": "lacking ethical or moral values",
+      "example": "The company was accused of being morally bankrupt after the scandal.",
+      "translation": "suy đồi đạo đức",
+      "count": 0
+    },
+    {
+      "word": "Conscience (noun)",
+      "meaning": "a person's inner sense of what is right or wrong",
+      "example": "His conscience wouldn’t let him lie under oath.",
+      "translation": "lương tâm",
+      "count": 0
+    },
+    {
+      "word": "Intolerant (adjective)",
+      "meaning": "unwilling to accept views or behaviors different from one’s own",
+      "example": "He was known to be intolerant of anyone who disagreed with him.",
+      "translation": "không khoan dung",
+      "count": 0
+    },
+    {
+      "word": "Prejudiced (adjective)",
+      "meaning": "showing unfair dislike for a group of people or ideas",
+      "example": "He was raised in a prejudiced household and struggled to see beyond stereotypes.",
+      "translation": "có thành kiến",
+      "count": 0
+    },
+    {
+      "word": "Moral Grey Area (noun)",
+      "meaning": "a situation that is neither clearly right nor wrong",
+      "example": "Using AI for surveillance remains a moral grey area for many.",
+      "translation": "vùng xám đạo đức",
+      "count": 0
+    },
+    {
+      "word": "Code of Ethics (noun)",
+      "meaning": "a set of principles guiding ethical behavior",
+      "example": "Every journalist is expected to follow a strict code of ethics.",
+      "translation": "bộ quy tắc đạo đức",
+      "count": 0
+    },
+    {
+      "word": "Strenuous (adjective)",
+      "meaning": "requiring great physical effort",
+      "example": "They went on a strenuous hike through the mountains.",
+      "translation": "vất vả",
+      "count": 0
+    },
+    {
+      "word": "Break a sweat (verb)",
+      "meaning": "to exercise enough to start sweating",
+      "example": "I break a sweat just walking to the office in the summer.",
+      "translation": "đổ mồ hôi",
+      "count": 0
+    },
+    {
+      "word": "An uphill struggle (noun)",
+      "meaning": "a difficult task that remains hard throughout",
+      "example": "Improving my diet has been an uphill struggle.",
+      "translation": "một việc rất khó khăn",
+      "count": 0
+    },
+    {
+      "word": "Push yourself to the limit",
+      "meaning": "to use all your strength or effort to do something",
+      "example": "She pushed herself to the limit during the triathlon.",
+      "translation": "cố gắng hết sức",
+      "count": 0
+    },
+    {
+      "word": "Six-pack (noun)",
+      "meaning": "defined abdominal muscles visible as six sections",
+      "example": "He worked out daily to build a six-pack before summer.",
+      "translation": "cơ bụng sáu múi",
+      "count": 0
+    },
+    {
+      "word": "Love handles (noun)",
+      "meaning": "fat deposits on the sides of the waist",
+      "example": "He’s been doing cardio to get rid of his love handles.",
+      "translation": "mỡ hai bên eo",
+      "count": 0
+    },
+    {
+      "word": "Burpee (noun)",
+      "meaning": "a high-intensity full-body exercise combining a jump and push-up",
+      "example": "The fitness challenge included 50 burpees in one set.",
+      "translation": "bài tập burpee",
+      "count": 0
+    },
+    {
+      "word": "Cardiovascular (adjective)",
+      "meaning": "relating to heart and blood circulation",
+      "example": "Cardiovascular workouts improve overall stamina and health.",
+      "translation": "thuộc tim mạch",
+      "count": 0
+    },
+    {
+      "word": "Lactic acid (noun)",
+      "meaning": "a chemical that causes muscle soreness after exercise",
+      "example": "He stopped lifting weights when the lactic acid buildup got too painful.",
+      "translation": "axit lactic",
+      "count": 0
+    },
+    {
+      "word": "Pump iron (verb)",
+      "meaning": "to lift weights for exercise",
+      "example": "He pumps iron five days a week at the gym.",
+      "translation": "tập tạ",
+      "count": 0
+    },
+    {
+      "word": "Run in the family",
+      "meaning": "to be a common trait among family members",
+      "example": "Musical talent seems to run in the family.",
+      "translation": "di truyền trong gia đình",
+      "count": 0
+    },
+    {
+      "word": "Take after someone",
+      "meaning": "to resemble a family member in appearance or behavior",
+      "example": "She takes after her grandfather in both looks and humor.",
+      "translation": "giống ai trong gia đình",
+      "count": 0
+    },
+    {
+      "word": "Stay-at-home mum/dad (noun)",
+      "meaning": "a parent who stays home to care for the children",
+      "example": "He became a stay-at-home dad after their second child was born.",
+      "translation": "bố/mẹ ở nhà chăm con",
+      "count": 0
+    },
+    {
+      "word": "Black Sheep (noun)",
+      "meaning": "a family member seen as different or a source of shame",
+      "example": "He always felt like the black sheep for not pursuing a business career.",
+      "translation": "kẻ lạc loài",
+      "count": 0
+    },
+    {
+      "word": "Dysfunctional family (noun)",
+      "meaning": "a family with frequent conflict or unhealthy behavior",
+      "example": "Growing up in a dysfunctional family taught her to be resilient.",
+      "translation": "gia đình rối loạn",
+      "count": 0
+    },
+    {
+      "word": "Sibling rivalry (noun)",
+      "meaning": "competition or tension between brothers and sisters",
+      "example": "Sibling rivalry between the twins often led to arguments.",
+      "translation": "sự ganh đua giữa anh chị em",
+      "count": 0
+    },
+    {
+      "word": "Follow in someone’s footsteps",
+      "meaning": "to pursue the same path as someone else, especially a family member",
+      "example": "He followed in his mother’s footsteps and became a lawyer.",
+      "translation": "nối nghiệp ai",
+      "count": 0
+    },
+    {
+      "word": "Patriarch (noun)",
+      "meaning": "the male leader of a family or group",
+      "example": "The patriarch made all important decisions in the household.",
+      "translation": "gia trưởng",
+      "count": 0
+    },
+    {
+      "word": "Extended family (noun)",
+      "meaning": "relatives beyond the immediate family",
+      "example": "We had a reunion with our extended family last summer.",
+      "translation": "đại gia đình",
+      "count": 0
+    },
+    {
+      "word": "Own flesh and blood (noun)",
+      "meaning": "a close family member",
+      "example": "He couldn’t believe his own flesh and blood would betray him.",
+      "translation": "ruột thịt",
+      "count": 0
+    },
+    {
+      "word": "Dietary requirements (noun)",
+      "meaning": "specific nutritional needs or restrictions",
+      "example": "The chef asked about any dietary requirements before preparing the meal.",
+      "translation": "nhu cầu ăn uống đặc biệt",
+      "count": 0
+    },
+    {
+      "word": "Staple (adjective)",
+      "meaning": "commonly used or essential, especially food",
+      "example": "Rice is a staple ingredient in many Asian dishes.",
+      "translation": "thực phẩm chính",
+      "count": 0
+    },
+    {
+      "word": "Delicacy (noun)",
+      "meaning": "a special or rare food that is highly valued or expensive",
+      "example": "Truffles are considered a delicacy in many gourmet cuisines.",
+      "translation": "cao lương mỹ vị",
+      "count": 0
+    },
+    {
+      "word": "Seasonal vegetable/fruit (nouns)",
+      "meaning": "produce that is only available during specific times of the year",
+      "example": "We prefer to cook with seasonal vegetables for freshness and taste.",
+      "translation": "rau củ/trái cây theo mùa",
+      "count": 0
+    },
+    {
+      "word": "Organic (adjective)",
+      "meaning": "grown without artificial chemicals or pesticides",
+      "example": "Organic apples may be smaller but often taste better.",
+      "translation": "hữu cơ",
+      "count": 0
+    },
+    {
+      "word": "Count calories",
+      "meaning": "to track how many calories one consumes",
+      "example": "She uses a fitness app to count calories during meals.",
+      "translation": "tính lượng calo",
+      "count": 0
+    },
+    {
+      "word": "Resist temptation",
+      "meaning": "to avoid doing something you desire but shouldn’t",
+      "example": "He couldn’t resist temptation and ate the entire cake.",
+      "translation": "cưỡng lại cám dỗ",
+      "count": 0
+    },
+    {
+      "word": "Packed with flavour (adjective)",
+      "meaning": "having a strong and rich taste",
+      "example": "The curry was packed with flavour and spices.",
+      "translation": "đậm đà hương vị",
+      "count": 0
+    },
+    {
+      "word": "You are what you eat (idiom)",
+      "meaning": "your health reflects the food you consume",
+      "example": "She believes in eating clean because you are what you eat.",
+      "translation": "bạn là những gì bạn ăn",
+      "count": 0
+    },
+    {
+      "word": "Nutritional benefits (noun)",
+      "meaning": "positive effects on health from food or drink",
+      "example": "Broccoli offers many nutritional benefits, including vitamins and fiber.",
+      "translation": "lợi ích dinh dưỡng",
+      "count": 0
+    },
+    {
+      "word": "Two peas in a pod (Metaphor, noun)",
+      "meaning": "two people who are extremely alike",
+      "example": "They finish each other’s sentences—they’re like two peas in a pod.",
+      "translation": "giống nhau như hai giọt nước",
+      "count": 0
+    },
+    {
+      "word": "A fair-weather friend (noun)",
+      "meaning": "a friend who only supports you in good times",
+      "example": "He disappeared during my struggles—a true fair-weather friend.",
+      "translation": "bạn chỉ tốt lúc thuận lợi",
+      "count": 0
+    },
+    {
+      "word": "To get on like a house on fire (idiom, verb)",
+      "meaning": "to form a close bond very quickly",
+      "example": "We got on like a house on fire from the first meeting.",
+      "translation": "hợp nhau ngay lập tức",
+      "count": 0
+    },
+    {
+      "word": "To hit it off (Idiom, verb)",
+      "meaning": "to get along well instantly",
+      "example": "They hit it off as soon as they started talking.",
+      "translation": "kết thân ngay",
+      "count": 0
+    },
+    {
+      "word": "Ups and downs (noun)",
+      "meaning": "a mix of good and bad experiences",
+      "example": "Every friendship has its ups and downs.",
+      "translation": "thăng trầm",
+      "count": 0
+    },
+    {
+      "word": "Bury the hatchet (idiom, verb)",
+      "meaning": "to make peace after a disagreement",
+      "example": "They finally buried the hatchet after years of tension.",
+      "translation": "làm hòa",
+      "count": 0
+    },
+    {
+      "word": "A shoulder to cry on (idiom, noun)",
+      "meaning": "someone who listens and provides comfort",
+      "example": "He was there for me—a true shoulder to cry on.",
+      "translation": "người để chia sẻ nỗi buồn",
+      "count": 0
+    },
+    {
+      "word": "Confidante (noun)",
+      "meaning": "a person you trust deeply with private matters",
+      "example": "She’s been my confidante since childhood.",
+      "translation": "người tâm sự",
+      "count": 0
+    },
+    {
+      "word": "Acquaintance (noun)",
+      "meaning": "someone you know but not closely",
+      "example": "He's just an acquaintance—I don't know him well.",
+      "translation": "người quen",
+      "count": 0
+    },
+    {
+      "word": "To fall out with",
+      "meaning": "to argue and damage a relationship",
+      "example": "They fell out over a misunderstanding but made up later.",
+      "translation": "cãi nhau, bất hòa",
+      "count": 0
+    },
+    {
+      "word": "Demographic (adjective)",
+      "meaning": "relating to the structure of a population",
+      "example": "The company targets a younger demographic for their ads.",
+      "translation": "liên quan đến dân số",
+      "count": 0
+    },
+    {
+      "word": "Altitude (noun)",
+      "meaning": "the height above sea level",
+      "example": "The hikers struggled with the high altitude.",
+      "translation": "độ cao so với mực nước biển",
+      "count": 0
+    },
+    {
+      "word": "Glacier (noun)",
+      "meaning": "a large, slow-moving mass of ice",
+      "example": "The glacier has been shrinking due to rising temperatures.",
+      "translation": "sông băng",
+      "count": 0
+    },
+    {
+      "word": "Hemisphere (noun)",
+      "meaning": "half of the Earth, usually divided north/south or east/west",
+      "example": "Seasons are reversed between the two hemispheres.",
+      "translation": "bán cầu",
+      "count": 0
+    },
+    {
+      "word": "Desertification (noun)",
+      "meaning": "the process of land becoming desert",
+      "example": "Overgrazing has contributed to desertification in the region.",
+      "translation": "sa mạc hóa",
+      "count": 0
+    },
+    {
+      "word": "Deforestation (noun)",
+      "meaning": "the large-scale removal of forests",
+      "example": "Deforestation has serious impacts on biodiversity and climate.",
+      "translation": "phá rừng",
+      "count": 0
+    },
+    {
+      "word": "Floodplain (noun)",
+      "meaning": "low-lying land near a river prone to flooding",
+      "example": "Building on a floodplain increases flood risk during storms.",
+      "translation": "vùng trũng ven sông",
+      "count": 0
+    },
+    {
+      "word": "Landslide (noun)",
+      "meaning": "a disaster where large amounts of earth slide down a slope, often after rain",
+      "example": "The landslide blocked the main road and destroyed several homes.",
+      "translation": "lở đất",
+      "count": 0
+    },
+    {
+      "word": "Body of water (noun)",
+      "meaning": "a general term for lakes, oceans, rivers, and other water areas",
+      "example": "They camped near a body of water so they could fish each morning.",
+      "translation": "vùng nước",
+      "count": 0
+    },
+    {
+      "word": "Jetlag (noun)",
+      "meaning": "tiredness caused by a long flight across time zones",
+      "example": "She felt jetlagged for days after returning from New York.",
+      "translation": "mệt do lệch múi giờ",
+      "count": 0
+    },
+    {
+      "word": "Outsource (verb)",
+      "meaning": "to delegate work to another company, often in a different country",
+      "example": "The business outsourced its IT services to reduce costs.",
+      "translation": "thuê ngoài",
+      "count": 0
+    },
+    {
+      "word": "Cost of labour (noun)",
+      "meaning": "the average expense of paying workers in a specific place",
+      "example": "Factories move to areas with lower cost of labour to save money.",
+      "translation": "chi phí lao động",
+      "count": 0
+    },
+    {
+      "word": "Supply Chain (noun)",
+      "meaning": "a system of suppliers and processes that deliver a final product",
+      "example": "COVID-19 disrupted the global supply chain for electronics.",
+      "translation": "chuỗi cung ứng",
+      "count": 0
+    },
+    {
+      "word": "Sweatshop (noun)",
+      "meaning": "a factory with harsh working conditions and very low wages",
+      "example": "Many clothes are made in sweatshops with poor safety standards.",
+      "translation": "xưởng bóc lột",
+      "count": 0
+    },
+    {
+      "word": "Fast Fashion (noun)",
+      "meaning": "cheap clothing made quickly to match current trends",
+      "example": "Fast fashion items often wear out after just a few washes.",
+      "translation": "thời trang nhanh",
+      "count": 0
+    },
+    {
+      "word": "Self-sufficient (adjective)",
+      "meaning": "able to survive or operate without outside help",
+      "example": "After moving to the countryside, they aimed to be self-sufficient.",
+      "translation": "tự cung tự cấp",
+      "count": 0
+    },
+    {
+      "word": "Ubiquitous (adjective)",
+      "meaning": "found everywhere or widely present",
+      "example": "Social media apps are now ubiquitous across all age groups.",
+      "translation": "phổ biến",
+      "count": 0
+    },
+    {
+      "word": "Integration (noun)",
+      "meaning": "the process of combining or joining groups into one",
+      "example": "Language classes help with integration into new communities.",
+      "translation": "sự hòa nhập",
+      "count": 0
+    },
+    {
+      "word": "Cultural convergence (noun)",
+      "meaning": "the trend of different cultures becoming more similar",
+      "example": "The internet has accelerated cultural convergence across countries.",
+      "translation": "sự hội tụ văn hóa",
+      "count": 0
+    },
+    {
+      "word": "Diversity (noun)",
+      "meaning": "the state of having many different kinds of people or ideas",
+      "example": "Diversity in the workplace can lead to more creative solutions.",
+      "translation": "sự đa dạng",
+      "count": 0
+    },
+    {
+      "word": "Pass legislation",
+      "meaning": "to officially create and approve laws",
+      "example": "Parliament passed legislation to protect endangered animals.",
+      "translation": "ban hành luật",
+      "count": 0
+    },
+    {
+      "word": "Prohibit (verb)",
+      "meaning": "to forbid something by law or rule",
+      "example": "The school prohibits smoking anywhere on campus.",
+      "translation": "cấm",
+      "count": 0
+    },
+    {
+      "word": "Public sector (noun)",
+      "meaning": "the part of the economy run by the government",
+      "example": "Teachers and police officers work in the public sector.",
+      "translation": "khu vực công",
+      "count": 0
+    },
+    {
+      "word": "Social security (noun)",
+      "meaning": "government-provided financial support for those in need",
+      "example": "Elderly citizens depend on social security for their income.",
+      "translation": "an sinh xã hội",
+      "count": 0
+    },
+    {
+      "word": "Anarchy (noun)",
+      "meaning": "a state where laws are not followed and order breaks down",
+      "example": "The country faced total anarchy after the government collapsed.",
+      "translation": "vô chính phủ",
+      "count": 0
+    },
+    {
+      "word": "Equality of opportunity (noun)",
+      "meaning": "the principle that everyone should have the same chances in life",
+      "example": "Education is key to achieving equality of opportunity.",
+      "translation": "bình đẳng cơ hội",
+      "count": 0
+    },
+    {
+      "word": "Crime rate (noun)",
+      "meaning": "the level of criminal activity in a location",
+      "example": "The city has seen a sharp drop in its crime rate.",
+      "translation": "tỷ lệ tội phạm",
+      "count": 0
+    },
+    {
+      "word": "Top-down approach (noun)",
+      "meaning": "a strategy where decisions are made at higher levels of authority",
+      "example": "A top-down approach was used to roll out the new policy nationwide.",
+      "translation": "cách tiếp cận từ trên xuống",
+      "count": 0
+    },
+    {
+      "word": "Policy (noun)",
+      "meaning": "a plan or course of action adopted by a group or government",
+      "example": "The new policy encourages companies to reduce carbon emissions.",
+      "translation": "chính sách",
+      "count": 0
+    },
+    {
+      "word": "Rhetoric (noun)",
+      "meaning": "persuasive or impressive speech, often lacking in substance",
+      "example": "His campaign speeches were full of rhetoric but light on details.",
+      "translation": "lời hùng biện",
+      "count": 0
+    },
+    {
+      "word": "Stigma (noun)",
+      "meaning": "a negative label or reputation attached to something",
+      "example": "Efforts are being made to reduce the stigma around mental illness.",
+      "translation": "kỳ thị",
+      "count": 0
+    },
+    {
+      "word": "Destructive behaviour (noun)",
+      "meaning": "actions that cause harm to oneself or others",
+      "example": "Therapy helped him overcome years of destructive behaviour.",
+      "translation": "hành vi phá hoại",
+      "count": 0
+    },
+    {
+      "word": "Trauma (noun)",
+      "meaning": "A deeply distressing experience that may lead to future psychological problems.",
+      "example": "Soldiers in execution squads aren't told whose gun is loaded to lessen the trauma of possibly taking a life.",
+      "translation": "tổn thương tâm lý",
+      "count": 0
+    },
+    {
+      "word": "Alzheimer’s disease (noun)",
+      "meaning": "A brain condition causing gradual memory loss and cognitive decline, often seen in older adults.",
+      "example": "Finding a cure for Alzheimer’s disease is essential for improving the lives of elderly individuals.",
+      "translation": "bệnh Alzheimer",
+      "count": 0
+    },
+    {
+      "word": "ADHD (noun)",
+      "meaning": "A mental health condition characterized by hyperactivity, impulsiveness, and difficulty maintaining attention.",
+      "example": "In the US, the number of children prescribed medication for ADHD continues to grow.",
+      "translation": "rối loạn tăng động giảm chú ý",
+      "count": 0
+    },
+    {
+      "word": "To be out of one’s mind (informal idiom, adjective)",
+      "meaning": "To act irrationally or appear mentally unstable, often said in jest or argument.",
+      "example": "You're out of your mind if you think I’ll lend you money after that.",
+      "translation": "mất trí",
+      "count": 0
+    },
+    {
+      "word": "Ticking time-bomb (noun)",
+      "meaning": "A seemingly minor issue that could lead to serious consequences if ignored.",
+      "example": "Experts warn that the emotional fallout of COVID-19 is a ticking time-bomb for future mental health.",
+      "translation": "quả bom nổ chậm",
+      "count": 0
+    },
+    {
+      "word": "Panic attack (noun)",
+      "meaning": "A sudden, intense episode of fear with physical symptoms like shortness of breath.",
+      "example": "While I get anxious at times, I’ve never experienced a true panic attack.",
+      "translation": "cơn hoảng loạn",
+      "count": 0
+    },
+    {
+      "word": "Depression (noun)",
+      "meaning": "A prolonged state of sadness that may require ongoing treatment or support.",
+      "example": "People with chronic depression often face a lifelong struggle with their mental health.",
+      "translation": "trầm cảm",
+      "count": 0
+    },
+    {
+      "word": "Counselling (noun)",
+      "meaning": "The process of discussing emotional or personal challenges with a trained professional.",
+      "example": "The stigma around mental illness still stops many from seeking counselling.",
+      "translation": "tư vấn tâm lý",
+      "count": 0
+    },
+    {
+      "word": "Check-up (noun)",
+      "meaning": "A general medical examination performed without specific symptoms present.",
+      "example": "Regular check-ups can catch issues early, even when you feel fine.",
+      "translation": "kiểm tra sức khỏe tổng quát",
+      "count": 0
+    },
+    {
+      "word": "Chronic disease (noun)",
+      "meaning": "A long-term illness that may be controlled but not cured.",
+      "example": "Chronic diseases like diabetes are often linked to obesity.",
+      "translation": "bệnh mãn tính",
+      "count": 0
+    },
+    {
+      "word": "As fit as a fiddle (idiom, adjective)",
+      "meaning": "Extremely healthy and physically well.",
+      "example": "We were shocked when my dad fell ill—he’d always been as fit as a fiddle.",
+      "translation": "khỏe mạnh như vâm",
+      "count": 0
+    },
+    {
+      "word": "Under the weather (idiom, adjective)",
+      "meaning": "Feeling unwell but not seriously ill.",
+      "example": "When I’m under the weather, I stay in and rest with plenty of fluids.",
+      "translation": "không được khỏe",
+      "count": 0
+    },
+    {
+      "word": "Immune system (noun)",
+      "meaning": "The body’s defense mechanism against infections and illnesses.",
+      "example": "Eating well and avoiding bad habits helps boost your immune system.",
+      "translation": "hệ miễn dịch",
+      "count": 0
+    },
+    {
+      "word": "Medication (noun)",
+      "meaning": "Drugs taken to treat or manage health conditions.",
+      "example": "Patients with chronic illnesses risk developing dependency on medication.",
+      "translation": "thuốc",
+      "count": 0
+    },
+    {
+      "word": "Prescription (noun, adjective)",
+      "meaning": "A doctor’s formal authorization for medication or treatment.",
+      "example": "With the doctor’s prescription, I was able to get stronger painkillers.",
+      "translation": "toa thuốc",
+      "count": 0
+    },
+    {
+      "word": "Over-the-counter (adjective)",
+      "meaning": "Available without a prescription from a healthcare provider.",
+      "example": "I usually rely on over-the-counter drugs for minor colds.",
+      "translation": "thuốc không kê đơn",
+      "count": 0
+    },
+    {
+      "word": "Physical well-being (noun)",
+      "meaning": "The overall state of a person's physical health and lifestyle habits.",
+      "example": "Promoting physical well-being can help reduce healthcare costs later on.",
+      "translation": "sức khỏe thể chất",
+      "count": 0
+    },
+    {
+      "word": "To put in the hard yards (phrasal verb, idiom)",
+      "meaning": "To make consistent effort toward a challenging goal.",
+      "example": "Getting fit isn’t easy—you have to put in the hard yards.",
+      "translation": "nỗ lực hết mình",
+      "count": 0
+    },
+    {
+      "word": "Out in the sticks (idiom)",
+      "meaning": "In a remote or rural area, far from the city.",
+      "example": "I’d rather live downtown than way out in the sticks.",
+      "translation": "vùng xa xôi hẻo lánh",
+      "count": 0
+    },
+    {
+      "word": "Urban sprawl (noun)",
+      "meaning": "The spread of a city into surrounding rural land.",
+      "example": "Urban sprawl is consuming green areas and raising environmental concerns.",
+      "translation": "sự mở rộng đô thị",
+      "count": 0
+    },
+    {
+      "word": "Dilapidated (adjective)",
+      "meaning": "Worn down or in very poor condition, especially buildings.",
+      "example": "While some neighborhoods are dilapidated, others are newly developed.",
+      "translation": "đổ nát, xiêu vẹo",
+      "count": 0
+    },
+    {
+      "word": "Green spaces (noun)",
+      "meaning": "Public areas in cities with nature, like parks or gardens.",
+      "example": "People value cities with plenty of accessible green spaces.",
+      "translation": "không gian xanh",
+      "count": 0
+    },
+    {
+      "word": "Liveable (adjective)",
+      "meaning": "Comfortable and suitable for living based on quality-of-life factors.",
+      "example": "Aside from real estate prices, my city ranks high in liveability.",
+      "translation": "đáng sống",
+      "count": 0
+    },
+    {
+      "word": "Gentrification (noun)",
+      "meaning": "The process of urban areas becoming wealthier, often displacing poorer residents.",
+      "example": "Gentrification brings investment but can raise living costs for long-time locals.",
+      "translation": "hiện tượng đô thị hóa",
+      "count": 0
+    },
+    {
+      "word": "Nightlife (noun)",
+      "meaning": "Entertainment and activities available at night, especially in urban areas.",
+      "example": "Although nightlife is lacking in my hometown, other attractions make up for it.",
+      "translation": "hoạt động về đêm",
+      "count": 0
+    },
+    {
+      "word": "Small-town vibe (noun)",
+      "meaning": "The familiar atmosphere or charm typically found in a smaller community.",
+      "example": "Many leave cities later in life, seeking the small-town vibe they remember from their youth.",
+      "translation": "cảm giác thị trấn nhỏ",
+      "count": 0
+    },
+    {
+      "word": "Upmarket (adjective)",
+      "meaning": "Targeted at or suitable for wealthy customers; luxurious or high-end.",
+      "example": "Thanks to gentrification, formerly run-down areas have become quite upmarket.",
+      "translation": "cao cấp",
+      "count": 0
+    },
+    {
+      "word": "Spring up (verb)",
+      "meaning": "To emerge or appear quickly and often unexpectedly.",
+      "example": "Many restaurants and bars have sprung up across the city in recent years.",
+      "translation": "mọc lên",
+      "count": 0
+    },
+    {
+      "word": "Minimalist (noun, adjective)",
+      "meaning": "A person who chooses to live with few possessions, valuing simplicity.",
+      "example": "Although I live like a minimalist, I still dream of owning a fancy coffee machine.",
+      "translation": "người sống tối giản",
+      "count": 0
+    },
+    {
+      "word": "Get on the property ladder",
+      "meaning": "To purchase one's first home, beginning the journey of home ownership.",
+      "example": "High property prices make it hard for young people to get on the property ladder.",
+      "translation": "mua căn nhà đầu tiên",
+      "count": 0
+    },
+    {
+      "word": "Downsize (verb)",
+      "meaning": "To move to a smaller home, typically for financial or lifestyle reasons.",
+      "example": "Many seniors downsize after their children move out to save money.",
+      "translation": "thu nhỏ quy mô nhà",
+      "count": 0
+    },
+    {
+      "word": "Renovate (verb)",
+      "meaning": "To restore or upgrade something old to make it new or modern again.",
+      "example": "I prefer homes that have been recently renovated for a fresh feel.",
+      "translation": "cải tạo",
+      "count": 0
+    },
+    {
+      "word": "Natural light (noun)",
+      "meaning": "Sunlight that enters a building through windows.",
+      "example": "Thanks to its south-facing position, our home gets plenty of natural light.",
+      "translation": "ánh sáng tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "Mortgage (noun, verb)",
+      "meaning": "A loan from a bank used to buy property, repaid over time.",
+      "example": "Without stable income, many are denied a mortgage and can't buy homes.",
+      "translation": "thế chấp",
+      "count": 0
+    },
+    {
+      "word": "House-hunting (noun)",
+      "meaning": "The process of searching for a new home to rent or purchase.",
+      "example": "I'm not a fan of house-hunting, so I usually stay put.",
+      "translation": "tìm nhà",
+      "count": 0
+    },
+    {
+      "word": "Generation Rent (noun)",
+      "meaning": "People who rent long-term because they can’t afford to buy property.",
+      "example": "Members of Generation Rent face low chances of ever owning a home.",
+      "translation": "thế hệ thuê nhà",
+      "count": 0
+    },
+    {
+      "word": "To feel at home",
+      "meaning": "To feel comfortable and relaxed in a place, even if it’s not your actual home.",
+      "example": "Wherever I live, I make sure I can feel at home there.",
+      "translation": "cảm thấy như ở nhà",
+      "count": 0
+    },
+    {
+      "word": "Home is where you hang your hat (phrasal verb, informal)",
+      "meaning": "You can treat any place as home if you’re comfortable there.",
+      "example": "I don’t get homesick because to me, home is where you hang your hat.",
+      "translation": "nơi nào cảm thấy thoải mái là nhà",
+      "count": 0
+    },
+    {
+      "word": "A helping hand (noun)",
+      "meaning": "Support or aid provided to someone in need.",
+      "example": "Sometimes, all it takes for a nation to succeed is a helping hand.",
+      "translation": "sự giúp đỡ",
+      "count": 0
+    },
+    {
+      "word": "Charity begins at home (idiom)",
+      "meaning": "You should care for your own community before helping others.",
+      "example": "I believe charity begins at home, especially when local issues are urgent.",
+      "translation": "làm từ thiện bắt đầu từ nhà",
+      "count": 0
+    },
+    {
+      "word": "The global north (noun)",
+      "meaning": "A term for wealthy nations, typically Western, not strictly geographical.",
+      "example": "The global north has a duty to assist poorer countries on global issues.",
+      "translation": "các nước phát triển",
+      "count": 0
+    },
+    {
+      "word": "Plight (noun)",
+      "meaning": "A serious or difficult situation someone is experiencing.",
+      "example": "Refugees often suffer great hardship due to the plight of displacement.",
+      "translation": "hoàn cảnh khó khăn",
+      "count": 0
+    },
+    {
+      "word": "Famine (noun)",
+      "meaning": "A severe shortage of food affecting large populations.",
+      "example": "War-torn regions are at greater risk of famine.",
+      "translation": "nạn đói",
+      "count": 0
+    },
+    {
+      "word": "Skim off the top",
+      "meaning": "To secretly take part of funds, often in corruption.",
+      "example": "People worry that aid donations are being skimmed off the top by corrupt officials.",
+      "translation": "rút ruột quỹ",
+      "count": 0
+    },
+    {
+      "word": "Slash spending (verb)",
+      "meaning": "To drastically reduce budget allocations for something.",
+      "example": "The debate continues over whether to boost or slash spending on foreign aid.",
+      "translation": "cắt giảm chi tiêu",
+      "count": 0
+    },
+    {
+      "word": "Extremism (noun)",
+      "meaning": "Radical beliefs, especially those that promote violence or terrorism.",
+      "example": "Foreign aid can help combat extremism by strengthening local communities.",
+      "translation": "chủ nghĩa cực đoan",
+      "count": 0
+    },
+    {
+      "word": "Vulnerable (adjective)",
+      "meaning": "At risk or exposed to harm, danger, or loss.",
+      "example": "Nations with little access to clean water are highly vulnerable to climate threats.",
+      "translation": "dễ bị tổn thương",
+      "count": 0
+    },
+    {
+      "word": "Multilateral (adjective)",
+      "meaning": "Involving multiple countries working together on common goals.",
+      "example": "Multilateral cooperation is often more effective than acting alone on global matters.",
+      "translation": "đa phương",
+      "count": 0
+    },
+    {
+      "word": "Nuance (noun)",
+      "meaning": "A subtle or slight distinction in meaning or expression.",
+      "example": "Even fluent learners can struggle with the nuances of a second language.",
+      "translation": "sắc thái",
+      "count": 0
+    },
+    {
+      "word": "Polyglot (noun)",
+      "meaning": "A person fluent in several languages.",
+      "example": "Becoming a polyglot is a dream, though mastering one language is already hard.",
+      "translation": "người nói nhiều thứ tiếng",
+      "count": 0
+    },
+    {
+      "word": "Make oneself understood",
+      "meaning": "To communicate effectively in a second language using simple words.",
+      "example": "Even though my grammar isn’t perfect, I can still make myself understood when traveling abroad.",
+      "translation": "Diễn đạt để người khác hiểu",
+      "count": 0
+    },
+    {
+      "word": "Get the gist",
+      "meaning": "To understand the main idea without grasping every detail.",
+      "example": "He didn’t catch every word of the lecture but got the gist of what was being explained.",
+      "translation": "Nắm ý chính",
+      "count": 0
+    },
+    {
+      "word": "Immerse oneself (verb)",
+      "meaning": "To fully engage in an environment where a new language is used.",
+      "example": "She immersed herself in Spanish by living in Madrid for a year without using English.",
+      "translation": "Đắm mình vào",
+      "count": 0
+    },
+    {
+      "word": "Proficient (adjective)",
+      "meaning": "Skilled and capable, though not necessarily perfect, at something.",
+      "example": "He's proficient in both Mandarin and Japanese thanks to years of practice.",
+      "translation": "Thành thạo",
+      "count": 0
+    },
+    {
+      "word": "Eloquent (adjective)",
+      "meaning": "Able to speak or write in a persuasive and impressive way.",
+      "example": "Her eloquent speech moved the entire audience to applause.",
+      "translation": "Hùng biện",
+      "count": 0
+    },
+    {
+      "word": "Tongue-tied (adjective)",
+      "meaning": "Too nervous or shy to speak clearly.",
+      "example": "I get tongue-tied whenever I have to speak in public.",
+      "translation": "Cứng họng vì lo lắng",
+      "count": 0
+    },
+    {
+      "word": "Sentence structure (noun)",
+      "meaning": "The way words are arranged to form a sentence in a language.",
+      "example": "French sentence structure is quite different from English, which confused me at first.",
+      "translation": "Cấu trúc câu",
+      "count": 0
+    },
+    {
+      "word": "Linguistic (adjective)",
+      "meaning": "Relating to language or the study of languages.",
+      "example": "Her linguistic background helped her pick up new dialects quickly.",
+      "translation": "Ngôn ngữ",
+      "count": 0
+    },
+    {
+      "word": "A romantic gesture (noun)",
+      "meaning": "An action intended to show love or affection.",
+      "example": "He surprised her with a candlelit dinner as a romantic gesture.",
+      "translation": "Cử chỉ lãng mạn",
+      "count": 0
+    },
+    {
+      "word": "Exclusive (adjective)",
+      "meaning": "Involving a commitment to only one partner in a relationship.",
+      "example": "They had a long talk before deciding to be exclusive.",
+      "translation": "Chỉ dành riêng",
+      "count": 0
+    },
+    {
+      "word": "Engaged (adjective)",
+      "meaning": "Formally promised to marry someone.",
+      "example": "They got engaged during a trip to Paris last spring.",
+      "translation": "Đính hôn",
+      "count": 0
+    },
+    {
+      "word": "Significant other (noun)",
+      "meaning": "A person’s romantic partner, such as a spouse or boyfriend/girlfriend.",
+      "example": "He always brings his significant other to family events.",
+      "translation": "Người yêu/ bạn đời",
+      "count": 0
+    },
+    {
+      "word": "Childhood sweetheart (noun)",
+      "meaning": "A person one had a romantic relationship with when very young.",
+      "example": "She ended up marrying her childhood sweetheart after reconnecting years later.",
+      "translation": "Người yêu thời thơ ấu",
+      "count": 0
+    },
+    {
+      "word": "Date (noun)",
+      "meaning": "A planned romantic meeting with someone.",
+      "example": "Their first date was at a quiet coffee shop downtown.",
+      "translation": "Cuộc hẹn hò",
+      "count": 0
+    },
+    {
+      "word": "Limelight (noun)",
+      "meaning": "Public attention or fame.",
+      "example": "He prefers working behind the scenes and avoiding the limelight.",
+      "translation": "Sự chú ý của công chúng",
+      "count": 0
+    },
+    {
+      "word": "Paparazzi (plural noun)",
+      "meaning": "Photographers who follow celebrities to take candid pictures.",
+      "example": "The actress was overwhelmed by paparazzi outside her hotel.",
+      "translation": "Thợ săn ảnh",
+      "count": 0
+    },
+    {
+      "word": "Opulent (adjective)",
+      "meaning": "Extravagantly rich or luxurious.",
+      "example": "Their wedding was held in an opulent ballroom full of chandeliers.",
+      "translation": "Xa hoa",
+      "count": 0
+    },
+    {
+      "word": "Household name (name)",
+      "meaning": "A person who is widely recognized by the general public.",
+      "example": "After winning the competition, she became a household name overnight.",
+      "translation": "Tên tuổi nổi tiếng",
+      "count": 0
+    },
+    {
+      "word": "Speculation (noun)",
+      "meaning": "Rumors or unverified talk about something.",
+      "example": "There was speculation that the singer was secretly engaged.",
+      "translation": "Suy đoán",
+      "count": 0
+    },
+    {
+      "word": "Wholesome (adjective)",
+      "meaning": "Innocent, moral, and suitable for all audiences.",
+      "example": "He had a wholesome image that appealed to a wide audience.",
+      "translation": "Lành mạnh",
+      "count": 0
+    },
+    {
+      "word": "Authenticity (noun)",
+      "meaning": "The quality of being real or genuine.",
+      "example": "Her authenticity online made her stand out from other influencers.",
+      "translation": "Tính xác thực",
+      "count": 0
+    },
+    {
+      "word": "A flash in the pan (noun)",
+      "meaning": "Something that is briefly popular or successful.",
+      "example": "The singer’s hit song turned out to be just a flash in the pan.",
+      "translation": "Thành công nhất thời",
+      "count": 0
+    },
+    {
+      "word": "Merchandise (noun)",
+      "meaning": "Products sold to promote a brand, event, or personality.",
+      "example": "The band’s tour merchandise sold out within days.",
+      "translation": "Hàng hóa",
+      "count": 0
+    },
+    {
+      "word": "Frugal (adjective)",
+      "meaning": "Careful in spending money, avoiding waste.",
+      "example": "He lives a frugal life and saves a lot each month.",
+      "translation": "Tiết kiệm",
+      "count": 0
+    },
+    {
+      "word": "Abandon (verb)",
+      "meaning": "To leave something behind or give up on it completely.",
+      "example": "The villagers had to abandon their homes during the flood.",
+      "translation": "Từ bỏ",
+      "count": 0
+    },
+    {
+      "word": "Abiding (adjective)",
+      "meaning": "Continuing to exist or last for a long time.",
+      "example": "She has an abiding respect for her mentor’s teachings.",
+      "translation": "Lâu dài",
+      "count": 0
+    },
+    {
+      "word": "Abolish (verb)",
+      "meaning": "To officially end or eliminate something, especially a law or system.",
+      "example": "The country voted to abolish the outdated tax regulation.",
+      "translation": "Bãi bỏ",
+      "count": 0
+    },
+    {
+      "word": "Abundance (noun)",
+      "meaning": "A large amount or plentiful supply of something.",
+      "example": "The garden yielded an abundance of fresh vegetables this season.",
+      "translation": "Sự phong phú",
+      "count": 0
+    },
+    {
+      "word": "Accessible (adjective)",
+      "meaning": "Able to be reached, entered, or used easily.",
+      "example": "The museum was designed to be accessible to everyone, including those with disabilities.",
+      "translation": "Có thể tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "Accommodate (verb)",
+      "meaning": "To adjust or adapt to meet someone’s needs or conditions.",
+      "example": "The hotel was able to accommodate all of the guests with special requirements.",
+      "translation": "Đáp ứng",
+      "count": 0
+    },
+    {
+      "word": "Accomplish (verb)",
+      "meaning": "To complete or succeed in doing something.",
+      "example": "She accomplished all of her goals before the end of the year.",
+      "translation": "Hoàn thành",
+      "count": 0
+    },
+    {
+      "word": "Accord (noun)",
+      "meaning": "A formal agreement or harmony between groups or people.",
+      "example": "Both parties reached an accord after several rounds of negotiation.",
+      "translation": "Hiệp định",
+      "count": 0
+    },
+    {
+      "word": "Accordingly (adverb)",
+      "meaning": "In a way that matches a situation or set of conditions.",
+      "example": "He adjusted his plans accordingly when the weather turned bad.",
+      "translation": "Tương ứng",
+      "count": 0
+    },
+    {
+      "word": "Accumulate (verb)",
+      "meaning": "To gather or collect over time.",
+      "example": "She accumulated hundreds of stamps throughout her travels.",
+      "translation": "Tích lũy",
+      "count": 0
+    },
+    {
+      "word": "Accurately (adverb)",
+      "meaning": "In a way that is correct and without mistakes.",
+      "example": "The data was recorded accurately by the research team.",
+      "translation": "Chính xác",
+      "count": 0
+    },
+    {
+      "word": "Acquire (verb)",
+      "meaning": "To obtain or gain something through effort or purchase.",
+      "example": "He acquired valuable skills during his internship.",
+      "translation": "Đạt được",
+      "count": 0
+    },
+    {
+      "word": "Adapt (verb)",
+      "meaning": "To change something to suit a different use or condition.",
+      "example": "Plants adapt to survive in extreme environments.",
+      "translation": "Thích nghi",
+      "count": 0
+    },
+    {
+      "word": "Address (verb)",
+      "meaning": "To speak to a group or deal with a matter.",
+      "example": "The director addressed the staff about upcoming changes.",
+      "translation": "Phát biểu",
+      "count": 0
+    },
+    {
+      "word": "Adjacent (adjective)",
+      "meaning": "Next to or close to something.",
+      "example": "Their apartment is adjacent to a large shopping center.",
+      "translation": "Liền kề",
+      "count": 0
+    },
+    {
+      "word": "Administer (verb)",
+      "meaning": "To manage or provide something officially.",
+      "example": "The teacher administered the final exam with clear instructions.",
+      "translation": "Quản lý/thi hành",
+      "count": 0
+    },
+    {
+      "word": "Admit (verb)",
+      "meaning": "To allow someone to enter a place.",
+      "example": "Only ticket holders were admitted into the event.",
+      "translation": "Cho vào",
+      "count": 0
+    },
+    {
+      "word": "Affection (noun)",
+      "meaning": "A gentle feeling of fondness or love.",
+      "example": "He showed great affection for his old pet dog.",
+      "translation": "Tình cảm",
+      "count": 0
+    },
+    {
+      "word": "Agent (noun)",
+      "meaning": "Someone or something that causes change or has an effect.",
+      "example": "Education is a powerful agent of progress.",
+      "translation": "Tác nhân",
+      "count": 0
+    },
+    {
+      "word": "Aggravate (verb)",
+      "meaning": "To make a situation worse or more severe.",
+      "example": "Scratching the rash will only aggravate it.",
+      "translation": "Làm trầm trọng thêm",
+      "count": 0
+    },
+    {
+      "word": "Allocate (verb)",
+      "meaning": "To set aside something for a specific purpose.",
+      "example": "The government allocated more funds for disaster relief.",
+      "translation": "Phân bổ",
+      "count": 0
+    },
+    {
+      "word": "Attain (verb)",
+      "meaning": "To reach or succeed in achieving something.",
+      "example": "She attained fluency in English after two years of practice.",
+      "translation": "Đạt được",
+      "count": 0
+    },
+    {
+      "word": "Attribute (noun)",
+      "meaning": "A feature or characteristic of someone or something.",
+      "example": "Creativity is a key attribute of successful entrepreneurs.",
+      "translation": "Đặc điểm",
+      "count": 0
+    },
+    {
+      "word": "Barrier (noun)",
+      "meaning": "Something that blocks or limits progress or movement.",
+      "example": "Language can be a barrier to effective communication.",
+      "translation": "Rào cản",
+      "count": 0
+    },
+    {
+      "word": "Barter (verb)",
+      "meaning": "To trade goods or services directly without using money.",
+      "example": "They bartered fresh produce for household items.",
+      "translation": "Trao đổi hàng hóa",
+      "count": 0
+    },
+    {
+      "word": "Biased (adjective)",
+      "meaning": "Showing unfair preference or prejudice.",
+      "example": "The judge was criticized for making a biased decision.",
+      "translation": "Thiên vị",
+      "count": 0
+    },
+    {
+      "word": "Boundary (noun)",
+      "meaning": "A line that marks the limits or edges of an area.",
+      "example": "They placed signs along the boundary to prevent trespassing.",
+      "translation": "Ranh giới",
+      "count": 0
+    },
+    {
+      "word": "Bountiful (adjective)",
+      "meaning": "Existing in large quantities; plentiful or generous.",
+      "example": "The farmer celebrated a bountiful apple harvest this year.",
+      "translation": "Dồi dào",
+      "count": 0
+    },
+    {
+      "word": "Brief (adjective)",
+      "meaning": "Short in duration or using few words.",
+      "example": "She gave a brief update before the meeting ended.",
+      "translation": "Ngắn gọn",
+      "count": 0
+    },
+    {
+      "word": "Brisk (adjective)",
+      "meaning": "Quick and energetic in movement or action.",
+      "example": "A brisk walk every morning helps him stay fit.",
+      "translation": "Nhanh nhẹn",
+      "count": 0
+    },
+    {
+      "word": "Bulk (adjective)",
+      "meaning": "In large size or quantity, often not divided.",
+      "example": "Buying rice in bulk is cheaper for our family.",
+      "translation": "Số lượng lớn",
+      "count": 0
+    },
+    {
+      "word": "Burden (noun)",
+      "meaning": "Something difficult or heavy to carry or deal with.",
+      "example": "Caring for both parents became an emotional burden.",
+      "translation": "Gánh nặng",
+      "count": 0
+    },
+    {
+      "word": "Calculate (verb)",
+      "meaning": "To find out a result using numbers or logic.",
+      "example": "Please calculate the total cost of the trip.",
+      "translation": "Tính toán",
+      "count": 0
+    },
+    {
+      "word": "Camouflage (verb)",
+      "meaning": "To hide by blending in with the surroundings.",
+      "example": "The soldier camouflaged himself in the forest environment.",
+      "translation": "Ngụy trang",
+      "count": 0
+    },
+    {
+      "word": "Capacity (noun)",
+      "meaning": "The maximum amount something can hold or contain.",
+      "example": "The elevator has a weight capacity of 800 kg.",
+      "translation": "Sức chứa",
+      "count": 0
+    },
+    {
+      "word": "Capitalize (verb)",
+      "meaning": "To take advantage of a situation or opportunity.",
+      "example": "The player capitalized on the defender’s mistake to score.",
+      "translation": "Tận dụng",
+      "count": 0
+    },
+    {
+      "word": "Caption (noun)",
+      "meaning": "Text that describes or explains a picture or graphic.",
+      "example": "The photo caption explained where it was taken.",
+      "translation": "Chú thích",
+      "count": 0
+    },
+    {
+      "word": "Catastrophic (adjective)",
+      "meaning": "Causing great damage or suffering.",
+      "example": "The oil spill had catastrophic effects on marine life.",
+      "translation": "Thảm khốc",
+      "count": 0
+    },
+    {
+      "word": "Challenge (verb)",
+      "meaning": "To invite someone to compete or to question something.",
+      "example": "He challenged me to a game of chess.",
+      "translation": "Thách thức",
+      "count": 0
+    },
+    {
+      "word": "Channel (noun)",
+      "meaning": "The physical path through which water flows.",
+      "example": "The river flowed through a narrow channel.",
+      "translation": "Kênh",
+      "count": 0
+    },
+    {
+      "word": "Chaotic (adjective)",
+      "meaning": "In a state of complete confusion and disorder.",
+      "example": "The evacuation was chaotic due to the fire alarm.",
+      "translation": "Hỗn loạn",
+      "count": 0
+    },
+    {
+      "word": "Characteristic (noun)",
+      "meaning": "A quality or feature that defines something.",
+      "example": "Kindness is one of her strongest characteristics.",
+      "translation": "Đặc điểm",
+      "count": 0
+    },
+    {
+      "word": "Chief (noun)",
+      "meaning": "The leader or most important person in a group.",
+      "example": "He was promoted to fire chief last year.",
+      "translation": "Trưởng nhóm",
+      "count": 0
+    },
+    {
+      "word": "Chronicle (noun)",
+      "meaning": "A record of events in the order they happened.",
+      "example": "The book is a chronicle of the Civil War.",
+      "translation": "Biên niên sử",
+      "count": 0
+    },
+    {
+      "word": "Clarify (verb)",
+      "meaning": "To make something easier to understand or explain.",
+      "example": "Let me clarify what I meant earlier.",
+      "translation": "Làm rõ",
+      "count": 0
+    },
+    {
+      "word": "Classify (verb)",
+      "meaning": "To group things based on common features.",
+      "example": "The teacher asked us to classify the animals by type.",
+      "translation": "Phân loại",
+      "count": 0
+    },
+    {
+      "word": "Cognitive (adjective)",
+      "meaning": "Related to mental processes such as thinking and learning.",
+      "example": "The test measures students’ cognitive abilities.",
+      "translation": "Nhận thức",
+      "count": 0
+    },
+    {
+      "word": "Cohesion (noun)",
+      "meaning": "The act of sticking or working well together.",
+      "example": "Team cohesion is vital in successful projects.",
+      "translation": "Sự gắn kết",
+      "count": 0
+    },
+    {
+      "word": "Component (noun)",
+      "meaning": "A part or element of a larger whole.",
+      "example": "This chip is an essential component of the circuit.",
+      "translation": "Thành phần",
+      "count": 0
+    },
+    {
+      "word": "Comprise (verb)",
+      "meaning": "To include or consist of several parts.",
+      "example": "The committee comprises five senior members.",
+      "translation": "Bao gồm",
+      "count": 0
+    },
+    {
+      "word": "Consecutive (adjective)",
+      "meaning": "Following one after another without interruption.",
+      "example": "She won three consecutive championships.",
+      "translation": "Liên tiếp",
+      "count": 0
+    },
+    {
+      "word": "consequence (noun)",
+      "meaning": "A result or effect, often negative, caused by an action.",
+      "example": "Failing to study had serious consequences for her exam results.",
+      "translation": "Hậu quả",
+      "count": 0
+    },
+    {
+      "word": "conversely (adverb)",
+      "meaning": "Used to express an opposite idea or contrast.",
+      "example": "He loves city life; conversely, his brother prefers the countryside.",
+      "translation": "Ngược lại",
+      "count": 0
+    },
+    {
+      "word": "debris (noun)",
+      "meaning": "Broken pieces left after something has been destroyed.",
+      "example": "After the explosion, debris was scattered everywhere.",
+      "translation": "Mảnh vỡ",
+      "count": 0
+    },
+    {
+      "word": "decay (verb)",
+      "meaning": "To slowly break down or deteriorate.",
+      "example": "Fruits decay quickly in the summer heat.",
+      "translation": "Phân hủy",
+      "count": 0
+    },
+    {
+      "word": "decline (verb)",
+      "meaning": "To gradually become worse or decrease.",
+      "example": "The economy declined after the crisis.",
+      "translation": "Suy giảm",
+      "count": 0
+    },
+    {
+      "word": "degree (noun)",
+      "meaning": "A level or stage in a process or scale.",
+      "example": "There was a high degree of difficulty in the task.",
+      "translation": "Mức độ",
+      "count": 0
+    },
+    {
+      "word": "deliberate (verb)",
+      "meaning": "To think about something carefully before deciding.",
+      "example": "The board will deliberate before making a final decision.",
+      "translation": "Cân nhắc",
+      "count": 0
+    },
+    {
+      "word": "deploy (verb)",
+      "meaning": "To position or arrange for use, often in a strategic way.",
+      "example": "The company deployed resources to handle the crisis.",
+      "translation": "Triển khai",
+      "count": 0
+    },
+    {
+      "word": "deposit (verb)",
+      "meaning": "To place something somewhere, especially for safekeeping.",
+      "example": "She deposited a check into her savings account.",
+      "translation": "Gửi vào",
+      "count": 0
+    },
+    {
+      "word": "derive (verb)",
+      "meaning": "To get or obtain something from another source.",
+      "example": "The word 'biology' is derived from Greek.",
+      "translation": "Bắt nguồn từ",
+      "count": 0
+    },
+    {
+      "word": "deteriorate (verb)",
+      "meaning": "To become worse in condition or quality.",
+      "example": "Her vision deteriorated over the years.",
+      "translation": "Suy yếu",
+      "count": 0
+    },
+    {
+      "word": "determine (verb)",
+      "meaning": "To decide or control the outcome of something.",
+      "example": "The test results will determine your placement.",
+      "translation": "Quyết định",
+      "count": 0
+    },
+    {
+      "word": "disaster (noun)",
+      "meaning": "A sudden event causing great damage or hardship.",
+      "example": "The earthquake was the worst disaster in decades.",
+      "translation": "Thảm họa",
+      "count": 0
+    },
+    {
+      "word": "discriminate (verb)",
+      "meaning": "To treat someone unfairly based on difference.",
+      "example": "It is illegal to discriminate based on gender.",
+      "translation": "Phân biệt đối xử",
+      "count": 0
+    },
+    {
+      "word": "disrupt (verb)",
+      "meaning": "To interrupt or disturb the normal flow of something.",
+      "example": "The construction noise disrupted our class.",
+      "translation": "Gây rối",
+      "count": 0
+    },
+    {
+      "word": "dissimilar (adjective)",
+      "meaning": "Not alike or different in nature.",
+      "example": "Although twins, their interests are quite dissimilar.",
+      "translation": "Không giống nhau",
+      "count": 0
+    },
+    {
+      "word": "distinct (adjective)",
+      "meaning": "Clearly separate or noticeably different.",
+      "example": "She speaks with a distinct accent.",
+      "translation": "Khác biệt",
+      "count": 0
+    },
+    {
+      "word": "domain (noun)",
+      "meaning": "A specific area of knowledge, control, or interest.",
+      "example": "Finance is not my domain of expertise.",
+      "translation": "Lĩnh vực",
+      "count": 0
+    },
+    {
+      "word": "duration (noun)",
+      "meaning": "The length of time something continues.",
+      "example": "The concert’s duration was over two hours.",
+      "translation": "Khoảng thời gian",
+      "count": 0
+    },
+    {
+      "word": "ease (noun)",
+      "meaning": "The state of being comfortable or free from difficulty.",
+      "example": "She completed the task with great ease.",
+      "translation": "Sự dễ dàng",
+      "count": 0
+    },
+    {
+      "word": "elaborate (verb)",
+      "meaning": "To give more details or explain more clearly.",
+      "example": "Can you elaborate on your idea?",
+      "translation": "Giải thích rõ",
+      "count": 0
+    },
+    {
+      "word": "eliminate (verb)",
+      "meaning": "To completely remove or get rid of something.",
+      "example": "They eliminated unnecessary steps in the process.",
+      "translation": "Loại bỏ",
+      "count": 0
+    },
+    {
+      "word": "embrace (verb)",
+      "meaning": "To accept something willingly or enthusiastically.",
+      "example": "She embraced the opportunity to study abroad.",
+      "translation": "Đón nhận",
+      "count": 0
+    },
+    {
+      "word": "emphasize (verb)",
+      "meaning": "To give special importance or attention to something.",
+      "example": "The teacher emphasized the importance of attendance.",
+      "translation": "Nhấn mạnh",
+      "count": 0
+    },
+    {
+      "word": "enable (verb)",
+      "meaning": "To make it possible for someone or something to do something.",
+      "example": "This app enables users to track their habits.",
+      "translation": "Cho phép",
+      "count": 0
+    },
+    {
+      "word": "endanger (verb)",
+      "meaning": "To put someone or something at risk of harm.",
+      "example": "Smoking near gas tanks can endanger lives.",
+      "translation": "Gây nguy hiểm",
+      "count": 0
+    },
+    {
+      "word": "endeavor (noun)",
+      "meaning": "An earnest attempt to accomplish a goal.",
+      "example": "Her scientific endeavor led to a major breakthrough.",
+      "translation": "Nỗ lực",
+      "count": 0
+    },
+    {
+      "word": "environment (noun)",
+      "meaning": "The surrounding conditions or natural world influencing something.",
+      "example": "He grew up in a creative environment filled with art and music.",
+      "translation": "Môi trường",
+      "count": 0
+    },
+    {
+      "word": "era (noun)",
+      "meaning": "A distinct period in history or time.",
+      "example": "We live in the digital era where information is instant.",
+      "translation": "Kỷ nguyên",
+      "count": 0
+    },
+    {
+      "word": "erupt (verb)",
+      "meaning": "To suddenly release force or energy, especially from the earth.",
+      "example": "Mount Fuji could erupt without warning.",
+      "translation": "Phun trào",
+      "count": 0
+    },
+    {
+      "word": "essential (adjective)",
+      "meaning": "Absolutely necessary or very important.",
+      "example": "Clean water is essential for survival.",
+      "translation": "Thiết yếu",
+      "count": 0
+    },
+    {
+      "word": "dry up (phrasal verb) /draɪ ʌp/",
+      "meaning": "To stop speaking due to forgetting what to say.",
+      "example": "He completely dried up during his presentation.",
+      "translation": "Quên lời",
+      "count": 0
+    },
+    {
+      "word": "explicit (adjective)",
+      "meaning": "Clearly stated without any confusion.",
+      "example": "The contract had explicit terms about payment.",
+      "translation": "Rõ ràng",
+      "count": 0
+    },
+    {
+      "word": "facet (noun)",
+      "meaning": "One part or aspect of something complex.",
+      "example": "Kindness is an important facet of leadership.",
+      "translation": "Khía cạnh",
+      "count": 0
+    },
+    {
+      "word": "facilitate (verb)",
+      "meaning": "To make an action or process easier.",
+      "example": "The software facilitates quick file sharing.",
+      "translation": "Tạo điều kiện",
+      "count": 0
+    },
+    {
+      "word": "faint (adjective)",
+      "meaning": "Barely noticeable or lacking strength.",
+      "example": "I heard a faint knock at the door.",
+      "translation": "Mờ nhạt",
+      "count": 0
+    },
+    {
+      "word": "feasible (adjective)",
+      "meaning": "Possible and practical to do easily.",
+      "example": "Building a bridge here is technically feasible.",
+      "translation": "Khả thi",
+      "count": 0
+    },
+    {
+      "word": "figure (noun)",
+      "meaning": "A visual representation such as a diagram or chart.",
+      "example": "Please refer to the figure below for details.",
+      "translation": "Hình minh họa",
+      "count": 0
+    },
+    {
+      "word": "finance (noun)",
+      "meaning": "The management or study of money and investments.",
+      "example": "He works in corporate finance.",
+      "translation": "Tài chính",
+      "count": 0
+    },
+    {
+      "word": "flourish (verb)",
+      "meaning": "To grow or develop successfully.",
+      "example": "Small businesses flourish in this area.",
+      "translation": "Phát triển mạnh",
+      "count": 0
+    },
+    {
+      "word": "fluid (adjective)",
+      "meaning": "Flexible and changing over time.",
+      "example": "The team's strategy remains fluid based on market conditions.",
+      "translation": "Linh hoạt",
+      "count": 0
+    },
+    {
+      "word": "foremost (adjective)",
+      "meaning": "Most important or first in rank.",
+      "example": "She is the foremost expert in her field.",
+      "translation": "Hàng đầu",
+      "count": 0
+    },
+    {
+      "word": "fuel (noun)",
+      "meaning": "Something that powers or stimulates an activity.",
+      "example": "His anger became fuel for his determination.",
+      "translation": "Nhiên liệu",
+      "count": 0
+    },
+    {
+      "word": "fundamental (noun)",
+      "meaning": "A basic and essential principle or element.",
+      "example": "Respect is a fundamental of teamwork.",
+      "translation": "Nguyên tắc cơ bản",
+      "count": 0
+    },
+    {
+      "word": "gauge (verb)",
+      "meaning": "To estimate or assess the amount or value of something.",
+      "example": "He tried to gauge the level of interest in his proposal.",
+      "translation": "Đo lường",
+      "count": 0
+    },
+    {
+      "word": "generate (verb)",
+      "meaning": "To produce or bring something into existence.",
+      "example": "Their new marketing campaign generated a lot of public interest.",
+      "translation": "Tạo ra",
+      "count": 0
+    },
+    {
+      "word": "gorgeous (adjective)",
+      "meaning": "Extremely beautiful or attractive.",
+      "example": "She looked absolutely gorgeous in that dress.",
+      "translation": "Tuyệt đẹp",
+      "count": 0
+    },
+    {
+      "word": "govern (verb)",
+      "meaning": "To control or direct the actions and policies of a group or country.",
+      "example": "The new leader promised to govern fairly.",
+      "translation": "Cai trị",
+      "count": 0
+    },
+    {
+      "word": "gradual (adjective)",
+      "meaning": "Happening slowly over time.",
+      "example": "There has been a gradual improvement in her health.",
+      "translation": "Dần dần",
+      "count": 0
+    },
+    {
+      "word": "grueling (adjective)",
+      "meaning": "Very tiring or demanding.",
+      "example": "Training for the triathlon was a grueling experience.",
+      "translation": "Kiệt sức",
+      "count": 0
+    },
+    {
+      "word": "guess (verb)",
+      "meaning": "To form an opinion without certain knowledge.",
+      "example": "He guessed the correct answer by chance.",
+      "translation": "Đoán",
+      "count": 0
+    },
+    {
+      "word": "habitat (noun)",
+      "meaning": "The natural environment where an organism lives.",
+      "example": "The forest is a natural habitat for many species.",
+      "translation": "Môi trường sống",
+      "count": 0
+    },
+    {
+      "word": "harsh (adjective)",
+      "meaning": "Severe or unpleasant in nature.",
+      "example": "The harsh winter took a toll on the crops.",
+      "translation": "Khắc nghiệt",
+      "count": 0
+    },
+    {
+      "word": "hence (conjunction)",
+      "meaning": "For this reason or as a result.",
+      "example": "He didn’t study, hence he failed the exam.",
+      "translation": "Do đó",
+      "count": 0
+    },
+    {
+      "word": "heterogeneous (adjective)",
+      "meaning": "Made up of different kinds or parts.",
+      "example": "The classroom was a heterogeneous mix of cultures.",
+      "translation": "Không đồng nhất",
+      "count": 0
+    },
+    {
+      "word": "hiatus (noun)",
+      "meaning": "A temporary break or interruption.",
+      "example": "After a two-year hiatus, the band went on tour again.",
+      "translation": "Gián đoạn",
+      "count": 0
+    },
+    {
+      "word": "hinder (verb)",
+      "meaning": "To make progress difficult.",
+      "example": "Poor internet access hindered their ability to work remotely.",
+      "translation": "Cản trở",
+      "count": 0
+    },
+    {
+      "word": "hybrid (noun)",
+      "meaning": "Something created from a combination of different elements.",
+      "example": "This car is a hybrid of electric and gasoline power.",
+      "translation": "Lai",
+      "count": 0
+    },
+    {
+      "word": "hypothesis (noun)",
+      "meaning": "A proposed explanation used as a starting point for further investigation.",
+      "example": "They tested the hypothesis in multiple experiments.",
+      "translation": "Giả thuyết",
+      "count": 0
+    },
+    {
+      "word": "identical (adjective)",
+      "meaning": "Exactly the same in every detail.",
+      "example": "The two shirts were completely identical.",
+      "translation": "Giống hệt",
+      "count": 0
+    },
+    {
+      "word": "ignite (verb)",
+      "meaning": "To start a fire or trigger an event.",
+      "example": "His speech ignited a heated debate.",
+      "translation": "Châm ngòi",
+      "count": 0
+    },
+    {
+      "word": "illusion (noun)",
+      "meaning": "A false appearance or impression.",
+      "example": "The magician created the illusion of levitation.",
+      "translation": "Ảo ảnh",
+      "count": 0
+    },
+    {
+      "word": "immense (adjective)",
+      "meaning": "Extremely large or great.",
+      "example": "The ocean stretches over an immense distance.",
+      "translation": "Mênh mông",
+      "count": 0
+    },
+    {
+      "word": "impact (verb)",
+      "meaning": "To strongly affect or influence something.",
+      "example": "The new law will impact all small businesses.",
+      "translation": "Tác động",
+      "count": 0
+    },
+    {
+      "word": "impasse (noun)",
+      "meaning": "A situation with no possible progress or solution.",
+      "example": "The talks ended in an impasse.",
+      "translation": "Bế tắc",
+      "count": 0
+    },
+    {
+      "word": "impede (verb)",
+      "meaning": "To slow down or block progress.",
+      "example": "Heavy traffic impeded the ambulance’s journey.",
+      "translation": "Ngăn cản",
+      "count": 0
+    },
+    {
+      "word": "incessant (adjective)",
+      "meaning": "Continuing without stopping.",
+      "example": "The incessant noise made it hard to concentrate.",
+      "translation": "Không ngừng nghỉ",
+      "count": 0
+    },
+    {
+      "word": "incident (noun)",
+      "meaning": "An event or occurrence, usually unplanned.",
+      "example": "The incident was reported to the authorities.",
+      "translation": "Sự cố",
+      "count": 0
+    },
+    {
+      "word": "incoherent (adjective)",
+      "meaning": "Unclear or lacking logical connection.",
+      "example": "His argument became incoherent under pressure.",
+      "translation": "Không mạch lạc",
+      "count": 0
+    },
+    {
+      "word": "indicate (verb)",
+      "meaning": "To show or suggest something clearly.",
+      "example": "All signs indicate that the storm is approaching.",
+      "translation": "Chỉ ra",
+      "count": 0
+    },
+    {
+      "word": "indispensable",
+      "meaning": "So important that it cannot be done without.",
+      "example": "Water is indispensable for human survival.",
+      "translation": "Không thể thiếu",
+      "count": 0
+    },
+    {
+      "word": "inevitable",
+      "meaning": "Certain to happen and impossible to avoid.",
+      "example": "With that attitude, failure was inevitable.",
+      "translation": "Không tránh khỏi",
+      "count": 0
+    },
+    {
+      "word": "infinite",
+      "meaning": "Without limits or end.",
+      "example": "There’s an infinite number of ways to express love.",
+      "translation": "Vô hạn",
+      "count": 0
+    },
+    {
+      "word": "influence",
+      "meaning": "The ability to shape or change behavior or outcomes.",
+      "example": "Her influence helped me choose my career path.",
+      "translation": "Ảnh hưởng",
+      "count": 0
+    },
+    {
+      "word": "infrastructure",
+      "meaning": "The physical and organizational systems supporting a society.",
+      "example": "The city invested heavily in modern infrastructure.",
+      "translation": "Cơ sở hạ tầng",
+      "count": 0
+    },
+    {
+      "word": "initiate",
+      "meaning": "To begin or set something in motion.",
+      "example": "The team initiated the new project last week.",
+      "translation": "Khởi xướng",
+      "count": 0
+    },
+    {
+      "word": "intense",
+      "meaning": "Very strong or extreme in force or feeling.",
+      "example": "The debate became increasingly intense.",
+      "translation": "Mãnh liệt",
+      "count": 0
+    },
+    {
+      "word": "invent",
+      "meaning": "To create something that has not existed before.",
+      "example": "He invented a portable solar-powered charger.",
+      "translation": "Phát minh",
+      "count": 0
+    },
+    {
+      "word": "jeopardy",
+      "meaning": "The state of being in danger of harm or failure.",
+      "example": "The error put the entire project in jeopardy.",
+      "translation": "Nguy cơ",
+      "count": 0
+    },
+    {
+      "word": "judicious",
+      "meaning": "Showing good judgment and reason.",
+      "example": "She made a judicious decision to delay the launch.",
+      "translation": "Sáng suốt",
+      "count": 0
+    },
+    {
+      "word": "justify",
+      "meaning": "To explain or defend something as reasonable.",
+      "example": "He tried to justify his actions to the board.",
+      "translation": "Biện minh",
+      "count": 0
+    },
+    {
+      "word": "keen",
+      "meaning": "Having a sharp or highly developed sense or interest.",
+      "example": "She has a keen interest in photography.",
+      "translation": "Sắc sảo",
+      "count": 0
+    },
+    {
+      "word": "key",
+      "meaning": "Very important or essential.",
+      "example": "Discipline is a key part of success.",
+      "translation": "Chủ chốt",
+      "count": 0
+    },
+    {
+      "word": "kin",
+      "meaning": "Family members or relatives.",
+      "example": "She visited her kin in the countryside.",
+      "translation": "Họ hàng",
+      "count": 0
+    },
+    {
+      "word": "lacking",
+      "meaning": "Not having enough of something needed.",
+      "example": "The plan is lacking key details.",
+      "translation": "Thiếu",
+      "count": 0
+    },
+    {
+      "word": "landslide",
+      "meaning": "A collapse of earth or rocks down a slope.",
+      "example": "The landslide blocked the highway for hours.",
+      "translation": "Lở đất",
+      "count": 0
+    },
+    {
+      "word": "launch",
+      "meaning": "To begin or introduce something new.",
+      "example": "They launched the app with great success.",
+      "translation": "Ra mắt",
+      "count": 0
+    },
+    {
+      "word": "leading",
+      "meaning": "Most important or in the first position.",
+      "example": "She is the leading expert in her field.",
+      "translation": "Hàng đầu",
+      "count": 0
+    },
+    {
+      "word": "legitimate",
+      "meaning": "Accepted by law or rules as valid.",
+      "example": "He gave a legitimate reason for his absence.",
+      "translation": "Hợp pháp",
+      "count": 0
+    },
+    {
+      "word": "levy",
+      "meaning": "To collect a tax or fee officially.",
+      "example": "The government will levy a new environmental tax.",
+      "translation": "Áp thuế",
+      "count": 0
+    },
+    {
+      "word": "lexicon",
+      "meaning": "The vocabulary of a language or group.",
+      "example": "Science has its own complex lexicon.",
+      "translation": "Từ vựng",
+      "count": 0
+    },
+    {
+      "word": "likewise",
+      "meaning": "In the same way; also.",
+      "example": "She enjoyed the dinner, and he felt likewise.",
+      "translation": "Tương tự",
+      "count": 0
+    },
+    {
+      "word": "link",
+      "meaning": "A connection between things or ideas.",
+      "example": "There’s a strong link between stress and illness.",
+      "translation": "Liên kết",
+      "count": 0
+    },
+    {
+      "word": "lobby",
+      "meaning": "To try to influence decisions by authorities.",
+      "example": "They lobbied the government for stricter laws.",
+      "translation": "Vận động hành lang",
+      "count": 0
+    },
+    {
+      "word": "luxury",
+      "meaning": "A state of great comfort and wealth.",
+      "example": "They stayed in a luxury resort by the sea.",
+      "translation": "Sang trọng",
+      "count": 0
+    },
+    {
+      "word": "magnificent (adjective)",
+      "meaning": "Impressively beautiful, elaborate, or grand in appearance",
+      "example": "The Louvre in Paris stands as a truly magnificent art museum.",
+      "translation": "tráng lệ",
+      "count": 0
+    },
+    {
+      "word": "mainly (adverb)",
+      "meaning": "Primarily or for the most part",
+      "example": "Gustavo mainly traveled to Europe to collect passport stamps.",
+      "translation": "chủ yếu",
+      "count": 0
+    },
+    {
+      "word": "maintain (verb)",
+      "meaning": "To keep in the same state or condition",
+      "example": "It was hard to maintain the audience’s focus after the mic failed.",
+      "translation": "duy trì",
+      "count": 0
+    },
+    {
+      "word": "mammoth (adjective)",
+      "meaning": "Extremely large or massive",
+      "example": "The First World Hotel in Malaysia is a mammoth structure.",
+      "translation": "khổng lồ",
+      "count": 0
+    },
+    {
+      "word": "manifest (adjective)",
+      "meaning": "Clearly visible or obvious to the eye or mind",
+      "example": "Her sadness was manifest in her expression.",
+      "translation": "hiển nhiên",
+      "count": 0
+    },
+    {
+      "word": "manipulate (verb)",
+      "meaning": "To skillfully control or influence something or someone",
+      "example": "He manipulated the situation to his advantage.",
+      "translation": "thao túng",
+      "count": 0
+    },
+    {
+      "word": "market (verb)",
+      "meaning": "To promote or sell a product or service",
+      "example": "The team is trying to market the new phone to teens.",
+      "translation": "tiếp thị",
+      "count": 0
+    },
+    {
+      "word": "metamorphosis (noun)",
+      "meaning": "A complete change in form, character, or structure",
+      "example": "The butterfly’s metamorphosis is a remarkable sight.",
+      "translation": "sự biến đổi",
+      "count": 0
+    },
+    {
+      "word": "migrate (verb)",
+      "meaning": "To move from one place to another, often seasonally",
+      "example": "Birds migrate south in the winter months.",
+      "translation": "di cư",
+      "count": 0
+    },
+    {
+      "word": "minimize (verb)",
+      "meaning": "To reduce something to the smallest possible amount",
+      "example": "We aim to minimize damage to the environment.",
+      "translation": "giảm thiểu",
+      "count": 0
+    },
+    {
+      "word": "mourn (verb)",
+      "meaning": "To feel or express deep sorrow for someone’s death",
+      "example": "Many gathered to mourn the loss of the hero.",
+      "translation": "than khóc",
+      "count": 0
+    },
+    {
+      "word": "myriad (noun)",
+      "meaning": "A countless or extremely large number",
+      "example": "A myriad of stars twinkled in the night sky.",
+      "translation": "vô số",
+      "count": 0
+    },
+    {
+      "word": "narrative (adjective)",
+      "meaning": "Related to storytelling or narration",
+      "example": "The novel uses a strong narrative structure.",
+      "translation": "có tính kể chuyện",
+      "count": 0
+    },
+    {
+      "word": "native (adjective)",
+      "meaning": "Belonging to a place by birth or origin",
+      "example": "She’s a native Spanish speaker.",
+      "translation": "bản địa",
+      "count": 0
+    },
+    {
+      "word": "nimble (adjective)",
+      "meaning": "Quick and light in movement or thought",
+      "example": "His nimble hands fixed the watch in minutes.",
+      "translation": "nhanh nhẹn",
+      "count": 0
+    },
+    {
+      "word": "notable (adjective)",
+      "meaning": "Worthy of attention or notice",
+      "example": "She won a notable science prize.",
+      "translation": "đáng chú ý",
+      "count": 0
+    },
+    {
+      "word": "notion (noun)",
+      "meaning": "An idea, belief, or opinion",
+      "example": "He had no notion what she meant.",
+      "translation": "ý niệm",
+      "count": 0
+    },
+    {
+      "word": "novel (adjective)",
+      "meaning": "New or unusual in an interesting way",
+      "example": "Their novel teaching method gained popularity.",
+      "translation": "mới lạ",
+      "count": 0
+    },
+    {
+      "word": "object (verb)",
+      "meaning": "To express disapproval or opposition",
+      "example": "They strongly objected to the new law.",
+      "translation": "phản đối",
+      "count": 0
+    },
+    {
+      "word": "oblige (verb)",
+      "meaning": "To require someone to do something by law or rule",
+      "example": "The rules oblige students to wear uniforms.",
+      "translation": "bắt buộc",
+      "count": 0
+    },
+    {
+      "word": "obliterate (verb)",
+      "meaning": "To destroy something completely",
+      "example": "The building was obliterated in the explosion.",
+      "translation": "xóa sổ",
+      "count": 0
+    },
+    {
+      "word": "obscure (adjective)",
+      "meaning": "Difficult to understand or hidden from view",
+      "example": "The book is filled with obscure references.",
+      "translation": "mơ hồ",
+      "count": 0
+    },
+    {
+      "word": "obsolete (adjective)",
+      "meaning": "Outdated or no longer used",
+      "example": "CDs have become obsolete in the streaming era.",
+      "translation": "lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "obstacle (noun)",
+      "meaning": "Something that blocks or hinders progress",
+      "example": "Lack of funds is a major obstacle.",
+      "translation": "trở ngại",
+      "count": 0
+    },
+    {
+      "word": "offset (verb)",
+      "meaning": "To counterbalance or compensate for something",
+      "example": "The cost was offset by a tax rebate.",
+      "translation": "bù lại",
+      "count": 0
+    },
+    {
+      "word": "onset (noun)",
+      "meaning": "The beginning or start of something",
+      "example": "The early onset of winter caught everyone by surprise.",
+      "translation": "sự bắt đầu",
+      "count": 0
+    },
+    {
+      "word": "operation (noun)",
+      "meaning": "An organized action or process; a mission or surgical procedure",
+      "example": "The rescue operation lasted several hours.",
+      "translation": "hoạt động",
+      "count": 0
+    },
+    {
+      "word": "ordinary (adjective)",
+      "meaning": "Common or normal; not special",
+      "example": "It felt like just another ordinary Monday.",
+      "translation": "bình thường",
+      "count": 0
+    },
+    {
+      "word": "outdo (verb)",
+      "meaning": "To perform better than someone else",
+      "example": "She outdid her rivals in the final round.",
+      "translation": "vượt trội",
+      "count": 0
+    },
+    {
+      "word": "outsource (verb)",
+      "meaning": "To assign work to a third-party provider",
+      "example": "They outsourced their IT support to reduce costs.",
+      "translation": "thuê ngoài",
+      "count": 0
+    },
+    {
+      "word": "outweigh (verb)",
+      "meaning": "To be more important or significant than something else",
+      "example": "The benefits clearly outweigh the risks.",
+      "translation": "nhiều hơn",
+      "count": 0
+    },
+    {
+      "word": "overcome (verb)",
+      "meaning": "To successfully deal with or defeat something",
+      "example": "He overcame every obstacle in his path.",
+      "translation": "vượt qua",
+      "count": 0
+    },
+    {
+      "word": "overwhelm (verb)",
+      "meaning": "To affect strongly or overpower emotionally or physically",
+      "example": "She was overwhelmed with gratitude.",
+      "translation": "áp đảo",
+      "count": 0
+    },
+    {
+      "word": "pace (noun)",
+      "meaning": "The speed or rate of movement or progress",
+      "example": "The pace of life is faster in big cities.",
+      "translation": "tốc độ",
+      "count": 0
+    },
+    {
+      "word": "paradox (noun)",
+      "meaning": "A situation or statement that seems contradictory but may be true",
+      "example": "It’s a paradox that exercise can be exhausting but also energizing.",
+      "translation": "nghịch lý",
+      "count": 0
+    },
+    {
+      "word": "parity (noun)",
+      "meaning": "Equality or equivalence in status or amount",
+      "example": "Gender parity in leadership is still lacking.",
+      "translation": "sự ngang bằng",
+      "count": 0
+    },
+    {
+      "word": "partial (adjective)",
+      "meaning": "Not complete; only a part of something",
+      "example": "We have only partial results at this point.",
+      "translation": "một phần",
+      "count": 0
+    },
+    {
+      "word": "peak (noun)",
+      "meaning": "The highest or most intense point",
+      "example": "Tourism reaches its peak during the summer.",
+      "translation": "đỉnh cao",
+      "count": 0
+    },
+    {
+      "word": "perception (noun)",
+      "meaning": "The way something is understood or interpreted",
+      "example": "Public perception of the event varied widely.",
+      "translation": "sự nhận thức",
+      "count": 0
+    },
+    {
+      "word": "periodic (adjective)",
+      "meaning": "Happening at regular intervals",
+      "example": "Periodic inspections ensure safety standards are met.",
+      "translation": "định kỳ",
+      "count": 0
+    },
+    {
+      "word": "permanent (adjective)",
+      "meaning": "Lasting or expected to last indefinitely",
+      "example": "He found a permanent job in the city.",
+      "translation": "vĩnh viễn",
+      "count": 0
+    },
+    {
+      "word": "persist (verb)",
+      "meaning": "To continue steadily in a course of action despite difficulty",
+      "example": "If you persist, success will come.",
+      "translation": "kiên trì",
+      "count": 0
+    },
+    {
+      "word": "phase (noun)",
+      "meaning": "A distinct stage in a process of development",
+      "example": "They entered the final phase of negotiations.",
+      "translation": "giai đoạn",
+      "count": 0
+    },
+    {
+      "word": "precede (verb)",
+      "meaning": "To come before something in time or order",
+      "example": "A short video will precede the documentary.",
+      "translation": "đi trước",
+      "count": 0
+    },
+    {
+      "word": "preserve (verb)",
+      "meaning": "To maintain or protect from harm or decay",
+      "example": "We work to preserve the natural landscape.",
+      "translation": "bảo tồn",
+      "count": 0
+    },
+    {
+      "word": "prohibit (verb)",
+      "meaning": "To formally forbid by law or rule",
+      "example": "The law prohibits alcohol sales to minors.",
+      "translation": "cấm",
+      "count": 0
+    },
+    {
+      "word": "prominent (adjective)",
+      "meaning": "Well-known or easily noticed",
+      "example": "She is a prominent leader in education reform.",
+      "translation": "nổi bật",
+      "count": 0
+    },
+    {
+      "word": "protest (verb)",
+      "meaning": "To express opposition through actions or words",
+      "example": "Citizens protested against rising fuel prices.",
+      "translation": "phản đối",
+      "count": 0
+    },
+    {
+      "word": "purpose (noun)",
+      "meaning": "The reason something is done or created",
+      "example": "His purpose is to inspire young artists.",
+      "translation": "mục đích",
+      "count": 0
+    },
+    {
+      "word": "questionable (adjective)",
+      "meaning": "Doubtful or open to suspicion",
+      "example": "His decision-making has been questionable lately.",
+      "translation": "đáng ngờ",
+      "count": 0
+    },
+    {
+      "word": "radical (adjective)",
+      "meaning": "Involving major or fundamental change",
+      "example": "The committee proposed radical reforms to the school curriculum.",
+      "translation": "căn bản",
+      "count": 0
+    },
+    {
+      "word": "ramification (noun)",
+      "meaning": "A consequence or result of an action",
+      "example": "They considered the legal ramifications of the merger.",
+      "translation": "hệ quả",
+      "count": 0
+    },
+    {
+      "word": "random (adjective)",
+      "meaning": "Happening without method or pattern",
+      "example": "The winners were chosen at random.",
+      "translation": "ngẫu nhiên",
+      "count": 0
+    },
+    {
+      "word": "range (noun)",
+      "meaning": "The span or extent of something",
+      "example": "The restaurant offers a wide range of dishes.",
+      "translation": "phạm vi",
+      "count": 0
+    },
+    {
+      "word": "readily",
+      "meaning": "Without hesitation or delay",
+      "example": "He readily accepted the job offer.",
+      "translation": "sẵn sàng",
+      "count": 0
+    },
+    {
+      "word": "reciprocal",
+      "meaning": "Mutual; shared by both sides",
+      "example": "They have a reciprocal friendship based on trust.",
+      "translation": "tương hỗ",
+      "count": 0
+    },
+    {
+      "word": "recognition",
+      "meaning": "The act of identifying or acknowledging something",
+      "example": "She received recognition for her contributions to the team.",
+      "translation": "sự công nhận",
+      "count": 0
+    },
+    {
+      "word": "record",
+      "meaning": "To capture or document something that happened",
+      "example": "He used his phone to record the meeting.",
+      "translation": "ghi lại",
+      "count": 0
+    },
+    {
+      "word": "recruit",
+      "meaning": "To find and enlist new people for a role",
+      "example": "The company needs to recruit more developers.",
+      "translation": "tuyển dụng",
+      "count": 0
+    },
+    {
+      "word": "recur",
+      "meaning": "To happen repeatedly or again",
+      "example": "Headaches may recur if you don’t rest enough.",
+      "translation": "tái diễn",
+      "count": 0
+    },
+    {
+      "word": "refine",
+      "meaning": "To improve or purify something",
+      "example": "The chef refined the recipe with better spices.",
+      "translation": "tinh chỉnh",
+      "count": 0
+    },
+    {
+      "word": "refute",
+      "meaning": "To disprove or challenge something as false",
+      "example": "She refuted the allegations with clear evidence.",
+      "translation": "bác bỏ",
+      "count": 0
+    },
+    {
+      "word": "relatively",
+      "meaning": "To a certain extent or in comparison",
+      "example": "The test was relatively easy compared to last year.",
+      "translation": "tương đối",
+      "count": 0
+    },
+    {
+      "word": "release",
+      "meaning": "To set free or let go of something",
+      "example": "The bird was released into the wild.",
+      "translation": "thả",
+      "count": 0
+    },
+    {
+      "word": "relevant",
+      "meaning": "Closely connected or applicable to the topic",
+      "example": "Please provide relevant examples for your argument.",
+      "translation": "liên quan",
+      "count": 0
+    },
+    {
+      "word": "replenish",
+      "meaning": "To refill or restore something",
+      "example": "They replenished the food supply for the camp.",
+      "translation": "bổ sung",
+      "count": 0
+    },
+    {
+      "word": "representative",
+      "meaning": "Typical of a group; acting on behalf of others",
+      "example": "The painting is representative of her early work.",
+      "translation": "tiêu biểu",
+      "count": 0
+    },
+    {
+      "word": "reproduce",
+      "meaning": "To make a copy or replicate something",
+      "example": "The artist reproduced the painting for the gallery.",
+      "translation": "tái tạo",
+      "count": 0
+    },
+    {
+      "word": "resilient",
+      "meaning": "Able to recover quickly from setbacks",
+      "example": "Children are often more resilient than we think.",
+      "translation": "kiên cường",
+      "count": 0
+    },
+    {
+      "word": "restrict",
+      "meaning": "To confine or place limits on something",
+      "example": "They restricted access to authorized personnel only.",
+      "translation": "hạn chế",
+      "count": 0
+    },
+    {
+      "word": "rigorous",
+      "meaning": "Strict or harsh in approach or conditions",
+      "example": "The training program is extremely rigorous.",
+      "translation": "nghiêm ngặt",
+      "count": 0
+    },
+    {
+      "word": "rue",
+      "meaning": "To feel regret or sorrow for something",
+      "example": "She will rue the day she made that choice.",
+      "translation": "hối tiếc",
+      "count": 0
+    },
+    {
+      "word": "sacred",
+      "meaning": "Regarded with deep respect or religious importance",
+      "example": "This forest is sacred to the local tribe.",
+      "translation": "thiêng liêng",
+      "count": 0
+    },
+    {
+      "word": "sallow",
+      "meaning": "Having a pale, yellowish skin tone",
+      "example": "He looked tired and had a sallow complexion.",
+      "translation": "vàng vọt",
+      "count": 0
+    },
+    {
+      "word": "sanction",
+      "meaning": "To officially approve or authorize something",
+      "example": "The board sanctioned the new project unanimously.",
+      "translation": "phê chuẩn",
+      "count": 0
+    },
+    {
+      "word": "satellite",
+      "meaning": "An object that orbits around a larger one, such as a moon or artificial device",
+      "example": "Modern phones use satellite signals for navigation.",
+      "translation": "vệ tinh",
+      "count": 0
+    },
+    {
+      "word": "scarce",
+      "meaning": "In limited supply; hard to find",
+      "example": "Fresh water is becoming increasingly scarce in some regions.",
+      "translation": "khan hiếm",
+      "count": 0
+    },
+    {
+      "word": "scrutinize",
+      "meaning": "To examine carefully in detail",
+      "example": "They scrutinized the document for any errors.",
+      "translation": "xem xét kỹ lưỡng",
+      "count": 0
+    },
+    {
+      "word": "seek",
+      "meaning": "To try to locate or pursue something",
+      "example": "They are seeking new opportunities abroad.",
+      "translation": "tìm kiếm",
+      "count": 0
+    },
+    {
+      "word": "sequence",
+      "meaning": "A particular order in which things follow",
+      "example": "She forgot the correct sequence of steps in the experiment.",
+      "translation": "chuỗi",
+      "count": 0
+    },
+    {
+      "word": "shallow",
+      "meaning": "Lacking depth or seriousness",
+      "example": "The conversation was too shallow for such a serious topic.",
+      "translation": "nông cạn",
+      "count": 0
+    },
+    {
+      "word": "simultaneously",
+      "meaning": "At the same time",
+      "example": "The cameras recorded the scene simultaneously from different angles.",
+      "translation": "đồng thời",
+      "count": 0
+    },
+    {
+      "word": "sinister",
+      "meaning": "Suggesting evil or harm",
+      "example": "There was a sinister tone in his voice.",
+      "translation": "độc ác",
+      "count": 0
+    },
+    {
+      "word": "soul",
+      "meaning": "The essential or spiritual part of a person or thing",
+      "example": "She poured her soul into the music.",
+      "translation": "linh hồn",
+      "count": 0
+    },
+    {
+      "word": "sovereign",
+      "meaning": "Independent; having full power",
+      "example": "Each state remained a sovereign entity.",
+      "translation": "có chủ quyền",
+      "count": 0
+    },
+    {
+      "word": "sporadic",
+      "meaning": "Happening irregularly or infrequently",
+      "example": "The city experienced sporadic power outages last week.",
+      "translation": "rời rạc",
+      "count": 0
+    },
+    {
+      "word": "spurn",
+      "meaning": "To reject with disdain",
+      "example": "He spurned the offer without a second thought.",
+      "translation": "hắt hủi",
+      "count": 0
+    },
+    {
+      "word": "stress",
+      "meaning": "To emphasize or highlight; to feel pressure",
+      "example": "The doctor stressed the importance of sleep.",
+      "translation": "nhấn mạnh",
+      "count": 0
+    },
+    {
+      "word": "stoic",
+      "meaning": "Calm and unaffected by pain or emotion",
+      "example": "She remained stoic despite the sad news.",
+      "translation": "bình thản",
+      "count": 0
+    },
+    {
+      "word": "strictly",
+      "meaning": "In a firm or rigid way",
+      "example": "The rules must be strictly followed.",
+      "translation": "nghiêm ngặt",
+      "count": 0
+    },
+    {
+      "word": "stupendous",
+      "meaning": "Extremely impressive or great in scale",
+      "example": "They achieved a stupendous victory.",
+      "translation": "to lớn",
+      "count": 0
+    },
+    {
+      "word": "subsidize",
+      "meaning": "To support financially, usually by a government",
+      "example": "Farmers are often subsidized to grow staple crops.",
+      "translation": "trợ cấp",
+      "count": 0
+    },
+    {
+      "word": "substantiate",
+      "meaning": "To prove something with evidence",
+      "example": "He couldn’t substantiate his claims in court.",
+      "translation": "chứng minh",
+      "count": 0
+    },
+    {
+      "word": "subtle",
+      "meaning": "Not obvious or easy to notice",
+      "example": "There was a subtle change in his tone.",
+      "translation": "tinh tế",
+      "count": 0
+    },
+    {
+      "word": "suitable",
+      "meaning": "Right or appropriate for a purpose",
+      "example": "We haven’t found a suitable venue yet.",
+      "translation": "phù hợp",
+      "count": 0
+    },
+    {
+      "word": "supine",
+      "meaning": "Lying on the back facing upward",
+      "example": "He lay supine under the clear sky.",
+      "translation": "nằm ngửa",
+      "count": 0
+    },
+    {
+      "word": "superfluous",
+      "meaning": "More than what is needed; unnecessary",
+      "example": "Delete any superfluous details from your report.",
+      "translation": "thừa thãi",
+      "count": 0
+    },
+    {
+      "word": "sustainable",
+      "meaning": "Able to be maintained over time without harm",
+      "example": "The building uses sustainable materials and practices.",
+      "translation": "bền vững",
+      "count": 0
+    },
+    {
+      "word": "tangible",
+      "meaning": "Real or touchable; perceptible by touch",
+      "example": "They needed tangible proof of progress.",
+      "translation": "hữu hình",
+      "count": 0
+    },
+    {
+      "word": "task",
+      "meaning": "A piece of work to be completed",
+      "example": "He finished the assigned task quickly.",
+      "translation": "nhiệm vụ",
+      "count": 0
+    },
+    {
+      "word": "taunt",
+      "meaning": "To mock or provoke in a scornful way",
+      "example": "The bullies taunted him for forgetting his lunch.",
+      "translation": "chế giễu",
+      "count": 0
+    },
+    {
+      "word": "temporal",
+      "meaning": "Related to worldly affairs or limited time",
+      "example": "He focused only on temporal matters, not spiritual ones.",
+      "translation": "thuộc về thời gian",
+      "count": 0
+    },
+    {
+      "word": "tenacious",
+      "meaning": "Determined and persistent in achieving goals",
+      "example": "She was tenacious in defending her ideas.",
+      "translation": "kiên trì",
+      "count": 0
+    },
+    {
+      "word": "tendency",
+      "meaning": "An inclination toward a certain type of behavior",
+      "example": "He has a tendency to be late.",
+      "translation": "xu hướng",
+      "count": 0
+    },
+    {
+      "word": "tenet",
+      "meaning": "A fundamental belief or principle",
+      "example": "Freedom of speech is a central tenet of democracy.",
+      "translation": "giáo lý",
+      "count": 0
+    },
+    {
+      "word": "territory",
+      "meaning": "A defined area under control of a group or authority",
+      "example": "Each team defended its territory fiercely.",
+      "translation": "lãnh thổ",
+      "count": 0
+    },
+    {
+      "word": "thoroughly",
+      "meaning": "Completely and with great attention to detail",
+      "example": "She cleaned the room thoroughly before the guests arrived.",
+      "translation": "một cách kỹ lưỡng",
+      "count": 0
+    },
+    {
+      "word": "tranquil",
+      "meaning": "Peaceful and quiet; free from disturbance",
+      "example": "They spent a tranquil evening by the lake.",
+      "translation": "thanh bình",
+      "count": 0
+    },
+    {
+      "word": "transformation",
+      "meaning": "A major change in form, appearance, or character",
+      "example": "The project led to a dramatic transformation of the neighborhood.",
+      "translation": "sự biến đổi",
+      "count": 0
+    },
+    {
+      "word": "trangress (verb)",
+      "meaning": "To violate a rule, law, or moral boundary",
+      "example": "He trangressed the company’s code of conduct.",
+      "translation": "vi phạm",
+      "count": 0
+    },
+    {
+      "word": "transition (noun)",
+      "meaning": "The process of shifting from one state or condition to another",
+      "example": "She helped him make the transition to college life.",
+      "translation": "sự chuyển đổi",
+      "count": 0
+    },
+    {
+      "word": "transient",
+      "meaning": "Lasting for a short time; temporary",
+      "example": "They stayed in a transient hotel for one night.",
+      "translation": "ngắn ngủi",
+      "count": 0
+    },
+    {
+      "word": "trivial (adjective)",
+      "meaning": "Of little importance or value",
+      "example": "He ignored the trivial complaints.",
+      "translation": "tầm thường",
+      "count": 0
+    },
+    {
+      "word": "ubiquitous (adjective)",
+      "meaning": "Found everywhere; widespread",
+      "example": "Smartphones have become ubiquitous in modern life.",
+      "translation": "phổ biến",
+      "count": 0
+    },
+    {
+      "word": "ultimately (adverb)",
+      "meaning": "In the end; eventually",
+      "example": "Ultimately, she decided to move abroad.",
+      "translation": "cuối cùng",
+      "count": 0
+    },
+    {
+      "word": "ultimatum (noun)",
+      "meaning": "A final demand or condition with consequences for rejection",
+      "example": "They issued an ultimatum to meet the deadline or lose the deal.",
+      "translation": "tối hậu thư",
+      "count": 0
+    },
+    {
+      "word": "unbecoming (adjective)",
+      "meaning": "Not appropriate or flattering",
+      "example": "His rude remarks were unbecoming of a leader.",
+      "translation": "không phù hợp",
+      "count": 0
+    },
+    {
+      "word": "uncanny (adjective)",
+      "meaning": "Strangely unusual or unsettling",
+      "example": "She had an uncanny ability to predict events.",
+      "translation": "kỳ lạ",
+      "count": 0
+    },
+    {
+      "word": "unconditional (adjective)",
+      "meaning": "Not limited by conditions; absolute",
+      "example": "He offered his unconditional support.",
+      "translation": "vô điều kiện",
+      "count": 0
+    },
+    {
+      "word": "uncouth (adjective)",
+      "meaning": "Lacking good manners or refinement",
+      "example": "His uncouth behavior embarrassed everyone at the dinner.",
+      "translation": "thô lỗ",
+      "count": 0
+    },
+    {
+      "word": "underestimate (noun)",
+      "meaning": "To judge something as less important or smaller than it is",
+      "example": "She underestimated how long the hike would take.",
+      "translation": "đánh giá thấp",
+      "count": 0
+    },
+    {
+      "word": "unequivocal (adjective)",
+      "meaning": "Clear and unambiguous",
+      "example": "His response was an unequivocal yes.",
+      "translation": "rõ ràng",
+      "count": 0
+    },
+    {
+      "word": "uniform (adjective)",
+      "meaning": "Always the same in form or character",
+      "example": "They applied a uniform rule across all departments.",
+      "translation": "đồng đều",
+      "count": 0
+    },
+    {
+      "word": "unique (adjective)",
+      "meaning": "One of a kind; unlike anything else",
+      "example": "Her design was truly unique.",
+      "translation": "độc đáo",
+      "count": 0
+    },
+    {
+      "word": "unison (noun)",
+      "meaning": "Simultaneous action or agreement",
+      "example": "They all sang in unison.",
+      "translation": "đồng thanh",
+      "count": 0
+    },
+    {
+      "word": "unwittingly (adverb)",
+      "meaning": "Without being aware; unintentionally",
+      "example": "She had unwittingly supported the people she disliked most.",
+      "translation": "một cách vô tình",
+      "count": 0
+    },
+    {
+      "word": "upset (adjective)",
+      "meaning": "Feeling unhappy or distressed",
+      "example": "Her kids often get upset over small disagreements at school.",
+      "translation": "buồn bực",
+      "count": 0
+    },
+    {
+      "word": "urge (verb)",
+      "meaning": "To encourage or push someone strongly",
+      "example": "The coach urged the team to keep trying until the end.",
+      "translation": "thúc giục",
+      "count": 0
+    },
+    {
+      "word": "utilize (verb)",
+      "meaning": "To make practical use of something",
+      "example": "They utilized the waterfall to generate electricity.",
+      "translation": "tận dụng",
+      "count": 0
+    },
+    {
+      "word": "vagrancy (noun)",
+      "meaning": "The act of roaming without a home or job",
+      "example": "Vagrancy is discouraged by most city ordinances.",
+      "translation": "tình trạng lang thang",
+      "count": 0
+    },
+    {
+      "word": "vanish (verb)",
+      "meaning": "To disappear suddenly or completely",
+      "example": "The fog vanished once the sun appeared.",
+      "translation": "biến mất",
+      "count": 0
+    },
+    {
+      "word": "vanquish (verb)",
+      "meaning": "To defeat thoroughly in battle or conflict",
+      "example": "They vanquished their opponents in the final round.",
+      "translation": "chinh phục",
+      "count": 0
+    },
+    {
+      "word": "variable (noun)",
+      "meaning": "A factor that can change in a situation",
+      "example": "Temperature is a key variable in this experiment.",
+      "translation": "biến số",
+      "count": 0
+    },
+    {
+      "word": "variety (noun)",
+      "meaning": "A number of different kinds",
+      "example": "The buffet included a variety of dishes.",
+      "translation": "đa dạng",
+      "count": 0
+    },
+    {
+      "word": "veneer (noun)",
+      "meaning": "A thin surface layer that hides the true nature",
+      "example": "He had a veneer of confidence that masked his nervousness.",
+      "translation": "lớp bề mặt",
+      "count": 0
+    },
+    {
+      "word": "versatile (adjective)",
+      "meaning": "Able to adapt to many functions or activities",
+      "example": "She’s a versatile performer who sings and acts equally well.",
+      "translation": "đa năng",
+      "count": 0
+    },
+    {
+      "word": "victim (noun)",
+      "meaning": "A person harmed by a situation or event",
+      "example": "The victim was taken to the hospital immediately.",
+      "translation": "nạn nhân",
+      "count": 0
+    },
+    {
+      "word": "vindication (noun)",
+      "meaning": "Proof that someone was right or justified",
+      "example": "He found vindication when his critics admitted they were wrong.",
+      "translation": "sự minh oan",
+      "count": 0
+    },
+    {
+      "word": "voracious (adjective)",
+      "meaning": "Having a huge appetite or eagerness",
+      "example": "He has a voracious appetite for science fiction novels.",
+      "translation": "ngấu nghiến",
+      "count": 0
+    },
+    {
+      "word": "vulnerable (adjective)",
+      "meaning": "Easily hurt or affected",
+      "example": "The elderly are more vulnerable to cold weather.",
+      "translation": "dễ bị tổn thương",
+      "count": 0
+    },
+    {
+      "word": "waive (verb)",
+      "meaning": "To give up a right or claim voluntarily",
+      "example": "She waived the late fee due to the emergency.",
+      "translation": "từ bỏ",
+      "count": 0
+    },
+    {
+      "word": "wary (adjective)",
+      "meaning": "Cautious or suspicious",
+      "example": "He’s wary of strangers offering deals.",
+      "translation": "cảnh giác",
+      "count": 0
+    },
+    {
+      "word": "whim (noun)",
+      "meaning": "A sudden and unplanned idea or desire",
+      "example": "They took a trip on a whim last weekend.",
+      "translation": "ý tưởng bất chợt",
+      "count": 0
+    },
+    {
+      "word": "whimsical (adjective)",
+      "meaning": "Playfully unusual or imaginative",
+      "example": "The decorations had a whimsical charm.",
+      "translation": "kỳ quặc, vui nhộn",
+      "count": 0
+    },
+    {
+      "word": "withstand (verb)",
+      "meaning": "To endure or resist something successfully",
+      "example": "This tent can withstand heavy winds.",
+      "translation": "chịu đựng",
+      "count": 0
+    },
+    {
+      "word": "wield (verb)",
+      "meaning": "To handle and use effectively",
+      "example": "The knight wielded his sword with skill.",
+      "translation": "sử dụng",
+      "count": 0
+    },
+    {
+      "word": "writhe (verb)",
+      "meaning": "To twist the body, often in pain",
+      "example": "He writhed in pain after twisting his ankle.",
+      "translation": "quằn quại",
+      "count": 0
+    },
+    {
+      "word": "self-study (n)",
+      "meaning": "Learning done without a teacher’s help",
+      "example": "She relied on self-study to pass the exam.",
+      "translation": "tự học",
+      "count": 0
+    },
+    {
+      "word": "seminar (n)",
+      "meaning": "A discussion-based academic class",
+      "example": "They had a seminar on climate policy.",
+      "translation": "hội thảo",
+      "count": 0
+    },
+    {
+      "word": "special needs (n)",
+      "meaning": "Educational or physical requirements for people with disabilities",
+      "example": "The school supports children with special needs.",
+      "translation": "nhu cầu đặc biệt",
+      "count": 0
+    },
+    {
+      "word": "tuition (n)",
+      "meaning": "Instruction or fees paid for teaching services",
+      "example": "He receives private tuition to improve his math skills.",
+      "translation": "học phí, giảng dạy",
+      "count": 0
+    },
+    {
+      "word": "tutorial (n)",
+      "meaning": "A session where a small group discusses a topic with a teacher",
+      "example": "The climate adaptation tutorial was very enlightening.",
+      "translation": "bài hướng dẫn",
+      "count": 0
+    },
+    {
+      "word": "adapt (v)",
+      "meaning": "To adjust thoughts or behavior for a new condition",
+      "example": "A smart company adapts to market changes quickly.",
+      "translation": "thích nghi",
+      "count": 0
+    },
+    {
+      "word": "adjust (v)",
+      "meaning": "To change slightly to improve accuracy or function",
+      "example": "You can adjust the brightness using that knob.",
+      "translation": "điều chỉnh",
+      "count": 0
+    },
+    {
+      "word": "alternate (v)",
+      "meaning": "To switch repeatedly between two things",
+      "example": "We alternate between study and rest every hour.",
+      "translation": "luân phiên",
+      "count": 0
+    },
+    {
+      "word": "alternate (adj)",
+      "meaning": "Happening in turns or every other time",
+      "example": "She works alternate weekends.",
+      "translation": "xen kẽ",
+      "count": 0
+    },
+    {
+      "word": "alternative (adj)",
+      "meaning": "Offering a different choice or substitute",
+      "example": "We’ll take an alternative route to avoid traffic.",
+      "translation": "thay thế",
+      "count": 0
+    },
+    {
+      "word": "amend (v)",
+      "meaning": "To revise or improve a rule, law, or document",
+      "example": "Please amend the document before submitting.",
+      "translation": "sửa đổi",
+      "count": 0
+    },
+    {
+      "word": "conservative (adj)",
+      "meaning": "Resistant to change; traditional",
+      "example": "The community was quite conservative in its views.",
+      "translation": "bảo thủ",
+      "count": 0
+    },
+    {
+      "word": "convert (v)",
+      "meaning": "To switch systems or forms",
+      "example": "The files were converted to a different format.",
+      "translation": "chuyển đổi",
+      "count": 0
+    },
+    {
+      "word": "convert (v)",
+      "meaning": "To adopt a different belief, especially religious",
+      "example": "She converted to Buddhism last year.",
+      "translation": "thay đổi tín ngưỡng",
+      "count": 0
+    },
+    {
+      "word": "convert (n)",
+      "meaning": "A person who adopts new beliefs",
+      "example": "He’s a recent convert to vegetarianism.",
+      "translation": "người cải đạo",
+      "count": 0
+    },
+    {
+      "word": "decay (v)",
+      "meaning": "To slowly break down over time due to natural causes",
+      "example": "The old building began to decay.",
+      "translation": "phân rã",
+      "count": 0
+    },
+    {
+      "word": "decay (n)",
+      "meaning": "The process of breaking down gradually",
+      "example": "Tooth decay is caused by sugary foods.",
+      "translation": "suy thoái",
+      "count": 0
+    },
+    {
+      "word": "deteriorate (v)",
+      "meaning": "To become worse over time",
+      "example": "The road surface has deteriorated badly.",
+      "translation": "trở nên tồi tệ hơn",
+      "count": 0
+    },
+    {
+      "word": "distort (v)",
+      "meaning": "To twist something out of its true meaning",
+      "example": "The article distorted the politician’s statement.",
+      "translation": "bóp méo",
+      "count": 0
+    },
+    {
+      "word": "dynamic (adj)",
+      "meaning": "Constantly changing or evolving",
+      "example": "Technology is a dynamic field.",
+      "translation": "năng động",
+      "count": 0
+    },
+    {
+      "word": "endure (v)",
+      "meaning": "To suffer through something difficult",
+      "example": "They endured the harsh winter conditions.",
+      "translation": "chịu đựng",
+      "count": 0
+    },
+    {
+      "word": "endure (v)",
+      "meaning": "To last or continue over time",
+      "example": "Their legacy has endured for generations.",
+      "translation": "kéo dài",
+      "count": 0
+    },
+    {
+      "word": "evolve (v)",
+      "meaning": "To grow or change gradually",
+      "example": "The system evolved over time.",
+      "translation": "tiến hóa",
+      "count": 0
+    },
+    {
+      "word": "evolve (v)",
+      "meaning": "To gradually transform into something new",
+      "example": "Our policies evolved to reflect new priorities.",
+      "translation": "tiến triển",
+      "count": 0
+    },
+    {
+      "word": "influence (v)",
+      "meaning": "To affect someone’s thoughts or behavior",
+      "example": "Media influences public opinion heavily.",
+      "translation": "ảnh hưởng",
+      "count": 0
+    },
+    {
+      "word": "influence (n)",
+      "meaning": "The power to affect others",
+      "example": "Her influence over the group is undeniable.",
+      "translation": "sức ảnh hưởng",
+      "count": 0
+    },
+    {
+      "word": "innovation (n)",
+      "meaning": "A new method, idea, or device",
+      "example": "Innovation is key to staying competitive.",
+      "translation": "sự đổi mới",
+      "count": 0
+    },
+    {
+      "word": "innovative (adj)",
+      "meaning": "Introducing new ideas or methods",
+      "example": "He proposed several innovative solutions.",
+      "translation": "có tính đổi mới",
+      "count": 0
+    },
+    {
+      "word": "last (v)",
+      "meaning": "To continue to exist or happen for a duration",
+      "example": "The movie lasts about two hours.",
+      "translation": "kéo dài",
+      "count": 0
+    },
+    {
+      "word": "maintain (v)",
+      "meaning": "To keep something the same over time",
+      "example": "He struggles to maintain his current lifestyle.",
+      "translation": "duy trì",
+      "count": 0
+    },
+    {
+      "word": "mature (v)",
+      "meaning": "To develop into an adult or become more sensible",
+      "example": "As you mature, your perspective will change.",
+      "translation": "trưởng thành",
+      "count": 0
+    },
+    {
+      "word": "mature (adj)",
+      "meaning": "Behaving responsibly like an adult",
+      "example": "He's more mature than most kids his age.",
+      "translation": "có tính trưởng thành",
+      "count": 0
+    },
+    {
+      "word": "modify (v)",
+      "meaning": "To make slight improvements or adjustments",
+      "example": "They modified the plan to avoid delays.",
+      "translation": "chỉnh sửa",
+      "count": 0
+    },
+    {
+      "word": "novel (adj)",
+      "meaning": "New, original, or unusual",
+      "example": "He introduced a novel method of teaching.",
+      "translation": "mới lạ",
+      "count": 0
+    },
+    {
+      "word": "persist (v)",
+      "meaning": "To continue doing something despite difficulty or opposition",
+      "example": "If you persist in lying, no one will trust you.",
+      "translation": "khăng khăng",
+      "count": 0
+    },
+    {
+      "word": "potential (n)",
+      "meaning": "The ability to grow or achieve something in the future",
+      "example": "She has great potential as a leader.",
+      "translation": "tiềm năng",
+      "count": 0
+    },
+    {
+      "word": "potential (adj)",
+      "meaning": "Capable of becoming real in the future",
+      "example": "That area is a potential development site.",
+      "translation": "thuộc tiềm năng",
+      "count": 0
+    },
+    {
+      "word": "progress (v)",
+      "meaning": "To improve or move forward over time",
+      "example": "The patient has progressed well since surgery.",
+      "translation": "tiến triển",
+      "count": 0
+    },
+    {
+      "word": "optimistic (adj) /ˌɒptɪˈmɪstɪk/",
+      "meaning": "Feeling hopeful or positive about the future",
+      "example": "He gave an optimistic speech about the economy.",
+      "translation": "tích cực",
+      "count": 0
+    },
+    {
+      "word": "paradox (n) /ˈpærədɒks/",
+      "meaning": "A situation that seems contradictory but may be true",
+      "example": "It’s a paradox that poorer people often donate more.",
+      "translation": "nghịch lý",
+      "count": 0
+    },
+    {
+      "word": "pessimistic (adj) /ˌpesɪˈmɪstɪk/",
+      "meaning": "Expecting the worst or having little hope for the future",
+      "example": "He’s pessimistic about finding a new job.",
+      "translation": "bi quan",
+      "count": 0
+    },
+    {
+      "word": "plausible (adj) /ˈplɔːzəbl/",
+      "meaning": "Seeming likely or reasonable",
+      "example": "His story sounded plausible, but still suspicious.",
+      "translation": "hợp lý, đáng tin",
+      "count": 0
+    },
+    {
+      "word": "ponder (v) /ˈpɒndər/",
+      "meaning": "To think deeply about something",
+      "example": "She pondered the question for a while before answering.",
+      "translation": "cân nhắc",
+      "count": 0
+    },
+    {
+      "word": "prejudiced (adj) /ˈpredʒədɪst/",
+      "meaning": "Having an unfair or unreasonable dislike",
+      "example": "He’s prejudiced against people from other cities.",
+      "translation": "có thành kiến",
+      "count": 0
+    },
+    {
+      "word": "presume (v) /prɪˈzjuːm/",
+      "meaning": "To assume something is true without proof",
+      "example": "I presume she’s on her way.",
+      "translation": "đoán chừng",
+      "count": 0
+    },
+    {
+      "word": "query (n) /ˈkwɪəri/",
+      "meaning": "A question or inquiry",
+      "example": "I have a few queries about the procedure.",
+      "translation": "câu hỏi, điều thắc mắc",
+      "count": 0
+    },
+    {
+      "word": "query (v) /ˈkwɪəri/",
+      "meaning": "To ask or question something out of doubt",
+      "example": "He queried the decision to delay the launch.",
+      "translation": "hỏi",
+      "count": 0
+    },
+    {
+      "word": "reckon (v) /ˈrekən/",
+      "meaning": "To believe or think something is true",
+      "example": "I reckon he’s right about that issue.",
+      "translation": "cho rằng",
+      "count": 0
+    },
+    {
+      "word": "reflect (v) /rɪˈflekt/",
+      "meaning": "To think seriously and carefully about something",
+      "example": "She reflected on her mistakes after the meeting.",
+      "translation": "ngẫm nghĩ",
+      "count": 0
+    },
+    {
+      "word": "sceptical (adj) /ˈskeptɪkl/",
+      "meaning": "Doubting or not easily convinced",
+      "example": "I’m sceptical about his promises.",
+      "translation": "hoài nghi",
+      "count": 0
+    },
+    {
+      "word": "speculate (v) /ˈspekjuleɪt/",
+      "meaning": "To guess possible answers or reasons",
+      "example": "Experts speculate that the market will recover soon.",
+      "translation": "suy xét",
+      "count": 0
+    },
+    {
+      "word": "suppose (v) /səˈpəʊz/",
+      "meaning": "To assume something is true without certain proof",
+      "example": "I suppose she’s at home now.",
+      "translation": "giả định",
+      "count": 0
+    },
+    {
+      "word": "academic (adj) /ˌækəˈdemɪk/",
+      "meaning": "Related to school or scholarly study",
+      "example": "He prefers academic work over practical tasks.",
+      "translation": "học thuật",
+      "count": 0
+    },
+    {
+      "word": "academic (n) /ˌækəˈdemɪk/",
+      "meaning": "A person involved in teaching or research in a scholarly field",
+      "example": "She's a respected academic in economics.",
+      "translation": "nhà học thuật",
+      "count": 0
+    },
+    {
+      "word": "conscientious (adj) /ˌkɒnʃiˈenʃəs/",
+      "meaning": "Showing great care and attention to detail in one's work",
+      "example": "He’s always been a conscientious student.",
+      "translation": "chu đáo",
+      "count": 0
+    },
+    {
+      "word": "cram (v) /kræm/",
+      "meaning": "To study intensively over a short period of time",
+      "example": "She crammed all night before the test.",
+      "translation": "nhồi nhét",
+      "count": 0
+    },
+    {
+      "word": "curriculum (n) /kəˈrɪkjələm/",
+      "meaning": "The set of courses or subjects taught in a school",
+      "example": "The curriculum includes math, science, and literature.",
+      "translation": "chương trình giảng dạy",
+      "count": 0
+    },
+    {
+      "word": "distance learning (n ph) /ˈdɪstəns ˈlɜːnɪŋ/",
+      "meaning": "A method of studying remotely without being physically present in a classroom",
+      "example": "He enrolled in a university through distance learning.",
+      "translation": "học từ xa",
+      "count": 0
+    },
+    {
+      "word": "graduate (n) /ˈɡrædʒuət/",
+      "meaning": "A person who has completed a university degree",
+      "example": "He’s a law graduate from Harvard.",
+      "translation": "người tốt nghiệp",
+      "count": 0
+    },
+    {
+      "word": "graduate (v) /ˈɡrædʒueɪt/",
+      "meaning": "To successfully complete a degree or course",
+      "example": "She graduated with honors in 2020.",
+      "translation": "tốt nghiệp",
+      "count": 0
+    },
+    {
+      "word": "ignorant (adj) /ˈɪɡnərənt/",
+      "meaning": "Lacking knowledge or awareness in general or in a specific subject",
+      "example": "He was ignorant of the local customs.",
+      "translation": "thiếu hiểu biết",
+      "count": 0
+    },
+    {
+      "word": "inattentive (adj) /ˌɪnəˈtentɪv/",
+      "meaning": "Not paying enough attention",
+      "example": "Students became inattentive during the long lecture.",
+      "translation": "không chú ý",
+      "count": 0
+    },
+    {
+      "word": "intellectual (adj) /ˌɪntəˈlektʃuəl/",
+      "meaning": "Involving serious thought or mental effort",
+      "example": "Chess is considered an intellectual game.",
+      "translation": "trí tuệ",
+      "count": 0
+    },
+    {
+      "word": "intellectual (n) /ˌɪntəˈlektʃuəl/",
+      "meaning": "A person interested in learning, art, or literature",
+      "example": "The cafe was popular with artists and intellectuals.",
+      "translation": "trí thức",
+      "count": 0
+    },
+    {
+      "word": "intelligent (adj) /ɪnˈtelɪdʒənt/",
+      "meaning": "Having or showing high mental capacity",
+      "example": "She's very intelligent and picks up things quickly.",
+      "translation": "thông minh",
+      "count": 0
+    },
+    {
+      "word": "intensive (adj) /ɪnˈtensɪv/",
+      "meaning": "Involving a lot of concentrated effort or activity",
+      "example": "He attended an intensive training program.",
+      "translation": "tập trung",
+      "count": 0
+    },
+    {
+      "word": "knowledgeable (adj) /ˈnɒlɪdʒəbl/",
+      "meaning": "Having a lot of knowledge or understanding",
+      "example": "She’s very knowledgeable about classical music.",
+      "translation": "am hiểu",
+      "count": 0
+    },
+    {
+      "word": "lecture (n) /ˈlektʃər/",
+      "meaning": "A formal talk given to students or an audience",
+      "example": "He gave a lecture on modern architecture.",
+      "translation": "bài thuyết giảng",
+      "count": 0
+    },
+    {
+      "word": "lecture (v) /ˈlektʃər/",
+      "meaning": "To give an educational talk to an audience",
+      "example": "She lectures in art history at the university.",
+      "translation": "giảng bài",
+      "count": 0
+    },
+    {
+      "word": "mock exam (n ph) /mɒk ɪɡˈzæm/",
+      "meaning": "A practice test taken before the real one",
+      "example": "Mock exams help students prepare for finals.",
+      "translation": "bài thi thử",
+      "count": 0
+    },
+    {
+      "word": "plagiarise (v) /ˈpleɪdʒəraɪz/",
+      "meaning": "To copy another’s work without permission",
+      "example": "He was caught plagiarising a published article.",
+      "translation": "đạo văn",
+      "count": 0
+    },
+    {
+      "word": "manual (adj)",
+      "meaning": "Done by hand rather than automatically or digitally",
+      "example": "This machine still needs manual control.",
+      "translation": "thủ công",
+      "count": 0
+    },
+    {
+      "word": "manual (n)",
+      "meaning": "A book containing instructions or information",
+      "example": "Refer to the manual for setup guidelines.",
+      "translation": "sách hướng dẫn",
+      "count": 0
+    },
+    {
+      "word": "network (v)",
+      "meaning": "To link computers for sharing information",
+      "example": "They networked all the office devices together.",
+      "translation": "kết nối",
+      "count": 0
+    },
+    {
+      "word": "network (n)",
+      "meaning": "A system of connected computers",
+      "example": "The company's internal network was down.",
+      "translation": "mạng lưới các máy tính được kết nối",
+      "count": 0
+    },
+    {
+      "word": "nuclear (adj)",
+      "meaning": "Related to atomic energy or weapons",
+      "example": "Nuclear power is a major energy source.",
+      "translation": "hạt nhân",
+      "count": 0
+    },
+    {
+      "word": "offline (adj)",
+      "meaning": "Not connected to the Internet",
+      "example": "You can play the game offline too.",
+      "translation": "ngoại tuyến",
+      "count": 0
+    },
+    {
+      "word": "online (adj)",
+      "meaning": "Connected to or available on the Internet",
+      "example": "Online learning is now widely accessible.",
+      "translation": "trực tuyến",
+      "count": 0
+    },
+    {
+      "word": "primitive (adj)",
+      "meaning": "At an early stage of development, lacking modern features or advancements",
+      "example": "Early humans used primitive tools made of stone.",
+      "translation": "nguyên thủy",
+      "count": 0
+    },
+    {
+      "word": "programmer (n)",
+      "meaning": "A person who writes and maintains computer software",
+      "example": "He works as a programmer specializing in mobile apps.",
+      "translation": "lập trình viên",
+      "count": 0
+    },
+    {
+      "word": "resource (n)",
+      "meaning": "Something used for support or help in achieving a goal",
+      "example": "Books and online databases are essential research resources.",
+      "translation": "tài nguyên",
+      "count": 0
+    },
+    {
+      "word": "technique (n)",
+      "meaning": "A particular way of doing something that involves skill",
+      "example": "She improved her painting technique through practice.",
+      "translation": "kỹ thuật",
+      "count": 0
+    },
+    {
+      "word": "upload (v)",
+      "meaning": "To send data from a local system to the internet or another system",
+      "example": "He uploaded the presentation to the shared drive.",
+      "translation": "tải lên mạng",
+      "count": 0
+    },
+    {
+      "word": "abrupt (adj)",
+      "meaning": "Happening suddenly and unexpectedly",
+      "example": "His departure was so abrupt it surprised everyone.",
+      "translation": "đột ngột",
+      "count": 0
+    },
+    {
+      "word": "anachronism (n)",
+      "meaning": "Something outdated or belonging to a different time period",
+      "example": "Using floppy disks today feels like an anachronism.",
+      "translation": "vật không đúng niên đại, việc lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "annual (adj)",
+      "meaning": "Happening once every year",
+      "example": "They hold an annual company picnic each summer.",
+      "translation": "hàng năm, thường niên",
+      "count": 0
+    },
+    {
+      "word": "antique (adj)",
+      "meaning": "Very old and often valuable",
+      "example": "She collects antique clocks from the 19th century.",
+      "translation": "cổ xưa",
+      "count": 0
+    },
+    {
+      "word": "antique (n)",
+      "meaning": "A valuable old item, often collected or displayed",
+      "example": "The shop sells antiques and rare books.",
+      "translation": "đồ cổ",
+      "count": 0
+    },
+    {
+      "word": "century (n)",
+      "meaning": "A period of one hundred years",
+      "example": "The 21st century began in the year 2000.",
+      "translation": "thế kỷ",
+      "count": 0
+    },
+    {
+      "word": "chronological (adj)",
+      "meaning": "Arranged in time order",
+      "example": "The events were listed in chronological sequence.",
+      "translation": "(theo) thứ tự thời gian",
+      "count": 0
+    },
+    {
+      "word": "contemporary (adj)",
+      "meaning": "Related to or existing in the present time",
+      "example": "Contemporary music often blends multiple genres.",
+      "translation": "đương đại",
+      "count": 0
+    },
+    {
+      "word": "contemporary (adj)",
+      "meaning": "Living or existing at the same time as something or someone else",
+      "example": "He was a contemporary of Albert Einstein.",
+      "translation": "cùng thời",
+      "count": 0
+    },
+    {
+      "word": "decade (n)",
+      "meaning": "A span of ten years",
+      "example": "She worked for the same company for a decade.",
+      "translation": "thập kỷ",
+      "count": 0
+    },
+    {
+      "word": "duration (n)",
+      "meaning": "The length of time that something lasts",
+      "example": "The duration of the exam is two hours.",
+      "translation": "khoảng thời gian",
+      "count": 0
+    },
+    {
+      "word": "eternal (adj)",
+      "meaning": "Lasting forever or for an unlimited time",
+      "example": "They promised each other eternal love.",
+      "translation": "vĩnh cửu",
+      "count": 0
+    },
+    {
+      "word": "expire (v)",
+      "meaning": "To come to an end, usually for legal or official documents",
+      "example": "Her passport will expire next month.",
+      "translation": "hết hiệu lực",
+      "count": 0
+    },
+    {
+      "word": "frequency (n)",
+      "meaning": "How often something happens in a period of time",
+      "example": "The frequency of traffic jams has increased.",
+      "translation": "tần suất",
+      "count": 0
+    },
+    {
+      "word": "instantaneous (adj)",
+      "meaning": "Happening or done immediately",
+      "example": "The reaction was almost instantaneous.",
+      "translation": "tức thời",
+      "count": 0
+    },
+    {
+      "word": "interim (adj)",
+      "meaning": "Temporary or provisional until something permanent is available",
+      "example": "They appointed an interim manager.",
+      "translation": "tạm thời",
+      "count": 0
+    },
+    {
+      "word": "interim (n)",
+      "meaning": "The time between two events or periods",
+      "example": "He took up painting in the interim between jobs.",
+      "translation": "thời gian chuyển tiếp",
+      "count": 0
+    },
+    {
+      "word": "interval (n)",
+      "meaning": "A short break between parts of a performance or activity",
+      "example": "There will be a 15-minute interval between acts.",
+      "translation": "giờ giải lao",
+      "count": 0
+    },
+    {
+      "word": "lapse (n)",
+      "meaning": "A pause or break in continuity",
+      "example": "There was a lapse of memory during the speech.",
+      "translation": "khoảng thời gian giữa 2 sự việc",
+      "count": 0
+    },
+    {
+      "word": "lapse (v)",
+      "meaning": "To gradually stop or slip into a different state",
+      "example": "His concentration lapsed after the first hour.",
+      "translation": "dần ngưng lại",
+      "count": 0
+    },
+    {
+      "word": "lifetime (n)",
+      "meaning": "The span of time someone is alive",
+      "example": "He made remarkable contributions during his lifetime.",
+      "translation": "cuộc đời",
+      "count": 0
+    },
+    {
+      "word": "long-standing (adj)",
+      "meaning": "Having existed for a significant period",
+      "example": "Their long-standing collaboration led to many achievements.",
+      "translation": "lâu đời, lâu dài",
+      "count": 0
+    },
+    {
+      "word": "millennium (n)",
+      "meaning": "A time period of one thousand years",
+      "example": "The monument dates back to the previous millennium.",
+      "translation": "thiên niên kỷ",
+      "count": 0
+    },
+    {
+      "word": "obsolete (adj)",
+      "meaning": "Outdated and no longer useful",
+      "example": "Many VHS tapes are now obsolete.",
+      "translation": "lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "overdue (adj)",
+      "meaning": "Past the expected or scheduled time",
+      "example": "The project report is long overdue.",
+      "translation": "quá hạn",
+      "count": 0
+    },
+    {
+      "word": "lapse (n)",
+      "meaning": "A temporary break or pause in activity",
+      "example": "There was a lapse in communication between the teams.",
+      "translation": "khoảng thời gian",
+      "count": 0
+    },
+    {
+      "word": "lapse (v)",
+      "meaning": "To gradually cease or come to a stop",
+      "example": "Her concentration lapsed after the long meeting.",
+      "translation": "dần ngừng lại",
+      "count": 0
+    },
+    {
+      "word": "period (n)",
+      "meaning": "A defined stretch of time",
+      "example": "They faced a difficult period after the merger.",
+      "translation": "thời kỳ",
+      "count": 0
+    },
+    {
+      "word": "permanent (adj)",
+      "meaning": "Meant to last indefinitely",
+      "example": "The tattoo is a permanent reminder of his trip.",
+      "translation": "vĩnh viễn",
+      "count": 0
+    },
+    {
+      "word": "phase (n)",
+      "meaning": "A specific stage in a sequence of events",
+      "example": "They entered the testing phase of the project.",
+      "translation": "giai đoạn",
+      "count": 0
+    },
+    {
+      "word": "postpone (v)",
+      "meaning": "To reschedule for a later time",
+      "example": "The school trip was postponed due to weather.",
+      "translation": "trì hoãn",
+      "count": 0
+    },
+    {
+      "word": "prior (adj)",
+      "meaning": "Occurring earlier in time",
+      "example": "You need prior approval to access the data.",
+      "translation": "trước",
+      "count": 0
+    },
+    {
+      "word": "prompt (adj)",
+      "meaning": "Done without delay or hesitation",
+      "example": "Prompt action prevented further damage.",
+      "translation": "nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "provisional (adj)",
+      "meaning": "Intended to be temporary or conditional",
+      "example": "The provisional schedule is subject to change.",
+      "translation": "lâm thời",
+      "count": 0
+    },
+    {
+      "word": "punctual (adj)",
+      "meaning": "Happening at the agreed or scheduled time",
+      "example": "He’s always punctual for team meetings.",
+      "translation": "đúng giờ",
+      "count": 0
+    },
+    {
+      "word": "seasonal (adj)",
+      "meaning": "Associated with or occurring in a season",
+      "example": "Seasonal discounts are available during the holidays.",
+      "translation": "theo mùa",
+      "count": 0
+    },
+    {
+      "word": "simultaneous (adj)",
+      "meaning": "Occurring at the same moment",
+      "example": "They held simultaneous press conferences in two cities.",
+      "translation": "đồng thời",
+      "count": 0
+    },
+    {
+      "word": "span (v)",
+      "meaning": "To cover a length of time",
+      "example": "Her career spans over four decades.",
+      "translation": "kéo dài",
+      "count": 0
+    },
+    {
+      "word": "span (n)",
+      "meaning": "A measurable extent of time",
+      "example": "The course lasted a span of eight weeks.",
+      "translation": "quãng thời gian",
+      "count": 0
+    },
+    {
+      "word": "spell (n)",
+      "meaning": "A short duration of time",
+      "example": "He spent a brief spell in the countryside.",
+      "translation": "đợt",
+      "count": 0
+    },
+    {
+      "word": "stint (n)",
+      "meaning": "a limited period spent doing a specific task or role",
+      "example": "He worked a short stint as a server in New York.",
+      "translation": "thời gian làm việc",
+      "count": 0
+    },
+    {
+      "word": "subsequent (adj)",
+      "meaning": "happening after something else",
+      "example": "In later interviews, he contradicted what he initially said.",
+      "translation": "tiếp theo",
+      "count": 0
+    },
+    {
+      "word": "temporary (adj)",
+      "meaning": "lasting or intended to last for a short time only",
+      "example": "He found a temporary job during the summer break.",
+      "translation": "tạm thời",
+      "count": 0
+    },
+    {
+      "word": "timely (adj)",
+      "meaning": "happening at the right or useful moment",
+      "example": "Their timely arrival prevented a major delay.",
+      "translation": "đúng lúc",
+      "count": 0
+    },
+    {
+      "word": "vintage (adj)",
+      "meaning": "typical or best of its kind, often from the past",
+      "example": "She gave a vintage performance in the final match.",
+      "translation": "điển hình, cổ điển",
+      "count": 0
+    },
+    {
+      "word": "vintage (n)",
+      "meaning": "the year or period something was made or produced",
+      "example": "He collects wines from different vintages.",
+      "translation": "năm sản xuất",
+      "count": 0
+    },
+    {
+      "word": "civil service (n phr)",
+      "meaning": "government departments and the employees working in them",
+      "example": "He has worked in the civil service for over a decade.",
+      "translation": "cơ quan nhà nước",
+      "count": 0
+    },
+    {
+      "word": "client (n)",
+      "meaning": "a person who pays for professional services",
+      "example": "Our firm provides financial advice to wealthy clients.",
+      "translation": "khách hàng",
+      "count": 0
+    },
+    {
+      "word": "colleague (n)",
+      "meaning": "a person you work with",
+      "example": "She always shares her ideas with her colleagues.",
+      "translation": "đồng nghiệp",
+      "count": 0
+    },
+    {
+      "word": "consultant (n)",
+      "meaning": "a person with expertise hired for advice",
+      "example": "They hired a marketing consultant to improve outreach.",
+      "translation": "chuyên gia tư vấn",
+      "count": 0
+    },
+    {
+      "word": "effective (adj)",
+      "meaning": "producing the intended result successfully",
+      "example": "This medication is highly effective for treating colds.",
+      "translation": "hiệu quả",
+      "count": 0
+    },
+    {
+      "word": "efficient (adj)",
+      "meaning": "working well without wasting time or effort",
+      "example": "Solar panels are becoming more efficient each year.",
+      "translation": "hiệu suất cao",
+      "count": 0
+    },
+    {
+      "word": "executive (n)",
+      "meaning": "a person with a senior managerial role",
+      "example": "The company’s top executives met to discuss the merger.",
+      "translation": "giám đốc điều hành",
+      "count": 0
+    },
+    {
+      "word": "headhunt (v)",
+      "meaning": "to recruit someone directly for a job",
+      "example": "She was headhunted by a tech startup.",
+      "translation": "săn đầu người",
+      "count": 0
+    },
+    {
+      "word": "income (n)",
+      "meaning": "the money earned from work or investments",
+      "example": "Her main source of income comes from freelance writing.",
+      "translation": "thu nhập",
+      "count": 0
+    },
+    {
+      "word": "industry (n)",
+      "meaning": "a field of economic activity producing goods or services",
+      "example": "The fashion industry changes rapidly each season.",
+      "translation": "ngành công nghiệp",
+      "count": 0
+    },
+    {
+      "word": "leave (n)",
+      "meaning": "a period of time off from work",
+      "example": "She took maternity leave after giving birth.",
+      "translation": "nghỉ phép",
+      "count": 0
+    },
+    {
+      "word": "marketing (n)",
+      "meaning": "activities to promote and sell products or services",
+      "example": "Their marketing strategy boosted product sales quickly.",
+      "translation": "tiếp thị",
+      "count": 0
+    },
+    {
+      "word": "multinational (n)",
+      "meaning": "a large corporation operating in multiple countries",
+      "example": "He works at a leading multinational in electronics.",
+      "translation": "công ty đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "multinational (adj)",
+      "meaning": "involving or relating to many countries",
+      "example": "The conference had multinational participants from five continents.",
+      "translation": "đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "promotion (n)",
+      "meaning": "advancement to a higher job position",
+      "example": "She received a promotion after just six months.",
+      "translation": "thăng chức",
+      "count": 0
+    },
+    {
+      "word": "prospects (n pl)",
+      "meaning": "chances for success or advancement",
+      "example": "He moved to the city for better career prospects.",
+      "translation": "triển vọng",
+      "count": 0
+    },
+    {
+      "word": "fire (v)",
+      "meaning": "to dismiss someone from their job",
+      "example": "He was fired for repeated absences.",
+      "translation": "sa thải",
+      "count": 0
+    },
+    {
+      "word": "marketing (n) /ˈmɑːrkɪtɪŋ/",
+      "meaning": "the strategies used to promote and sell products or services",
+      "example": "She works in digital marketing to help boost online sales.",
+      "translation": "tiếp thị",
+      "count": 0
+    },
+    {
+      "word": "multinational (n) /ˌmʌltɪˈnæʃənəl/",
+      "meaning": "a corporation with operations in several countries",
+      "example": "He works for a multinational based in three continents.",
+      "translation": "công ty đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "multinational (adj) /ˌmʌltɪˈnæʃənəl/",
+      "meaning": "operating in or involving many nations",
+      "example": "They launched a multinational project across Asia and Europe.",
+      "translation": "thuộc về công ty đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "private sector (n) /ˈpraɪvət ˈsɛktər/",
+      "meaning": "part of the economy run by private individuals or companies",
+      "example": "Jobs in the private sector often offer higher salaries.",
+      "translation": "khối tư nhân",
+      "count": 0
+    },
+    {
+      "word": "promotion (n) /prəˈmoʊʃən/",
+      "meaning": "an advancement to a higher position in a company",
+      "example": "She was thrilled to receive a promotion after one year.",
+      "translation": "sự thăng tiến",
+      "count": 0
+    },
+    {
+      "word": "promotion (n) /prəˈmoʊʃən/",
+      "meaning": "the process of advertising something to increase sales",
+      "example": "The store offered a special promotion for the holidays.",
+      "translation": "sự quảng cáo",
+      "count": 0
+    },
+    {
+      "word": "prospects (n phr) /ˈprɒspɛkts/",
+      "meaning": "the chances or likelihood of something happening",
+      "example": "Her prospects for a new job are looking good.",
+      "translation": "triển vọng",
+      "count": 0
+    },
+    {
+      "word": "public sector (n) /ˈpʌblɪk ˈsɛktər/",
+      "meaning": "government-controlled services and industries",
+      "example": "He has spent his whole career in the public sector.",
+      "translation": "khu vực nhà nước",
+      "count": 0
+    },
+    {
+      "word": "recruit (n) /rɪˈkruːt/",
+      "meaning": "a person who has recently joined a group or organization",
+      "example": "The manager assigned a mentor to help the new recruit.",
+      "translation": "lính mới",
+      "count": 0
+    },
+    {
+      "word": "recruit (v) /rɪˈkruːt/",
+      "meaning": "to find and hire people for a job or organization",
+      "example": "The company is recruiting engineers for the new branch.",
+      "translation": "tuyển dụng",
+      "count": 0
+    },
+    {
+      "word": "redundant (adj) /rɪˈdʌndənt/",
+      "meaning": "no longer needed for a job and dismissed from it",
+      "example": "Many workers were made redundant due to automation.",
+      "translation": "bị sa thải",
+      "count": 0
+    },
+    {
+      "word": "sack (v) /sæk/",
+      "meaning": "to fire someone from their job",
+      "example": "He got sacked for repeatedly showing up late.",
+      "translation": "sa thải",
+      "count": 0
+    },
+    {
+      "word": "strike (n) /straɪk/",
+      "meaning": "a protest in which workers stop working temporarily",
+      "example": "The teachers went on strike to demand better pay.",
+      "translation": "đình công",
+      "count": 0
+    },
+    {
+      "word": "strike (v) /straɪk/",
+      "meaning": "to stop working as a form of protest",
+      "example": "They decided to strike after failed negotiations.",
+      "translation": "đình công",
+      "count": 0
+    },
+    {
+      "word": "union (n) /ˈjuːnjən/",
+      "meaning": "a group formed to protect workers' rights and interests",
+      "example": "The union negotiated a better health plan for employees.",
+      "translation": "công đoàn",
+      "count": 0
+    },
+    {
+      "word": "accelerate (v) /əkˈsɛləˌreɪt/",
+      "meaning": "to move or make something move faster",
+      "example": "The company plans to accelerate the product launch.",
+      "translation": "tăng tốc",
+      "count": 0
+    },
+    {
+      "word": "approach (v) /əˈproʊʧ/",
+      "meaning": "to move closer in distance or time",
+      "example": "As we approached the station, it started to rain.",
+      "translation": "tiến gần",
+      "count": 0
+    },
+    {
+      "word": "approach (v) /əˈproʊʧ/",
+      "meaning": "to contact or speak to someone about something",
+      "example": "She approached her boss with the proposal.",
+      "translation": "tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "approach (n) /əˈproʊʧ/",
+      "meaning": "a method or way of doing something",
+      "example": "They used a new approach to solve the issue.",
+      "translation": "cách tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "ascend (v) /əˈsɛnd/",
+      "meaning": "to go upward, especially towards a higher place",
+      "example": "We slowly ascended the steep mountain trail.",
+      "translation": "đi lên",
+      "count": 0
+    },
+    {
+      "word": "bounce (v) /baʊns/",
+      "meaning": "to spring back after hitting a surface",
+      "example": "The ball bounced high off the floor.",
+      "translation": "nảy",
+      "count": 0
+    },
+    {
+      "word": "bounce (n) /baʊns/",
+      "meaning": "the act of rebounding off a surface",
+      "example": "The bounce of the basketball surprised the players.",
+      "translation": "sự nảy",
+      "count": 0
+    },
+    {
+      "word": "clamber (v) /ˈklæmbər/",
+      "meaning": "to climb up with difficulty using hands and feet",
+      "example": "They clambered over the rocks to reach the cave.",
+      "translation": "leo",
+      "count": 0
+    },
+    {
+      "word": "clench (v) /klɛnʧ/",
+      "meaning": "to close tightly due to anger or tension",
+      "example": "He clenched his fists in frustration.",
+      "translation": "nghiến",
+      "count": 0
+    },
+    {
+      "word": "clutch (v) /klʌʧ/",
+      "meaning": "to hold onto something tightly due to fear or anxiety",
+      "example": "She clutched her bag nervously on the crowded train.",
+      "translation": "giữ chặt",
+      "count": 0
+    },
+    {
+      "word": "crawl (v) /krɔːl/",
+      "meaning": "to move slowly along the ground using hands and knees",
+      "example": "The baby crawled across the carpet to reach the toy.",
+      "translation": "bò",
+      "count": 0
+    },
+    {
+      "word": "creep (v) /kriːp/",
+      "meaning": "to move slowly and quietly, often to avoid being noticed",
+      "example": "She crept downstairs so she wouldn't wake anyone.",
+      "translation": "trườn",
+      "count": 0
+    },
+    {
+      "word": "dash (v) /dæʃ/",
+      "meaning": "to run quickly and suddenly",
+      "example": "He dashed into the room with exciting news.",
+      "translation": "lao tới",
+      "count": 0
+    },
+    {
+      "word": "descend (v) /dɪˈsɛnd/",
+      "meaning": "to go downward from a higher position",
+      "example": "The hikers began to descend the steep slope.",
+      "translation": "xuống",
+      "count": 0
+    },
+    {
+      "word": "drift (v) /drɪft/",
+      "meaning": "to move slowly without control, especially by wind or water",
+      "example": "The boat drifted gently down the river.",
+      "translation": "trôi dạt",
+      "count": 0
+    },
+    {
+      "word": "drift (n) /drɪft/",
+      "meaning": "a slow and gradual movement or change",
+      "example": "There's been a drift in public opinion over time.",
+      "translation": "sự thay đổi",
+      "count": 0
+    },
+    {
+      "word": "crawl (n) /krɔːl/",
+      "meaning": "a slow movement using hands and knees",
+      "example": "He moved at a crawl through the traffic jam.",
+      "translation": "bò",
+      "count": 0
+    },
+    {
+      "word": "strike (n) /straɪk/",
+      "meaning": "an organized stoppage of work by employees",
+      "example": "Workers went on strike over low wages.",
+      "translation": "đình công",
+      "count": 0
+    },
+    {
+      "word": "fire (v) /faɪər/",
+      "meaning": "to remove someone from their job as a penalty",
+      "example": "She was fired for violating company policies.",
+      "translation": "sa thải",
+      "count": 0
+    },
+    {
+      "word": "headhunt (v) /ˈhedhʌnt/",
+      "meaning": "to approach someone with a job offer from another company",
+      "example": "He was headhunted by a major tech firm last year.",
+      "translation": "tuyển dụng đặc biệt",
+      "count": 0
+    },
+    {
+      "word": "leave (n) /liːv/",
+      "meaning": "time off from work for personal or official reasons",
+      "example": "She took maternity leave for three months.",
+      "translation": "thời gian nghỉ việc",
+      "count": 0
+    },
+    {
+      "word": "marketing (n) /ˈmɑːrkɪtɪŋ/",
+      "meaning": "activities aimed at promoting and selling products or services",
+      "example": "He’s responsible for managing the marketing team.",
+      "translation": "tiếp thị",
+      "count": 0
+    },
+    {
+      "word": "multinational (n) /ˌmʌltiˈnæʃənl/",
+      "meaning": "a large company operating in many countries",
+      "example": "She joined a multinational with offices in over 40 countries.",
+      "translation": "công ty đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "multinational (adj) /ˌmʌltiˈnæʃənl/",
+      "meaning": "having business activities in several countries",
+      "example": "The multinational company opened a branch in Vietnam.",
+      "translation": "đa quốc gia",
+      "count": 0
+    },
+    {
+      "word": "private sector (n) /ˈpraɪvət ˈsektər/",
+      "meaning": "businesses owned and managed independently of the government",
+      "example": "Many job opportunities exist in the private sector.",
+      "translation": "khu vực tư nhân",
+      "count": 0
+    },
+    {
+      "word": "promotion (n) /prəˈmoʊʃn/",
+      "meaning": "a move to a higher position at work",
+      "example": "She received a promotion to team leader last month.",
+      "translation": "sự thăng tiến",
+      "count": 0
+    },
+    {
+      "word": "promotion (n) /prəˈmoʊʃn/",
+      "meaning": "efforts to increase awareness or sales of something",
+      "example": "The promotion of the product was handled through social media.",
+      "translation": "sự quảng cáo",
+      "count": 0
+    },
+    {
+      "word": "prospects (n phr) /ˈprɒspekts/",
+      "meaning": "future opportunities or chances for success",
+      "example": "She moved abroad to improve her career prospects.",
+      "translation": "triển vọng",
+      "count": 0
+    },
+    {
+      "word": "public sector (n) /ˈpʌblɪk ˈsektər/",
+      "meaning": "industries and services controlled by the government",
+      "example": "He works in the public sector as a school teacher.",
+      "translation": "khu vực công",
+      "count": 0
+    },
+    {
+      "word": "recruit (v) /rɪˈkruːt/",
+      "meaning": "to hire new people to join a company or group",
+      "example": "The organization is recruiting staff for a new office.",
+      "translation": "tuyển dụng",
+      "count": 0
+    },
+    {
+      "word": "recruit (n) /rɪˈkruːt/",
+      "meaning": "a person who has recently joined an organization",
+      "example": "The recruit completed training before joining the team.",
+      "translation": "nhân viên mới",
+      "count": 0
+    },
+    {
+      "word": "redundant (adj) /rɪˈdʌndənt/",
+      "meaning": "dismissed from a job due to no longer being needed",
+      "example": "He became redundant when the company restructured.",
+      "translation": "dư thừa",
+      "count": 0
+    },
+    {
+      "word": "sack (v) /sæk/",
+      "meaning": "to dismiss someone from their job",
+      "example": "They sacked the employee after repeated misconduct.",
+      "translation": "sa thải",
+      "count": 0
+    },
+    {
+      "word": "strike (n) /straɪk/",
+      "meaning": "a work stoppage as a form of protest",
+      "example": "The strike lasted for several days across the region.",
+      "translation": "cuộc đình công",
+      "count": 0
+    },
+    {
+      "word": "strike (v) /straɪk/",
+      "meaning": "to stop working temporarily to protest",
+      "example": "Workers decided to strike after failed negotiations.",
+      "translation": "đình công",
+      "count": 0
+    },    
+    {
+      "word": "union (n) /ˈjuːnjən/",
+      "meaning": "an organization that supports and defends workers’ rights",
+      "example": "The union negotiated a better contract for employees.",
+      "translation": "công đoàn",
+      "count": 0
+    },
+    {
+      "word": "accelerate (v) /əkˈseləreɪt/",
+      "meaning": "to increase speed or cause something to happen more quickly",
+      "example": "The car suddenly accelerated down the road.",
+      "translation": "tăng tốc",
+      "count": 0
+    },
+    {
+      "word": "approach (v) /əˈproʊtʃ/",
+      "meaning": "to move toward someone or something",
+      "example": "As we approached the station, the train arrived.",
+      "translation": "tiến lại gần",
+      "count": 0
+    },
+    {
+      "word": "approach (v) /əˈproʊtʃ/",
+      "meaning": "to contact someone with a request or offer",
+      "example": "He approached his manager with a proposal.",
+      "translation": "tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "approach (n) /əˈproʊtʃ/",
+      "meaning": "a method or plan to deal with something",
+      "example": "Her approach to problem-solving is very logical.",
+      "translation": "cách tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "ascend (v) /əˈsend/",
+      "meaning": "to go upward or climb something",
+      "example": "They ascended the steep stairs carefully.",
+      "translation": "trèo lên",
+      "count": 0
+    },
+    {
+      "word": "bounce (v) /baʊns/",
+      "meaning": "to spring back after hitting a surface",
+      "example": "The ball bounced off the wall and rolled away.",
+      "translation": "nảy",
+      "count": 0
+    },
+    {
+      "word": "clamber (v) /ˈklæmbər/",
+      "meaning": "to climb awkwardly using hands and feet",
+      "example": "The children clambered over the rocks.",
+      "translation": "leo trèo",
+      "count": 0
+    },
+    {
+      "word": "clench (v) /klentʃ/",
+      "meaning": "to tightly close your hands, teeth, or jaw",
+      "example": "She clenched her fists in anger.",
+      "translation": "nghiến",
+      "count": 0
+    },
+    {
+      "word": "clutch (v) /klʌtʃ/",
+      "meaning": "to hold something firmly, often with fear or urgency",
+      "example": "He clutched the steering wheel during the storm.",
+      "translation": "nắm chặt",
+      "count": 0
+    },
+    {
+      "word": "crawl (v) /krɔːl/",
+      "meaning": "to move slowly on hands and knees",
+      "example": "The injured man crawled toward the exit.",
+      "translation": "bò",
+      "count": 0
+    },
+    {
+      "word": "creep (v) /kriːp/",
+      "meaning": "to move slowly and quietly to avoid being noticed",
+      "example": "He crept out of the room so no one would hear.",
+      "translation": "lẻn vào",
+      "count": 0
+    },
+    {
+      "word": "dash (v) /dæʃ/",
+      "meaning": "to run quickly and suddenly",
+      "example": "She dashed out the door to catch her bus.",
+      "translation": "lao tới",
+      "count": 0
+    },
+    {
+      "word": "descend (v) /dɪˈsend/",
+      "meaning": "to go downward",
+      "example": "They descended the stairs in silence.",
+      "translation": "đi xuống",
+      "count": 0
+    },
+    {
+      "word": "drift (v) /drɪft/",
+      "meaning": "to move slowly due to wind or water",
+      "example": "Clouds drifted across the sky.",
+      "translation": "trôi",
+      "count": 0
+    },
+    {
+      "word": "drift (n) /drɪft/",
+      "meaning": "a slow and steady change in direction or meaning",
+      "example": "There was a drift in policy over the last year.",
+      "translation": "sự thay đổi dần dần",
+      "count": 0
+    },
+    {
+      "word": "flow (v) /floʊ/",
+      "meaning": "to move continuously and smoothly, especially as a liquid",
+      "example": "Traffic flowed steadily through the tunnel.",
+      "translation": "chảy",
+      "count": 0
+    },
+    {
+      "word": "gesture (n) /ˈdʒestʃər/",
+      "meaning": "a movement of the body to express an idea or feeling",
+      "example": "She waved her hand in a friendly gesture.",
+      "translation": "cử chỉ",
+      "count": 0
+    },
+    {
+      "word": "drift (v)",
+      "meaning": "to understand the general meaning of what someone says",
+      "example": "I didn’t catch every word, but I got the drift.",
+      "translation": "ý nghĩ",
+      "count": 0
+    },
+    {
+      "word": "emigrate (v)",
+      "meaning": "to move permanently from one country to another",
+      "example": "They emigrated to Canada in search of a better life.",
+      "translation": "di cư",
+      "count": 0
+    },
+    {
+      "word": "float (v)",
+      "meaning": "to remain on the surface of a liquid without sinking",
+      "example": "A leaf floated gently on the water.",
+      "translation": "nổi",
+      "count": 0
+    },
+    {
+      "word": "flow (v)",
+      "meaning": "to move like a stream in a consistent direction",
+      "example": "The water flows through the pipes smoothly.",
+      "translation": "chảy",
+      "count": 0
+    },
+    {
+      "word": "fumble (v)",
+      "meaning": "to handle something clumsily or with difficulty",
+      "example": "He fumbled for his keys in the dark.",
+      "translation": "sờ soạng, lần mò",
+      "count": 0
+    },
+    {
+      "word": "gesture (n)",
+      "meaning": "a physical signal expressing a message or intent",
+      "example": "She made a rude gesture and walked away.",
+      "translation": "chỉ cử",
+      "count": 0
+    },
+    {
+      "word": "glide (v)",
+      "meaning": "to move smoothly, quietly, and effortlessly",
+      "example": "The bird glided through the air without flapping its wings.",
+      "translation": "lướt đi",
+      "count": 0
+    },
+    {
+      "word": "grab (v)",
+      "meaning": "to take hold of something suddenly and roughly",
+      "example": "He grabbed the book from my hands without asking.",
+      "translation": "vồ lấy",
+      "count": 0
+    },
+    {
+      "word": "grasp (v)",
+      "meaning": "to hold something tightly with your hand",
+      "example": "She grasped the rope to stop herself from falling.",
+      "translation": "nắm chặt",
+      "count": 0
+    },
+    {
+      "word": "hop (v)",
+      "meaning": "to move by jumping on one foot",
+      "example": "She hopped across the playground on one leg.",
+      "translation": "nhảy lò cò",
+      "count": 0
+    },
+    {
+      "word": "hop (n)",
+      "meaning": "a small jump on one foot",
+      "example": "He cleared the puddle with a hop.",
+      "translation": "cú nhảy lò cò",
+      "count": 0
+    },
+    {
+      "word": "immigrant (n)",
+      "meaning": "a person who moves to another country to live permanently",
+      "example": "The city welcomed thousands of immigrants last year.",
+      "translation": "người nhập cư",
+      "count": 0
+    },
+    {
+      "word": "jog (v)",
+      "meaning": "to run slowly for exercise or recreation",
+      "example": "She jogs every morning to stay in shape.",
+      "translation": "chạy bộ chậm",
+      "count": 0
+    },
+    {
+      "word": "jog (n)",
+      "meaning": "a slow run done for fitness or fun",
+      "example": "Let’s go for a jog before dinner.",
+      "translation": "buổi chạy bộ chậm",
+      "count": 0
+    },
+    {
+      "word": "leap (v)",
+      "meaning": "to jump a long distance or to a great height",
+      "example": "The cat leapt onto the kitchen counter.",
+      "translation": "nhảy bật qua",
+      "count": 0
+    },
+    {
+      "word": "leap (n)",
+      "meaning": "a large or high jump",
+      "example": "She made a leap over the puddle.",
+      "translation": "cú nhảy bật",
+      "count": 0
+    },
+    {
+      "word": "march (v)",
+      "meaning": "to walk with steady steps in a group, especially soldiers",
+      "example": "The soldiers marched across the field in formation.",
+      "translation": "đi đều hành",
+      "count": 0
+    },
+    {
+      "word": "march (n)",
+      "meaning": "a steady and organized walk, usually by a group",
+      "example": "The parade included a long military march.",
+      "translation": "cuộc diễu hành",
+      "count": 0
+    },
+    {
+      "word": "migrate (v)",
+      "meaning": "to move from one region to another, often seasonally",
+      "example": "The birds migrate south for the winter.",
+      "translation": "di cư",
+      "count": 0
+    },
+    {
+      "word": "point (v)",
+      "meaning": "to indicate a direction or object using a finger or tool",
+      "example": "He pointed at the map to show the route.",
+      "translation": "chỉ vào",
+      "count": 0
+    },
+    {
+      "word": "punch (v)",
+      "meaning": "to hit something or someone with a closed hand",
+      "example": "He punched the wall in frustration.",
+      "translation": "đấm",
+      "count": 0
+    },
+    {
+      "word": "refugee (n)",
+      "meaning": "someone who flees their country due to conflict or danger",
+      "example": "The refugees were given temporary shelter in the camp.",
+      "translation": "người tị nạn",
+      "count": 0
+    },
+    {
+      "word": "roam (v)",
+      "meaning": "to wander or travel without a fixed destination",
+      "example": "Cows were roaming freely in the field.",
+      "translation": "đi lang thang",
+      "count": 0
+    },
+    {
+      "word": "roll (v)",
+      "meaning": "to move by turning over and over on a surface",
+      "example": "She rolled the ball across the floor.",
+      "translation": "xoay",
+      "count": 0
+    },
+    {
+      "word": "rotate (v)",
+      "meaning": "to turn something around a central point",
+      "example": "The fan blades rotate slowly during winter mode.",
+      "translation": "xoay",
+      "count": 0
+    },
+    {
+      "word": "route (n)",
+      "meaning": "the path or direction taken to get from one place to another",
+      "example": "We planned the fastest route to the hotel.",
+      "translation": "lộ trình",
+      "count": 0
+    },
+    {
+      "word": "sink (v)",
+      "meaning": "to go below the surface of water or another liquid",
+      "example": "The boat sank after hitting a rock.",
+      "translation": "chìm",
+      "count": 0
+    },
+    {
+      "word": "skid (v)",
+      "meaning": "to slide uncontrollably across a surface",
+      "example": "The bike skidded on the wet pavement.",
+      "translation": "trượt",
+      "count": 0
+    },
+    {
+      "word": "skid (n)",
+      "meaning": "an uncontrolled slide by a vehicle or object",
+      "example": "They lost control of the car in a skid.",
+      "translation": "cú trượt",
+      "count": 0
+    },
+    {
+      "word": "skip (v)",
+      "meaning": "to jump lightly with alternate steps from one foot to the other",
+      "example": "The children skipped happily on the way to school.",
+      "translation": "nhảy chân sáo",
+      "count": 0
+    },
+    {
+      "word": "slide (v)",
+      "meaning": "to move smoothly along a surface",
+      "example": "She slid the book across the table.",
+      "translation": "trượt",
+      "count": 0
+    },
+    {
+      "word": "slide (n)",
+      "meaning": "a playground structure where children slide down a slope",
+      "example": "The kids were lining up to go down the slide.",
+      "translation": "cầu trượt",
+      "count": 0
+    },
+    {
+      "word": "slip (v)",
+      "meaning": "to accidentally slide and lose your balance",
+      "example": "He slipped on the icy pavement and nearly fell.",
+      "translation": "trượt chân",
+      "count": 0
+    },
+    {
+      "word": "step (v)",
+      "meaning": "to place one foot in front of the other while walking",
+      "example": "He stepped forward to get a closer look.",
+      "translation": "bước đi",
+      "count": 0
+    },
+    {
+      "word": "step (n)",
+      "meaning": "a single move in a series of actions towards a goal",
+      "example": "The next step is to finalize the design.",
+      "translation": "bước (trong kế hoạch)",
+      "count": 0
+    },
+    {
+      "word": "stride (v)",
+      "meaning": "to walk confidently with long steps",
+      "example": "He strode into the room as if he owned it.",
+      "translation": "sải bước",
+      "count": 0
+    },
+    {
+      "word": "stride (n)",
+      "meaning": "a long, confident step while walking",
+      "example": "She took a few quick strides across the stage.",
+      "translation": "bước dài, sải chân",
+      "count": 0
+    },
+    {
+      "word": "trip (v)",
+      "meaning": "to stumble and nearly fall after hitting your foot",
+      "example": "She tripped over the rug and dropped the tray.",
+      "translation": "vấp chân",
+      "count": 0
+    },
+    {
+      "word": "velocity (n)",
+      "meaning": "the speed at which something moves in a particular direction",
+      "example": "The meteor entered the atmosphere at high velocity.",
+      "translation": "vận tốc",
+      "count": 0
+    },
+    {
+      "word": "wander (v)",
+      "meaning": "to move around without a specific purpose or destination",
+      "example": "They wandered through the park for hours.",
+      "translation": "đi lang thang",
+      "count": 0
+    },
+    {
+      "word": "wave (v)",
+      "meaning": "to move your hand to greet, say goodbye, or signal",
+      "example": "She waved at us from across the street.",
+      "translation": "vẫy tay chào",
+      "count": 0
+    },
+    {
+      "word": "wave (n)",
+      "meaning": "a hand movement used to greet or signal",
+      "example": "He gave a quick wave before leaving.",
+      "translation": "cái vẫy tay chào",
+      "count": 0
+    },
+    {
+      "word": "airline (n) /ˈeə.laɪn/",
+      "meaning": "a company that provides air transportation for passengers or cargo",
+      "example": "She has been working for an international airline.",
+      "translation": "hãng hàng không",
+      "count": 0
+    },
+    {
+      "word": "cargo (n) /ˈkɑː.ɡəʊ/",
+      "meaning": "goods transported by ship, plane, train, or truck",
+      "example": "The ship was loaded with heavy cargo.",
+      "translation": "hàng hóa",
+      "count": 0
+    },
+    {
+      "word": "carriage (n) /ˈkær.ɪdʒ/",
+      "meaning": "a section of a train that carries passengers",
+      "example": "We found an empty carriage at the back of the train.",
+      "translation": "toa tàu",
+      "count": 0
+    },
+    {
+      "word": "charter (v) /ˈtʃɑː.tər/",
+      "meaning": "to rent a vehicle such as a plane or boat for a specific use",
+      "example": "They chartered a yacht for the week-long trip.",
+      "translation": "thuê bao",
+      "count": 0
+    },
+    {
+      "word": "commute (v) /kəˈmjuːt/",
+      "meaning": "to travel regularly between home and workplace",
+      "example": "She commutes two hours each day to her job.",
+      "translation": "đi làm (khoảng cách xa)",
+      "count": 0
+    },
+    {
+      "word": "destination (n) /ˌdes.tɪˈneɪ.ʃən/",
+      "meaning": "the place someone is going to",
+      "example": "After a long flight, they arrived at their destination.",
+      "translation": "điểm đến",
+      "count": 0
+    },
+    {
+      "word": "hiker (n) /ˈhaɪ.kər/",
+      "meaning": "a person who walks long distances in nature for enjoyment",
+      "example": "The trail was filled with hikers enjoying the weather.",
+      "translation": "người đi bộ đường dài",
+      "count": 0
+    },
+    {
+      "word": "hitchhiker (n) /ˈhɪtʃ.haɪ.kər/",
+      "meaning": "a person who travels by asking for free rides from drivers",
+      "example": "They picked up a hitchhiker on their road trip.",
+      "translation": "người đi nhờ xe",
+      "count": 0
+    },
+    {
+      "word": "jet lag (n) /ˈdʒet ˌlæɡ/",
+      "meaning": "fatigue and confusion from traveling across time zones",
+      "example": "He was struggling with jet lag after the flight to New York.",
+      "translation": "sự mệt mỏi do lệch múi giờ",
+      "count": 0
+    },
+    {
+      "word": "legroom (n) /ˈleɡ.ruːm/",
+      "meaning": "the space for your legs in front of your seat",
+      "example": "This seat offers plenty of legroom for tall passengers.",
+      "translation": "chỗ duỗi chân",
+      "count": 0
+    },
+    {
+      "word": "load (v) /ləʊd/",
+      "meaning": "to put goods or items onto or into something",
+      "example": "They loaded the boxes into the van.",
+      "translation": "chất hàng",
+      "count": 0
+    },
+    {
+      "word": "passenger (n) /ˈpæs.ɪn.dʒər/",
+      "meaning": "a person traveling in a vehicle without driving it",
+      "example": "Each passenger must wear a seatbelt.",
+      "translation": "hành khách",
+      "count": 0
+    },
+    {
+      "word": "pedestrian (n) /pəˈdes.tri.ən/",
+      "meaning": "a person walking in a city or along a road",
+      "example": "That area is closed to traffic and reserved for pedestrians.",
+      "translation": "người đi bộ",
+      "count": 0
+    },
+    {
+      "word": "pier (n) /pɪər/",
+      "meaning": "a platform built into the water for boats to dock",
+      "example": "We sat on the pier and watched the sunset.",
+      "translation": "bến tàu",
+      "count": 0
+    },
+    {
+      "word": "pilot (v) /ˈpaɪ.lət/",
+      "meaning": "to control and fly an aircraft",
+      "example": "He learned how to pilot a small plane.",
+      "translation": "lái máy bay",
+      "count": 0
+    },
+    {
+      "word": "quay (n) /kiː/",
+      "meaning": "a platform near the water where boats dock",
+      "example": "Several fishing boats were moored at the quay.",
+      "translation": "bến cảng",
+      "count": 0
+    },
+    {
+      "word": "return fare (n phr) /rɪˈtɜːn feər/",
+      "meaning": "the price for a round trip to and from a location",
+      "example": "How much is the return fare to Edinburgh?",
+      "translation": "vé khứ hồi",
+      "count": 0
+    },
+    {
+      "word": "round trip (n phr) /raʊnd trɪp/",
+      "meaning": "a journey to a place and back again",
+      "example": "The round trip between the cities took six hours.",
+      "translation": "chuyến đi khứ hồi",
+      "count": 0
+    },
+    {
+      "word": "steer (v) /stɪər/",
+      "meaning": "to guide the direction of a vehicle or vessel",
+      "example": "He steered the boat towards the shore.",
+      "translation": "lái",
+      "count": 0
+    },
+    {
+      "word": "steward (n) /ˈstjuː.əd/",
+      "meaning": "a man who serves passengers on a plane, ship, or train",
+      "example": "The steward offered drinks during the flight.",
+      "translation": "tiếp viên",
+      "count": 0
+    },
+    {
+      "word": "allege (v) /əˈledʒ/",
+      "meaning": "to claim something is true without proof",
+      "example": "He alleged that the manager had misused company funds.",
+      "translation": "cáo buộc",
+      "count": 0
+    },
+    {
+      "word": "ambiguous (adj) /æmˈbɪɡ.ju.əs/",
+      "meaning": "unclear because it can be interpreted in multiple ways",
+      "example": "His statement was so ambiguous that no one knew what he meant.",
+      "translation": "mơ hồ",
+      "count": 0
+    },
+    {
+      "word": "assert (v) /əˈsɜːt/",
+      "meaning": "to declare something confidently as true",
+      "example": "She asserted her right to remain silent.",
+      "translation": "khẳng định",
+      "count": 0
+    },
+    {
+      "word": "blunt (adj) /blʌnt/",
+      "meaning": "speaking in a direct and sometimes rude way",
+      "example": "He was blunt and told her the idea was terrible.",
+      "translation": "thẳng thắn",
+      "count": 0
+    },
+    {
+      "word": "boast (n) /bəʊst/",
+      "meaning": "a statement showing pride in an achievement or possession",
+      "example": "Her biggest boast was winning the regional tennis title.",
+      "translation": "khoe khoang",
+      "count": 0
+    },
+    {
+      "word": "clarification (n) /ˌklær.ɪ.fɪˈkeɪ.ʃən/",
+      "meaning": "an explanation to make something easier to understand",
+      "example": "Can you give a clarification of that rule?",
+      "translation": "sự giải thích",
+      "count": 0
+    },
+    {
+      "word": "colloquial (adj) /kəˈləʊ.kwi.əl/",
+      "meaning": "used in casual conversation rather than formal speech or writing",
+      "example": "He prefers to use colloquial expressions in everyday speech.",
+      "translation": "thông tục",
+      "count": 0
+    },
+    {
+      "word": "comprehend (v) /ˌkɒm.prɪˈhend/",
+      "meaning": "to fully understand something",
+      "example": "She couldn’t comprehend the sudden change in his behavior.",
+      "translation": "hiểu",
+      "count": 0
+    },
+    {
+      "word": "confide (v) /kənˈfaɪd/",
+      "meaning": "to share personal thoughts or secrets with someone you trust",
+      "example": "He confided in his friend about the job offer.",
+      "translation": "tâm sự",
+      "count": 0
+    },
+    {
+      "word": "confirm (v) /kənˈfɜːm/",
+      "meaning": "to verify that something is accurate or true",
+      "example": "They confirmed the results after double-checking the data.",
+      "translation": "chứng thực",
+      "count": 0
+    },
+    {
+      "word": "confirm (v) /kənˈfɜːm/",
+      "meaning": "to officially say that something has been arranged or agreed",
+      "example": "Please confirm your attendance by Friday.",
+      "translation": "xác nhận",
+      "count": 0
+    },
+    {
+      "word": "context (n) /ˈkɒn.tekst/",
+      "meaning": "the situation or environment surrounding something",
+      "example": "You need to understand the historical context of the event.",
+      "translation": "bối cảnh",
+      "count": 0
+    },
+    {
+      "word": "context (n) /ˈkɒn.tekst/",
+      "meaning": "the words around a specific word that help define its meaning",
+      "example": "The meaning of 'bark' depends on the context of the sentence.",
+      "translation": "ngữ cảnh",
+      "count": 0
+    },
+    {
+      "word": "contradict (v) /ˌkɒn.trəˈdɪkt/",
+      "meaning": "to say the opposite of what someone else has said",
+      "example": "She contradicted his version of the story.",
+      "translation": "cải lại",
+      "count": 0
+    },
+    {
+      "word": "contradict (v) /ˌkɒn.trəˈdɪkt/",
+      "meaning": "to show that two statements or ideas cannot both be true",
+      "example": "Their statements clearly contradict each other.",
+      "translation": "mâu thuẫn",
+      "count": 0
+    },
+    {
+      "word": "pier (n) /pɪər/",
+      "meaning": "a long platform extending into the water for boarding or unloading boats",
+      "example": "Tourists gathered at the pier to take boat rides.",
+      "translation": "bến tàu",
+      "count": 0
+    },
+    {
+      "word": "pilot (v) /ˈpaɪ.lət/",
+      "meaning": "to operate and navigate an aircraft or boat",
+      "example": "He piloted the helicopter through heavy fog.",
+      "translation": "lái",
+      "count": 0
+    },
+    {
+      "word": "quay (n) /kiː/",
+      "meaning": "a structure beside water where ships load and unload goods",
+      "example": "Cargo was stacked neatly on the quay.",
+      "translation": "bến cảng",
+      "count": 0
+    },
+    {
+      "word": "top /tɒp/",
+      "meaning": "the highest point or position of something",
+      "example": "They climbed to the top of the tower.",
+      "translation": "đỉnh",
+      "count": 0
+    },
+    {
+      "word": "tough /tʌf/",
+      "meaning": "physically or mentally strong and able to endure difficulty",
+      "example": "She proved to be a tough negotiator.",
+      "translation": "mạnh mẽ, bền bỉ",
+      "count": 0
+    },
+    {
+      "word": "town /taʊn/",
+      "meaning": "a populated urban area that is smaller than a city",
+      "example": "She bought a house in a quiet town.",
+      "translation": "thị trấn",
+      "count": 0
+    },
+    {
+      "word": "worse /wɜːs/",
+      "meaning": "a comparative form of 'bad' indicating a lower quality or condition",
+      "example": "The traffic was even worse than yesterday.",
+      "translation": "tồi tệ hơn",
+      "count": 0
+    },
+    {
+      "word": "worst /wɜːst/",
+      "meaning": "the superlative form of 'bad', meaning the lowest quality or condition",
+      "example": "That was the worst performance I've ever seen.",
+      "translation": "tệ nhất",
+      "count": 0
+    },
+    {
+      "word": "youth /juːθ/",
+      "meaning": "the period of life when a person is young",
+      "example": "He spent his youth traveling across Asia.",
+      "translation": "tuổi trẻ",
+      "count": 0
+    },
+    {
+      "word": "transpire (/trænˈspaɪər/)",
+      "meaning": "to occur or take place",
+      "example": "We may never fully understand what transpired that evening.",
+      "translation": "xảy ra",
+      "count": 0
+    },
+    {
+      "word": "uncertainty (/ʌnˈsɜːrtnəti/)",
+      "meaning": "a situation in which something is not known or decided",
+      "example": "People were anxious because of the ongoing uncertainty.",
+      "translation": "sự không chắc chắn",
+      "count": 0
+    },
+    {
+      "word": "wobble (/ˈwɒbl/)",
+      "meaning": "to shake or move unsteadily from side to side",
+      "example": "The chair wobbled when I sat on it.",
+      "translation": "lắc lư",
+      "count": 0
+    },
+    {
+      "word": "agriculture (/ˈæɡrɪkʌltʃər/)",
+      "meaning": "the science or business of farming",
+      "example": "He plans to study agriculture at university.",
+      "translation": "ngành nông nghiệp",
+      "count": 0
+    },
+    {
+      "word": "appreciate (/əˈpriːʃieɪt/)",
+      "meaning": "to recognize the full value or seriousness of something",
+      "example": "She appreciated how difficult the task really was.",
+      "translation": "đánh giá đúng",
+      "count": 0
+    },
+    {
+      "word": "appreciate (/əˈpriːʃieɪt/)",
+      "meaning": "to be thankful for something",
+      "example": "I truly appreciate your support during this time.",
+      "translation": "cảm kích",
+      "count": 0
+    },
+    {
+      "word": "catastrophe (/kəˈtæstrəfi/)",
+      "meaning": "a sudden and severe disaster",
+      "example": "The flood was an environmental catastrophe.",
+      "translation": "thảm họa",
+      "count": 0
+    },
+    {
+      "word": "crop (/krɒp/)",
+      "meaning": "a plant grown in large amounts for food or other use",
+      "example": "This year’s rice crop is much larger than usual.",
+      "translation": "cây trồng",
+      "count": 0
+    },
+    {
+      "word": "drought (/draʊt/)",
+      "meaning": "a long period with little or no rainfall",
+      "example": "The region is suffering from its worst drought in decades.",
+      "translation": "hạn hán",
+      "count": 0
+    },
+    {
+      "word": "evacuate (/ɪˈvækjueɪt/)",
+      "meaning": "to remove people from a place for safety reasons",
+      "example": "Residents were evacuated before the hurricane hit.",
+      "translation": "sơ tán",
+      "count": 0
+    },
+    {
+      "word": "exploit (/ɪkˈsplɔɪt/)",
+      "meaning": "to unfairly use someone for personal gain",
+      "example": "Some employers exploit cheap labor to cut costs.",
+      "translation": "bóc lột",
+      "count": 0
+    },
+    {
+      "word": "famine (/ˈfæmɪn/)",
+      "meaning": "a severe lack of food affecting a large population",
+      "example": "Thousands died in the famine of 1845.",
+      "translation": "nạn đói",
+      "count": 0
+    },
+    {
+      "word": "flood (/flʌd/)",
+      "meaning": "to overflow with water, covering normally dry land",
+      "example": "The streets flooded after the heavy rain.",
+      "translation": "gây ngập nước",
+      "count": 0
+    },
+    {
+      "word": "flood (/flʌd/)",
+      "meaning": "an overflow of water onto normally dry land",
+      "example": "The flood forced hundreds to evacuate their homes.",
+      "translation": "lũ lụt",
+      "count": 0
+    },
+    {
+      "word": "fossil fuels (/ˈfɒsl fjuːəlz/)",
+      "meaning": "natural fuels such as coal, oil, or gas",
+      "example": "The world is trying to reduce its dependence on fossil fuels.",
+      "translation": "nhiên liệu hóa thạch",
+      "count": 0
+    },
+    {
+      "word": "greenery (/ˈɡriːnəri/)",
+      "meaning": "lush green plants or vegetation",
+      "example": "The garden was full of beautiful greenery.",
+      "translation": "cây xanh",
+      "count": 0
+    },
+    {
+      "word": "habitat (/ˈhæbɪtæt/)",
+      "meaning": "the natural environment of a plant or animal",
+      "example": "Pollution is destroying the natural habitat of many species.",
+      "translation": "môi trường sống",
+      "count": 0
+    },
+    {
+      "word": "harvest (/ˈhɑːrvɪst/)",
+      "meaning": "the time of year when crops are gathered",
+      "example": "The harvest usually begins in late summer.",
+      "translation": "vụ thu hoạch",
+      "count": 0
+    },
+    {
+      "word": "hurricane (/ˈhɜːrəkeɪn/)",
+      "meaning": "a violent storm with strong winds and heavy rain",
+      "example": "The hurricane damaged hundreds of homes.",
+      "translation": "bão nhiệt đới",
+      "count": 0
+    },
+    {
+      "word": "instinct (/ˈɪnstɪŋkt/)",
+      "meaning": "a natural ability or behavior that does not need to be learned",
+      "example": "By instinct, the animal fled from danger.",
+      "translation": "bản năng",
+      "count": 0
+    },
+    {
+      "word": "natural disaster (/ˈnætʃrəl dɪˈzæstər/)",
+      "meaning": "a major event caused by nature that causes damage or loss of life",
+      "example": "Floods and earthquakes are examples of natural disasters.",
+      "translation": "thiên tai",
+      "count": 0
+    },
+    {
+      "word": "resource (/rɪˈsɔːrs/)",
+      "meaning": "natural materials like coal, gas, or oil used by people",
+      "example": "We must conserve our natural resources for future generations.",
+      "translation": "tài nguyên",
+      "count": 0
+    },
+    {
+      "word": "scarce (/skɛrs/)",
+      "meaning": "not available in large amounts; hard to find",
+      "example": "Water is scarce in desert areas.",
+      "translation": "khan hiếm",
+      "count": 0
+    },
+    {
+      "word": "species (/ˈspiːʃiːz/)",
+      "meaning": "a group of similar plants or animals that can reproduce",
+      "example": "Several endangered species are protected by law.",
+      "translation": "loài",
+      "count": 0
+    },
+    {
+      "word": "abundant (/əˈbʌndənt/)",
+      "meaning": "present in large amounts or quantities",
+      "example": "The region has abundant natural resources.",
+      "translation": "dồi dào",
+      "count": 0
+    },
+    {
+      "word": "ample (/ˈæmpl/)",
+      "meaning": "more than enough in size or quantity",
+      "example": "We had ample time to catch our flight.",
+      "translation": "đủ",
+      "count": 0
+    },
+    {
+      "word": "area (/ˈɛəriə/)",
+      "meaning": "a particular space or surface location",
+      "example": "Apply the lotion to the affected area.",
+      "translation": "khu vực",
+      "count": 0
+    },
+    {
+      "word": "average (/ˈævərɪdʒ/)",
+      "meaning": "a value calculated by dividing the sum by the number of items",
+      "example": "The average temperature in July is 30°C.",
+      "translation": "trung bình",
+      "count": 0
+    },
+    {
+      "word": "average (/ˈævərɪdʒ/)",
+      "meaning": "typical or ordinary, not exceptional",
+      "example": "He's of average height for his age.",
+      "translation": "tầm thường",
+      "count": 0
+    },
+    {
+      "word": "average (/ˈævərɪdʒ/)",
+      "meaning": "a typical level or standard of something",
+      "example": "Their income is below the national average.",
+      "translation": "tiêu chuẩn",
+      "count": 0
+    },
+    {
+      "word": "batch (/bætʃ/)",
+      "meaning": "a group of similar items processed or handled together",
+      "example": "She baked a fresh batch of muffins.",
+      "translation": "nhóm",
+      "count": 0
+    },
+    {
+      "word": "batch (/bætʃ/)",
+      "meaning": "to collect or organize things into a group",
+      "example": "We’ll batch the documents for easier review.",
+      "translation": "gom lại",
+      "count": 0
+    },
+    {
+      "word": "bulk (/bʌlk/)",
+      "meaning": "a large mass or size of something",
+      "example": "The bulk of the shipment arrived yesterday.",
+      "translation": "đống lớn",
+      "count": 0
+    },
+    {
+      "word": "attribute (v) /əˈtrɪbjuːt/",
+      "meaning": "to regard something as the cause or result of something else",
+      "example": "She attributed her success to hard work and luck.",
+      "translation": "quy cho",
+      "count": 0
+    },
+    {
+      "word": "bereavement (n) /bɪˈriːvmənt/",
+      "meaning": "a deep feeling of loss after someone close dies",
+      "example": "She struggled with grief during her bereavement.",
+      "translation": "mất mát",
+      "count": 0
+    },
+    {
+      "word": "cause (v) /kɔːz/",
+      "meaning": "to make something happen, especially something bad",
+      "example": "Smoking can cause serious health problems.",
+      "translation": "gây ra",
+      "count": 0
+    },
+    {
+      "word": "cause (n) /kɔːz/",
+      "meaning": "the reason why something happens",
+      "example": "The cause of the fire is still under investigation.",
+      "translation": "nguyên nhân",
+      "count": 0
+    },
+    {
+      "word": "coincidence (n) /kəʊˈɪnsɪdəns/",
+      "meaning": "an unexpected and accidental occurrence of similar events",
+      "example": "It was a coincidence that we met at the airport.",
+      "translation": "sự trùng hợp",
+      "count": 0
+    },
+    {
+      "word": "curse (v) /kɜːs/",
+      "meaning": "to wish something bad to happen using magical powers",
+      "example": "He believed the old woman had cursed him.",
+      "translation": "nguyền rủa",
+      "count": 0
+    },
+    {
+      "word": "curse (n) /kɜːs/",
+      "meaning": "a magical spell that brings bad luck or harm",
+      "example": "They say the tomb carries a deadly curse.",
+      "translation": "lời nguyền",
+      "count": 0
+    },
+    {
+      "word": "deliberate (adj) /dɪˈlɪbərət/",
+      "meaning": "intentional and done on purpose",
+      "example": "It was a deliberate attempt to mislead the public.",
+      "translation": "có chủ đích",
+      "count": 0
+    },
+    {
+      "word": "determine (v) /dɪˈtɜːmɪn/",
+      "meaning": "to discover something through analysis or evidence",
+      "example": "They are trying to determine the cause of the explosion.",
+      "translation": "xác định",
+      "count": 0
+    },
+    {
+      "word": "fate (n) /feɪt/",
+      "meaning": "a power that is believed to control future events",
+      "example": "She believes that fate brought them together.",
+      "translation": "định mệnh",
+      "count": 0
+    },
+    {
+      "word": "fluctuate (v) /ˈflʌktʃueɪt/",
+      "meaning": "to change irregularly in level, strength, or value",
+      "example": "Oil prices have fluctuated wildly this year.",
+      "translation": "biến động",
+      "count": 0
+    },
+    {
+      "word": "foresee (v) /fɔːˈsiː/",
+      "meaning": "to know or expect something before it happens",
+      "example": "We couldn't foresee the crisis that followed.",
+      "translation": "dự đoán",
+      "count": 0
+    },
+    {
+      "word": "freak (n) /friːk/",
+      "meaning": "someone or something very unusual or unexpected",
+      "example": "He’s considered a freak for collecting rare insects.",
+      "translation": "kì dị",
+      "count": 0
+    },
+    {
+      "word": "freak (adj) /friːk/",
+      "meaning": "highly unusual and unexpected",
+      "example": "Several people were injured during a freak accident.",
+      "translation": "kì dị",
+      "count": 0
+    },
+    {
+      "word": "gamble (v) /ˈɡæmbl/",
+      "meaning": "to risk something valuable in hopes of gaining more",
+      "example": "He never gambles more than he can afford to lose.",
+      "translation": "đánh bạc",
+      "count": 0
+    },
+    {
+      "word": "haphazard (adj) /ˌhæpˈhæzəd/",
+      "meaning": "lacking planning or order",
+      "example": "Their furniture arrangement looked completely haphazard.",
+      "translation": "bừa bãi",
+      "count": 0
+    },
+    {
+      "word": "hazard (n) /ˈhæzəd/",
+      "meaning": "a potential source of danger or harm",
+      "example": "They were warned of the fire hazards in the building.",
+      "translation": "nguy hiểm",
+      "count": 0
+    },
+    {
+      "word": "inadvertent (adj) /ˌɪnədˈvɜːtənt/",
+      "meaning": "not done on purpose; unintentional",
+      "example": "Her comment was an inadvertent insult.",
+      "translation": "vô ý",
+      "count": 0
+    },
+    {
+      "word": "instrumental (adj) /ˌɪnstrəˈmentl/",
+      "meaning": "playing a key role in achieving something",
+      "example": "He was instrumental in securing the deal.",
+      "translation": "quan trọng",
+      "count": 0
+    },
+    {
+      "word": "jinxed (adj) /dʒɪŋkst/",
+      "meaning": "considered to bring bad luck",
+      "example": "She felt jinxed after missing her flight again.",
+      "translation": "xui xẻo",
+      "count": 0
+    },
+    {
+      "word": "likelihood (n) /ˈlaɪklihʊd/",
+      "meaning": "the chance of something happening",
+      "example": "There's a strong likelihood of rain tomorrow.",
+      "translation": "khả năng xảy ra",
+      "count": 0
+    },
+    {
+      "word": "lucky charm (n phr) /ˌlʌki ˈtʃɑːm/",
+      "meaning": "an object believed to bring good fortune",
+      "example": "She always carries a lucky charm in her pocket.",
+      "translation": "vật may mắn",
+      "count": 0
+    },
+    {
+      "word": "meander (v) /miˈændə/",
+      "meaning": "to wander without a clear direction or goal",
+      "example": "We spent the afternoon meandering through the park.",
+      "translation": "lang thang",
+      "count": 0
+    },
+    {
+      "word": "mishap (n) /ˈmɪshæp/",
+      "meaning": "a small accident or unlucky event",
+      "example": "Apart from a few mishaps, the trip went smoothly.",
+      "translation": "tai nạn",
+      "count": 0
+    },
+    {
+      "word": "mutate (v) /mjuːˈteɪt/",
+      "meaning": "to change physically, often in a genetic way",
+      "example": "The virus can mutate into new variants.",
+      "translation": "biến đổi",
+      "count": 0
+    },
+    {
+      "word": "odds (n) /ɒdz/",
+      "meaning": "the probability of something happening",
+      "example": "The odds of getting that job are pretty low.",
+      "translation": "tỉ lệ",
+      "count": 0
+    },
+    {
+      "word": "pick (v) /pɪk/",
+      "meaning": "to select something from a group",
+      "example": "He picked a red shirt from the rack.",
+      "translation": "chọn",
+      "count": 0
+    },
+    {
+      "word": "pick (n) /pɪk/",
+      "meaning": "a choice or selected option",
+      "example": "Take your pick from the list of destinations.",
+      "translation": "sự lựa chọn",
+      "count": 0
+    },
+    {
+      "word": "pot luck (n phr) /pɒt ˈlʌk/",
+      "meaning": "a situation with an unpredictable outcome",
+      "example": "Choosing a restaurant without checking reviews is pure pot luck.",
+      "translation": "may rủi",
+      "count": 0
+    },
+    {
+      "word": "random (adj) /ˈrændəm/",
+      "meaning": "happening without a definite pattern or reason",
+      "example": "He was chosen through a random draw.",
+      "translation": "ngẫu nhiên",
+      "count": 0
+    },
+    {
+      "word": "sign (n) /saɪn/",
+      "meaning": "evidence that something is happening or about to happen",
+      "example": "The dark clouds were a sign of an approaching storm.",
+      "translation": "dấu hiệu",
+      "count": 0
+    },
+    {
+      "word": "speculate (v) /ˈspekjuleɪt/",
+      "meaning": "to form ideas or theories without firm evidence",
+      "example": "People began to speculate about the cause of the delay.",
+      "translation": "suy đoán",
+      "count": 0
+    },
+    {
+      "word": "spontaneous (adj) /spɒnˈteɪniəs/",
+      "meaning": "done naturally, without being planned",
+      "example": "Their spontaneous trip turned out to be the best one.",
+      "translation": "tự phát",
+      "count": 0
+    },
+    {
+      "word": "startle (v) /ˈstɑːtl/",
+      "meaning": "to surprise or scare someone suddenly",
+      "example": "The loud bang startled everyone in the room.",
+      "translation": "làm giật mình",
+      "count": 0
+    },
+    {
+      "word": "statistics (n) /stəˈtɪstɪks/",
+      "meaning": "numerical data representing facts or information",
+      "example": "According to statistics, sales dropped last quarter.",
+      "translation": "số liệu thống kê",
+      "count": 0
+    },
+    {
+      "word": "stray (v) /streɪ/",
+      "meaning": "to move away from the intended route",
+      "example": "Don’t stray from the main trail.",
+      "translation": "đi lạc",
+      "count": 0
+    },
+    {
+      "word": "stray (adj) /streɪ/",
+      "meaning": "lost or separated from the group or home",
+      "example": "The shelter takes care of stray animals.",
+      "translation": "lạc",
+      "count": 0
+    },
+    {
+      "word": "stray (n) /streɪ/",
+      "meaning": "an animal without a home or owner",
+      "example": "We adopted a stray that wandered into our yard.",
+      "translation": "vật nuôi bị lạc",
+      "count": 0
+    },
+    {
+      "word": "superstition (n) /ˌsuːpəˈstɪʃn/",
+      "meaning": "a belief that supernatural forces influence events",
+      "example": "Do you really believe in that old superstition?",
+      "translation": "mê tín",
+      "count": 0
+    },
+    {
+      "word": "superstitious (adj) /ˌsuːpəˈstɪʃəs/",
+      "meaning": "believing that certain events bring good or bad luck",
+      "example": "I'm quite superstitious and avoid walking under ladders.",
+      "translation": "mê tín",
+      "count": 0
+    },
+    {
+      "word": "stutter (v)",
+      "meaning": "to repeat sounds when speaking due to nervousness or a speech issue",
+      "example": "He began to stutter as he answered the question.",
+      "translation": "nói lắp",
+      "count": 0
+    },
+    {
+      "word": "tip (n)",
+      "meaning": "a helpful piece of advice",
+      "example": "The booklet offers some great travel tips.",
+      "translation": "mẹo",
+      "count": 0
+    },
+    {
+      "word": "utter (v)",
+      "meaning": "to speak or make a sound",
+      "example": "She didn’t utter a word during the meeting.",
+      "translation": "nói ra",
+      "count": 0
+    },
+    {
+      "word": "vague (adj)",
+      "meaning": "unclear or not detailed",
+      "example": "The instructions were so vague that I got confused.",
+      "translation": "mơ hồ",
+      "count": 0
+    },
+    {
+      "word": "anchor (n)",
+      "meaning": "a person who presents news on TV or radio",
+      "example": "She became the main news anchor for the evening show.",
+      "translation": "người dẫn chương trình",
+      "count": 0
+    },
+    {
+      "word": "broadcast (v)",
+      "meaning": "to air a TV or radio program",
+      "example": "The ceremony will be broadcast live on national television.",
+      "translation": "phát sóng",
+      "count": 0
+    },
+    {
+      "word": "caption (n)",
+      "meaning": "a line of text that explains a photo or illustration",
+      "example": "The caption under the image explained its origin.",
+      "translation": "chú thích",
+      "count": 0
+    },
+    {
+      "word": "columnist (n)",
+      "meaning": "a writer who regularly contributes articles to a publication",
+      "example": "He’s a popular columnist for a major magazine.",
+      "translation": "nhà báo chuyên mục",
+      "count": 0
+    },
+    {
+      "word": "correspondent (n)",
+      "meaning": "a journalist who reports news from a particular area",
+      "example": "Our foreign correspondent reported from the scene.",
+      "translation": "phóng viên",
+      "count": 0
+    },
+    {
+      "word": "coverage (n)",
+      "meaning": "the reporting of events in the media",
+      "example": "Media coverage of the election was extensive.",
+      "translation": "tin tức",
+      "count": 0
+    },
+    {
+      "word": "critic (n)",
+      "meaning": "someone who evaluates and comments on artistic work",
+      "example": "The critic gave the movie a poor review.",
+      "translation": "nhà phê bình",
+      "count": 0
+    },
+    {
+      "word": "footnote (n)",
+      "meaning": "a note at the bottom of a page for extra details",
+      "example": "He added a footnote to explain the term.",
+      "translation": "chú thích cuối trang",
+      "count": 0
+    },
+    {
+      "word": "ghostwriter (n)",
+      "meaning": "a person who writes for another who is credited as the author",
+      "example": "The biography was written by a ghostwriter.",
+      "translation": "người viết thuê",
+      "count": 0
+    },
+    {
+      "word": "handbook (n)",
+      "meaning": "a small book with instructions or information",
+      "example": "Read the employee handbook before starting your job.",
+      "translation": "sổ tay",
+      "count": 0
+    },
+    {
+      "word": "manifesto (n)",
+      "meaning": "a public declaration of policies and goals",
+      "example": "Their manifesto outlines their future plans.",
+      "translation": "tuyên ngôn",
+      "count": 0
+    },
+    {
+      "word": "novelist (n)",
+      "meaning": "a person who writes fictional books",
+      "example": "She became a successful novelist after publishing her first book.",
+      "translation": "tiểu thuyết gia",
+      "count": 0
+    },
+    {
+      "word": "pamphlet (n)",
+      "meaning": "a small unbound booklet",
+      "example": "The pamphlet outlines the new recycling rules.",
+      "translation": "tờ rơi",
+      "count": 0
+    },
+    {
+      "word": "prerecorded (adj)",
+      "meaning": "recorded in advance for later use",
+      "example": "The show aired a prerecorded segment.",
+      "translation": "ghi hình trước",
+      "count": 0
+    },
+    {
+      "word": "reviewer (n)",
+      "meaning": "a person who writes reviews of books, movies, etc.",
+      "example": "The reviewer gave the novel high praise.",
+      "translation": "người phê bình",
+      "count": 0
+    },
+    {
+      "word": "spine (n)",
+      "meaning": "the part of a book where pages are bound",
+      "example": "The book’s title is printed on the spine.",
+      "translation": "gáy sách",
+      "count": 0
+    },
+    {
+      "word": "subtitles (n)",
+      "meaning": "text on screen translating spoken words in a film",
+      "example": "I watched the movie with English subtitles.",
+      "translation": "phụ đề",
+      "count": 0
+    },
+    {
+      "word": "supplement (n)",
+      "meaning": "an extra section in a newspaper or magazine",
+      "example": "The weekend paper includes a travel supplement.",
+      "translation": "phần phụ lục",
+      "count": 0
+    },
+    {
+      "word": "tabloid (adj)",
+      "meaning": "relating to short-form or sensationalist newspapers",
+      "example": "He enjoys reading tabloid stories.",
+      "translation": "báo lá cải",
+      "count": 0
+    },
+    {
+      "word": "tabloid (n)",
+      "meaning": "a newspaper with small pages that often focuses on sensational news",
+      "example": "He reads the tabloid for celebrity gossip every morning.",
+      "translation": "báo khổ nhỏ",
+      "count": 0
+    },
+    {
+      "word": "trailer (n)",
+      "meaning": "a short promotional video for a movie or show",
+      "example": "We watched the trailer for the new Marvel film.",
+      "translation": "đoạn giới thiệu phim",
+      "count": 0
+    },
+    {
+      "word": "approximate (v)",
+      "meaning": "to estimate or calculate something roughly",
+      "example": "We approximated the cost to be around $500.",
+      "translation": "ước tính",
+      "count": 0
+    },
+    {
+      "word": "approximate (adj)",
+      "meaning": "close to the actual number or value but not exact",
+      "example": "The approximate distance is 10 kilometers.",
+      "translation": "xấp xỉ",
+      "count": 0
+    },
+    {
+      "word": "ascribe (v)",
+      "meaning": "to say that something is caused by a particular thing or person",
+      "example": "They ascribed the success to teamwork.",
+      "translation": "gán cho",
+      "count": 0
+    },
+    {
+      "word": "assign (v)",
+      "meaning": "to give someone a specific duty or position",
+      "example": "She was assigned to lead the new project.",
+      "translation": "phân công",
+      "count": 0
+    },
+    {
+      "word": "ghostwriter (n)",
+      "meaning": "a person who writes for someone else who gets the credit",
+      "example": "His biography was written by a ghostwriter.",
+      "translation": "người viết thuê",
+      "count": 0
+    },
+    {
+      "word": "handbook (n)",
+      "meaning": "a small guidebook giving useful information",
+      "example": "The employee handbook explains all the company rules.",
+      "translation": "sổ tay hướng dẫn",
+      "count": 0
+    },
+    {
+      "word": "convey (v)",
+      "meaning": "to express a thought, feeling, or idea",
+      "example": "She used a photo to convey her emotions.",
+      "translation": "truyền đạt",
+      "count": 0
+    },
+    {
+      "word": "declare (v)",
+      "meaning": "to formally state something publicly",
+      "example": "They declared victory after the final vote.",
+      "translation": "tuyên bố",
+      "count": 0
+    },
+    {
+      "word": "denounce (v)",
+      "meaning": "to publicly criticize something as wrong or evil",
+      "example": "The leader denounced the corruption in his speech.",
+      "translation": "lên án",
+      "count": 0
+    },
+    {
+      "word": "disclose (v)",
+      "meaning": "to make information known, especially secret ones",
+      "example": "He refused to disclose any names.",
+      "translation": "tiết lộ",
+      "count": 0
+    },
+    {
+      "word": "exaggerate (v)",
+      "meaning": "to overstate or make something appear more extreme",
+      "example": "She exaggerated the problem to get attention.",
+      "translation": "phóng đại",
+      "count": 0
+    },
+    {
+      "word": "flatter (v)",
+      "meaning": "to praise excessively, often insincerely",
+      "example": "He always flatters the manager to gain favor.",
+      "translation": "tâng bốc",
+      "count": 0
+    },
+    {
+      "word": "gist (n)",
+      "meaning": "the general or main idea of something",
+      "example": "I didn’t understand every word, but I got the gist.",
+      "translation": "ý chính",
+      "count": 0
+    },
+    {
+      "word": "hint (n)",
+      "meaning": "a small suggestion or clue",
+      "example": "She dropped a hint about wanting a promotion.",
+      "translation": "gợi ý",
+      "count": 0
+    },
+    {
+      "word": "illegible (adj)",
+      "meaning": "impossible or difficult to read",
+      "example": "His writing was so messy it was illegible.",
+      "translation": "khó đọc",
+      "count": 0
+    },
+    {
+      "word": "inkling (n)",
+      "meaning": "a slight idea or suspicion about something",
+      "example": "I had no inkling that he was planning a surprise.",
+      "translation": "manh mối",
+      "count": 0
+    },
+    {
+      "word": "insist (v)",
+      "meaning": "to demand something strongly",
+      "example": "She insisted that he stay for dinner.",
+      "translation": "khăng khăng",
+      "count": 0
+    },
+    {
+      "word": "jargon (n)",
+      "meaning": "special words used by professionals or groups",
+      "example": "The report was full of legal jargon.",
+      "translation": "thuật ngữ",
+      "count": 0
+    },
+    {
+      "word": "literal (adj)",
+      "meaning": "representing the exact meaning of words",
+      "example": "She took the comment in its literal sense.",
+      "translation": "nghĩa đen",
+      "count": 0
+    },
+    {
+      "word": "mumble (v)",
+      "meaning": "to speak unclearly and quietly",
+      "example": "He mumbled something under his breath.",
+      "translation": "lẩm bẩm",
+      "count": 0
+    },
+    {
+      "word": "murmur (n)",
+      "meaning": "a soft and low sound made by voices or objects",
+      "example": "A gentle murmur ran through the audience.",
+      "translation": "tiếng thì thầm",
+      "count": 0
+    },
+    {
+      "word": "petition (n)",
+      "meaning": "a formal written request signed by many people",
+      "example": "They submitted a petition to stop the project.",
+      "translation": "kiến nghị",
+      "count": 0
+    },
+    {
+      "word": "placard (n)",
+      "meaning": "a large sign used for protest or demonstration",
+      "example": "The protesters waved placards demanding justice.",
+      "translation": "biểu ngữ",
+      "count": 0
+    },
+    {
+      "word": "quibble (v)",
+      "meaning": "to argue over small and unimportant details",
+      "example": "Let’s not quibble about who should pay the bill.",
+      "translation": "cãi vặt",
+      "count": 0
+    },
+    {
+      "word": "rant (n)",
+      "meaning": "an angry, often loud complaint about something",
+      "example": "He went on a long rant about unfair taxes.",
+      "translation": "lời phàn nàn dữ dội",
+      "count": 0
+    },
+    {
+      "word": "rave (v)",
+      "meaning": "to talk enthusiastically about something you admire",
+      "example": "Everyone raved about the new restaurant.",
+      "translation": "nói một cách say mê",
+      "count": 0
+    },
+    {
+      "word": "relevant (adj)",
+      "meaning": "closely connected or appropriate to the matter at hand",
+      "example": "Only include relevant facts in your report.",
+      "translation": "liên quan",
+      "count": 0
+    },
+    {
+      "word": "scribble (v)",
+      "meaning": "to write something quickly and carelessly",
+      "example": "She scribbled a number on the napkin.",
+      "translation": "viết nguệch ngoạc",
+      "count": 0
+    },
+    {
+      "word": "slang (n)",
+      "meaning": "informal language used by particular groups",
+      "example": "Teenagers use a lot of modern slang.",
+      "translation": "từ lóng",
+      "count": 0
+    },
+    {
+      "word": "stumble (v)",
+      "meaning": "to make an error while speaking or reading",
+      "example": "He stumbled several times during his speech.",
+      "translation": "nói vấp",
+      "count": 0
+    },
+    {
+      "word": "stutter (v)",
+      "meaning": "to repeat sounds or syllables while speaking",
+      "example": "He began to stutter when he was nervous.",
+      "translation": "nói lắp",
+      "count": 0
+    },
+    {
+      "word": "imply (v)",
+      "meaning": "to suggest something without saying it directly",
+      "example": "Are you implying that it was my fault?",
+      "translation": "ngụ ý",
+      "count": 0
+    },
+    {
+      "word": "interpret (v)",
+      "meaning": "to explain or understand the meaning of something",
+      "example": "How do you interpret these figures?",
+      "translation": "diễn giải",
+      "count": 0
+    },
+    {
+      "word": "pronounce (v)",
+      "meaning": "to speak a word clearly and correctly",
+      "example": "He can’t pronounce her name properly.",
+      "translation": "phát âm",
+      "count": 0
+    },
+    {
+      "word": "propose (v)",
+      "meaning": "to suggest an idea or plan",
+      "example": "She proposed that we delay the meeting.",
+      "translation": "đề xuất",
+      "count": 0
+    },
+    {
+      "word": "reveal (v)",
+      "meaning": "to make something previously unknown known",
+      "example": "The witness revealed new evidence.",
+      "translation": "tiết lộ",
+      "count": 0
+    },
+    {
+      "word": "state (v)",
+      "meaning": "to express something formally or clearly",
+      "example": "He stated his position firmly.",
+      "translation": "phát biểu",
+      "count": 0
+    },
+    {
+      "word": "utter (v)",
+      "meaning": "to speak or express something out loud",
+      "example": "She didn’t utter a word the whole evening.",
+      "translation": "thốt ra",
+      "count": 0
+    },
+    {
+      "word": "vocal (adj)",
+      "meaning": "expressing opinions clearly, especially in speech",
+      "example": "He was very vocal in his criticism of the plan.",
+      "translation": "nói thẳng, bộc lộ rõ",
+      "count": 0
+    },
+    {
+      "word": "progress (n)",
+      "meaning": "movement towards improvement or a goal",
+      "example": "Technology has made remarkable progress.",
+      "translation": "sự tiến bộ",
+      "count": 0
+    },
+    {
+      "word": "radical (adj)",
+      "meaning": "relating to major or fundamental change",
+      "example": "They made a radical decision to reorganize the company.",
+      "translation": "triệt để",
+      "count": 0
+    },
+    {
+      "word": "refine (v)",
+      "meaning": "to improve something by making small changes",
+      "example": "You should refine your writing before submission.",
+      "translation": "trau chuốt",
+      "count": 0
+    },
+    {
+      "word": "reform (v)",
+      "meaning": "to improve by removing faults or errors",
+      "example": "They want to reform the education system.",
+      "translation": "cải cách",
+      "count": 0
+    },
+    {
+      "word": "reform (n)",
+      "meaning": "a change made to improve a system or law",
+      "example": "Tax reform is high on the agenda.",
+      "translation": "cuộc cải cách",
+      "count": 0
+    },
+    {
+      "word": "remain (v)",
+      "meaning": "to stay in the same condition or place",
+      "example": "Despite the storm, the structure remained intact.",
+      "translation": "giữ nguyên",
+      "count": 0
+    },
+    {
+      "word": "revise (v)",
+      "meaning": "to reconsider or change something after thought",
+      "example": "He revised his plan after the feedback.",
+      "translation": "xem xét lại",
+      "count": 0
+    },
+    {
+      "word": "revolution (n)",
+      "meaning": "a sudden and major change in a system or way of life",
+      "example": "The internet sparked a revolution in communication.",
+      "translation": "cuộc cách mạng",
+      "count": 0
+    },
+    {
+      "word": "revolution (n)",
+      "meaning": "a political uprising that replaces the government",
+      "example": "The revolution overthrew the old regime.",
+      "translation": "cách mạng chính trị",
+      "count": 0
+    },
+    {
+      "word": "shift (v)",
+      "meaning": "to change direction, focus, or approach",
+      "example": "Public opinion began to shift after the new policy was announced.",
+      "translation": "thay đổi",
+      "count": 0
+    },
+    {
+      "word": "shift (n)",
+      "meaning": "a movement or change in position or perspective",
+      "example": "There’s been a shift in consumer expectations recently.",
+      "translation": "sự thay đổi",
+      "count": 0
+    },
+    {
+      "word": "spoil (v)",
+      "meaning": "to ruin the value, quality, or enjoyment of something",
+      "example": "Heavy rain spoiled our plans for a picnic.",
+      "translation": "làm hỏng",
+      "count": 0
+    },
+    {
+      "word": "status quo (n)",
+      "meaning": "the current situation or existing state of affairs",
+      "example": "Many voters preferred to maintain the status quo.",
+      "translation": "hiện trạng hiện tại",
+      "count": 0
+    },
+    {
+      "word": "steady (v)",
+      "meaning": "to keep something from moving or falling",
+      "example": "He reached out to steady the chair before sitting.",
+      "translation": "giữ vững",
+      "count": 0
+    },
+    {
+      "word": "steady (adj)",
+      "meaning": "firm and not likely to move or change suddenly",
+      "example": "She kept a steady pace throughout the race.",
+      "translation": "vững vàng",
+      "count": 0
+    },
+    {
+      "word": "steady (adj)",
+      "meaning": "consistent in level or rate",
+      "example": "Sales have remained steady over the past quarter.",
+      "translation": "đều đều",
+      "count": 0
+    },
+    {
+      "word": "substitute (v)",
+      "meaning": "to use something instead of something else",
+      "example": "You can substitute yogurt for sour cream in the recipe.",
+      "translation": "thay thế",
+      "count": 0
+    },
+    {
+      "word": "substitute (n)",
+      "meaning": "a thing or person used in place of another",
+      "example": "Almond milk is a common substitute for dairy milk.",
+      "translation": "vật thay thế",
+      "count": 0
+    },
+    {
+      "word": "sustain (v)",
+      "meaning": "to support or keep something going continuously",
+      "example": "They couldn’t sustain the effort without more funding.",
+      "translation": "duy trì",
+      "count": 0
+    },
+    {
+      "word": "switch (v)",
+      "meaning": "to exchange one thing for another",
+      "example": "She switched her major from biology to economics.",
+      "translation": "hoán đổi",
+      "count": 0
+    },
+    {
+      "word": "switch (n)",
+      "meaning": "a change from one thing to another",
+      "example": "The switch from manual to automatic processing improved efficiency.",
+      "translation": "hoán đổi",
+      "count": 0
+    },
+    {
+      "word": "switch (n)",
+      "meaning": "a device for turning something on or off",
+      "example": "I flipped the switch and the lights came on.",
+      "translation": "công tắc",
+      "count": 0
+    },
+    {
+      "word": "transform (v)",
+      "meaning": "to change something completely in appearance or character",
+      "example": "The renovation transformed the old building into a modern office.",
+      "translation": "biến đổi",
+      "count": 0
+    },
+    {
+      "word": "trend (n)",
+      "meaning": "a general direction of change or development",
+      "example": "There’s a growing trend toward plant-based diets.",
+      "translation": "xu hướng",
+      "count": 0
+    },
+    {
+      "word": "uniform (adj)",
+      "meaning": "remaining the same across all situations or places",
+      "example": "The rules are applied in a uniform manner.",
+      "translation": "giống nhau",
+      "count": 0
+    },
+    {
+      "word": "breakthrough (n)",
+      "meaning": "an important development or discovery after effort",
+      "example": "The scientist made a breakthrough in cancer research.",
+      "translation": "bước đột phá",
+      "count": 0
+    },
+    {
+      "word": "broadband (adj)",
+      "meaning": "able to transmit multiple signals simultaneously",
+      "example": "Broadband technology enables fast internet access.",
+      "translation": "băng thông rộng",
+      "count": 0
+    },
+    {
+      "word": "broadband (n)",
+      "meaning": "a fast internet connection",
+      "example": "We upgraded to broadband for smoother streaming.",
+      "translation": "băng thông rộng",
+      "count": 0
+    },
+    {
+      "word": "click (v)",
+      "meaning": "to press a mouse button to select or activate something",
+      "example": "Click the icon to open the application.",
+      "translation": "nhấp chuột",
+      "count": 0
+    },
+    {
+      "word": "complex (adj)",
+      "meaning": "involving many parts or details, hard to understand",
+      "example": "The instructions were too complex for beginners.",
+      "translation": "phức tạp",
+      "count": 0
+    },
+    {
+      "word": "consumer electronics (n phr)",
+      "meaning": "electronic products used by the general public",
+      "example": "New trends in consumer electronics appear every year.",
+      "translation": "đồ điện tử",
+      "count": 0
+    },
+    {
+      "word": "craft (v)",
+      "meaning": "to carefully make something using skill",
+      "example": "He crafted a beautiful wooden bowl by hand.",
+      "translation": "gia công",
+      "count": 0
+    },
+    {
+      "word": "craft (n)",
+      "meaning": "a handmade art or skill using traditional methods",
+      "example": "She sells her handmade crafts at the market.",
+      "translation": "nghề thủ công",
+      "count": 0
+    },
+    {
+      "word": "data (n)",
+      "meaning": "facts or information stored digitally and used by computers",
+      "example": "The researchers collected data from 500 participants.",
+      "translation": "dữ liệu",
+      "count": 0
+    },
+    {
+      "word": "download (verb)",
+      "meaning": "to transfer data from the Internet to your computer",
+      "example": "She downloaded all the lecture materials last night.",
+      "translation": "tải xuống",
+      "count": 0
+    },
+    {
+      "word": "download (noun)",
+      "meaning": "a file that has been saved from the Internet to your device",
+      "example": "The download completed in just five minutes.",
+      "translation": "tệp đã tải xuống",
+      "count": 0
+    },
+    {
+      "word": "file (verb)",
+      "meaning": "to store or organize data electronically",
+      "example": "Please file the scanned receipts under the correct folder.",
+      "translation": "nhập liệu",
+      "count": 0
+    },
+    {
+      "word": "file (noun)",
+      "meaning": "a collection of data stored under one name on a computer",
+      "example": "You should back up your files regularly.",
+      "translation": "tệp dữ liệu",
+      "count": 0
+    },
+    {
+      "word": "games console (noun phrase)",
+      "meaning": "an electronic device used to play video games",
+      "example": "He spent the weekend playing on his new games console.",
+      "translation": "máy chơi game",
+      "count": 0
+    },
+    {
+      "word": "assess (verb)",
+      "meaning": "to evaluate a situation or person to form a judgment",
+      "example": "The teacher will assess each student’s presentation.",
+      "translation": "đánh giá",
+      "count": 0
+    },
+    {
+      "word": "assume (verb)",
+      "meaning": "to accept something as true without proof",
+      "example": "We can't just assume he's guilty without evidence.",
+      "translation": "cho rằng",
+      "count": 0
+    },
+    {
+      "word": "baffle (verb)",
+      "meaning": "to completely confuse or puzzle someone",
+      "example": "The instructions completely baffled me.",
+      "translation": "làm bối rối",
+      "count": 0
+    },
+    {
+      "word": "biased (adjective)",
+      "meaning": "unfairly supporting one side over another",
+      "example": "The article was clearly biased against the mayor.",
+      "translation": "thiên vị",
+      "count": 0
+    },
+    {
+      "word": "concentrate (verb)",
+      "meaning": "to focus all your attention on a task",
+      "example": "I can’t concentrate with all this noise around.",
+      "translation": "tập trung",
+      "count": 0
+    },
+    {
+      "word": "consider (verb)",
+      "meaning": "to think about something carefully before making a decision",
+      "example": "Have you considered applying for the scholarship?",
+      "translation": "cân nhắc",
+      "count": 0
+    },
+    {
+      "word": "contemplate (verb)",
+      "meaning": "to think deeply about something that might happen",
+      "example": "She contemplated taking a gap year.",
+      "translation": "suy tính",
+      "count": 0
+    },
+    {
+      "word": "cynical (adjective)",
+      "meaning": "believing that people are mostly motivated by selfishness",
+      "example": "He's grown cynical about politics.",
+      "translation": "hoài nghi",
+      "count": 0
+    },
+    {
+      "word": "deduce (verb)",
+      "meaning": "to reach a conclusion based on known facts",
+      "example": "From the footprints, we deduced that someone had left recently.",
+      "translation": "suy luận",
+      "count": 0
+    },
+    {
+      "word": "deliberate (verb)",
+      "meaning": "to discuss something thoroughly before making a decision",
+      "example": "The jury will deliberate before reaching a verdict.",
+      "translation": "cân nhắc, thảo luận kỹ",
+      "count": 0
+    },
+    {
+      "word": "dilemma (noun)",
+      "meaning": "a difficult situation where a choice must be made",
+      "example": "He faced a dilemma about whether to report the incident.",
+      "translation": "tiến thoái lưỡng nan",
+      "count": 0
+    },
+    {
+      "word": "discriminate (verb)",
+      "meaning": "to treat someone unfairly due to race, gender, or other reason",
+      "example": "It is illegal to discriminate against someone in the workplace.",
+      "translation": "phân biệt đối xử",
+      "count": 0
+    },
+    {
+      "word": "dubious (adjective)",
+      "meaning": "feeling doubt or suspicion about something",
+      "example": "She gave me a dubious look when I explained the plan.",
+      "translation": "đáng ngờ",
+      "count": 0
+    },
+    {
+      "word": "estimate (noun)",
+      "meaning": "a rough calculation of the value or number of something",
+      "example": "The repairman gave us an estimate for the costs.",
+      "translation": "sự ước tính",
+      "count": 0
+    },
+    {
+      "word": "faith (noun)",
+      "meaning": "strong belief or confidence in someone or something",
+      "example": "He never lost faith in his team.",
+      "translation": "niềm tin",
+      "count": 0
+    },
+    {
+      "word": "gather (verb)",
+      "meaning": "to come to understand something through clues or evidence",
+      "example": "From his expression, I gathered that he was upset.",
+      "translation": "hiểu, suy ra",
+      "count": 0
+    },
+    {
+      "word": "genius (noun)",
+      "meaning": "exceptional intellectual or creative ability",
+      "example": "Her genius for math was clear even at a young age.",
+      "translation": "thiên tài",
+      "count": 0
+    },
+    {
+      "word": "grasp (verb)",
+      "meaning": "to understand something clearly and completely",
+      "example": "It took me a while to grasp the concept.",
+      "translation": "hiểu thấu",
+      "count": 0
+    },
+    {
+      "word": "guesswork (noun)",
+      "meaning": "a method of finding an answer by guessing",
+      "example": "Predicting the weather is often just guesswork.",
+      "translation": "đoán mò",
+      "count": 0
+    },
+    {
+      "word": "hunch (noun)",
+      "meaning": "a gut feeling about something without proof",
+      "example": "I had a hunch he was hiding something.",
+      "translation": "linh cảm",
+      "count": 0
+    },
+    {
+      "word": "ideology (noun)",
+      "meaning": "a structured set of beliefs or ideas, often influencing politics or behavior",
+      "example": "Their policies are shaped by a strict political ideology.",
+      "translation": "hệ tư tưởng",
+      "count": 0
+    },
+    {
+      "word": "ingenious (adjective)",
+      "meaning": "showing cleverness or creativity in solving problems",
+      "example": "He built an ingenious device to water the plants automatically.",
+      "translation": "khéo léo, tài tình",
+      "count": 0
+    },
+    {
+      "word": "inspiration (noun)",
+      "meaning": "a sudden creative idea or motivation, often sparked by something",
+      "example": "Her latest painting was inspired by a dream.",
+      "translation": "nguồn cảm hứng",
+      "count": 0
+    },
+    {
+      "word": "intuition (noun)",
+      "meaning": "the ability to understand something without conscious reasoning",
+      "example": "He had a strong intuition that something was wrong.",
+      "translation": "trực giác",
+      "count": 0
+    },
+    {
+      "word": "justify (verb)",
+      "meaning": "to explain or give reasons for actions or decisions",
+      "example": "Can you justify why this decision was made?",
+      "translation": "biện minh",
+      "count": 0
+    },
+    {
+      "word": "naïve (adjective)",
+      "meaning": "lacking experience or judgment, often overly trusting",
+      "example": "She was too naïve to recognize the scam.",
+      "translation": "ngây thơ",
+      "count": 0
+    },
+    {
+      "word": "notion (noun)",
+      "meaning": "an idea, belief, or concept about something",
+      "example": "He has a romantic notion of life in the countryside.",
+      "translation": "khái niệm",
+      "count": 0
+    },
+    {
+      "word": "optimistic (adjective)",
+      "meaning": "expecting positive outcomes or success",
+      "example": "They remained optimistic despite the challenges.",
+      "translation": "lạc quan",
+      "count": 0
+    },
+    {
+      "word": "pessimistic (adjective)",
+      "meaning": "expecting the worst or focusing on negative outcomes",
+      "example": "Her pessimistic view discouraged the rest of the team.",
+      "translation": "bi quan",
+      "count": 0
+    },
+    {
+      "word": "prejudice (noun)",
+      "meaning": "an unfair opinion or bias formed without facts",
+      "example": "We must challenge social and racial prejudice.",
+      "translation": "định kiến",
+      "count": 0
+    },
+    {
+      "word": "query (verb)",
+      "meaning": "to ask about something in order to clarify or verify",
+      "example": "She queried the total on the invoice.",
+      "translation": "hỏi",
+      "count": 0
+    },
+    {
+      "word": "reckon (verb)",
+      "meaning": "to believe or assume something is true",
+      "example": "I reckon we’ll need more time to finish this.",
+      "translation": "đoán chắc",
+      "count": 0
+    },
+    {
+      "word": "reflect (verb)",
+      "meaning": "to think deeply about something",
+      "example": "He took a moment to reflect on the consequences.",
+      "translation": "suy nghĩ",
+      "count": 0
+    },
+    {
+      "word": "sceptical (adjective)",
+      "meaning": "having doubts about whether something is true or useful",
+      "example": "Many people are sceptical of the new treatment.",
+      "translation": "hoài nghi",
+      "count": 0
+    },
+    {
+      "word": "speculate (verb)",
+      "meaning": "to guess possible answers or outcomes without sufficient evidence",
+      "example": "People speculated about the reason for his resignation.",
+      "translation": "suy đoán",
+      "count": 0
+    },
+    {
+      "word": "suppose (verb)",
+      "meaning": "to believe something to be true or likely, often uncertainly",
+      "example": "I suppose we could try a different route.",
+      "translation": "giả định",
+      "count": 0
+    },
+    {
+      "word": "draw the short straw",
+      "meaning": "to be chosen to do an unpleasant or undesired task",
+      "example": "He drew the short straw and had to clean the bathroom.",
+      "translation": "bị ép phải làm",
+      "count": 0
+    },
+    {
+      "word": "fifty-fifty",
+      "meaning": "evenly split or shared between two parties",
+      "example": "We decided to go fifty-fifty on the expenses.",
+      "translation": "50-50, bằng nhau, như nhau",
+      "count": 0
+    },
+    {
+      "word": "absorb (verb)",
+      "meaning": "to take in liquid, energy, or information",
+      "example": "These towels absorb moisture quickly.",
+      "translation": "hấp thụ",
+      "count": 0
+    },
+    {
+      "word": "force (verb) /fɔːs/",
+      "meaning": "to push or move something using physical strength",
+      "example": "She forced the drawer open with a screwdriver.",
+      "translation": "đẩy",
+      "count": 0
+    },
+    {
+      "word": "fraction (noun) /ˈfrækʃən/",
+      "meaning": "a small portion or part of a larger whole",
+      "example": "Only a fraction of the audience understood the joke.",
+      "translation": "phần",
+      "count": 0
+    },
+    {
+      "word": "fraction (noun) /ˈfrækʃən/",
+      "meaning": "a numerical part of a whole, expressed with a slash or bar",
+      "example": "Three-quarters is a common fraction used in cooking.",
+      "translation": "phân số",
+      "count": 0
+    },
+    {
+      "word": "heap (noun) /hiːp/",
+      "meaning": "a messy pile of objects stacked together",
+      "example": "There was a heap of dirty laundry in the corner.",
+      "translation": "đống",
+      "count": 0
+    },
+    {
+      "word": "heap (verb) /hiːp/",
+      "meaning": "to stack things into a messy or large pile",
+      "example": "They heaped logs near the firepit.",
+      "translation": "chất đống",
+      "count": 0
+    },
+    {
+      "word": "imbalance (noun) /ɪmˈbæləns/",
+      "meaning": "a lack of equal or fair proportion between things",
+      "example": "There’s a major imbalance in income between rural and urban areas.",
+      "translation": "sự mất cân bằng",
+      "count": 0
+    },
+    {
+      "word": "immense (adjective) /ɪˈmens/",
+      "meaning": "extremely large in size or amount",
+      "example": "The project demanded an immense amount of time and dedication.",
+      "translation": "vô hạn",
+      "count": 0
+    },
+    {
+      "word": "intensity (noun) /ɪnˈtensəti/",
+      "meaning": "the strength or power of something such as emotion or activity",
+      "example": "The debate reached a new level of intensity.",
+      "translation": "cường độ",
+      "count": 0
+    },
+    {
+      "word": "magnitude (noun) /ˈmæɡnɪtjuːd/",
+      "meaning": "the great size, extent, or importance of something",
+      "example": "We underestimated the magnitude of the challenge ahead.",
+      "translation": "tầm cỡ",
+      "count": 0
+    },
+    {
+      "word": "major (adjective) /ˈmeɪdʒər/",
+      "meaning": "very important or serious in effect or scale",
+      "example": "Losing the contract was a major setback for the company.",
+      "translation": "lớn",
+      "count": 0
+    },
+    {
+      "word": "mass (noun) /mæs/",
+      "meaning": "a large quantity of something with no particular shape",
+      "example": "A dark mass of clouds gathered above us.",
+      "translation": "khối",
+      "count": 0
+    },
+    {
+      "word": "masses (noun plural) /ˈmæsɪz/",
+      "meaning": "a very large amount or number of something",
+      "example": "There were masses of people at the festival.",
+      "translation": "nhiều",
+      "count": 0
+    },
+    {
+      "word": "meagre (adjective) /ˈmiːɡər/",
+      "meaning": "insufficient in quantity or quality",
+      "example": "Many families survive on a meagre income.",
+      "translation": "ít ỏi",
+      "count": 0
+    },
+    {
+      "word": "minor (adjective) /ˈmaɪnər/",
+      "meaning": "not very significant or serious",
+      "example": "Luckily, he suffered only minor injuries.",
+      "translation": "nhỏ",
+      "count": 0
+    },
+    {
+      "word": "multiple (adjective) /ˈmʌltɪpl/",
+      "meaning": "involving or consisting of many parts or elements",
+      "example": "The product has multiple uses in the home.",
+      "translation": "nhiều",
+      "count": 0
+    },
+    {
+      "word": "rate (noun) /reɪt/",
+      "meaning": "the speed or frequency at which something occurs",
+      "example": "The unemployment rate has dropped this quarter.",
+      "translation": "tốc độ",
+      "count": 0
+    },
+    {
+      "word": "rate (verb) /reɪt/",
+      "meaning": "to judge or evaluate something as having a particular level",
+      "example": "The film was rated as one of the year’s best.",
+      "translation": "đánh giá",
+      "count": 0
+    },
+    {
+      "word": "ratio (noun) /ˈreɪʃiəʊ/",
+      "meaning": "a relationship between two values, typically in numbers",
+      "example": "The ratio of teachers to students is 1 to 25.",
+      "translation": "tỉ lệ",
+      "count": 0
+    },
+    {
+      "word": "shrink (verb) /ʃrɪŋk/",
+      "meaning": "to become smaller or cause something to become smaller",
+      "example": "The profits have continued to shrink over time.",
+      "translation": "co lại",
+      "count": 0
+    },
+    {
+      "word": "sum (noun) /sʌm/",
+      "meaning": "a specific amount of money",
+      "example": "They raised a considerable sum for charity.",
+      "translation": "khoản tiền",
+      "count": 0
+    },
+    {
+      "word": "uneven (adjective) /ʌnˈiːvn/",
+      "meaning": "not smooth or equal in surface, distribution, or quality",
+      "example": "The pavement is quite uneven, so be careful.",
+      "translation": "không bằng phẳng",
+      "count": 0
+    },
+    {
+      "word": "vast (adjective) /vɑːst/",
+      "meaning": "extremely large in scope or size",
+      "example": "The desert stretched across a vast area of land.",
+      "translation": "mênh mông",
+      "count": 0
+    },
+    {
+      "word": "volume (noun) /ˈvɒljuːm/",
+      "meaning": "the amount or quantity of something, often measured in units",
+      "example": "They handle a high volume of calls daily.",
+      "translation": "thể tích",
+      "count": 0
+    },
+    {
+      "word": "widespread (adjective) /ˈwaɪdspred/",
+      "meaning": "occurring across a large area or among many people",
+      "example": "There was widespread flooding after the storm.",
+      "translation": "lan rộng",
+      "count": 0
+    },
+    {
+      "word": "weight (noun) /weɪt/",
+      "meaning": "how heavy something is",
+      "example": "The box had a weight of over 20 kilograms.",
+      "translation": "trọng lượng",
+      "count": 0
+    },
+    {
+      "word": "weight (noun) /weɪt/",
+      "meaning": "the significance or impact of something",
+      "example": "His speech carried great emotional weight.",
+      "translation": "sức nặng",
+      "count": 0
+    },
+    {
+      "word": "benefit of the doubt (phrase)",
+      "meaning": "a decision to trust or believe someone despite uncertainty",
+      "example": "She got the benefit of the doubt and was released.",
+      "translation": "quyết định tin tưởng",
+      "count": 0
+    },
+    {
+      "word": "force (verb) /fɔːs/",
+      "meaning": "to push or apply power to move something",
+      "example": "He forced the door open with a crowbar.",
+      "translation": "đẩy",
+      "count": 0
+    },
+    {
+      "word": "fraction (noun) /ˈfrækʃən/",
+      "meaning": "a small segment or portion of something",
+      "example": "She earns only a fraction of what he does.",
+      "translation": "phần",
+      "count": 0
+    },
+    {
+      "word": "fraction (noun) /ˈfrækʃən/",
+      "meaning": "a mathematical expression for part of a whole",
+      "example": "The fraction 1/3 represents one-third of a whole.",
+      "translation": "phân số",
+      "count": 0
+    },
+    {
+      "word": "heap (noun) /hiːp/",
+      "meaning": "a large and often messy pile of items",
+      "example": "She dropped the laundry in a heap.",
+      "translation": "đống",
+      "count": 0
+    },
+    {
+      "word": "heap (verb) /hiːp/",
+      "meaning": "to pile up things in an untidy way",
+      "example": "She heaped her clothes on the bed before packing.",
+      "translation": "chất đống",
+      "count": 0
+    },
+    {
+      "word": "imbalance (noun) /ɪmˈbæləns/",
+      "meaning": "a lack of equality or proportion between two things",
+      "example": "Economic imbalance can lead to social unrest.",
+      "translation": "sự mất cân bằng",
+      "count": 0
+    },
+    {
+      "word": "immense (adjective) /ɪˈmens/",
+      "meaning": "extremely large or great",
+      "example": "He inherited an immense fortune from his grandfather.",
+      "translation": "vô hạn",
+      "count": 0
+    },
+    {
+      "word": "intensity (noun) /ɪnˈtensəti/",
+      "meaning": "the strength or force of something",
+      "example": "The intensity of the storm caught everyone off guard.",
+      "translation": "cường độ",
+      "count": 0
+    },
+    {
+      "word": "magnitude (noun) /ˈmæɡnɪtjuːd/",
+      "meaning": "the size, extent, or importance of something",
+      "example": "The magnitude of the crisis was not fully realized.",
+      "translation": "tầm cỡ",
+      "count": 0
+    },
+    {
+      "word": "major (adjective) /ˈmeɪdʒər/",
+      "meaning": "very large or important",
+      "example": "Climate change is a major global issue.",
+      "translation": "lớn",
+      "count": 0
+    },
+    {
+      "word": "mass (noun) /mæs/",
+      "meaning": "a large body of matter with no clear shape",
+      "example": "A dark mass of clouds formed overhead.",
+      "translation": "khối",
+      "count": 0
+    },
+    {
+      "word": "masses (noun plural) /ˈmæsɪz/",
+      "meaning": "a large quantity of people or things",
+      "example": "Masses of tourists crowded the beach.",
+      "translation": "nhiều",
+      "count": 0
+    },
+    {
+      "word": "meagre (adjective) /ˈmiːɡər/",
+      "meaning": "too small in amount or quality",
+      "example": "His meagre savings couldn't cover the rent.",
+      "translation": "ít ỏi",
+      "count": 0
+    },
+    {
+      "word": "minor (adjective) /ˈmaɪnər/",
+      "meaning": "not very important or serious",
+      "example": "There was a minor error in the report.",
+      "translation": "nhỏ",
+      "count": 0
+    },
+    {
+      "word": "multiple (adjective) /ˈmʌltɪpl/",
+      "meaning": "consisting of or involving several parts",
+      "example": "The building has multiple entrances.",
+      "translation": "nhiều",
+      "count": 0
+    },
+    {
+      "word": "rate (noun) /reɪt/",
+      "meaning": "the speed or frequency of something happening",
+      "example": "The heart rate increased during exercise.",
+      "translation": "tốc độ",
+      "count": 0
+    },
+    {
+      "word": "rate (verb) /reɪt/",
+      "meaning": "to judge the value or quality of something",
+      "example": "He rates among the best in his field.",
+      "translation": "đánh giá",
+      "count": 0
+    },
+    {
+      "word": "ratio (noun) /ˈreɪʃiəʊ/",
+      "meaning": "a relationship between two values, often in numbers",
+      "example": "They calculated the student-teacher ratio.",
+      "translation": "tỉ lệ",
+      "count": 0
+    },
+    {
+      "word": "shrink (verb) /ʃrɪŋk/",
+      "meaning": "to reduce in size or amount",
+      "example": "The fabric may shrink if washed in hot water.",
+      "translation": "co lại",
+      "count": 0
+    },
+    {
+      "word": "sum (noun) /sʌm/",
+      "meaning": "a quantity of money",
+      "example": "She received a large sum as a settlement.",
+      "translation": "khoản tiền",
+      "count": 0
+    },
+    {
+      "word": "uneven (adjective) /ʌnˈiːvn/",
+      "meaning": "not level or smooth",
+      "example": "The stairs were uneven and dangerous.",
+      "translation": "không bằng phẳng",
+      "count": 0
+    },
+    {
+      "word": "vast (adjective) /vɑːst/",
+      "meaning": "extremely large or extensive",
+      "example": "They explored the vast desert on camelback.",
+      "translation": "mênh mông",
+      "count": 0
+    },
+    {
+      "word": "volume (noun) /ˈvɒljuːm/",
+      "meaning": "the total amount or size of something",
+      "example": "We need to reduce the volume of waste produced.",
+      "translation": "thể tích",
+      "count": 0
+    },
+    {
+      "word": "widespread (adjective) /ˈwaɪdspred/",
+      "meaning": "happening or existing in many places or among many people",
+      "example": "Widespread internet access has changed communication.",
+      "translation": "lan rộng",
+      "count": 0
+    },
+    {
+      "word": "weight (noun) /weɪt/",
+      "meaning": "the measurement of how heavy something is",
+      "example": "She lost a significant amount of weight.",
+      "translation": "trọng lượng",
+      "count": 0
+    },
+    {
+      "word": "weight (noun) /weɪt/",
+      "meaning": "the significance or influence of something",
+      "example": "Her words carried a lot of emotional weight.",
+      "translation": "sức nặng",
+      "count": 0
+    },
+    {
+      "word": "benefit of the doubt (phrase)",
+      "meaning": "choosing to believe someone is innocent or truthful without proof",
+      "example": "I’ll give you the benefit of the doubt this time.",
+      "translation": "quyết định tin tưởng",
+      "count": 0
+    },
+    {
+      "word": "ratio (noun) /ˈreɪʃiəʊ/",
+      "meaning": "a comparison of two quantities",
+      "example": "They maintained a healthy ratio of work to rest.",
+      "translation": "tỉ lệ",
+      "count": 0
+    },
+    {
+      "word": "ration (noun) /ˈræʃn/",
+      "meaning": "a limited portion of food or supplies",
+      "example": "Each soldier received a daily food ration.",
+      "translation": "khẩu phần",
+      "count": 0
+    },
+    {
+      "word": "ration (verb) /ˈreɪʃn/",
+      "meaning": "to limit the amount of something people can use",
+      "example": "Water was rationed due to the severe drought.",
+      "translation": "chia phần, hạn chế",
+      "count": 0
+    },
+    {
+      "word": "shrink (verb) /ʃrɪŋk/",
+      "meaning": "to become smaller in size or amount",
+      "example": "The sweater shrank after washing in hot water.",
+      "translation": "co lại",
+      "count": 0
+    },
+    {
+      "word": "sufficient (adjective) /səˈfɪʃənt/",
+      "meaning": "enough for a particular purpose",
+      "example": "There was sufficient food for everyone at the party.",
+      "translation": "đủ",
+      "count": 0
+    },
+    {
+      "word": "sum (noun) /sʌm/",
+      "meaning": "a specific amount of money",
+      "example": "They donated a large sum to the charity.",
+      "translation": "khoản tiền",
+      "count": 0
+    },
+    {
+      "word": "sum (noun) /sʌm/",
+      "meaning": "a basic mathematical calculation",
+      "example": "He helped his sister solve the math sums.",
+      "translation": "phép toán",
+      "count": 0
+    },
+    {
+      "word": "uneven (adjective) /ʌnˈiːvən/",
+      "meaning": "not equal or consistent in quality or size",
+      "example": "Progress across regions has been uneven.",
+      "translation": "thất thường",
+      "count": 0
+    },
+    {
+      "word": "vast (adjective) /vɑːst/",
+      "meaning": "very large in extent or quantity",
+      "example": "They explored a vast stretch of wilderness.",
+      "translation": "bao la",
+      "count": 0
+    },
+    {
+      "word": "volume (noun) /ˈvɒljʊm/",
+      "meaning": "a quantity or amount of something",
+      "example": "The store handles a high volume of orders daily.",
+      "translation": "lượng",
+      "count": 0
+    },
+    {
+      "word": "volume (noun) /ˈvɒljʊm/",
+      "meaning": "the space an object occupies",
+      "example": "The container has a volume of 2 liters.",
+      "translation": "khối lượng",
+      "count": 0
+    },
+    {
+      "word": "widespread (adjective) /ˌwaɪdˈspred/",
+      "meaning": "existing or happening in many places",
+      "example": "Widespread power outages affected the region.",
+      "translation": "lan rộng, phổ biến",
+      "count": 0
+    },
+    {
+      "word": "benefit (noun) /ˈbenɪfɪt/",
+      "meaning": "financial help from the government",
+      "example": "They applied for housing benefit after losing their jobs.",
+      "translation": "tiền trợ cấp",
+      "count": 0
+    },
+    {
+      "word": "benefit (noun) /ˈbenɪfɪt/",
+      "meaning": "an advantage or positive result",
+      "example": "Exercise has many health benefits.",
+      "translation": "lợi ích",
+      "count": 0
+    },
+    {
+      "word": "benefit (verb) /bəˈnefɪt/",
+      "meaning": "to gain or receive a good result",
+      "example": "Employees benefited from the new training program.",
+      "translation": "hưởng lợi",
+      "count": 0
+    },
+    {
+      "word": "compensation (noun) /ˌkɒmpenˈseɪʃən/",
+      "meaning": "money given for loss or damage",
+      "example": "The company offered compensation for the delays.",
+      "translation": "khoản bồi thường",
+      "count": 0
+    },
+    {
+      "word": "damages (noun) /ˈdæmɪdʒɪz/",
+      "meaning": "money paid as legal reparation for harm",
+      "example": "He received damages for the injury caused.",
+      "translation": "tiền bồi thường thiệt hại",
+      "count": 0
+    },
+    {
+      "word": "debt (noun) /det/",
+      "meaning": "money that is owed to someone",
+      "example": "She worked two jobs to pay off her debts.",
+      "translation": "khoản nợ",
+      "count": 0
+    },
+    {
+      "word": "deduct (verb) /dɪˈdʌkt/",
+      "meaning": "to subtract an amount from a total",
+      "example": "They deducted tax from his monthly salary.",
+      "translation": "khấu trừ",
+      "count": 0
+    },
+    {
+      "word": "deposit (noun) /dɪˈpɒzɪt/",
+      "meaning": "a partial payment made in advance",
+      "example": "She paid a deposit to reserve the apartment.",
+      "translation": "tiền đặt cọc",
+      "count": 0
+    },
+    {
+      "word": "deposit (noun) /dɪˈpɒzɪt/",
+      "meaning": "money placed into a bank account",
+      "example": "He checked his bank deposit the next day.",
+      "translation": "tiền gửi (ngân hàng)",
+      "count": 0
+    },
+    {
+      "word": "deposit (verb) /dɪˈpɒzɪt/",
+      "meaning": "to place money into a bank account",
+      "example": "She deposited her paycheck this morning.",
+      "translation": "gửi tiền (ngân hàng)",
+      "count": 0
+    },
+    {
+      "word": "direct debit (noun) /ˌdaɪˈrekt ˈdebɪt/",
+      "meaning": "an arrangement to pay bills automatically",
+      "example": "My rent is paid by direct debit every month.",
+      "translation": "ủy nhiệm chi",
+      "count": 0
+    },
+    {
+      "word": "dividend (noun) /ˈdɪvɪˌdend/",
+      "meaning": "a portion of a company's profits paid to shareholders",
+      "example": "Investors were pleased with the high dividend payout.",
+      "translation": "cổ tức",
+      "count": 0
+    },
+    {
+      "word": "down payment (noun) /ˈdaʊn ˈpeɪmənt/",
+      "meaning": "initial partial payment for something expensive",
+      "example": "They made a down payment on a new car.",
+      "translation": "khoản trả trước",
+      "count": 0
+    },
+    {
+      "word": "finance (noun) /ˈfaɪnæns/",
+      "meaning": "management of money and investments",
+      "example": "He chose to specialize in finance and accounting.",
+      "translation": "tài chính",
+      "count": 0
+    },
+    {
+      "word": "finance (noun) /ˈfaɪnæns/",
+      "meaning": "funds used for a specific purpose or project",
+      "example": "The government will provide finance for the new school.",
+      "translation": "vốn",
+      "count": 0
+    },
+    {
+      "word": "finance (verb) /faɪˈnæns/",
+      "meaning": "to provide money for a project or purpose",
+      "example": "The trip was financed by a local charity.",
+      "translation": "cấp tiền",
+      "count": 0
+    },
+    {
+      "word": "insurance (noun) /ɪnˈʃʊərəns/",
+      "meaning": "a contract that protects against financial loss",
+      "example": "Car insurance is mandatory in most countries.",
+      "translation": "hợp đồng bảo hiểm",
+      "count": 0
+    },
+    {
+      "word": "interest (noun) /ˈɪntrəst/",
+      "meaning": "a fee paid for borrowing money",
+      "example": "The loan carries an interest rate of 5%.",
+      "translation": "lãi suất cho vay",
+      "count": 0
+    },
+    {
+      "word": "investment (noun) /ɪnˈvestmənt/",
+      "meaning": "money used to generate future income",
+      "example": "They made an investment in renewable energy.",
+      "translation": "khoản đầu tư",
+      "count": 0
+    },
+    {
+      "word": "investment (noun) /ɪnˈvestmənt/",
+      "meaning": "the act of using resources to improve something",
+      "example": "Investment in education boosts long-term growth.",
+      "translation": "sự đầu tư",
+      "count": 0
+    },
+    {
+      "word": "lump sum (noun) /lʌmp sʌm/",
+      "meaning": "a single large payment",
+      "example": "They received a lump sum when they retired.",
+      "translation": "trả một cục",
+      "count": 0
+    },
+    {
+      "word": "mortgage (noun) /ˈmɔːɡɪdʒ/",
+      "meaning": "a loan to buy property",
+      "example": "They applied for a mortgage to purchase their first home.",
+      "translation": "khoản vay mua nhà",
+      "count": 0
+    },
+    {
+      "word": "overdraft (noun) /ˈəʊvədrɑːft/",
+      "meaning": "permission to withdraw more money than available",
+      "example": "He was fined for exceeding his overdraft limit.",
+      "translation": "thấu chi",
+      "count": 0
+    },
+    {
+      "word": "pension (noun) /ˈpenʃən/",
+      "meaning": "money paid regularly after retirement",
+      "example": "She receives a monthly pension from the government.",
+      "translation": "tiền lương hưu",
+      "count": 0
+    },
+    {
+      "word": "block (verb) /blɒk/",
+      "meaning": "to prevent movement through a space",
+      "example": "The road was blocked by fallen trees.",
+      "translation": "chặn lại",
+      "count": 0
+    },
+    {
+      "word": "block (noun) /blɒk/",
+      "meaning": "a solid piece of material with flat surfaces",
+      "example": "He carved a statue from a block of wood.",
+      "translation": "khối",
+      "count": 0
+    },
+    {
+      "word": "brittle (adjective) /ˈbrɪtl/",
+      "meaning": "easily broken or cracked",
+      "example": "The dry leaves became brittle and crumbled easily.",
+      "translation": "giòn",
+      "count": 0
+    },
+    {
+      "word": "chip (verb) /tʃɪp/",
+      "meaning": "to break off a small piece from something hard",
+      "example": "She chipped her phone screen on the pavement.",
+      "translation": "làm sứt mẻ",
+      "count": 0
+    },
+    {
+      "word": "chip (noun) /tʃɪp/",
+      "meaning": "a small broken piece from a larger object",
+      "example": "There were chips of paint on the floor.",
+      "translation": "mảnh vụn",
+      "count": 0
+    },
+    {
+      "word": "compact (verb) /kəmˈpækt/",
+      "meaning": "to press something tightly together",
+      "example": "They compacted the trash before collection.",
+      "translation": "nén lại",
+      "count": 0
+    },
+    {
+      "word": "compact (adjective) /ˈkɒmpækt/",
+      "meaning": "small and efficiently arranged",
+      "example": "The camera is compact and easy to carry.",
+      "translation": "chặt",
+      "count": 0
+    },
+    {
+      "word": "concentrate (verb) /ˈkɒnsəntreɪt/",
+      "meaning": "to make a substance stronger by removing liquid",
+      "example": "They concentrated the juice by boiling off water.",
+      "translation": "cô đặc",
+      "count": 0
+    },
+    {
+      "word": "crack (verb) /kræk/",
+      "meaning": "to damage something so a line appears but it doesn’t break apart",
+      "example": "He accidentally cracked the mirror while moving it.",
+      "translation": "làm vỡ",
+      "count": 0
+    },
+    {
+      "word": "crack (noun) /kræk/",
+      "meaning": "a thin break on a surface",
+      "example": "There's a crack in the windshield.",
+      "translation": "vết nứt",
+      "count": 0
+    },
+    {
+      "word": "crumb (noun) /krʌm/",
+      "meaning": "a tiny piece of food, usually from bread or cake",
+      "example": "She brushed the crumbs off the table.",
+      "translation": "vụn",
+      "count": 0
+    },
+    {
+      "word": "crush (verb) /krʌʃ/",
+      "meaning": "to flatten something with pressure",
+      "example": "He crushed the can with his foot.",
+      "translation": "nghiền",
+      "count": 0
+    },
+    {
+      "word": "crush (noun) /krʌʃ/",
+      "meaning": "a large crowd of tightly packed people",
+      "example": "There was a crush of fans at the entrance.",
+      "translation": "đám đông chen chúc",
+      "count": 0
+    },
+    {
+      "word": "dense (adjective) /dens/",
+      "meaning": "having a lot of mass in a small space",
+      "example": "The fog was too dense to drive through.",
+      "translation": "có tỷ trọng nặng",
+      "count": 0
+    },
+    {
+      "word": "dilute (verb) /daɪˈluːt/",
+      "meaning": "to make a liquid weaker by adding water",
+      "example": "Dilute the syrup with water before drinking.",
+      "translation": "pha loãng",
+      "count": 0
+    },
+    {
+      "word": "dilute (adjective) /daɪˈluːt/",
+      "meaning": "made weaker by adding another liquid",
+      "example": "Use a dilute solution for cleaning surfaces.",
+      "translation": "loãng",
+      "count": 0
+    },
+    {
+      "word": "dissolve (verb) /dɪˈzɒlv/",
+      "meaning": "to mix a solid completely into a liquid",
+      "example": "The sugar dissolved quickly in the hot tea.",
+      "translation": "hòa tan",
+      "count": 0
+    },
+    {
+      "word": "fabric (noun) /ˈfæbrɪk/",
+      "meaning": "material used for making clothes or furniture",
+      "example": "She chose a soft fabric for the curtains.",
+      "translation": "vải",
+      "count": 0
+    },
+    {
+      "word": "firm (adjective) /fɜːm/",
+      "meaning": "solid and slightly hard when pressed",
+      "example": "The pillow should be firm to support your neck.",
+      "translation": "chắc",
+      "count": 0
+    },
+    {
+      "word": "flake (verb) /fleɪk/",
+      "meaning": "to break or peel off in small thin pieces",
+      "example": "The old wallpaper started to flake off the walls.",
+      "translation": "bong tróc",
+      "count": 0
+    },
+    {
+      "word": "flake (noun) /fleɪk/",
+      "meaning": "a thin, flat piece that has broken off something",
+      "example": "Flakes of paint were scattered on the ground.",
+      "translation": "vảy",
+      "count": 0
+    },
+    {
+      "word": "fragile (adjective) /ˈfrædʒaɪl/",
+      "meaning": "easily broken or damaged",
+      "example": "The package contains fragile items. Handle with care.",
+      "translation": "dễ vỡ",
+      "count": 0
+    },
+    {
+      "word": "friction (noun) /ˈfrɪkʃən/",
+      "meaning": "the resistance between two surfaces when they move",
+      "example": "The brakes work by creating friction.",
+      "translation": "lực ma sát",
+      "count": 0
+    },
+    {
+      "word": "grain (noun) /ɡreɪn/",
+      "meaning": "a tiny hard piece of a substance like sand or sugar",
+      "example": "She brushed a few grains of sugar from the table.",
+      "translation": "hạt",
+      "count": 0
+    },
+    {
+      "word": "gravity (noun) /ˈɡrævəti/",
+      "meaning": "the force that pulls things toward the ground",
+      "example": "Gravity keeps the planets in orbit around the sun.",
+      "translation": "trọng lực",
+      "count": 0
+    },
+    {
+      "word": "grind (verb) /ɡraɪnd/",
+      "meaning": "to crush something into powder or small bits",
+      "example": "He grinds his own coffee beans every morning.",
+      "translation": "nghiền, mài",
+      "count": 0
+    },
+    {
+      "word": "hollow (adjective) /ˈhɒləʊ/",
+      "meaning": "having an empty space inside",
+      "example": "The sculpture was hollow to reduce weight.",
+      "translation": "rỗng",
+      "count": 0
+    },
+    {
+      "word": "liquid (noun) /ˈlɪkwɪd/",
+      "meaning": "a flowing substance that takes the shape of its container",
+      "example": "Check if any liquid is leaking from the bottle.",
+      "translation": "chất lỏng",
+      "count": 0
+    },
+    {
+      "word": "liquid (adjective) /ˈlɪkwɪd/",
+      "meaning": "in a fluid state that flows easily",
+      "example": "This medicine is available in both tablet and liquid form.",
+      "translation": "ở dạng lỏng",
+      "count": 0
+    },
+    {
+      "word": "lump (verb) /lʌmp/",
+      "meaning": "to group things together without considering differences",
+      "example": "Don't lump all teenagers into one category.",
+      "translation": "gộp chung",
+      "count": 0
+    },
+    {
+      "word": "lump (noun) /lʌmp/",
+      "meaning": "a solid piece that is not evenly shaped",
+      "example": "She found a lump of coal near the tracks.",
+      "translation": "tảng",
+      "count": 0
+    },
+    {
+      "word": "mineral (noun) /ˈmɪnərəl/",
+      "meaning": "a naturally occurring solid substance found in the earth",
+      "example": "Iron is a common mineral found in soil.",
+      "translation": "khoáng chất",
+      "count": 0
+    },
+    {
+      "word": "mould (verb) /məʊld/",
+      "meaning": "to form something into a shape using a container",
+      "example": "They moulded the wax into a candle.",
+      "translation": "đúc",
+      "count": 0
+    },
+    {
+      "word": "mould (noun) /məʊld/",
+      "meaning": "a form used to give shape to something soft or liquid",
+      "example": "The cake was baked in a heart-shaped mould.",
+      "translation": "khuôn",
+      "count": 0
+    },
+    {
+      "word": "opaque (adjective) /əʊˈpeɪk/",
+      "meaning": "not allowing light to pass through",
+      "example": "The windows were covered with opaque film for privacy.",
+      "translation": "mờ",
+      "count": 0
+    },
+    {
+      "word": "pat (verb) /pæt/",
+      "meaning": "to touch someone gently with a flat hand",
+      "example": "She patted the child on the head to comfort him.",
+      "translation": "vỗ",
+      "count": 0
+    },
+    {
+      "word": "pat (noun) /pæt/",
+      "meaning": "a light touch with an open hand",
+      "example": "He gave me a friendly pat on the back.",
+      "translation": "cái vỗ",
+      "count": 0
+    },
+    {
+      "word": "pile (verb) /paɪl/",
+      "meaning": "to stack things on top of each other",
+      "example": "She piled the dishes in the sink.",
+      "translation": "chất đống",
+      "count": 0
+    },
+    {
+      "word": "share (noun) /ʃeər/",
+      "meaning": "a portion of ownership in a company",
+      "example": "He bought 50 shares in the company.",
+      "translation": "cổ phiếu",
+      "count": 0
+    },
+    {
+      "word": "speculate (verb) /ˈspekjuleɪt/",
+      "meaning": "to invest money hoping to gain profits, with some risk",
+      "example": "Investors began speculating in real estate.",
+      "translation": "đầu cơ",
+      "count": 0
+    },
+    {
+      "word": "withdraw (verb) /wɪðˈdrɔː/",
+      "meaning": "to take money out of a bank account",
+      "example": "She withdrew $100 from her savings account.",
+      "translation": "rút tiền",
+      "count": 0
+    },
+    {
+      "word": "pile (noun) /paɪl/",
+      "meaning": "a group of items placed on top of each other",
+      "example": "She dropped the pile of laundry on the bed.",
+      "translation": "đống, chồng",
+      "count": 0
+    },
+    {
+      "word": "polish (verb) /ˈpɒlɪʃ/",
+      "meaning": "to rub something to make it smooth and shiny",
+      "example": "He polished his shoes until they gleamed.",
+      "translation": "đánh bóng",
+      "count": 0
+    },
+    {
+      "word": "polish (noun) /ˈpɒlɪʃ/",
+      "meaning": "a substance used to shine a surface",
+      "example": "Use a bit of polish to brighten the wood.",
+      "translation": "chất đánh bóng",
+      "count": 0
+    },
+    {
+      "word": "scratch (verb) /skrætʃ/",
+      "meaning": "to rub skin or a surface with nails or a sharp object",
+      "example": "Stop scratching your arm or it’ll bleed.",
+      "translation": "gãi",
+      "count": 0
+    },
+    {
+      "word": "scratch (verb) /skrætʃ/",
+      "meaning": "to damage a surface by scraping it",
+      "example": "You scratched the paint with your keys.",
+      "translation": "cào",
+      "count": 0
+    },
+    {
+      "word": "scratch (noun) /skrætʃ/",
+      "meaning": "a thin mark made by something sharp",
+      "example": "There’s a scratch across the car door.",
+      "translation": "vết xước",
+      "count": 0
+    },
+    {
+      "word": "scrub (verb) /skrʌb/",
+      "meaning": "to clean something by rubbing it hard",
+      "example": "He scrubbed the sink with a sponge.",
+      "translation": "chà xát, lau chùi",
+      "count": 0
+    },
+    {
+      "word": "scrub (noun) /skrʌb/",
+      "meaning": "the act of cleaning by rubbing hard",
+      "example": "These pots need a good scrub.",
+      "translation": "sự cọ rửa",
+      "count": 0
+    },
+    {
+      "word": "smash (verb) /smæʃ/",
+      "meaning": "to break something noisily into many pieces",
+      "example": "She accidentally smashed the window with a ball.",
+      "translation": "đập vỡ",
+      "count": 0
+    },
+    {
+      "word": "solid (noun) /ˈsɒlɪd/",
+      "meaning": "a substance with a firm shape and volume",
+      "example": "Ice is a solid form of water.",
+      "translation": "chất rắn",
+      "count": 0
+    },
+    {
+      "word": "solid (adjective) /ˈsɒlɪd/",
+      "meaning": "firm and not hollow or liquid",
+      "example": "The house is built on solid ground.",
+      "translation": "rắn",
+      "count": 0
+    },
+    {
+      "word": "speck (noun) /spek/",
+      "meaning": "a tiny mark or spot",
+      "example": "There was a speck of paint on her shirt.",
+      "translation": "vết, lốm đốm",
+      "count": 0
+    },
+    {
+      "word": "squash (verb) /skwɒʃ/",
+      "meaning": "to press something so that it becomes flat or crushed",
+      "example": "He squashed the bug with a tissue.",
+      "translation": "làm bẹp",
+      "count": 0
+    },
+    {
+      "word": "squash (noun) /skwɒʃ/",
+      "meaning": "a crowded situation with little space",
+      "example": "It was a squash on the train during rush hour.",
+      "translation": "tình trạng chen chúc",
+      "count": 0
+    },
+    {
+      "word": "squeeze (verb) /skwiːz/",
+      "meaning": "to press something firmly from opposite sides",
+      "example": "She squeezed my hand gently.",
+      "translation": "nén, ép",
+      "count": 0
+    },
+    {
+      "word": "squeeze (noun) /skwiːz/",
+      "meaning": "a firm pressure with hands or fingers",
+      "example": "He gave her a reassuring squeeze on the arm.",
+      "translation": "sự nén, ép, bóp",
+      "count": 0
+    },
+    {
+      "word": "stack (verb) /stæk/",
+      "meaning": "to place things neatly in a pile",
+      "example": "They stacked the chairs in the corner.",
+      "translation": "xếp",
+      "count": 0
+    },
+    {
+      "word": "stack (noun) /stæk/",
+      "meaning": "a neat pile of things arranged on top of each other",
+      "example": "A stack of magazines sat on the table.",
+      "translation": "đống, cụm",
+      "count": 0
+    },
+    {
+      "word": "stiff (adjective) /stɪf/",
+      "meaning": "not flexible or difficult to bend",
+      "example": "The fabric was too stiff to sew easily.",
+      "translation": "cứng",
+      "count": 0
+    },
+    {
+      "word": "stroke (verb) /strəʊk/",
+      "meaning": "to gently move your hand over something",
+      "example": "He stroked the cat’s fur slowly.",
+      "translation": "vuốt ve",
+      "count": 0
+    },
+    {
+      "word": "stroke (noun) /strəʊk/",
+      "meaning": "a gentle touch or movement of the hand",
+      "example": "She smiled at the soft stroke on her arm.",
+      "translation": "động tác vuốt ve",
+      "count": 0
+    },
+    {
+      "word": "stuff (verb) /stʌf/",
+      "meaning": "to fill or pack tightly into a space",
+      "example": "He stuffed the bag with clothes.",
+      "translation": "nhồi nhét",
+      "count": 0
+    },
+    {
+      "word": "stuff (noun) /stʌf/",
+      "meaning": "a collection of various objects or things",
+      "example": "Clear all that stuff off the desk.",
+      "translation": "món, thứ (đồ)",
+      "count": 0
+    },
+    {
+      "word": "substance (noun) /ˈsʌbstəns/",
+      "meaning": "a type of matter with specific properties",
+      "example": "This cleaning product contains strong substances.",
+      "translation": "chất",
+      "count": 0
+    },
+    {
+      "word": "synthetic (adjective) /sɪnˈθetɪk/",
+      "meaning": "artificially made, not found in nature",
+      "example": "The jacket is made from synthetic fibers.",
+      "translation": "tổng hợp, nhân tạo",
+      "count": 0
+    },
+    {
+      "word": "tear (v) /teər/",
+      "meaning": "to pull something apart so it splits or rips",
+      "example": "She tore the wrapping paper off the gift in excitement.",
+      "translation": "xé",
+      "count": 0
+    },
+    {
+      "word": "tear (n) /teər/",
+      "meaning": "a rip or break in something like fabric or paper",
+      "example": "I need to sew the tear in my backpack before class.",
+      "translation": "vết rách",
+      "count": 0
+    },
+    {
+      "word": "texture (n) /ˈtekstʃər/",
+      "meaning": "the physical feel or surface quality of something",
+      "example": "The fabric has a rough texture that feels scratchy on the skin.",
+      "translation": "kết cấu, bề mặt",
+      "count": 0
+    },
+    {
+      "word": "transparent (adj) /trænˈspærənt/",
+      "meaning": "allowing light to pass through so objects can be clearly seen",
+      "example": "The transparent curtain gave us a view of the garden.",
+      "translation": "trong suốt",
+      "count": 0
+    },
+    {
+      "word": "built-up (adj) /ˌbɪlt ˈʌp/",
+      "meaning": "filled with many buildings close together",
+      "example": "The built-up area near the highway has become very congested.",
+      "translation": "có nhà cửa san sát",
+      "count": 0
+    },
+    {
+      "word": "bypass (v) /ˈbaɪpɑːs/",
+      "meaning": "to go around a place to avoid passing through it",
+      "example": "We bypassed the city center to save time.",
+      "translation": "đi vòng",
+      "count": 0
+    },
+    {
+      "word": "bypass (n) /ˈbaɪpɑːs/",
+      "meaning": "a road built to go around a city or busy area",
+      "example": "The new bypass will reduce traffic in the downtown area.",
+      "translation": "đường vòng",
+      "count": 0
+    },
+    {
+      "word": "construct (v) /kənˈstrʌkt/",
+      "meaning": "to build something, especially large or complex",
+      "example": "The company plans to construct a bridge over the river.",
+      "translation": "xây dựng",
+      "count": 0
+    },
+    {
+      "word": "demolish (v) /dɪˈmɒlɪʃ/",
+      "meaning": "to destroy a building completely and intentionally",
+      "example": "They demolished the old cinema to make way for a mall.",
+      "translation": "dỡ bỏ",
+      "count": 0
+    },
+    {
+      "word": "district (n) /ˈdɪstrɪkt/",
+      "meaning": "a specific area within a city or country",
+      "example": "She works as a teacher in the school district nearby.",
+      "translation": "khu vực, quận/huyện",
+      "count": 0
+    },
+    {
+      "word": "dwell (v) /dwel/",
+      "meaning": "to live or stay in a particular place",
+      "example": "They dwell in a quiet mountain village far from the city.",
+      "translation": "sinh sống",
+      "count": 0
+    },
+    {
+      "word": "estate (n) /ɪˈsteɪt/",
+      "meaning": "a group of buildings, especially housing, in a planned area",
+      "example": "Crime rates have been rising on the estate recently.",
+      "translation": "khu dân cư",
+      "count": 0
+    },
+    {
+      "word": "evict (v) /ɪˈvɪkt/",
+      "meaning": "to legally force someone to leave the property they occupy",
+      "example": "The landlord is trying to evict tenants who haven't paid rent.",
+      "translation": "đuổi khỏi",
+      "count": 0
+    },
+    {
+      "word": "high-rise (adj) /ˈhaɪˌraɪz/",
+      "meaning": "referring to a tall building with many floors",
+      "example": "They bought a flat in a modern high-rise downtown.",
+      "translation": "cao tầng",
+      "count": 0
+    },
+    {
+      "word": "housing (n) /ˈhaʊzɪŋ/",
+      "meaning": "places built for people to live in",
+      "example": "Affordable housing remains a major issue in big cities.",
+      "translation": "nhà ở",
+      "count": 0
+    },
+    {
+      "word": "infrastructure (n) /ˈɪnfrəstrʌktʃər/",
+      "meaning": "the essential systems and structures for a society to function",
+      "example": "The storm caused major damage to local infrastructure.",
+      "translation": "cơ sở hạ tầng",
+      "count": 0
+    },
+    {
+      "word": "inner city (n phr) /ˌɪnə ˈsɪti/",
+      "meaning": "the central part of a city, often with social or economic issues",
+      "example": "Many youth programs target the inner city to prevent crime.",
+      "translation": "nội đô, khu ổ chuột",
+      "count": 0
+    },
+    {
+      "word": "occupy (v) /ˈɒkjʊpaɪ/",
+      "meaning": "to use or live in a building or space",
+      "example": "Several families still occupy the old apartment block.",
+      "translation": "chiếm giữ, cư trú",
+      "count": 0
+    },
+    {
+      "word": "stiff (adj) /stɪf/",
+      "meaning": "hard and not flexible",
+      "example": "Use a stiff brush to remove the dried paint.",
+      "translation": "cứng",
+      "count": 0
+    },
+    {
+      "word": "glum (adj) /ɡlʌm/",
+      "meaning": "looking unhappy or discouraged",
+      "example": "She looked glum after failing her driving test.",
+      "translation": "rầu rĩ",
+      "count": 0
+    },
+    {
+      "word": "grimace (n) /ˈɡrɪməs/",
+      "meaning": "a twisted expression showing pain or dislike",
+      "example": "He made a grimace as he tasted the bitter soup.",
+      "translation": "biểu hiện nhăn nhó",
+      "count": 0
+    },
+    {
+      "word": "grimace (v) /ˈɡrɪməs/",
+      "meaning": "to twist your face to show pain or displeasure",
+      "example": "She grimaced as she bent her injured leg.",
+      "translation": "nhăn mặt",
+      "count": 0
+    },
+    {
+      "word": "grin (n) /ɡrɪn/",
+      "meaning": "a wide smile showing amusement or happiness",
+      "example": "He gave me a big grin when he saw me arrive.",
+      "translation": "nụ cười tươi",
+      "count": 0
+    },
+    {
+      "word": "grin (v) /ɡrɪn/",
+      "meaning": "to smile widely, often showing your teeth",
+      "example": "She couldn’t help but grin when she saw the surprise party.",
+      "translation": "cười tươi",
+      "count": 0
+    },
+    {
+      "word": "handle (v) /ˈhændl/",
+      "meaning": "to manage or deal with a situation effectively",
+      "example": "She knows how to handle stressful customer complaints calmly.",
+      "translation": "xử lý",
+      "count": 0
+    },
+    {
+      "word": "impatient (adj) /ɪmˈpeɪʃnt/",
+      "meaning": "annoyed by delays or unwilling to wait",
+      "example": "He grew impatient while waiting for the bus to arrive.",
+      "translation": "thiếu kiên nhẫn",
+      "count": 0
+    },
+    {
+      "word": "inertia (n) /ɪˈnɜːʃə/",
+      "meaning": "a lack of activity or unwillingness to change",
+      "example": "The project failed due to political inertia.",
+      "translation": "sự trì trệ",
+      "count": 0
+    },
+    {
+      "word": "manners (n) /ˈmænəz/",
+      "meaning": "socially acceptable ways of behaving",
+      "example": "He has excellent manners and always says ‘please’ and ‘thank you’.",
+      "translation": "tác phong",
+      "count": 0
+    },
+    {
+      "word": "manoeuvre (n) /məˈnuːvər/",
+      "meaning": "a movement that needs careful skill or planning",
+      "example": "The pilot performed a complex landing manoeuvre.",
+      "translation": "động tác khéo léo",
+      "count": 0
+    },
+    {
+      "word": "manoeuvre (v) /məˈnuːvər/",
+      "meaning": "to move carefully or skillfully around something",
+      "example": "She manoeuvred her wheelchair easily through the narrow hallway.",
+      "translation": "điều khiển khéo léo",
+      "count": 0
+    },
+    {
+      "word": "moan (n) /məʊn/",
+      "meaning": "a low sound made from pain or discomfort",
+      "example": "The injured player let out a moan as he clutched his leg.",
+      "translation": "tiếng rên",
+      "count": 0
+    },
+    {
+      "word": "moan (v) /məʊn/",
+      "meaning": "to complain in an annoying or repeated way",
+      "example": "He's always moaning about how much work he has to do.",
+      "translation": "than vãn",
+      "count": 0
+    },
+    {
+      "word": "mock (v) /mɒk/",
+      "meaning": "to tease or laugh at someone in a hurtful way",
+      "example": "The students mocked his accent behind his back.",
+      "translation": "chế giễu",
+      "count": 0
+    },
+    {
+      "word": "neglect (n) /nɪˈɡlekt/",
+      "meaning": "a failure to provide necessary care or attention",
+      "example": "The animal shelter rescued dogs suffering from severe neglect.",
+      "translation": "sự bỏ bê",
+      "count": 0
+    },
+    {
+      "word": "neglect (v) /nɪˈɡlekt/",
+      "meaning": "to fail to take care of someone properly",
+      "example": "The authorities intervened when the child was neglected by his parents.",
+      "translation": "bỏ bê",
+      "count": 0
+    },
+    {
+      "word": "neglect (v) /nɪˈɡlekt/",
+      "meaning": "to fail to do something you are responsible for",
+      "example": "He was criticized for neglecting his responsibilities at work.",
+      "translation": "sao nhãng",
+      "count": 0
+    },
+    {
+      "word": "peep (n) /piːp/",
+      "meaning": "a quick or secret glance at something",
+      "example": "He took a quick peep into the box before sealing it.",
+      "translation": "cái nhìn trộm",
+      "count": 0
+    },
+    {
+      "word": "peep (v) /piːp/",
+      "meaning": "to look secretly or briefly at something",
+      "example": "She peeped through the curtains to see who was outside.",
+      "translation": "nhìn trộm",
+      "count": 0
+    },
+    {
+      "word": "peer (v) /pɪər/",
+      "meaning": "to look closely or with difficulty at something",
+      "example": "He peered into the dark cave, trying to see what was inside.",
+      "translation": "nhìn săm soi",
+      "count": 0
+    },
+    {
+      "word": "populated (adj) /ˈpɒpjʊleɪtɪd/",
+      "meaning": "having people living in a specific area",
+      "example": "This island is one of the most densely populated in the region.",
+      "translation": "đông dân",
+      "count": 0
+    },
+    {
+      "word": "skyline (n) /ˈskaɪlaɪn/",
+      "meaning": "the outline of buildings or natural features seen against the sky",
+      "example": "The city’s skyline is beautiful at sunset.",
+      "translation": "hình dáng in lên nền trời",
+      "count": 0
+    },
+    {
+      "word": "skyscraper (n) /ˈskaɪskreɪpər/",
+      "meaning": "a tall modern building with many floors",
+      "example": "New York is famous for its skyscrapers.",
+      "translation": "tòa nhà chọc trời",
+      "count": 0
+    },
+    {
+      "word": "structure (n) /ˈstrʌktʃər/",
+      "meaning": "a large object that has been built, such as a building or bridge",
+      "example": "That steel structure will eventually become a new museum.",
+      "translation": "cấu trúc",
+      "count": 0
+    },
+    {
+      "word": "suburban (adj) /səˈbɜːrbən/",
+      "meaning": "relating to the outer areas of a city or town",
+      "example": "They moved to a quiet suburban neighborhood after retirement.",
+      "translation": "ngoại ô",
+      "count": 0
+    },
+    {
+      "word": "surroundings (n pl) /səˈraʊndɪŋz/",
+      "meaning": "the environment or conditions around a place",
+      "example": "She enjoyed the peaceful surroundings of the countryside.",
+      "translation": "môi trường xung quanh",
+      "count": 0
+    },
+    {
+      "word": "urban (adj) /ˈɜːrbən/",
+      "meaning": "relating to cities and towns",
+      "example": "Urban development is spreading rapidly in the region.",
+      "translation": "thành thị",
+      "count": 0
+    },
+    {
+      "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
+      "meaning": "to admit that something exists or is true",
+      "example": "She refused to acknowledge her role in the mistake.",
+      "translation": "công nhận, thừa nhận",
+      "count": 0
+    },
+    {
+      "word": "acknowledge (v) /əkˈnɒlɪdʒ/",
+      "meaning": "to express appreciation or thanks for something",
+      "example": "We gratefully acknowledge the support of our volunteers.",
+      "translation": "bày tỏ lòng biết ơn",
+      "count": 0
+    },
+    {
+      "word": "acknowledge (v) /ækˈnɒlɪdʒ/",
+      "meaning": "to show that you notice someone, such as by smiling or nodding",
+      "example": "She walked past me without even acknowledging my presence.",
+      "translation": "tỏ ra đã nhận ra",
+      "count": 0
+    },
+    {
+      "word": "agonise (v) /ˈæɡənaɪz/",
+      "meaning": "to suffer mentally over a decision or situation for a long time",
+      "example": "He agonised for weeks over whether to quit his job.",
+      "translation": "chịu lo lắng, khổ sở",
+      "count": 0
+    },
+    {
+      "word": "apathy (n) /ˈæpəθi/",
+      "meaning": "a lack of interest, enthusiasm, or concern",
+      "example": "The students' apathy towards politics was concerning.",
+      "translation": "sự lãnh đạm",
+      "count": 0
+    },
+    {
+      "word": "avoid (v) /əˈvɔɪd/",
+      "meaning": "to try to stop something from happening",
+      "example": "Regular backups help avoid data loss.",
+      "translation": "ngăn ngừa",
+      "count": 0
+    },
+    {
+      "word": "avoid (v) /əˈvɔɪd/",
+      "meaning": "to stay away from someone or something",
+      "example": "I crossed the street to avoid the crowd.",
+      "translation": "tránh xa",
+      "count": 0
+    },
+    {
+      "word": "avoid (adj) /ədˈvaɪdəbl/",
+      "meaning": "able to be avoided or prevented for better results",
+      "example": "Infections are avoidable with proper hygiene.",
+      "translation": "nên tránh",
+      "count": 0
+    },
+    {
+      "word": "behaviour (n) /bɪˈheɪvjər/",
+      "meaning": "the actions or reactions of a person",
+      "example": "His rude behaviour shocked everyone at the meeting.",
+      "translation": "hành vi",
+      "count": 0
+    },
+    {
+      "word": "chuckle (n) /ˈtʃʌkl/",
+      "meaning": "a soft or quiet laugh",
+      "example": "He gave a chuckle at the joke.",
+      "translation": "nụ cười thầm",
+      "count": 0
+    },
+    {
+      "word": "chuckle (v) /ˈtʃʌkl/",
+      "meaning": "to laugh quietly to yourself",
+      "example": "She chuckled at the memory of their adventure.",
+      "translation": "cười thầm",
+      "count": 0
+    },
+    {
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a state of physical ease and relaxation",
+      "example": "This new mattress offers excellent comfort.",
+      "translation": "sự an nhiên",
+      "count": 0
+    },
+    {
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a feeling of support that helps you feel better emotionally",
+      "example": "She took comfort in his kind words.",
+      "translation": "sự an ủi",
+      "count": 0
+    },
+    {
+      "word": "comfort (n) /ˈkʌmfət/",
+      "meaning": "a life situation in which one has everything needed and feels at ease",
+      "example": "After retirement, they enjoyed a life of comfort.",
+      "translation": "sung túc",
+      "count": 0
+    },
+    {
+      "word": "comfort (v) /ˈkʌmfət/",
+      "meaning": "to make someone feel less sad or anxious",
+      "example": "She comforted the crying child after the fall.",
+      "translation": "an ủi",
+      "count": 0
+    },
+    {
+      "word": "conduct (n) /kənˈdʌkt/",
+      "meaning": "the way a person acts, especially in relation to rules",
+      "example": "The athlete was penalized for unsportsmanlike conduct.",
+      "translation": "cách đạo đức",
+      "count": 0
+    },
+    {
+      "word": "conduct (v) /kənˈdʌkt/",
+      "meaning": "to organize and carry out an activity",
+      "example": "The scientists conducted an important experiment.",
+      "translation": "thực hiện",
+      "count": 0
+    },
+    {
+      "word": "consequence (n) /ˈkɒnsɪkwəns/",
+      "meaning": "a result or outcome of an action",
+      "example": "Every decision you make has consequences.",
+      "translation": "hậu quả",
+      "count": 0
+    },
+    {
+      "word": "contentment (n) /kənˈtentmənt/",
+      "meaning": "a state of happiness and satisfaction",
+      "example": "She smiled with contentment after finishing the project.",
+      "translation": "sự mãn nguyện",
+      "count": 0
+    },
+    {
+      "word": "cross (adj) /krɒs/",
+      "meaning": "annoyed or angry",
+      "example": "Don’t get cross just because I was late.",
+      "translation": "bực mình, cáu",
+      "count": 0
+    },
+    {
+      "word": "dignity (n) /ˈdɪgnəti/",
+      "meaning": "calm and serious behavior that earns respect",
+      "example": "Even in defeat, she maintained her dignity.",
+      "translation": "phẩm giá",
+      "count": 0
+    },
+    {
+      "word": "disgust (n) /dɪsˈɡʌst/",
+      "meaning": "a strong feeling of dislike or revulsion",
+      "example": "She turned away in disgust at the smell.",
+      "translation": "sự ghê tởm",
+      "count": 0
+    },
+    {
+      "word": "disgust (v) /dɪsˈɡʌst/",
+      "meaning": "to cause someone to feel strong dislike",
+      "example": "His rude comments disgusted everyone in the room.",
+      "translation": "làm ghê tởm",
+      "count": 0
+    },
+    {
+      "word": "disillusioned (adj) /ˌdɪsɪˈluːʒənd/",
+      "meaning": "feeling disappointed because something is not as good as expected",
+      "example": "Many workers became disillusioned with the company's promises.",
+      "translation": "vỡ mộng",
+      "count": 0
+    },
+    {
+      "word": "fed up (adj) /ˈfed ʌp/",
+      "meaning": "bored or annoyed with a situation you’ve had for too long",
+      "example": "I’m fed up with doing the same thing every day.",
+      "translation": "chán ghét",
+      "count": 0
+    },
+    {
+      "word": "giggle (n) /ˈgɪgəl/",
+      "meaning": "a silly or nervous laugh",
+      "example": "They exchanged giggles during the boring lecture.",
+      "translation": "cười khúc khích",
+      "count": 0
+    },
+    {
+      "word": "giggle (v) /ˈgɪgəl/",
+      "meaning": "to laugh in a high-pitched, silly way",
+      "example": "The girls giggled when they saw the puppy.",
+      "translation": "cười khúc khích",
+      "count": 0
+    },
+    {
+      "word": "glance (n) /ɡlɑːns/",
+      "meaning": "a quick or brief look at something or someone",
+      "example": "He took a glance at his phone before entering the room.",
+      "translation": "cái liếc mắt",
+      "count": 0
+    },
+    {
+      "word": "glance (v) /ɡlɑːns/",
+      "meaning": "to look quickly at someone or something and then away",
+      "example": "She glanced at the clock and sighed.",
+      "translation": "liếc",
+      "count": 0
+    },
+    {
+      "word": "glimpse (n) /ɡlɪmps/",
+      "meaning": "a short or incomplete view of something",
+      "example": "Fans waited for a glimpse of the actor through the crowd.",
+      "translation": "cái nhìn thoáng qua",
+      "count": 0
+    },
+    {
+      "word": "glimpse (v) /ɡlɪmps/",
+      "meaning": "to catch sight of briefly or partially",
+      "example": "She glimpsed the bird before it flew away.",
+      "translation": "nhìn thoáng qua",
+      "count": 0
+    },
+    {
+      "word": "gloat (v) /ɡloʊt/",
+      "meaning": "to express self-satisfaction over another's misfortune",
+      "example": "He couldn’t help but gloat after winning the argument.",
+      "translation": "hách dịch",
+      "count": 0
+    },
+    {
+      "word": "prevent (v) /prɪˈvent/",
+      "meaning": "to stop something from happening or someone from doing something",
+      "example": "The vaccine helps prevent serious illness.",
+      "translation": "cản, ngăn",
+      "count": 0
+    },
+    {
+      "word": "rejoice (v) /rɪˈdʒɔɪs/",
+      "meaning": "to feel or express great happiness",
+      "example": "They rejoiced at the news of the baby’s birth.",
+      "translation": "vui mừng",
+      "count": 0
+    },
+    {
+      "word": "resent (v) /rɪˈzent/",
+      "meaning": "to feel angry or bitter about unfair treatment",
+      "example": "She resented being treated like a child.",
+      "translation": "bực tức",
+      "count": 0
+    },
+    {
+      "word": "resolve (v) /rɪˈzɒlv/",
+      "meaning": "to decide firmly on a course of action",
+      "example": "They resolved to fix the issue without delay.",
+      "translation": "kiên quyết",
+      "count": 0
+    },
+    {
+      "word": "smirk (n) /smɜːk/",
+      "meaning": "a self-satisfied or mocking smile",
+      "example": "He gave a smug smirk after answering correctly.",
+      "translation": "nụ cười nhếch mép",
+      "count": 0
+    },
+    {
+      "word": "smirk (v) /smɜːk/",
+      "meaning": "to smile in a smug or arrogant way",
+      "example": "She smirked when she saw the mistake.",
+      "translation": "cười nhếch mép",
+      "count": 0
+    },
+    {
+      "word": "snap (v) /snæp/",
+      "meaning": "to suddenly become angry and lose self-control",
+      "example": "He finally snapped under pressure and yelled.",
+      "translation": "nổi cáu",
+      "count": 0
+    },
+    {
+      "word": "snap (v) /snæp/",
+      "meaning": "to speak sharply or angrily",
+      "example": "She snapped at him for interrupting.",
+      "translation": "quát tháo",
+      "count": 0
+    },
+    {
+      "word": "tactic (n) /ˈtæktɪk/",
+      "meaning": "a specific method used to achieve a goal",
+      "example": "Changing tactics helped them win the match.",
+      "translation": "chiến thuật",
+      "count": 0
+    },
+    {
+      "word": "terror (n) /ˈterər/",
+      "meaning": "a feeling of intense fear",
+      "example": "She screamed in terror as the fire spread.",
+      "translation": "sự kinh hoàng",
+      "count": 0
+    },
+    {
+      "word": "terror (n) /ˈterər/",
+      "meaning": "the use of violence to cause fear for political aims",
+      "example": "The city was paralyzed by acts of terror.",
+      "translation": "sự khủng bố",
+      "count": 0
+    },
+    {
+      "word": "administer (v) /ədˈmɪnɪstər/",
+      "meaning": "to give a drug or medical care to someone",
+      "example": "The nurse administered the injection carefully.",
+      "translation": "phát thuốc",
+      "count": 0
+    },
+    {
+      "word": "admit (v) /ədˈmɪt/",
+      "meaning": "to take someone into hospital for treatment",
+      "example": "He was admitted with severe chest pain.",
+      "translation": "tiếp nhận vào viện",
+      "count": 0
+    },
+    {
+      "word": "agony (n) /ˈæɡəni/",
+      "meaning": "severe physical pain",
+      "example": "He lay in agony after the accident.",
+      "translation": "cơn đau đớn",
+      "count": 0
+    },
+    {
+      "word": "agony (n) /ˈæɡəni/",
+      "meaning": "extreme emotional distress or suffering",
+      "example": "She went through agony waiting for the test results.",
+      "translation": "sự đau khổ",
+      "count": 0
+    },
+    {
+      "word": "antidote (n) /ˈæntidəʊt/",
+      "meaning": "a medicine that counters the effects of poison",
+      "example": "Doctors administered the antidote immediately.",
+      "translation": "thuốc giải độc",
+      "count": 0
+    },
+    {
+      "word": "consultant (n) /kənˈsʌltənt/",
+      "meaning": "a senior doctor with expertise in a specific medical field",
+      "example": "He met with a consultant to review his condition.",
+      "translation": "bác sĩ tham vấn",
+      "count": 0
+    }
+  ],
+  "grammar": [    
+    {
+      "word": "The passive",
+      "meaning": "The passive voice highlights the action or outcome rather than the performer. It's commonly used when the agent is unknown, irrelevant, or deliberately omitted, and often appears in formal contexts.",
+      "example": "The documents were sent yesterday; This bridge was built in 1992; All guests are invited to the ceremony; The laptop was repaired by a technician; He was promoted to manager last month.",
+      "translation": "Câu bị động nhấn mạnh hành động hoặc kết quả, thường dùng khi không rõ hoặc không cần nhắc đến người thực hiện hành động.",
+      "count": 0
+    },
+    {
+      "word": "Impersonal passive",
+      "meaning": "Used to express general beliefs, expectations, or assumptions. Often starts with phrases like 'It is thought' or 'Tourism is expected to'.",
+      "example": "Tourism is expected to become a major part of the country’s economy; It is thought that the new railway will provide employment opportunities; There are reported to have been a record number of accidents.",
+      "translation": "Dùng bị động vô danh để nói về suy nghĩ/quan điểm chung",
+      "count": 0
+    },
+    {
+      "word": "Direct and indirect object",
+      "meaning": "Some verbs allow two objects — a person and a thing. In passive constructions, either object can become the subject.",
+      "example": "Michael gave the plane tickets to Jill; Jill was given the plane tickets (by Michael); The plane tickets were given to Jill (by Michael); How to drive the train was explained to me.",
+      "translation": "Dùng bị động với câu có 2 tân ngữ — trực tiếp và gián tiếp",
+      "count": 0
+    },
+    {
+      "word": "Avoiding the passive",
+      "meaning": "Used when passive constructions are awkward or unnatural in continuous or perfect tenses. Prepositional phrases are used instead.",
+      "example": "Preparations for the flight will be in progress as the President arrives; At the end of this year, I will have been in training as a pilot for four years; Vintage cars have been on display in the town centre; The problem had been under consideration; The railway station has been under construction for two years now.",
+      "translation": "Tránh dùng bị động bằng cách dùng cụm giới từ phù hợp hơn",
+      "count": 0
+    },
+    {
+      "word": "Causative: get/have something done",
+      "meaning": "Used when someone arranges for another person to do something on their behalf.",
+      "example": "Did you finally get your bike fixed?; I heard that Susie had her motorbike stolen; I’d like those cars washed by this evening; We’ll set off as soon as I’ve got the car fixed.",
+      "translation": "Cấu trúc nhờ ai đó làm gì cho mình",
+      "count": 0
+    },
+    {
+      "word": "Causative: get sb to do / have sb do",
+      "meaning": "Used when someone persuades or arranges for another person to do something.",
+      "example": "Did you get Alex to drive you all the way to London?; I had my assistant book the tickets.",
+      "translation": "Dùng khi khiến ai đó làm việc gì",
+      "count": 0
+    },
+    {
+      "word": "Causative: get/have sb doing",
+      "meaning": "Used when someone causes another person to start doing something.",
+      "example": "Don’t worry. We’ll soon have your car running like new; That film got me thinking about my childhood.",
+      "translation": "Dùng khi khiến ai đó bắt đầu làm gì đó",
+      "count": 0
+    },
+    {
+      "word": "Modals - Overview and Structure",
+      "meaning": "Core modal verbs (will, would, can, could, may, might, shall, should, must) have one form and are followed by a bare infinitive.",
+      "example": "could do; could be doing; could have done; must go; should arrive",
+      "translation": "Tổng quan về động từ khiếm khuyết, theo sau là động từ nguyên mẫu",
+      "count": 0
+    },
+    {
+      "word": "Modals - Criticism and Annoyance",
+      "meaning": "Used to express disapproval, reproach, or frustration about past or habitual actions.",
+      "example": "You shouldn’t have spoken to her like that; You could have told me; He will slam the door every time; I might as well be dead for all you care",
+      "translation": "Dùng để chỉ trích hoặc thể hiện thất vọng về hành vi",
+      "count": 0
+    },
+    {
+      "word": "Semi‑modals - Obligation",
+      "meaning": "Semi‑modals (have to, need to, ought to, had better) express necessity or requirement in present, past, or future.",
+      "example": "You have to finish this by Friday; I had to come up with three questions; You’ll have to do more research; You don’t need to worry",
+      "translation": "Dùng để diễn tả nghĩa vụ hoặc yêu cầu",
+      "count": 0
+    },
+    {
+      "word": "Modals - Advice and Permission",
+      "meaning": "Modals like should, ought to offer advice; can, may grant or refuse permission.",
+      "example": "You should try that new method; Hadn’t you better check first?; Can I leave now?; You may borrow my notes",
+      "translation": "Dùng để đưa ra lời khuyên hoặc xin phép",
+      "count": 0
+    },
+    {
+      "word": "Modals - Ability and Possibility",
+      "meaning": "Modals such as can, could, may, might express ability, possibility, or hypothetical situations.",
+      "example": "She can speak five languages; You could win the prize; It might rain tomorrow; One day, all will be able to read",
+      "translation": "Dùng để diễn tả khả năng và khả năng xảy ra",
+      "count": 0
+    },
+    {
+      "word": "Adjective Position",
+      "meaning": "Adjectives normally go before a noun or follow linking verbs like appear, become, feel, get, look, seem, smell, sound, taste, and turn.",
+      "example": "The fragrant bakery smells delightful each morning.; Her energy grew strong after the workout.; He appeared confident during the interview.; The soup tastes too salty.; She got bored waiting in line.",
+      "translation": "Tính từ thường đứng trước danh từ hoặc sau một số động từ chỉ trạng thái",
+      "count": 0
+    },
+    {
+      "word": "Order of Adjectives",
+      "meaning": "When several adjectives describe the same noun, they follow this order: opinion, size, age, shape, color, origin, material, purpose.",
+      "example": "She bought a beautiful small antique round brass clock.; They live in a charming old Spanish stone villa.; He handed me a bright red Italian leather handbag.; We found a lovely tiny modern ceramic vase.",
+      "translation": "Thứ tự tính từ khi có nhiều tính từ đi trước danh từ",
+      "count": 0
+    },
+    {
+      "word": "Adjectives as Nouns",
+      "meaning": "Some adjectives function as nouns to refer to groups of people or classes.",
+      "example": "The elderly need special assistance.; Volunteers helped the homeless in the park.; The accused entered the courtroom.; The rich often invest in real estate.",
+      "translation": "Tính từ có thể dùng như danh từ để chỉ nhóm người hoặc quốc tịch",
+      "count": 0
+    },
+    {
+      "word": "Adverb Position",
+      "meaning": "Adverbs may appear at the start, middle, or end of a clause, depending on their type.",
+      "example": "Surprisingly, the meeting ended early.; She always arrives on time.; They completed the survey successfully.; He barely noticed the change.",
+      "translation": "Trạng từ có thể đứng đầu, giữa hoặc cuối mệnh đề tùy loại",
+      "count": 0
+    },
+    {
+      "word": "Comparisons",
+      "meaning": "Comparative and superlative forms compare qualities between people or things.",
+      "example": "This laptop is significantly lighter than my old one.; Of all the proposals, hers was the most innovative.; I believe my second book is better received.",
+      "translation": "Dùng để so sánh các người hoặc vật",
+      "count": 0
+    },
+    {
+      "word": "Comparative and Superlative Modifiers",
+      "meaning": "Words like very, far, much, and easily enhance comparative or superlative adjectives.",
+      "example": "The project became far more complex than expected.; He was easily the most experienced candidate.; This year's festival is much better organized.",
+      "translation": "Các từ bổ nghĩa dùng để nhấn mạnh tính từ so sánh",
+      "count": 0
+    },
+    {
+      "word": "Comparison Patterns",
+      "meaning": "Use patterns like 'as ... as', 'not as ... as', and 'the more ... the more ...' for comparisons.",
+      "example": "She is as skilled as her mentor.; The movie wasn’t as exciting as the trailer.; The more you practice, the more confident you become.",
+      "translation": "Các cấu trúc so sánh phức như the more ... the more ... hoặc not as ... as",
+      "count": 0
+    },
+    {
+      "word": "Gradable versus Ungradable Adjectives",
+      "meaning": "Gradable adjectives admit degrees and modifiers; ungradable adjectives denote absolute states and take adverbs like absolutely.",
+      "example": "The coffee was quite hot.; She felt somewhat tired after the run.; The view was absolutely stunning.; The instructions are completely clear.",
+      "translation": "Tính từ chia làm loại có mức độ và loại tuyệt đối",
+      "count": 0
+    },
+    {
+      "word": "Adjective and Adverb Confusion",
+      "meaning": "Some words can serve as adjectives or adverbs, but their adverbial use may change meaning or form.",
+      "example": "He drove fast to avoid traffic.; This problem is hard enough already.; She arrived late and missed the start.",
+      "translation": "Một số từ có thể là cả tính từ và trạng từ, đôi khi nghĩa khác nhau",
+      "count": 0
+    },  
+    {
+      "word": "Clauses - Relative pronouns",
+      "meaning": "Words like who, which, that, whom, whose, when, where, why, and what link clauses to nouns.",
+      "example": "The artist whom I met was inspired by nature; The house where we stayed had a beautiful garden; The letter that arrived yesterday was from my cousin; She explained the reason why she left early; I remember the day when we first spoke.",
+      "translation": "Đại từ quan hệ dùng để nối mệnh đề quan hệ với danh từ chính",
+      "count": 0
+    },
+    {
+      "word": "Clauses - Defining & non‑defining",
+      "meaning": "Defining clauses specify exactly which person or thing is meant; non‑defining clauses add extra information about them.",
+      "example": "The chef who invented this dish won an award; The book that I borrowed has already been returned; My neighbor, who travels frequently, sent me a souvenir; London, which I visited last year, is very rainy.",
+      "translation": "Mệnh đề quan hệ xác định và không xác định",
+      "count": 0
+    },
+    {
+      "word": "Clauses - Participle clauses",
+      "meaning": "Participle clauses use -ing, past participle, or having + past participle to shorten relative clauses or add detail.",
+      "example": "Having finished the test, she relaxed with a cup of tea; Surprised by the news, he dropped his phone; Built in 1900, the library still serves the community.",
+      "translation": "Mệnh đề rút gọn dùng phân từ hiện tại/quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Clauses - Infinitive clauses",
+      "meaning": "Infinitive clauses (to + verb) express purpose or follow certain verbs and adjectives.",
+      "example": "To win the scholarship is her greatest ambition; He was eager to help the stranded motorist; My goal is to finish the marathon next month.",
+      "translation": "Mệnh đề với động từ nguyên mẫu dùng để thể hiện mục đích hoặc theo sau một số động từ nhất định",
+      "count": 0
+    },
+    {
+      "word": "Clauses - Concession clauses",
+      "meaning": "Concession clauses use words like although, even though, despite, and however to show contrast or surprising results.",
+      "example": "Although it rained, they continued the picnic; Despite the warnings, he climbed the mountain; However hard she tried, she couldn’t solve the puzzle.",
+      "translation": "Mệnh đề nhượng bộ dùng để diễn tả sự trái ngược hoặc bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for time",
+      "meaning": "Time expressions use a/an for unspecified moments, the for specific periods, or no article for general references.",
+      "example": "I’ll see you in an hour; She was born in the 1990s; Winter in Canada is very cold; I usually jog at night.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (thời gian)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for people/work",
+      "meaning": "Job titles and groups take a/an when new, the for known individuals or groups, and no article for general plurals.",
+      "example": "She wants to be a doctor; I met a famous actor yesterday; The president will speak tomorrow; Teachers often work long hours.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (người/nghề nghiệp)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for places",
+      "meaning": "Geographical names may take the, a, or no article depending on type (rivers, mountains, cities).",
+      "example": "We sailed down the Nile; They climbed Mount Fuji; I live in Paris; She dreams of visiting the Pacific Ocean.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (địa danh)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for public buildings",
+      "meaning": "Names of public buildings take the when defined by location or purpose, or no article when speaking generally.",
+      "example": "He went to the hospital for treatment; Students attend school five days a week; She visited the post office yesterday.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (công trình công cộng)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for entertainment/sport",
+      "meaning": "Names of sports and media use no article, while instruments and channels take the.",
+      "example": "They play tennis every weekend; I watched the match on television; She can play the piano beautifully.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (giải trí/thể thao)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for organisations",
+      "meaning": "Organisation names often take the, except when they function as proper names without an article.",
+      "example": "He works for the United Nations; She studied at NATO; The police arrived quickly.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (tổ chức)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for education",
+      "meaning": "Educational contexts use a/an for classes or exams, the for year groups, and no article for subjects.",
+      "example": "I have an exam tomorrow; She’s in the first year; He studies mathematics at university.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (giáo dục)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for travel",
+      "meaning": "Transport and travel terms take a/an for vehicles, the for specified modes, and no article for general means.",
+      "example": "We took a taxi to the station; She traveled by train; He went home on foot.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (du lịch)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Articles for health",
+      "meaning": "Health conditions take a/an for single occurrences, the for specific illnesses, and no article when general.",
+      "example": "He caught a cold last week; She has the flu now; Eating too much sugar can cause diabetes.",
+      "translation": "Một số danh từ theo nhóm có quy tắc dùng mạo từ đặc trưng (sức khỏe)",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Countable nouns",
+      "meaning": "Countable nouns have singular and plural forms and can use a/an or numbers.",
+      "example": "I bought two books yesterday; She saw a rare bird in the park; Many people attended the concert.",
+      "translation": "Danh từ đếm được có dạng số ít và số nhiều, dùng với a/an hoặc số đếm",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Uncountable nouns (singular)",
+      "meaning": "Uncountable nouns only have singular forms and take singular verbs.",
+      "example": "Information is key to progress; The furniture in my home is modern; Knowledge is power.",
+      "translation": "Danh từ không đếm được chỉ có dạng số ít và đi với động từ số ít",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Uncountable nouns (plural form)",
+      "meaning": "Some uncountable nouns appear in plural forms and take plural verbs.",
+      "example": "Scissors are on the desk; The goods were delivered on time; My pajamas are very comfortable.",
+      "translation": "Một số danh từ không đếm được có dạng số nhiều và đi với động từ số nhiều",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Quantifiers",
+      "meaning": "Quantifiers like some, many, much, and a few indicate amounts and agree with countable or uncountable nouns.",
+      "example": "She has many friends; He drank much water; Only a few people showed up.",
+      "translation": "Một số từ chỉ định lượng chỉ dùng với danh từ đếm được, không đếm được, hoặc cả hai",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Indefinite article",
+      "meaning": "Use a/an with singular countable nouns to introduce something for the first time or leave it unspecified.",
+      "example": "I saw a movie last night; She found an umbrella in the street; A student asked a question.",
+      "translation": "Dùng với danh từ đếm được số ít, để nói về một vật chưa xác định hoặc mới nhắc đến lần đầu",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Definite article",
+      "meaning": "Use the to refer to specific or previously mentioned nouns known to both speaker and listener.",
+      "example": "The book you lent me was excellent; The weather today is lovely; The children are playing outside.",
+      "translation": "Dùng để nói về điều đã biết hoặc xác định được",
+      "count": 0
+    },
+    {
+      "word": "Noun phrases - Zero article",
+      "meaning": "Omit the article with plural or uncountable nouns when speaking generally or in set expressions.",
+      "example": "Dogs make great pets; Water is essential for life; She studies biology.",
+      "translation": "Không dùng mạo từ khi nói chung hoặc trong các cụm thành ngữ",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – verb + -ing",
+      "meaning": "Some verbs are followed by an –ing form to express actions or experiences",
+      "example": "She admitted knowing the truth; He enjoys jogging in the park; I can’t help feeling excited; They postponed making a decision; We risk losing the contract",
+      "translation": "Một số động từ đi với dạng V‑ing",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – verb + object + -ing",
+      "meaning": "Certain perception verbs take an object plus an –ing form to show observed actions",
+      "example": "They heard the baby crying; I saw him completing the assignment; We noticed her smiling at us; She caught him cheating on the exam",
+      "translation": "Một số động từ đi với tân ngữ + V‑ing",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – verb + full infinitive",
+      "meaning": "Many verbs require to + infinitive to indicate intention or purpose",
+      "example": "He agreed to help with the project; She hopes to finish before noon; They plan to visit us next week; I managed to solve the problem",
+      "translation": "Nhiều động từ đi với to + V nguyên mẫu",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – verb + object + full infinitive",
+      "meaning": "Some verbs need an object followed by to + infinitive to show directed actions",
+      "example": "She asked him to close the window; We advised her to take a break; He persuaded me to join the team; They encouraged us to apply early",
+      "translation": "Một số động từ cần cả tân ngữ và to + V",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – verb + object + bare infinitive",
+      "meaning": "Verbs like let, make, help take an object plus a verb without to",
+      "example": "The coach let the players rest; She made him promise; I helped her carry the bags; They had me sign the form",
+      "translation": "Một số động từ theo sau là tân ngữ + V không 'to'",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – inf/ing no change",
+      "meaning": "Some verbs can take either to + infinitive or –ing with little change in meaning",
+      "example": "I like to read; I like reading; They started to laugh; They started laughing",
+      "translation": "Một số động từ đi với to V hoặc V‑ing mà không thay đổi nghĩa nhiều",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – inf/ing change meaning",
+      "meaning": "Other verbs change meaning depending on whether they take to + infinitive or –ing",
+      "example": "I stopped to rest; I stopped resting; She remembered to call; She remembered calling",
+      "translation": "Một số động từ thay đổi nghĩa tùy thuộc vào to V hay V‑ing",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – preparatory it",
+      "meaning": "Some verbs use a dummy subject “it” before an infinitive clause for emphasis",
+      "example": "I find it hard to believe; She considers it essential to practice; We made it clear to everyone",
+      "translation": "Dùng 'it' như chủ ngữ giả với một số động từ",
+      "count": 0
+    },
+    {
+      "word": "Verbal complements – subjunctive",
+      "meaning": "In that‑clauses after verbs of necessity or importance, use the base form without –s",
+      "example": "The board insisted that he resign; It’s vital that she be present; I recommend that you arrive early",
+      "translation": "Câu giả định dùng động từ nguyên mẫu để diễn tả điều quan trọng hoặc cần thiết",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – conditional",
+      "meaning": "Sentences expressing hypothetical situations and their results",
+      "example": "If I had wings, I would fly; Were I rich, I would travel the world",
+      "translation": "Câu điều kiện giả định cho tình huống không có thật",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – imagine",
+      "meaning": "To think about something that is not real or likely",
+      "example": "Imagine winning the lottery; Picture yourself on a tropical island",
+      "translation": "Tưởng tượng về điều không có thật hoặc ít có khả năng",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – suppose",
+      "meaning": "To assume something for the sake of discussion",
+      "example": "Suppose we lose power tomorrow, what would we do?; Let’s suppose she arrives late, how will we start?",
+      "translation": "Giả sử điều gì đó để thảo luận",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – as if/as though",
+      "meaning": "Phrases used to create comparisons that aren’t real",
+      "example": "He speaks as if he owned the place; She danced as though no one was watching",
+      "translation": "Dùng để so sánh mang tính chất không có thật",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – polite requests",
+      "meaning": "Structures that make questions and requests more polite",
+      "example": "I was wondering if you could help; Would you mind closing the door?",
+      "translation": "Cách nói lịch sự khi yêu cầu hoặc đặt câu hỏi",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – it’s time",
+      "meaning": "Used to suggest that something should happen now or soon",
+      "example": "It’s time we left; It’s high time you studied",
+      "translation": "Dùng để đề xuất việc nên làm ngay hoặc sắp tới",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – would rather/sooner",
+      "meaning": "Expresses preference about current or past actions",
+      "example": "I’d rather stay home tonight; We’d sooner not discuss this again",
+      "translation": "Diễn tả sự ưu tiên về hành động hiện tại hoặc quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Unreal time – wish/if only",
+      "meaning": "Expresses regret or desire for unreal present or past situations",
+      "example": "I wish I were taller; If only I had studied harder",
+      "translation": "Diễn tả ước muốn hoặc tiếc nuối về điều không có thật",
+      "count": 0
+    },
+    {
+      "word": "Reporting – tense changes",
+      "meaning": "In reported speech, move tenses back when the reporting verb is past",
+      "example": "He said he was tired; They told me they had left",
+      "translation": "Lùi thì trong câu tường thuật khi động từ tường thuật ở thì quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Reporting – modal changes",
+      "meaning": "Modals often change form in reported speech (e.g., will → would)",
+      "example": "She said she could come; He promised he would help",
+      "translation": "Một số động từ khuyết thiếu thay đổi trong câu tường thuật",
+      "count": 0
+    },
+    {
+      "word": "Reporting – pronoun/place shifts",
+      "meaning": "Pronouns and place/time words adjust to the new context",
+      "example": "I said it was my turn; She said they would meet there tomorrow",
+      "translation": "Đại từ và từ chỉ thời gian/địa điểm thay đổi trong câu tường thuật",
+      "count": 0
+    },
+    {
+      "word": "Reporting – questions & commands",
+      "meaning": "Questions lose question order and commands use tell/order + to infinitive",
+      "example": "He asked what time it was; She told me to sit down",
+      "translation": "Câu hỏi không dùng dấu hỏi và mệnh lệnh dùng tell/order + to V trong câu tường thuật",
+      "count": 0
+    },
+    {
+      "word": "Complex sentences – clefts & emphasis",
+      "meaning": "Cleft structures place emphasis by splitting the clause (It was/wasn’t … that)",
+      "example": "It was John who solved the puzzle; What I need is a holiday",
+      "translation": "Cấu trúc cleft dùng để nhấn mạnh một phần câu",
+      "count": 0
+    },
+    {
+      "word": "Complex sentences – so/such/too/enough",
+      "meaning": "Words like so, such, too, and enough express degree and often link to a result clause",
+      "example": "It was so cold that we left early; She has such talent; He’s too busy; Are you old enough to drive?",
+      "translation": "Dùng để diễn tả mức độ và kết quả",
+      "count": 0
+    },
+    {
+      "word": "Complex sentences – inversion",
+      "meaning": "Beginning a sentence with negative or place adverbials triggers subject‑verb inversion",
+      "example": "Never have I seen such beauty; Here comes the bus; Hardly had he arrived when it started raining",
+      "translation": "Đảo ngữ với trạng từ phủ định hoặc cụm chỉ nơi chốn",
+      "count": 0
+    },
+    {
+      "word": "Future time – will",
+      "meaning": "Used for predictions, instant decisions, promises, offers, and requests",
+      "example": "I will call you later; She’ll help with the project; Will you join us for dinner?",
+      "translation": "Dùng cho dự đoán, quyết định ngay lập tức, hứa hẹn, đề nghị và yêu cầu",
+      "count": 0
+    },
+    {
+      "word": "Future time – be going to",
+      "meaning": "Used for predictions based on evidence and pre‑formed plans",
+      "example": "Look, it’s going to rain; I’m going to start my own business",
+      "translation": "Dùng cho dự đoán có cơ sở và kế hoạch đã định",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Present continuous",
+      "meaning": "Used to talk about definite plans or arrangements in the near future, often with time references.",
+      "example": "I’m having dinner with the CEO tomorrow evening; We’re flying to Bangkok next Monday; She’s meeting her mentor at 10 AM on Friday.",
+      "translation": "Dùng cho các kế hoạch cụ thể sắp diễn ra",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Present simple",
+      "meaning": "Used for scheduled or timetabled events in the future, especially in formal or official contexts.",
+      "example": "The train leaves at 6 PM this Saturday; School starts at 8 AM on weekdays; The conference begins on the 12th of August.",
+      "translation": "Dùng để nói về lịch trình hoặc sự kiện cố định trong tương lai",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Future perfect simple",
+      "meaning": "Describes actions that will be completed before a specific future moment or that continue up to that point.",
+      "example": "By midnight, I will have submitted the report; They will have built the bridge by next year; She’ll have finished her book before June.",
+      "translation": "Dùng cho hành động hoàn tất hoặc tiếp diễn đến một thời điểm xác định trong tương lai",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Future perfect continuous",
+      "meaning": "Emphasizes the duration of an action that will be ongoing up to a future time.",
+      "example": "By this time tomorrow, I’ll have been studying for ten hours; They’ll have been living here for five years by December; She’ll have been training nonstop by the marathon date.",
+      "translation": "Nhấn mạnh khoảng thời gian của hành động kéo dài đến tương lai",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Future continuous",
+      "meaning": "Used for actions that will be in progress at a certain future time or for expected future routines.",
+      "example": "At 9 PM tonight, I’ll be watching the webinar; Next summer, we’ll be staying at our beach house; He’ll be working late all next week.",
+      "translation": "Dùng cho hành động đang diễn ra hoặc thói quen dự kiến ở tương lai",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Time clauses",
+      "meaning": "After time conjunctions (when, as soon as, until, before, after, once), we use present tenses to describe future conditions.",
+      "example": "I’ll call you when I arrive; We’ll start the meeting as soon as the manager gets here; I won’t leave until you say so.",
+      "translation": "Dùng mệnh đề thời gian để mô tả điều kiện cho hành động tương lai",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Other ways to express the future",
+      "meaning": "Alternative future forms (be about to, be due to, modal verbs) convey imminent actions, plans, duties, or likelihood.",
+      "example": "I’m about to sign the contract; The train is due to depart in ten minutes; You’re to submit your proposal by Friday; They might postpone the launch.",
+      "translation": "Các cấu trúc diễn tả tương lai gần, kế hoạch, nghĩa vụ, hoặc khả năng xảy ra",
+      "count": 0
+    },
+    {
+      "word": "Future Time - Future in the past",
+      "meaning": "Describes past perspectives on future events; will changes to would and present tenses shift to past.",
+      "example": "She thought the meeting would start at nine; He said he would call me later; I believed the play was going to be a hit.",
+      "translation": "Dùng khi nói về điều trong quá khứ được xem là tương lai",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past simple",
+      "meaning": "Used for actions completed in the past, past habits, general truths, or story backgrounds.",
+      "example": "They launched the product in 2005; She lived in Paris for two years; Children played outside until dusk.",
+      "translation": "Dùng cho hành động hoàn tất, thói quen hoặc tình huống cố định trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Emphatic past simple",
+      "meaning": "Adds emphasis or contrast to past actions, often with did + base verb.",
+      "example": "I did finish my homework before dinner; He did apologise for being late; We did see the comet last night.",
+      "translation": "Dùng để nhấn mạnh hoặc đối lập hành động quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past simple vs present perfect",
+      "meaning": "Past simple refers to finished past periods; present perfect links past actions to the present or uses unspecified time.",
+      "example": "I visited Rome in 2010; I have visited Rome several times; She ate breakfast an hour ago; She has just eaten.",
+      "translation": "So sánh hành động đã hoàn tất và hành động liên quan đến hiện tại",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past continuous",
+      "meaning": "Describes past actions in progress, background events, temporary activities, or repeated past behaviour.",
+      "example": "I was reading when the phone rang; They were living abroad last year; She was always losing her keys.",
+      "translation": "Dùng cho hành động đang diễn ra hoặc lặp lại trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past continuous vs past simple",
+      "meaning": "Past continuous sets the scene or background; past simple describes the main event.",
+      "example": "I was cooking when he arrived; She entered the room as I was speaking.",
+      "translation": "Past continuous cho bối cảnh, past simple cho hành động chính",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past continuous vs present perfect continuous",
+      "meaning": "Past continuous focuses on a past duration; present perfect continuous links that duration to the present.",
+      "example": "I was studying for three hours yesterday; I have been studying for three hours today.",
+      "translation": "So sánh hành động quá khứ đang diễn ra và hành động kéo dài đến hiện tại",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past perfect simple",
+      "meaning": "Describes actions completed before another past event or time.",
+      "example": "She had left by the time I arrived; They had finished the project before deadline; He had never seen snow before that trip.",
+      "translation": "Dùng cho hành động hoàn tất trước một hành động khác trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Past perfect continuous",
+      "meaning": "Emphasizes the duration of an action or state up to a past moment.",
+      "example": "They had been waiting for hours before the show started; She had been living there all her childhood.",
+      "translation": "Dùng cho hành động kéo dài đến một thời điểm trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Would (past habit)",
+      "meaning": "Describes habitual actions in the distant past.",
+      "example": "When we were kids, we would play hide‑and‑seek daily; He would visit his grandmother every Sunday.",
+      "translation": "Dùng để diễn tả thói quen trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Past Time - Used to",
+      "meaning": "Expresses past habits or states no longer true.",
+      "example": "I used to cycle to work; She used to be shy as a child.",
+      "translation": "Dùng cho thói quen hoặc trạng thái đã từng xảy ra trong quá khứ",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Present simple",
+      "meaning": "Used for facts, habits, permanent situations, headlines, instructions, and scheduled events.",
+      "example": "Water boils at 100°C; She goes jogging every morning; The train departs at noon.",
+      "translation": "Dùng cho sự thật, thói quen, tình trạng cố định, tiêu đề, lịch trình",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Emphatic present simple",
+      "meaning": "Adds emphasis or contrast in the present with do/does + base verb.",
+      "example": "I do understand your concerns; He does want to help.",
+      "translation": "Dùng để nhấn mạnh cảm xúc hoặc sự tương phản",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Present continuous",
+      "meaning": "Describes current actions, changing situations, temporary states, arranged future plans, and habitual annoyance with always.",
+      "example": "I’m reading a fascinating book; They’re renovating their kitchen; She’s always arriving late.",
+      "translation": "Dùng cho hành động đang xảy ra, tình huống thay đổi, sắp xếp tương lai, hoặc thói quen gây phiền",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Present perfect simple",
+      "meaning": "Used for actions or states from the past to the present, recent events, experiences, and present results.",
+      "example": "I’ve visited London twice; She’s already seen that movie; They’ve just returned from vacation.",
+      "translation": "Dùng cho hành động từ quá khứ kéo dài tới hiện tại hoặc ảnh hưởng tới hiện tại",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Present perfect continuous",
+      "meaning": "Highlights actions in progress from past up to now, emphasizing duration.",
+      "example": "I’ve been learning Spanish for three months; They’ve been working on the project all day.",
+      "translation": "Dùng cho hành động đang diễn ra từ quá khứ và nhấn mạnh thời lượng",
+      "count": 0
+    },
+    {
+      "word": "Present Time - Stative vs non‑stative verbs",
+      "meaning": "Stative verbs describe states, not actions, and are rarely used in continuous forms.",
+      "example": "I know the answer; They believe in fair play; I’m thinking about the proposal; She’s tasting the soup.",
+      "translation": "Động từ chỉ trạng thái thường không dùng ở thì tiếp diễn",
+      "count": 0
+    }      
+  ],
+  "phrases, collocations": [   
+    {
+      "word": "pay /peɪ/",
+      "meaning": "pay dearly for; pay sb a compliment; pay your way; pay your respects; pay the price; pay rise",
+      "example": "After ignoring safety rules, he paid dearly for the mistake; The professor paid her a compliment on her research; Even as a student, she insisted on paying her way; Soldiers lined up to pay their respects to the fallen; He paid the price for breaking the agreement; The staff demanded a fair pay rise after the merger",
+      "translation": "trả giá đắt; khen ngợi ai đó; tự trả phần mình; bày tỏ lòng kính trọng; gánh hậu quả; tăng lương",
+      "count": 0
+    },
+    {
+      "word": "peer /pɪər/",
+      "meaning": "peer group; peer pressure",
+      "example": "Joining the school orchestra helped him bond with a new peer group; She skipped class because of peer pressure from her friends",
+      "translation": "nhóm bạn cùng lứa; áp lực từ bạn bè",
+      "count": 0
+    },
+    {
+      "word": "pen /pen/",
+      "meaning": "put pen to paper; the pen is mightier than the sword; pen-pusher",
+      "example": "He finally put pen to paper to start his first novel; Writers believe the pen is mightier than the sword when promoting social change; He was tired of working as a pen-pusher in a boring government job",
+      "translation": "bắt đầu viết; ngòi bút mạnh hơn gươm giáo; người làm công việc giấy tờ nhàm chán",
+      "count": 0
+    },
+    {
+      "word": "person /ˈpɜːsn/",
+      "meaning": "do sth in person; meet sb in person",
+      "example": "She insisted on delivering the gift in person; I was thrilled to meet the artist in person after the exhibition",
+      "translation": "đích thân làm gì đó; gặp ai đó trực tiếp",
+      "count": 0
+    },
+    {
+      "word": "perspective /pəˈspektɪv/",
+      "meaning": "put into perspective; from the perspective of; a sense of perspective",
+      "example": "Spending time abroad really put her priorities into perspective; From the perspective of a doctor, the treatment was a success; Failing the test gave me a stronger sense of perspective about my goals",
+      "translation": "nhìn nhận đúng mức; theo quan điểm của; cái nhìn thực tế",
+      "count": 0
+    },
+    {
+      "word": "place /pleɪs/",
+      "meaning": "change places with; take the place of; take sb’s place; put in place; in place of; out of place; place of work",
+      "example": "I wouldn’t want to change places with a celebrity; Robots are taking the place of human workers in factories; Can you take my place during the interview?; New traffic laws have been put in place this week; Use banana in place of eggs in vegan baking; He felt out of place at the luxury event; Please confirm your current place of work on the form",
+      "translation": "đổi vị trí; thay thế cho; thay chỗ ai đó; được áp dụng; thay cho; lạc lõng; nơi làm việc",
+      "count": 0
+    },
+    {
+      "word": "play /pleɪ/",
+      "meaning": "play against; play a role in; play the fool; play along; play by the rules; play fair",
+      "example": "They will play against Spain in the semi-finals; He played a role in developing the vaccine; She played the fool to hide her real intentions; I decided to play along until I figured out his plan; We expect everyone to play by the rules in this tournament; Let's play fair and not cheat",
+      "translation": "thi đấu với; đóng vai trò trong; giả vờ ngốc nghếch; giả vờ đồng ý; chơi đúng luật; chơi công bằng",
+      "count": 0
+    },
+    {
+      "word": "point /pɔɪnt/",
+      "meaning": "point to; get to the point; make a point of doing sth; beside the point; up to a point; make your point; take sb’s point; there’s no point in",
+      "example": "He pointed to the north as the direction of escape; Let’s get to the point and discuss the contract; She always makes a point of thanking her staff; His comments were beside the point in that meeting; I support your idea up to a point; You've made your point, no need to repeat; I take your point about the cost being high; There’s no point in continuing the debate",
+      "translation": "chỉ vào; đi thẳng vào vấn đề; chú ý làm gì; không liên quan; đồng ý một phần; bạn đã nêu rõ ý kiến; hiểu quan điểm của ai đó; không có ích",
+      "count": 0
+    },
+    {
+      "word": "polite /pəˈlaɪt/",
+      "meaning": "polite to sb; polite of sb to do; just being polite; polite conversation; polite society",
+      "example": "He was always polite to the delivery workers; It was polite of him to wait for everyone; She smiled, just being polite, not interested; They exchanged polite conversation over coffee; He felt awkward in polite society at the gala",
+      "translation": "lịch sự với ai đó; ai đó lịch sự khi làm gì; chỉ xã giao; cuộc trò chuyện lịch sự; tầng lớp xã hội lịch thiệp",
+      "count": 0
+    },
+    {
+      "word": "poor /pɔːr/",
+      "meaning": "come a poor second; poor loser; poor boy; poor relation; poor health; the rich and the poor",
+      "example": "He came a poor second in the election; Don’t be a poor loser — it’s just a game; The poor boy had to walk barefoot to school; The arts often feel like a poor relation in public funding; She’s been struggling with poor health recently; The gap between the rich and the poor is alarming",
+      "translation": "về nhì một cách tệ; người thua cay cú; cậu bé tội nghiệp; người bị đối xử thấp kém; sức khỏe yếu; người giàu và người nghèo",
+      "count": 0
+    },
+    {
+      "word": "power /ˈpaʊər/",
+      "meaning": "take power; exercise power; have power to do; power over; beyond sb’s power; the powers that be; power structure",
+      "example": "The new president took power after the election; He exercises power through negotiation, not force; She has the power to approve the budget; The manager had power over hiring decisions; Fixing this is beyond my power; The powers that be have issued new guidelines; The power structure in the company is changing",
+      "translation": "giành quyền lực; thực thi quyền lực; có quyền làm gì; quyền kiểm soát; ngoài khả năng của ai; các thế lực cầm quyền; cơ cấu quyền lực",
+      "count": 0
+    },
+    {
+      "word": "praise /preɪz/",
+      "meaning": "praise sb for doing; win praise; receive praise; earn praise; be full of praise for; be in praise of",
+      "example": "She praised him for helping the new intern; The charity won praise from donors for its transparency; The author received praise at the book launch; He earned praise from his coach for perseverance; Colleagues were full of praise for her presentation; The statue was erected in praise of local heroes",
+      "translation": "khen ngợi ai vì đã làm gì; giành được lời khen; nhận được lời khen; xứng đáng nhận lời khen; tràn đầy lời khen ngợi; để ca ngợi",
+      "count": 0
+    },
+    {
+      "word": "prefer /prɪˈfɜːr/",
+      "meaning": "prefer sb to do; prefer sth to; prefer doing; would prefer",
+      "example": "I’d prefer you to email me the report; She prefers tea to coffee in the afternoon; He prefers jogging to cycling before work; They prefer working in small teams; I would prefer to relax at home tonight",
+      "translation": "thích ai làm gì hơn; thích cái gì hơn; thích làm gì hơn; sẽ muốn hơn",
+      "count": 0
+    },
+    {
+      "word": "principle /ˈprɪnsəpl/",
+      "meaning": "have principles; be against sb’s principles; principle of sth; matter of principle",
+      "example": "She has principles she never compromises; It’s against my principles to spread rumors; The principle of equality underpins our policy; He declined on a matter of principle",
+      "translation": "có nguyên tắc; trái với nguyên tắc của ai; nguyên tắc của điều gì; vấn đề về nguyên tắc",
+      "count": 0
+    },
+    {
+      "word": "print /prɪnt/",
+      "meaning": "print sth out; print sth off; be in print; be out of print",
+      "example": "Please print out the presentation slides; She printed off the boarding pass at home; His article is still in print after decades; That magazine is long out of print",
+      "translation": "in tài liệu; in và xuất ra; đang được xuất bản; ngưng xuất bản",
+      "count": 0
+    },
+    {
+      "word": "prison /ˈprɪzn/",
+      "meaning": "go to prison; serve a sentence; prison term; prison reform; prison officer",
+      "example": "He went to prison after the verdict; She is serving a five-year sentence; That crime carries a long prison term; The government proposed prison reform yesterday; The prison officer escorted the visitor",
+      "translation": "bị đi tù; thụ án; thời hạn tù; cải cách nhà tù; nhân viên trại giam",
+      "count": 0
+    },
+    {
+      "word": "process /ˈprəʊses/",
+      "meaning": "in the process of doing; peace process; election process; judicial process; due process",
+      "example": "We’re in the process of restructuring the team; The peace process stalled after negotiations broke down; The election process began with candidate registrations; He challenged the fairness of the judicial process; All citizens deserve due process",
+      "translation": "đang trong quá trình; quá trình hòa bình; quá trình bầu cử; quá trình tư pháp; thủ tục công bằng",
+      "count": 0
+    },
+    {
+      "word": "provoke /prəˈvəʊk/",
+      "meaning": "provoke sb into doing; provoke a reaction; provoke a protest; provoke an outcry",
+      "example": "His remarks provoked her into speaking up; The announcement provoked a strong reaction; The policy change provoked mass protests; The article provoked an outcry on social media",
+      "translation": "khiến ai đó làm gì; gây phản ứng; kích động biểu tình; gây làn sóng phản đối",
+      "count": 0
+    },
+    {
+      "word": "purpose /ˈpɜːpəs/",
+      "meaning": "serve a purpose; purpose of doing; do sth on purpose; for the purpose of; escape sb’s purpose",
+      "example": "This tool serves a purpose in our workflow; The purpose of conducting surveys is to gather feedback; She did it on purpose to prove a point; He spoke for the purpose of educating the audience; His argument escaped my purpose",
+      "translation": "phục vụ mục đích; mục đích làm gì; làm điều gì có chủ ý; nhằm mục đích; vượt ngoài ý định của ai",
+      "count": 0
+    },
+    {
+      "word": "quality /ˈkwɒləti/",
+      "meaning": "high quality; good quality; poor quality; personal qualities; quality of life; quality time",
+      "example": "They manufacture high-quality components; The product was praised for its good quality; Customers complained about poor quality service; Her personal qualities impressed the panel; We aim to improve quality of life in the city; I cherish spending quality time with family",
+      "translation": "chất lượng cao; chất lượng tốt; chất lượng kém; phẩm chất cá nhân; chất lượng cuộc sống; thời gian chất lượng",
+      "count": 0
+    },
+    {
+      "word": "question /ˈkwestʃən/",
+      "meaning": "beg the question; a question of; be in question; be out of the question; beyond question; some question over; awkward question",
+      "example": "The data gaps beg the question of our methodology; It’s a question of resources, not willingness; His integrity was in question after the audit; Cancelling is out of the question now; Her competence is beyond question; There’s some question over the report’s accuracy; That was an awkward question to answer",
+      "translation": "gợi ra câu hỏi; vấn đề về; bị nghi ngờ; không thể chấp nhận; không thể nghi ngờ; có nghi vấn về; câu hỏi khó xử",
+      "count": 0
+    },
+    {
+      "word": "rain /reɪn/",
+      "meaning": "rain heavily; rain hard; pour with rain; heavy rain; light rain; get caught in the rain",
+      "example": "It rained heavily throughout the night; The forecast says it will rain hard this afternoon; We were pouring with rain on the hike; They experienced heavy rain during the storm; We only had light rain in the morning; I got caught in the rain without an umbrella",
+      "translation": "mưa to; mưa nặng hạt; mưa xối xả; mưa lớn; mưa nhẹ; bị ướt khi mưa",
+      "count": 0
+    },
+    {
+      "word": "raise /reɪz/",
+      "meaning": "raise your hand; raise sth with sb; raise an objection; raise your voice; raise a child; raise sb’s hopes; raise awareness; raise money",
+      "example": "Please raise your hand if you have a question; He raised the issue with his manager; She raised an objection during the meeting; His remark raised his voice in surprise; They raised their children bilingually; The news raised everyone’s hopes; The campaign raised awareness of climate change; We raised money for the charity event",
+      "translation": "giơ tay; nêu vấn đề với ai; phản đối; lên giọng; nuôi dạy con; làm ai đó hy vọng; nâng cao nhận thức; quyên góp tiền",
+      "count": 0
+    },
+    {
+      "word": "react /riˈækt/",
+      "meaning": "react to sth; react by doing; react accordingly; react against",
+      "example": "She reacted to the criticism with grace; They reacted by implementing new protocols; Management reacted accordingly to the feedback; The community reacted against the proposed closure",
+      "translation": "phản ứng với; phản ứng bằng cách; phản ứng phù hợp; phản đối",
+      "count": 0
+    },
+    {
+      "word": "reaction /riˈækʃən/",
+      "meaning": "cause a reaction; provoke a reaction; trigger a reaction; reaction to; reaction against",
+      "example": "The policy caused a public reaction; His speech provoked a strong reaction; That announcement triggered a market reaction; Her reaction to the news was relief; There was a reaction against the new tax",
+      "translation": "gây ra phản ứng; kích động phản ứng; khơi dậy phản ứng; phản ứng với; phản ứng chống lại",
+      "count": 0
+    },
+    {
+      "word": "read /riːd/",
+      "meaning": "read sb’s mind; read sb like a book; read between the lines; read out loud; read from cover to cover",
+      "example": "He can almost read your mind; I read him like a book after years of knowing him; You need to read between the lines in her email; She read the poem out loud to the class; I read the novel from cover to cover over the weekend",
+      "translation": "đọc tâm tư; hiểu rõ ai; đọc ngầm; đọc thành tiếng; đọc hết từ đầu đến cuối",
+      "count": 0
+    },
+    {
+      "word": "reality /riˈæləti/",
+      "meaning": "escape from reality; face reality; in reality; reality TV",
+      "example": "Some people use fiction to escape from reality; It’s time to face reality and adapt; In reality, the project was underfunded; She appears on a reality TV show every week",
+      "translation": "trốn tránh thực tế; đối mặt với thực tế; thực tế thì; chương trình thực tế",
+      "count": 0
+    },
+    {
+      "word": "record /ˈrekɔːd/",
+      "meaning": "keep a record of; break a record; set a record; on record; off the record",
+      "example": "We keep a record of all transactions; She broke the world record in sprinting; They set a record for fundraising; These statements are on record; He spoke off the record to the press",
+      "translation": "ghi chép; phá kỷ lục; thiết lập kỷ lục; được ghi lại; ngoài hồ sơ",
+      "count": 0
+    },
+    {
+      "word": "relative /ˈrelətɪv/",
+      "meaning": "close relative; distant relative; relative newcomer; relative clause; relative pronoun",
+      "example": "She’s a close relative of the founder; He discovered a distant relative in the archives; The startup is a relative newcomer to the market; Identify the relative clause in the sentence; Use a relative pronoun to connect clauses",
+      "translation": "họ hàng gần; họ hàng xa; người mới; mệnh đề quan hệ; đại từ quan hệ",
+      "count": 0
+    },
+    {
+      "word": "respect /rɪˈspekt/",
+      "meaning": "respect sb for sth; win sb’s respect; lose sb’s respect; show respect for; in this respect; with respect to",
+      "example": "I respect her for her integrity; He won the respect of his peers; She lost my respect by lying; We show respect for different opinions; In this respect, I agree with you; With respect to your request, we will comply",
+      "translation": "tôn trọng ai vì điều gì; giành được sự tôn trọng; mất sự tôn trọng; thể hiện sự tôn trọng; về khía cạnh này; liên quan đến",
+      "count": 0
+    },
+    {
+      "word": "response /rɪˈspɒns/",
+      "meaning": "in response to; response to; no response; quick response",
+      "example": "In response to your email, please find attached; His response to the proposal was positive; There was no response after five reminders; They provided a quick response to the emergency",
+      "translation": "để đáp lại; phản hồi; không có phản hồi; phản hồi nhanh",
+      "count": 0
+    },
+    {
+      "word": "rest /rest/",
+      "meaning": "take a rest; have a rest; rest on; rest assured; come to rest",
+      "example": "After the hike, we took a rest by the lake; Let’s have a rest before continuing; The painting rests on a sturdy frame; Rest assured, we won’t be late; The ball came to rest at the goal line",
+      "translation": "nghỉ ngơi; nghỉ ngơi; đặt trên; yên tâm; dừng lại",
+      "count": 0
+    },
+    {
+      "word": "rich /rɪtʃ/",
+      "meaning": "rich in; filthy rich; be rich and famous; the rich and the poor",
+      "example": "Dark chocolate is rich in antioxidants; They became filthy rich after the IPO; He dreams of being rich and famous; The documentary examines the lives of the rich and the poor",
+      "translation": "giàu có về; vô cùng giàu; giàu và nổi tiếng; người giàu và người nghèo",
+      "count": 0
+    },
+    {
+      "word": "right /raɪt/",
+      "meaning": "have the right to do; have a right to; give sb the right to do; know right from wrong; human rights",
+      "example": "Everyone has the right to free speech; We have a right to privacy; The law gives citizens the right to vote; Children learn to know right from wrong; They campaign for human rights",
+      "translation": "có quyền làm gì; có quyền; trao quyền cho ai; biết đúng sai; quyền con người",
+      "count": 0
+    },
+    {
+      "word": "risk /rɪsk/",
+      "meaning": "run the risk of doing; pose a risk to; take a risk; be at risk; at the risk of",
+      "example": "He ran the risk of losing his license; Smoking poses a risk to health; You have to take a risk to succeed; The species is at risk of extinction; At the risk of repeating myself, listen carefully",
+      "translation": "đối mặt nguy cơ; gây rủi ro; chấp nhận rủi ro; gặp nguy hiểm; có nguy cơ",
+      "count": 0
+    },
+    {
+      "word": "rule /ruːl/",
+      "meaning": "follow the rules; break the rules; bend the rules; rule of law; rule out",
+      "example": "All students must follow the rules; She broke the rules and was reprimanded; Sometimes you have to bend the rules; Democracy relies on the rule of law; They ruled out further discussion",
+      "translation": "tuân theo quy tắc; vi phạm quy tắc; linh hoạt quy tắc; nguyên tắc pháp quyền; loại trừ",
+      "count": 0
+    },
+    {
+      "word": "run /rʌn/",
+      "meaning": "run a business; run out of; run into; run through; run the risk",
+      "example": "She runs a successful café; We ran out of time during the exam; He ran into an old colleague at the conference; Let’s run through the agenda one more time; You run the risk of error without backups",
+      "translation": "vận hành; hết; vô tình gặp; xem lại nhanh; gặp rủi ro",
+      "count": 0
+    },
+    {
+      "word": "rush /rʌʃ/",
+      "meaning": "rush to do; be in a rush; rush hour; rush sb into; do sth in a rush",
+      "example": "Don’t rush to conclusions without evidence; I’m in a rush this morning; Traffic jams peak during rush hour; They rushed me into signing the contract; He completed the task in a rush",
+      "translation": "vội vàng làm gì; vội; giờ cao điểm; thúc ép ai; làm gì một cách vội vã",
+      "count": 0
+    },
+    {
+      "word": "say /seɪ/",
+      "meaning": "have your say; say the word; say for certain; say your piece; nothing to say",
+      "example": "Everyone will have their say at the meeting; Just say the word and I’ll start; I can’t say for certain yet; She said her piece before leaving; I have nothing to say on the matter",
+      "translation": "được phát biểu; nói một tiếng; khẳng định; bày tỏ ý kiến; không còn gì để nói",
+      "count": 0
+    },
+    {
+      "word": "second /ˈsekənd/",
+      "meaning": "give a second; take a second; a split second; second-hand; second best",
+      "example": "Give me a second to think it over; It happened in a split second; She bought the jacket second-hand; I won’t settle for second best",
+      "translation": "cho một chút; khoảnh khắc nhanh; đồ cũ; thứ hai tốt nhất",
+      "count": 0
+    },
+    {
+      "word": "sense /sens/",
+      "meaning": "make sense of; see sense; have the sense to; common sense",
+      "example": "I can’t make sense of this map; She finally saw sense and apologized; He had the sense to ask for help; Use your common sense in emergencies",
+      "translation": "hiểu; nhận ra điều đúng đắn; có óc phán đoán; lẽ thường",
+      "count": 0
+    },
+    {
+      "word": "sentence /ˈsentəns/",
+      "meaning": "pass sentence on; serve a sentence; prison sentence; death sentence; life sentence",
+      "example": "The judge passed sentence on the offender; He served a ten-year prison sentence; That crime carries a death sentence; She received a life sentence",
+      "translation": "tuyên án; thụ án; án tù; án tử hình; chung thân",
+      "count": 0
+    },
+    {
+      "word": "shape /ʃeɪp/",
+      "meaning": "get in shape; stay in shape; take shape; out of shape; in the shape of",
+      "example": "He exercises daily to get in shape; She stays in shape with yoga; The plan started to take shape quickly; He’s out of shape after illness; The gift was in the shape of a heart",
+      "translation": "tập luyện; giữ vóc dáng; bắt đầu hình thành; mất dáng; có hình dạng",
+      "count": 0
+    },
+    {
+      "word": "share /ʃeər/",
+      "meaning": "share with; share between; share among; shareholder; share index; share option",
+      "example": "I’ll share this story with you; The profits are shared between partners; They share responsibilities among the team; She is a major shareholder in the firm; The share index rose sharply; He exercised his share options",
+      "translation": "chia sẻ với; chia giữa; chia trong số; cổ đông; chỉ số cổ phiếu; quyền chọn cổ phiếu",
+      "count": 0
+    },
+    {
+      "word": "sharp /ʃɑːp/",
+      "meaning": "keep a sharp eye on; sharp rise; sharp drop; sharp criticism",
+      "example": "Keep a sharp eye on your belongings; There was a sharp rise in sales; Analysts noted a sharp drop in temperature; He faced sharp criticism for the policy",
+      "translation": "để mắt kỹ; tăng mạnh; giảm mạnh; chỉ trích gay gắt",
+      "count": 0
+    },
+    {
+      "word": "short /ʃɔːt/",
+      "meaning": "run short of; be short of; short-term; short notice; short while",
+      "example": "We ran short of supplies; I’m short of cash at the moment; It was a short-term solution; She resigned at short notice; He stayed only a short while",
+      "translation": "cạn kiệt; thiếu; ngắn hạn; thông báo gấp; chốc lát",
+      "count": 0
+    },
+    {
+      "word": "law /lɔː/",
+      "meaning": "become law; break the law; uphold the law; pass a law; lay down the law",
+      "example": "The new bill will become law next month; He broke the law and was arrested; Courts must uphold the law; Parliament passed a landmark law; Parents sometimes lay down the law at home",
+      "translation": "trở thành luật; vi phạm luật; giữ vững luật pháp; thông qua luật; đặt ra quy tắc",
+      "count": 0
+    },
+    {
+      "word": "lead /liːd/",
+      "meaning": "lead the way; lead sb to do; take the lead; hold the lead; follow sb’s lead",
+      "example": "He will lead the way through the forest; His example led me to reconsider; I took the lead in negotiations; She held the lead until the final lap; We followed her lead on that project",
+      "translation": "dẫn đường; khiến ai làm gì; dẫn đầu; giữ vị trí dẫn đầu; theo sau hướng dẫn",
+      "count": 0
+    },
+    {
+      "word": "leisure /ˈleʒər/",
+      "meaning": "at your leisure; leisure time; leisure centre; leisure activities",
+      "example": "Read this document at your leisure; He spends his leisure time gardening; We joined the local leisure centre; Painting is one of her leisure activities",
+      "translation": "khi rảnh rỗi; thời gian rảnh rỗi; trung tâm giải trí; hoạt động giải trí",
+      "count": 0
+    },
+    {
+      "word": "length /leŋkθ/",
+      "meaning": "go to great lengths; run the length of; in length; of equal length; length of time",
+      "example": "She went to great lengths to help him; The road runs the length of the valley; The rope is five meters in length; The two bridges are of equal length; It took a considerable length of time",
+      "translation": "nỗ lực hết sức; chạy dài; chiều dài; cùng chiều dài; khoảng thời gian",
+      "count": 0
+    },
+    {
+      "word": "letter /ˈletər/",
+      "meaning": "get a letter from; write a letter to; send sb a letter; letter bomb",
+      "example": "I got a letter from my cousin; She wrote a letter to the editor; They sent me a letter yesterday; Police intercepted a letter bomb at the embassy",
+      "translation": "nhận thư từ; viết thư cho; gửi thư cho ai; bom thư",
+      "count": 0
+    },
+    {
+      "word": "life /laɪf/",
+      "meaning": "put sb’s life at risk; bring sth to life; come to life; save sb’s life; take sb’s life; lose a life; quality of life",
+      "example": "Speeding puts lives at risk; The story was brought to life on stage; The city centre came to life at night; The doctor saved his life; The suspect took his own life; The crash claimed three lives; They enjoy a high quality of life",
+      "translation": "đặt ai đó vào nguy hiểm; làm cho thứ gì đó sống động; sống lại; cứu sống ai; cướp đi sinh mạng; mất mạng; chất lượng cuộc sống",
+      "count": 0
+    },
+    {
+      "word": "lightning /ˈlaɪtnɪŋ/",
+      "meaning": "lightning bolt; lightning flash; be struck by lightning; lightning speed",
+      "example": "A bolt of lightning hit the tree; He was struck by lightning during the storm; She responded with lightning speed",
+      "translation": "tia sét; chớp; bị sét đánh; tốc độ cực nhanh",
+      "count": 0
+    },
+    {
+      "word": "like /laɪk/",
+      "meaning": "like doing; like to do; anything like; nothing like; alike; in like manner; just like; be like sb to do",
+      "example": "I like playing guitar in my free time; There’s nothing like a warm bath; They look alike; She sings just like her mother; It’s like him to show up late",
+      "translation": "thích làm gì; thích làm gì; bất cứ điều gì giống; không gì giống; giống nhau; bằng cách tương tự; giống như; điển hình của ai đó",
+      "count": 0
+    },
+    {
+      "word": "link /lɪŋk/",
+      "meaning": "link to; link with; find a link; prove a link; establish a link; click a link; follow a link",
+      "example": "This disease is linked to poor diet; They found a link between stress and heart disease; Click this link to join the call",
+      "translation": "liên kết đến; liên quan; tìm mối liên hệ; chứng minh mối liên hệ; thiết lập mối liên hệ; nhấp vào liên kết; theo liên kết",
+      "count": 0
+    },
+    {
+      "word": "live /lɪv/",
+      "meaning": "live a life of crime; live a life of luxury; live to do; live and let live; live in hope; live in fear; live to tell the tale",
+      "example": "He lived a life of crime before reform; She lives to help others; I say live and let live; We live in hope that things improve; He survived the crash and lived to tell the tale",
+      "translation": "sống cuộc đời tội phạm; sống sang trọng; sống để làm gì; sống và để người khác sống; sống trong hy vọng; sống trong sợ hãi; sống để kể lại",
+      "count": 0
+    },
+    {
+      "word": "load /ləʊd/",
+      "meaning": "load sth with; load sth into; take a load off; a (whole) load of; loads of; a heavy load to bear; carry a heavy load",
+      "example": "She loaded the cart with groceries; Sit down and take a load off your feet; We had a whole load of laundry; He’s got loads of work today; Caring for his family is a heavy load to carry",
+      "translation": "chất đầy; xếp vào; gỡ bớt gánh nặng; lượng lớn; rất nhiều; gánh nặng to lớn; mang gánh nặng",
+      "count": 0
+    },
+    {
+      "word": "lock /lɒk/",
+      "meaning": "lock sth in; lock sth behind; lock sth under; lock horns with; locksmith",
+      "example": "He locked the files in a drawer; They locked horns during the debate; Call a locksmith if you're locked out",
+      "translation": "khóa trong; khóa lại phía sau; khóa bên dưới; tranh cãi gay gắt; thợ khóa",
+      "count": 0
+    },
+    {
+      "word": "long /lɒŋ/",
+      "meaning": "last long; take a long time; all day long; a long way; long distance; at long last; long and hard; long time ago",
+      "example": "The meeting didn’t last long; It took a long time to recover; They talked all day long; He walked a long way home; They maintained a long-distance relationship; At long last, they found peace; She thought long and hard about it; That happened a long time ago",
+      "translation": "kéo dài; mất nhiều thời gian; suốt cả ngày; một quãng đường dài; khoảng cách xa; cuối cùng; suy nghĩ kỹ lưỡng; từ lâu",
+      "count": 0
+    },
+    {
+      "word": "lot /lɒt/",
+      "meaning": "a lot of; lots of; a lot on; a lot to do with; the lot",
+      "example": "There are a lot of options; We have lots of time; He’s got a lot on his mind; Her mood has a lot to do with stress; They ate the lot in one sitting",
+      "translation": "rất nhiều; rất nhiều; nhiều việc; liên quan rất nhiều; tất cả",
+      "count": 0
+    },
+    {
+      "word": "love /lʌv/",
+      "meaning": "love doing; love to do; fall in love with; be in love; love affair; love for",
+      "example": "She loves baking cakes; He fell in love with Paris; They are still in love after 20 years; Their romance started as a love affair; She has a deep love for animals",
+      "translation": "thích làm gì; thích làm gì; phải lòng; đang yêu; mối tình; tình yêu với",
+      "count": 0
+    },
+    {
+      "word": "luck /lʌk/",
+      "meaning": "push your luck; be in luck; lucky charm; bring luck; leave luck; wish sb luck",
+      "example": "Don’t push your luck by asking for more; You’re in luck—we have an extra ticket; That rabbit’s foot is my lucky charm; That song always brings me luck; Don’t leave your luck to chance; I wished her luck before the presentation",
+      "translation": "liều lĩnh; gặp may; bùa may mắn; đem lại may mắn; bỏ mặc may mắn; chúc may mắn",
+      "count": 0
+    },
+    {
+      "word": "mark /mɑːk/",
+      "meaning": "mark sb/sth on; leave a mark; mark the occasion; make a mark on; be quick off the mark; slow off the mark; hit the mark",
+      "example": "The teacher marked us on our creativity; The accident left a mark on his reputation; We planted a tree to mark the occasion; She made her mark on the industry; He was quick off the mark with his response; They were slow off the mark in updating the software; His joke really hit the mark",
+      "translation": "chấm điểm; để lại dấu ấn; đánh dấu sự kiện; ghi dấu ấn; nhanh chóng; chậm trễ; trúng đích",
+      "count": 0
+    },
+    {
+      "word": "marriage /ˈmærɪdʒ/",
+      "meaning": "related by marriage; marriage guidance; marriage vows; marriage certificate; marriage proposal",
+      "example": "They became related by marriage last year; The couple sought marriage guidance before tying the knot; They exchanged heartfelt marriage vows; They showed me their marriage certificate; He nervously made his marriage proposal",
+      "translation": "quan hệ hôn nhân; tư vấn hôn nhân; lời thề hôn nhân; giấy đăng ký kết hôn; lời cầu hôn",
+      "count": 0
+    },
+    {
+      "word": "material /məˈtɪəriəl/",
+      "meaning": "material goods; material possessions; material wealth; material resources; raw materials",
+      "example": "She donated material goods to the shelter; He values his material possessions highly; The company's goal is to accumulate material wealth; The project requires extensive material resources; The factory sources raw materials locally",
+      "translation": "hàng hóa; tài sản vật chất; sự giàu có vật chất; nguồn lực vật chất; nguyên liệu thô",
+      "count": 0
+    },
+    {
+      "word": "matter /ˈmætər/",
+      "meaning": "a matter of; in a matter of (time); to make matters worse; no matter what/how; no laughing matter; a matter of opinion; a matter of urgency",
+      "example": "It’s only a matter of time before it rains; In a matter of hours they arrived; To make matters worse, the power went out; No matter what happens, stay calm; This is no laughing matter; Whether to move is a matter of opinion; The leak is a matter of urgency",
+      "translation": "vấn đề; chỉ mất; càng tệ hơn; dù thế nào; không phải trò đùa; mang tính chủ quan; khẩn cấp",
+      "count": 0
+    },
+    {
+      "word": "medicine /ˈmedsn/",
+      "meaning": "take medicine; alternative medicine; complementary medicine; herbal medicine; modern medicine",
+      "example": "She needs to take medicine twice daily; He practices alternative medicine in his clinic; Patients often combine complementary medicine with therapy; I prefer herbal medicine for colds; Advances in modern medicine save lives",
+      "translation": "uống thuốc; y học thay thế; y học bổ sung; y học thảo dược; y học hiện đại",
+      "count": 0
+    },
+    {
+      "word": "mental /ˈmentl/",
+      "meaning": "make a mental note; mental arithmetic; mental illness; mental health; mental block",
+      "example": "I’ll make a mental note to call him; She excels at mental arithmetic; He’s seeking help for mental illness; Public awareness of mental health is improving; She has a mental block when speaking in public",
+      "translation": "ghi nhớ trong đầu; tính toán trong đầu; bệnh tâm thần; sức khỏe tinh thần; tắc nghẽn tư duy",
+      "count": 0
+    },
+    {
+      "word": "metal /ˈmetl/",
+      "meaning": "precious metal; base metal; metal detector; heavy metal; scrap metal",
+      "example": "Gold is a precious metal; Copper is a base metal used in wiring; Airport security uses a metal detector; The concert featured classic heavy metal bands; They collected scrap metal for recycling",
+      "translation": "kim loại quý; kim loại cơ bản; máy dò kim loại; nhạc metal; phế liệu kim loại",
+      "count": 0
+    },
+    {
+      "word": "sick /sɪk/",
+      "meaning": "call in sick; feel sick; make sb sick; sick as a parrot; sick and tired of; sick with fear; sick at heart; sick bag",
+      "example": "He had to call in sick today; I feel sick after that roller coaster; The smell made me sick; She was sick as a parrot when she lost; I’m sick and tired of the delays; He was sick with fear before the jump; He was sick at heart over the news; The flight attendant handed me a sick bag",
+      "translation": "xin nghỉ ốm; cảm thấy buồn nôn; khiến ai đó buồn nôn; thất vọng tột độ; chán ngấy; sợ hãi tột cùng; buồn nôn trong lòng; túi nôn",
+      "count": 0
+    },
+    {
+      "word": "side /saɪd/",
+      "meaning": "side with sb; take sides; see both sides; the other side; on either side; on the plus side; on the minus side; side by side",
+      "example": "Don’t side with one person over another; They refused to take sides; I can see both sides of the argument; She stood on the other side of the room; Trees line on either side of the road; On the plus side, it’s cheaper; On the minus side, it’s slower; They walked side by side down the path",
+      "translation": "đứng về phía; chọn phe; nhìn hai phía; bên kia; hai bên; mặt tích cực; mặt tiêu cực; song song",
+      "count": 0
+    },
+    {
+      "word": "size /saɪz/",
+      "meaning": "that’s about the size of it; cut sth to size; in size; of a certain size; increase in size; reduce in size",
+      "example": "So we lost the contract? That’s about the size of it; Cut the wood to size before assembly; The fish was large in size; We need envelopes of a certain size; The company increased in size last year; They reduced the file size for emailing",
+      "translation": "đúng như vậy; cắt cho vừa; về kích cỡ; có kích thước nhất định; tăng kích thước; giảm kích thước",
+      "count": 0
+    },
+    {
+      "word": "small /smɔːl/",
+      "meaning": "feel small; in a small way; it’s a small world; small talk; small change; small number; small amount; small business",
+      "example": "His insult made me feel small; She contributed in a small way; We ran into each other—it’s a small world; They made polite small talk; I paid with small change; Only a small number attended; There’s only a small amount left; He runs a small business locally",
+      "translation": "cảm thấy thua kém; theo cách nhỏ; thế giới nhỏ bé; nói chuyện xã giao; tiền lẻ; số lượng nhỏ; lượng nhỏ; doanh nghiệp nhỏ",
+      "count": 0
+    },
+    {
+      "word": "smooth /smuːð/",
+      "meaning": "smooth the way for; smooth-talking; smooth sailing",
+      "example": "Her connections smoothed the way for our proposal; He’s known for his smooth-talking style; After the upgrade it was smooth sailing",
+      "translation": "làm cho thuận tiện; nói chuyện bẽn lẽn; thuận buồm xuôi gió",
+      "count": 0
+    },
+    {
+      "word": "social /ˈsəʊʃl/",
+      "meaning": "social conditions; social contact; social security; social services; social call; social worker",
+      "example": "Poor social conditions fuel unrest; He misses social contact while traveling; Many rely on social security in retirement; She works in social services; I dropped by on a social call; The social worker visited the family",
+      "translation": "điều kiện xã hội; giao tiếp xã hội; an sinh xã hội; dịch vụ xã hội; thăm xã giao; nhân viên xã hội",
+      "count": 0
+    },
+    {
+      "word": "speaking /ˈspiːkɪŋ/",
+      "meaning": "speak well of; speak highly of; speak badly of; speak ill of; speak your mind; speak out; speak the same language; so to speak",
+      "example": "They spoke well of her performance; He spoke highly of the team's effort; Don’t speak badly of your colleagues; She will speak ill of no one; You should speak your mind honestly; He spoke out against corruption; We speak the same language on values; I’m tired, so to speak",
+      "translation": "khen ngợi; ca ngợi; nói xấu; phê bình; bày tỏ suy nghĩ; lên tiếng; cùng chung quan điểm; có thể nói",
+      "count": 0
+    },
+    {
+      "word": "start /stɑːt/",
+      "meaning": "make a good start; make a bad start; get off to a good start; get off to a flying start; have a head start; start from scratch; for a start; right from the start",
+      "example": "She made a good start on the project; He made a bad start in the race; We got off to a good start in negotiations; They got off to a flying start at launch; She had a head start over competitors; He had to start from scratch; For a start, we need funding; Right from the start, it was clear",
+      "translation": "khởi đầu tốt; khởi đầu tồi; khởi đầu thuận lợi; khởi đầu xuất sắc; lợi thế ban đầu; bắt đầu lại; trước hết; ngay từ đầu",
+      "count": 0
+    },
+    {
+      "word": "steady /ˈstedi/",
+      "meaning": "steady yourself; steady your nerves; hold sth steady; steady relationship; steady growth; steady look; steady pace",
+      "example": "She steadied herself on the railing; He steadied his nerves before the exam; Hold the camera steady while I shoot; They enjoy a steady relationship; The company shows steady growth; He gave her a steady look; They walked at a steady pace",
+      "translation": "giữ thăng bằng; bình tĩnh; giữ ổn định; mối quan hệ bền chặt; tăng trưởng ổn định; ánh nhìn kiên định; nhịp độ đều",
+      "count": 0
+    },
+    {
+      "word": "straight /streɪt/",
+      "meaning": "set sb straight; get sth straight; think straight; see straight; straight talking; straight answer",
+      "example": "Let me set you straight about the rules; I want to get this straight before moving on; He couldn’t think straight under pressure; I see things straight now; I appreciate your straight talking; Just give me a straight answer",
+      "translation": "làm rõ; hiểu chính xác; suy nghĩ rõ; nhìn thẳng; nói thẳng; câu trả lời thẳng thắn",
+      "count": 0
+    },
+    {
+      "word": "style /staɪl/",
+      "meaning": "style yourself as; travel in style; in style; out of style; with style; personal style",
+      "example": "He styled himself as a guru; They traveled in style first class; She always dresses in style; Bell-bottoms are out of style; He handled it with style; Her personal style is unique",
+      "translation": "tự phong; đi sang trọng; hợp mốt; lỗi mốt; phong cách; phong cách cá nhân",
+      "count": 0
+    },
+    {
+      "word": "subject /ˈsʌbdʒɪkt/",
+      "meaning": "subject to; bring up a subject; get onto a subject; drop the subject; subject sb to; be the subject of; British subject",
+      "example": "These terms are subject to change; She brought up the subject of pay; Let’s get onto a different subject; Please drop the subject now; They subjected us to intense questioning; He was the subject of the study; He’s a British subject by birth",
+      "translation": "tuân theo; đưa ra; chuyển sang; bỏ qua; bắt ai chịu; là đối tượng của; công dân Anh",
+      "count": 0
+    },
+    {
+      "word": "sun /sʌn/",
+      "meaning": "sun yourself; sit in the sun; be in the sun; be in the shade; enjoy sunshine; sunset",
+      "example": "They sun themselves on the deck; We sat in the sun all afternoon; Don’t be in the sun without protection; She preferred to be in the shade; I love morning sunshine; We watched the beautiful sunset",
+      "translation": "tắm nắng; ngồi dưới nắng; dưới nắng; dưới bóng râm; tận hưởng nắng; hoàng hôn",
+      "count": 0
+    },
+    {
+      "word": "support /səˈpɔːt/",
+      "meaning": "support doing sth; support sb; support sth; support sb financially; support sb emotionally; support a team",
+      "example": "I support improving education; Her family supports her ambitions; I fully support the initiative; He supports his children financially; She supports friends emotionally; We support our home team",
+      "translation": "ủng hộ làm gì; ủng hộ ai; ủng hộ điều gì; hỗ trợ tài chính; hỗ trợ tinh thần; ủng hộ đội",
+      "count": 0
+    },
+    {
+      "word": "surface /ˈsɜːfɪs/",
+      "meaning": "on the surface; beneath the surface; under the surface; surface area; kitchen surface; smooth surface",
+      "example": "On the surface, it seemed fine; Beneath the surface, tensions grew; The fish swam under the surface; Calculate the surface area for paint; Wipe down the kitchen surface; The floor has a smooth surface",
+      "translation": "bề mặt; bên dưới bề mặt; dưới bề mặt; diện tích bề mặt; bề mặt bếp; bề mặt nhẵn",
+      "count": 0
+    },
+    {
+      "word": "table /ˈteɪbl/",
+      "meaning": "set the table; clear the table; lay the table; table a proposal; table manners; on the table; under the table",
+      "example": "She set the table for dinner; He cleared the table after guests left; They laid the tablecloth neatly; They tabled a new proposal; His table manners impressed everyone; That offer is on the table; They paid under the table",
+      "translation": "bày bàn; dọn bàn; phủ bàn; đưa ra đề xuất; phép tắc bàn ăn; được bàn tới; lén lút",
+      "count": 0
+    },
+    {
+      "word": "talk /tɔːk/",
+      "meaning": "talk sb into doing; talk sb out of doing; talk sense; talk is cheap; talk your way into; talk your way out of",
+      "example": "She talked me into joining the club; He talked her out of resigning; Finally, he talked sense into them; Talk is cheap—actions matter; He talked his way into the meeting; She talked her way out of trouble",
+      "translation": "thuyết phục ai; ngăn cản ai; nói lý; nói suông; giành quyền; trốn tránh",
+      "count": 0
+    },
+    {
+      "word": "taste /teɪst/",
+      "meaning": "develop a taste for; have a taste for; acquire a taste for; in good taste; in bad taste; sense of taste",
+      "example": "He developed a taste for jazz; She acquired a taste for spicy food; His joke was in bad taste; That decor is in good taste; My sense of taste returned after illness",
+      "translation": "hình thành sở thích; có sở thích; tiếp nhận sở thích; hợp gu; kém nhã; khứu giác",
+      "count": 0
+    },
+    {
+      "word": "tell /tel/",
+      "meaning": "tell the truth; tell a lie; tell sb to do sth; tell sb what; tell the difference; be told; tell on sb",
+      "example": "Please tell the truth; He told a lie to protect her; She told me to wait; Can you tell me what happened?; I can’t tell the difference; I was told to leave; His habits will tell on him",
+      "translation": "nói sự thật; nói dối; ra lệnh; kể cho; phân biệt; được bảo; tố cáo",
+      "count": 0
+    },
+    {
+      "word": "term /tɜːm/",
+      "meaning": "in the short term; in the long term; term of office; prison term; fixed term; term time",
+      "example": "In the short term, costs will rise; In the long term, benefits will accrue; He served a four-year term of office; She received a five-year prison term; The contract has a fixed term; The campus is busy during term time",
+      "translation": "ngắn hạn; dài hạn; nhiệm kỳ; thời hạn tù; thời hạn cố định; thời gian học",
+      "count": 0
+    },
+    {
+      "word": "thin /θɪn/",
+      "meaning": "have thin skin; be thin on top; be thin on the ground; appear out of thin air; vanish into thin air",
+      "example": "She has thin skin and takes criticism hard; He’s a bit thin on top these days; Volunteers are thin on the ground; The idea appeared out of thin air; The documents vanished into thin air",
+      "translation": "dễ tổn thương; thưa thớt; khan hiếm; xuất hiện đột ngột; biến mất hoàn toàn",
+      "count": 0
+    },
+    {
+      "word": "threat /θret/",
+      "meaning": "pose a threat to; be under threat; threat of; bomb threat; death threat",
+      "example": "Pollution poses a threat to health; The species is under threat of extinction; There’s a threat of conflict; They received a bomb threat; She got a death threat on social media",
+      "translation": "đe dọa; bị đe dọa; mối đe dọa; đe dọa đánh bom; đe dọa giết người",
+      "count": 0
+    },
+    {
+      "word": "time /taɪm/",
+      "meaning": "pass the time; spend time doing; make time; find time; take time; in time; on time; time limit",
+      "example": "We played cards to pass the time; I spent time reading; Try to make time for exercise; Can you find time for a call?; Take your time with the form; I arrived just in time; The train was on time; There’s a time limit on the exam",
+      "translation": "tiêu thời gian; dành thời gian làm gì; thu xếp thời gian; tìm thời gian; tốn thời gian; kịp giờ; đúng giờ; giới hạn thời gian",
+      "count": 0
+    },
+    {
+      "word": "want /wɒnt/",
+      "meaning": "want sb to do; want sth done; for want of",
+      "example": "I want you to help me; I want this report done by Friday; For want of evidence, the case was dismissed",
+      "translation": "muốn ai làm gì; muốn điều gì được làm; vì thiếu",
+      "count": 0
+    },
+    {
+      "word": "way /weɪ/",
+      "meaning": "get in sb’s way; know the way; lose your way; get sth out of the way; be in the way; on the way; in this way; way of doing",
+      "example": "Try not to get in his way; Do you know the way home?; We lost our way in the fog; Let’s get this out of the way; The chair is in the way; I met her on the way to work; We solve problems in this way; That’s her way of teaching",
+      "translation": "cản đường; biết đường; lạc đường; giải quyết trước; chắn đường; trên đường; bằng cách này; cách làm",
+      "count": 0
+    },
+    {
+      "word": "weak /wiːk/",
+      "meaning": "weak at the knees; weak on; weak argument; weak point; weak‑willed",
+      "example": "She felt weak at the knees when she saw him; I’m weak on algebra; That’s a weak argument; Patience is my weak point; He’s too weak‑willed to protest",
+      "translation": "yếu lòng; kém về; lập luận yếu; điểm yếu; thiếu ý chí",
+      "count": 0
+    },
+    {
+      "word": "weather /ˈweðər/",
+      "meaning": "good weather; bad weather; freak weather; in all weathers; under the weather; weather forecast; weatherproof",
+      "example": "We had good weather all week; Bad weather cancelled the flight; A freak weather event caused floods; He works in all weathers; I feel under the weather today; Check the weather forecast; These shoes are weatherproof",
+      "translation": "thời tiết đẹp; thời tiết xấu; thời tiết bất thường; trong mọi thời tiết; mệt mỏi; dự báo thời tiết; chống chịu thời tiết",
+      "count": 0
+    },
+    {
+      "word": "web /web/",
+      "meaning": "surf the web; on the web; website; webcam; World Wide Web; web page",
+      "example": "I love to surf the web; I found it on the web; Visit our website; Turn on your webcam; He studies the World Wide Web; This web page is broken",
+      "translation": "lướt web; trên mạng; trang web; webcam; mạng toàn cầu; trang web",
+      "count": 0
+    },
+    {
+      "word": "wedding /ˈwedɪŋ/",
+      "meaning": "wedding anniversary; wedding cake; wedding ceremony; wedding dress; wedding invitation; wedding present",
+      "example": "They celebrated their wedding anniversary; The wedding cake was huge; The wedding ceremony was outdoors; She wore a white wedding dress; I received a wedding invitation; They bought a wedding present",
+      "translation": "kỷ niệm cưới; bánh cưới; lễ cưới; váy cưới; thiệp cưới; quà cưới",
+      "count": 0
+    },
+    {
+      "word": "wheel /wiːl/",
+      "meaning": "take the wheel; behind the wheel; wheel of fortune",
+      "example": "She asked me to take the wheel; He was behind the wheel during the accident; They spun the wheel of fortune",
+      "translation": "cầm lái; sau tay lái; vòng quay vận may",
+      "count": 0
+    },
+    {
+      "word": "wind /wɪnd/",
+      "meaning": "high wind; strong wind; light wind; against the wind; in the wind; out of the wind; gust of wind; winds of change",
+      "example": "High winds closed the airport; A strong wind broke the fence; We enjoyed a light wind at sea; They cycled against the wind; Rumors were in the wind; Stay out of the wind; A gust of wind slammed the door; The winds of change are here",
+      "translation": "gió to; gió mạnh; gió nhẹ; đi ngược gió; tin đồn; tránh gió; cơn gió mạnh; làn sóng thay đổi",
+      "count": 0
+    },
+    {
+      "word": "window /ˈwɪndəʊ/",
+      "meaning": "window‑shopping; window display; window dresser; out the window; a window on; window into",
+      "example": "We spent the afternoon window‑shopping; The window display attracted customers; She works as a window dresser; The opportunity went out the window; The report offers a window on the past; This film gives a window into rural life",
+      "translation": "đi ngắm đồ; trưng bày; người trang trí cửa sổ; mất đi; cái nhìn; góc nhìn",
+      "count": 0
+    },
+    {
+      "word": "word /wɜːd/",
+      "meaning": "put in a word for; have a word with; spread the word; from the word go; in other words",
+      "example": "Could you put in a word for me?; I need to have a word with you; They spread the word online; He knew from the word go; In other words, it’s settled",
+      "translation": "nói giúp; trao đổi; lan truyền tin; ngay từ đầu; nói cách khác",
+      "count": 0
+    },
+    {
+      "word": "work /wɜːk/",
+      "meaning": "work on; work in; work with; work as; work at; work for; work like a charm; work both ways; work a treat; work wonders; work your way up; work your way through",
+      "example": "She works on new designs; He works in finance; They work with volunteers; She works as a teacher; I work at a bank; He works for a nonprofit; The remedy worked like a charm; Respect works both ways; The app works a treat; Education works wonders; He worked his way up the ranks; I’m working my way through college",
+      "translation": "làm về; làm trong; làm cùng; làm với vai trò; làm tại; làm cho; rất hiệu quả; đôi bên cùng có lợi; hoạt động tốt; mang lại hiệu quả; thăng tiến; vừa học vừa làm",
+      "count": 0
+    },
+    {
+      "word": "worse /wɜːs/",
+      "meaning": "get worse; make matters worse; worse for wear; for the worse; if worst comes to worst",
+      "example": "My cold is getting worse; He made matters worse by arguing; The sofa is worse for wear; Their relationship changed for the worse; If worst comes to worst, call me",
+      "translation": "trở nên tồi tệ hơn; càng tệ hơn; xuống cấp; theo chiều hướng xấu; nếu tình huống xấu nhất xảy ra",
+      "count": 0
+    },
+    {
+      "word": "worst /wɜːst/",
+      "meaning": "do your worst; fear the worst; be your own worst enemy; at worst",
+      "example": "Go ahead, do your worst; I feared the worst when I saw the damage; He’s his own worst enemy; At worst, we’ll have to start over",
+      "translation": "làm tệ nhất; lo sợ điều tệ nhất; tự hại bản thân; tệ nhất cũng chỉ vậy",
+      "count": 0
+    },
+    {
+      "word": "write /raɪt/",
+      "meaning": "write for; have sth written all over your face; write about; write of; write on; write sb off; writer’s block",
+      "example": "He writes for a local paper; Guilt was written all over her face; She writes about social issues; He wrote of his travels; They write on the topic regularly; The coach wrote him off too soon; She’s suffering from writer’s block",
+      "translation": "viết cho; hiện rõ trên mặt; viết về; viết về; viết trên; loại bỏ; bế tắc viết lách",
+      "count": 0
+    },
+    {
+      "word": "year /jɪər/",
+      "meaning": "years of age; year on year; for years; year after year; never in a million years; year full of",
+      "example": "She is ten years of age; Profits rose year on year; We’ve worked here for years; He wins that race year after year; Never in a million years did I imagine this; It was a year full of challenges",
+      "translation": "tuổi; theo năm; nhiều năm; năm này qua năm khác; không bao giờ; tràn đầy",
+      "count": 0
+    },
+    {
+      "word": "tool /tuːl/",
+      "meaning": "a tool for; a tool of; toolbar; tool kit; power tool",
+      "example": "A wrench is a tool for repairs; Language is a tool of communication; Customize your toolbar in settings; He bought a new tool kit; They used power tools on site",
+      "translation": "công cụ để; công cụ của; thanh công cụ; bộ dụng cụ; dụng cụ điện",
+      "count": 0
+    },
+    {
+      "word": "top /tɒp/",
+      "meaning": "come out on top; get on top of; be on top of; on top of; off the top of your head; from the top; at the top; top of the world; top priority; top secret",
+      "example": "She came out on top in the competition; I need to get on top of my inbox; He’s on top of his workload; On top of that, we need more staff; Off the top of my head, I’d say five; Let’s start from the top; At the top of the hill is a view; He felt on top of the world; Health is our top priority; This file is top secret",
+      "translation": "chiếm ưu thế; quản lý; nắm bắt; ngoài ra; nhớ nhanh; từ đầu; ở đỉnh; tuyệt vời; ưu tiên hàng đầu; tối mật",
+      "count": 0
+    },
+    {
+      "word": "tough /tʌf/",
+      "meaning": "get tough with; be tough on; tough luck; tough love; tough guy",
+      "example": "The manager got tough with latecomers; The law is tough on fraud; Tough luck if you miss the train; Parents sometimes show tough love; He acts like a tough guy but is kind inside",
+      "translation": "nghiêm khắc với; khắt khe với; xui xẻo; tình yêu nghiêm khắc; gã cứng rắn",
+      "count": 0
+    },
+    {
+      "word": "town /taʊn/",
+      "meaning": "town planning; the town of; in town; outskirts of town; town centre",
+      "example": "She studied town planning at university; The town of Hoi An is historic; Are you in town this weekend?; They moved to the outskirts of town; Let’s meet in the town centre",
+      "translation": "quy hoạch đô thị; thị trấn; trong thành phố; ngoại ô; trung tâm thành phố",
+      "count": 0
+    },
+    {
+      "word": "track /træk/",
+      "meaning": "keep track of; lose track of; on track; track sb; off the beaten track",
+      "example": "I keep track of my expenses; I lost track of time reading; We’re on track to finish early; The police tracked the suspect; We hiked off the beaten track",
+      "translation": "theo dõi; mất dấu; đúng tiến độ; theo dõi; xa lối mòn",
+      "count": 0
+    },
+    {
+      "word": "treat /triːt/",
+      "meaning": "treat sb for; treat sb to; treat sb with; treat a disease; treat a patient; treat cruelly; treat fairly",
+      "example": "The doctor treated her for flu; I’ll treat you to dinner; They treated him with respect; This drug treats the disease effectively; Nurses treat patients compassionately; Don’t treat him cruelly; They always treat me fairly",
+      "translation": "điều trị; chiêu đãi; đối xử; chữa bệnh; chăm sóc; đối xử tàn nhẫn; đối xử công bằng",
+      "count": 0
+    },
+    {
+      "word": "turn /tɜːn/",
+      "meaning": "turn to sb/sth; turn a gun on; turn to sb for help; turn cold; turn 40",
+      "example": "When in doubt, turn to a mentor; The suspect turned a gun on himself; She turned to her friend for advice; The weather turned cold overnight; He turned forty last week",
+      "translation": "tìm đến; chĩa súng vào; nhờ cậy; trở lạnh; tròn bốn mươi",
+      "count": 0
+    },
+    {
+      "word": "understanding /ˌʌndəˈstændɪŋ/",
+      "meaning": "come to an understanding; reach an understanding; have an understanding with; an understanding of",
+      "example": "We came to an understanding after talks; They reached an understanding on terms; I have an understanding with my boss; He has a deep understanding of physics",
+      "translation": "đạt được thỏa thuận; có thỏa thuận với; hiểu biết; nhận thức về",
+      "count": 0
+    },
+    {
+      "word": "use /juːz/",
+      "meaning": "use sth for doing; use sth to do; use sth properly; have many uses; in use; of use; no use doing; what’s the use of doing",
+      "example": "We use knives for cutting; I used my phone to take photos; Make sure you use this properly; This tool has many uses; Is the printer in use?; That tip is of no use; It’s no use crying; What’s the use of waiting?",
+      "translation": "sử dụng để; sử dụng để; sử dụng đúng cách; nhiều công dụng; đang sử dụng; có ích; vô ích; dùng để làm gì",
+      "count": 0
+    },
+    {
+      "word": "view /vjuː/",
+      "meaning": "take the view that; have a view on; come into view; in view of; view from; viewpoint",
+      "example": "I take the view that honesty matters; What’s your view on this?; The mountains came into view; In view of recent events, we canceled; The view from here is stunning; His viewpoint is always insightful",
+      "translation": "có quan điểm rằng; quan điểm về; xuất hiện; xét tới; tầm nhìn từ; góc nhìn",
+      "count": 0
+    },
+    {
+      "word": "mind /maɪnd/",
+      "meaning": "make up your mind; cross/slip your mind; bear in mind; keep in mind; have a one‑track mind; be in two minds; on your mind; take your mind off; bring to mind; never mind",
+      "example": "Make up your mind quickly; It never crossed my mind; Bear in mind the deadline; Keep in mind his advice; She has a one‑track mind; I’m in two minds about that; It’s on my mind all day; Music takes my mind off stress; That smell brings wine to mind; Never mind the noise",
+      "translation": "quyết định; thoáng qua; nhớ; ghi nhớ; tập trung; phân vân; nghĩ về; quên đi; gợi nhớ; đừng bận tâm",
+      "count": 0
+    },
+    {
+      "word": "misapprehension /ˌmɪsæprɪˈhenʃn/",
+      "meaning": "under the misapprehension that",
+      "example": "She was under the misapprehension that the meeting was today",
+      "translation": "hiểu sai rằng",
+      "count": 0
+    },
+    {
+      "word": "moment /ˈməʊmənt/",
+      "meaning": "take a moment; be a moment; just a moment; wait a moment; at the moment; in a moment; moment of truth; for the moment",
+      "example": "Please wait a moment; It’ll be a moment; He’ll call in a moment; At the moment, I’m busy; In a moment, we’ll begin; This is the moment of truth; For the moment, it’s fine",
+      "translation": "chờ một chút; sẽ mất chút; ngay; đợi một lát; lúc này; trong chốc lát; thời khắc quyết định; tạm thời",
+      "count": 0
+    },
+    {
+      "word": "money /ˈmʌni/",
+      "meaning": "make money; earn money; spend money; cost money; get money; save money; have money; do sth for money; put your money where your mouth is; get your money’s worth; pay good money for",
+      "example": "He makes good money selling cars; I just want to get my money’s worth; She paid good money for that dress",
+      "translation": "kiếm tiền; tiêu tiền; tiết kiệm tiền; có tiền; làm vì tiền; làm thay vì nói; xứng đáng; trả nhiều tiền",
+      "count": 0
+    },
+    {
+      "word": "mother /ˈmʌðər/",
+      "meaning": "mother of; single mother; working mother; mother-to-be; mother figure; mother country; mother tongue; in-law; Mother Nature",
+      "example": "She’s a single mother with two children; Vietnamese is my mother tongue",
+      "translation": "mẹ của; mẹ đơn thân; mẹ làm việc; mẹ tương lai; người mẹ tinh thần; mẫu quốc; tiếng mẹ đẻ; mẹ chồng; Mẹ Thiên nhiên",
+      "count": 0
+    },
+    {
+      "word": "move /muːv/",
+      "meaning": "move to; get a move on; follow someone’s every move; make a move; on the move",
+      "example": "We decided to move to Da Nang; Let’s get a move on or we’ll be late; This company is constantly on the move",
+      "translation": "chuyển đến; nhanh lên; theo dõi; hành động; đang di chuyển/tiến triển",
+      "count": 0
+    },
+    {
+      "word": "national /ˈnæʃnəl/",
+      "meaning": "national anthem; national costume; national debt; national holiday",
+      "example": "Everyone stood for the national anthem; Tet is a national holiday in Vietnam",
+      "translation": "quốc ca; trang phục truyền thống; nợ quốc gia; ngày lễ toàn quốc",
+      "count": 0
+    },
+    {
+      "word": "native /ˈneɪtɪv/",
+      "meaning": "native to; a native of; native speaker; non-native; native land; native tongue; native species",
+      "example": "The panda is native to China; He’s a native speaker of English; That bird is a native species of Vietnam",
+      "translation": "bản địa; người bản địa; người nói bản ngữ; không bản địa; quê hương; tiếng mẹ đẻ; loài sinh vật bản địa",
+      "count": 0
+    },
+    {
+      "word": "natural /ˈnætʃrəl/",
+      "meaning": "natural causes; natural ability; natural resource; natural selection",
+      "example": "She has a natural ability for music; The country is rich in natural resources",
+      "translation": "nguyên nhân tự nhiên; năng lực bẩm sinh; tài nguyên thiên nhiên; chọn lọc tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "nature /ˈneɪtʃər/",
+      "meaning": "the nature of something; in nature; Nature; human nature; second nature",
+      "example": "The nature of the problem is complex; Spending time outdoors helps you reconnect with nature",
+      "translation": "bản chất của...; về bản chất; Mẹ Thiên nhiên; bản chất con người; trở thành thói quen tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "near /nɪər/",
+      "meaning": "near to doing something; the near future; from near and far; near thing; the nearest thing to; nearest and dearest",
+      "example": "He came near to quitting; We’ll see each other in the near future; They traveled from near and far to attend",
+      "translation": "sắp làm gì; tương lai gần; từ khắp nơi; suýt thất bại; gần giống nhất với; người thân cận",
+      "count": 0
+    },
+    {
+      "word": "need /niːd/",
+      "meaning": "need someone to do; need doing; meet a need; have no need of; in need",
+      "example": "We need to fix the roof; The plan needs reviewing; She helped a family in need",
+      "translation": "cần ai làm gì; cần được làm; đáp ứng nhu cầu; không cần; đang cần",
+      "count": 0
+    },
+    {
+      "word": "never /ˈnevər/",
+      "meaning": "you never know; never again; never mind; never-ending",
+      "example": "Never again will I trust him; This winter feels never-ending; You never know who’s watching",
+      "translation": "ai mà biết được; không bao giờ nữa; đừng bận tâm; không có hồi kết",
+      "count": 0
+    },
+    {
+      "word": "new /njuː/",
+      "meaning": "new to; brand new; whole new; good as new; new look; new age",
+      "example": "I’m new to this job; The phone looks as good as new; He’s into new age music",
+      "translation": "chưa quen; mới toanh; hoàn toàn mới; như mới; diện mạo mới; phong cách hiện đại",
+      "count": 0
+    },
+    {
+      "word": "nice /naɪs/",
+      "meaning": "nice to someone; nice of someone to do; nice for someone to do; nice to meet/hear/see someone; nice and clean; nice and safe; nice and warm",
+      "example": "It was nice of you to help; This blanket is nice and warm; Nice to meet you",
+      "translation": "tốt với ai; ai đó tốt khi làm gì; rất vui gặp/nghe/thấy ai; rất sạch; an toàn; ấm áp",
+      "count": 0
+    },
+    {
+      "word": "notice /ˈnəʊtɪs/",
+      "meaning": "notice someone doing something; bring something to someone’s notice; come to someone’s notice; escape someone’s notice; take notice of; at short notice; until further notice",
+      "example": "She didn’t notice him come in; It came to my notice that she was late; We canceled the meeting at short notice",
+      "translation": "để ý thấy ai làm gì; nhắc nhở ai điều gì; ai đó chú ý; ai đó không để ý; chú ý đến; gấp; cho đến khi có thông báo tiếp theo",
+      "count": 0
+    },
+    {
+      "word": "now /naʊ/",
+      "meaning": "now is the time to do; from now on; for now; now that; just now; any day/moment now",
+      "example": "Now is the time to act; From now on, I’ll be more careful; She’ll be here any moment now",
+      "translation": "lúc để làm gì; từ giờ trở đi; hiện tại; bởi vì giờ đây; mới đây; bất cứ lúc nào",
+      "count": 0
+    },
+    {
+      "word": "odds /ɒdz/",
+      "meaning": "odds are (that); the odds of doing; the odds are in favor; the odds are against; against all odds; take a chance; take chances; take a guess",
+      "example": "The odds are he’ll arrive late; She succeeded against all odds",
+      "translation": "rất có khả năng là; khả năng xảy ra; khả năng ủng hộ; khả năng chống lại; bất chấp mọi khó khăn; đoán; nắm lấy cơ hội",
+      "count": 0
+    },
+    {
+      "word": "off /ɒf/",
+      "meaning": "have the day off; take the day off; be given the day off; off work; off duty; off the top of your head; off and on; on and off; off balance; off limits",
+      "example": "I’m off duty now; He’s off work due to illness; This room is off limits",
+      "translation": "nghỉ làm; hết ca trực; ngay lập tức; lúc có lúc không; mất thăng bằng; cấm vào",
+      "count": 0
+    },
+    {
+      "word": "office /ˈɒfɪs/",
+      "meaning": "take office; run for office; hold office; head office; office holder; office job; office hours",
+      "example": "He took office last year; She’s running for public office",
+      "translation": "nhậm chức; tranh cử; giữ chức; trụ sở chính; người nắm giữ chức vụ; công việc văn phòng; giờ làm việc",
+      "count": 0
+    },
+    {
+      "word": "old /əʊld/",
+      "meaning": "get old; grow old; old age; old folks; old hand; old-fashioned; old money; old flame; old-fashioned ideas",
+      "example": "He’s getting old but still strong; She’s an old hand at negotiation",
+      "translation": "trở nên già; tuổi già; người già; người dày dạn; cổ hủ; gia đình giàu lâu đời; tình cũ; tư tưởng cổ hủ",
+      "count": 0
+    },
+    {
+      "word": "on /ɒn/",
+      "meaning": "on purpose; on your own; on and on; on the one hand; on the other hand; on top; on time; on demand; on loan",
+      "example": "I didn’t do it on purpose; She arrived on time; This book is on loan from the library",
+      "translation": "cố tình; tự mình; dài dòng mãi; một mặt; mặt khác; trên đầu; đúng giờ; khi cần; cho mượn",
+      "count": 0
+    },
+    {
+      "word": "opt /ɒpt/",
+      "meaning": "opt for; opt to do",
+      "example": "She opted for the vegetarian dish; I opted to stay at home",
+      "translation": "chọn; chọn làm gì",
+      "count": 0
+    },
+    {
+      "word": "option /ˈɒpʃn/",
+      "meaning": "have no option but to; consider your options; keep your options open; leave your options open; the option of doing; the option to do",
+      "example": "We had no option but to leave; I’m keeping my options open for now",
+      "translation": "không còn lựa chọn nào; cân nhắc lựa chọn; giữ lựa chọn; để lựa chọn; lựa chọn làm gì; lựa chọn để làm gì",
+      "count": 0
+    },
+    {
+      "word": "paper /ˈpeɪpər/",
+      "meaning": "piece of paper; sheet of paper; present a paper on; write a paper on; set a paper on; paper round; paper qualifications; paperwork",
+      "example": "Please fill out this sheet of paper; He gave a paper on renewable energy",
+      "translation": "mảnh giấy; giấy; trình bày đề tài; viết đề tài; nghề phát báo; bằng cấp giấy; công việc giấy tờ",
+      "count": 0
+    },
+    {
+      "word": "end /end/",
+      "meaning": "come to an end; bring something to an end; put an end to; at an end; (for) hours on end",
+      "example": "The meeting finally came to an end; We must put an end to this behavior; She studied for hours on end",
+      "translation": "kết thúc; chấm dứt; đã kết thúc; liên tục hàng giờ",
+      "count": 0
+    },
+    {
+      "word": "energy /ˈenədʒi/",
+      "meaning": "have the energy to do; lack the energy to do; put energy into; source of energy; nuclear energy; alternative energy; renewable energy",
+      "example": "I didn’t have the energy to cook; He puts a lot of energy into his work; Solar power is a renewable energy source",
+      "translation": "có năng lượng làm gì; thiếu năng lượng làm gì; dồn năng lượng vào; nguồn năng lượng; năng lượng hạt nhân; năng lượng thay thế; năng lượng tái tạo",
+      "count": 0
+    },
+    {
+      "word": "equal /ˈiːkwəl/",
+      "meaning": "call for equal quality; call for equal value; equal in size; equal in quality; equal in value; roughly equal to; of equal size; of equal quality; of equal value",
+      "example": "Both tasks are equal in difficulty; His salary is roughly equal to mine; These shoes are of equal size",
+      "translation": "có chất lượng tương đương; có giá trị tương đương; bằng kích thước; bằng chất lượng; bằng giá trị; tương đương với; có cùng kích thước; có cùng chất lượng; có cùng giá trị",
+      "count": 0
+    },
+    {
+      "word": "erect /ɪˈrekt/",
+      "meaning": "erect a statue; erect a monument; erect posture",
+      "example": "They erected a statue in her honor; He stood with an erect posture during the ceremony",
+      "translation": "dựng tượng; tư thế thẳng",
+      "count": 0
+    },
+    {
+      "word": "ever /ˈevər/",
+      "meaning": "hardly ever; if ever; first time ever; only time ever; last time ever; bigger than ever; better than ever; as ever",
+      "example": "I hardly ever go to the gym; It was the first time ever I met him; She's as friendly as ever",
+      "translation": "hầu như không bao giờ; nếu có cũng hiếm; lần đầu tiên; duy nhất; cuối cùng; lớn hơn bao giờ hết; tốt hơn bao giờ hết; như thường lệ",
+      "count": 0
+    },
+    {
+      "word": "example /ɪɡˈzɑːmpl/",
+      "meaning": "an example of; follow an example; set an example; classic example; prime example",
+      "example": "He set a good example for his peers; This is a classic example of poor planning; Her presentation was a prime example of succinct design",
+      "translation": "một ví dụ về; làm gương; ví dụ điển hình; ví dụ điển hình nhất",
+      "count": 0
+    },
+    {
+      "word": "fall /fɔːl/",
+      "meaning": "fall ill; fall in love; fall into a category; fall short; fall asleep; fall to pieces",
+      "example": "She fell ill after the hike; He fell in love while traveling; He fell into a category of specialists; Our efforts fell short of expectations; He fell asleep during the movie; The plan fell to pieces at the last moment",
+      "translation": "ngã bệnh; yêu; thuộc loại; thiếu hụt; ngủ gật; sụp đổ",
+      "count": 0
+    },
+    {
+      "word": "family /ˈfæməli/",
+      "meaning": "start a family; nuclear family; extended family; close relative; near relative; distant relative; family friend; family name; family tree",
+      "example": "They plan to start a family next year; We visited my nuclear family over the holidays; Our extended family gathered for the reunion; He’s a close family friend; She drew her family tree",
+      "translation": "bắt đầu một gia đình; gia đình hạt nhân; gia đình mở rộng; họ hàng gần; họ hàng xa; bạn của gia đình; họ; cây gia phả",
+      "count": 0
+    },
+    {
+      "word": "fat",
+      "meaning": "get/grow fat; fat chance; a fat lot of good",
+      "example": "Fat chance he’ll agree to it! That expensive car did a fat lot of good stuck in traffic.",
+      "translation": "trở nên giàu có/mập; khó có thể xảy ra; không hề hữu ích",
+      "count": 0
+    },
+    {
+      "word": "feature",
+      "meaning": "feature in sth; a feature of; distinguishing feature; safety feature; feature writer",
+      "example": "The curved roof is a feature of this design. She works as a feature writer for the magazine.",
+      "translation": "nổi bật trong; đặc điểm của; đặc điểm nổi bật; tính năng an toàn; tác giả bài nổi bật",
+      "count": 0
+    },
+    {
+      "word": "feel",
+      "meaning": "feel like doing; feel as if/though; feel strongly about; feel the effects/benefits; feel guilty/nervous/etc; feel at home",
+      "example": "I feel like taking a nap. I feel as if I’ve forgotten something. She felt the benefits of the new workout.",
+      "translation": "cảm thấy muốn làm; cảm giác như; cảm thấy mạnh mẽ về; cảm nhận ảnh hưởng/lợi ích; cảm thấy tội lỗi...; cảm thấy tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "find",
+      "meaning": "find yourself doing; find sb doing sth; find it difficult to do; find your way",
+      "example": "I found myself staring at the stars. She found him sleeping on the sofa. I can’t find my way in this city.",
+      "translation": "tự dưng làm gì; bắt gặp ai đó; gặp khó khăn khi làm; tìm đường/giải pháp",
+      "count": 0
+    },
+    {
+      "word": "fine",
+      "meaning": "cut it fine; fine sb for sth; a heavy/small fine",
+      "example": "He was fined for speeding. They cut it fine but still made the train.",
+      "translation": "xoay sở vừa kịp; phạt vì...; mức phạt nặng/nhẹ",
+      "count": 0
+    },
+    {
+      "word": "floor",
+      "meaning": "take the floor; floor show; ground/first/etc floor; floor plan",
+      "example": "He took the floor to address the issue. The apartment is on the second floor.",
+      "translation": "lên phát biểu; buổi diễn trên sàn; tầng trệt/thứ nhất...; sơ đồ tầng",
+      "count": 0
+    },
+    {
+      "word": "fly",
+      "meaning": "fly a flag/kite; fly at sb; fly open; fly by",
+      "example": "The kite flew high in the sky. Time flew by during the holidays.",
+      "translation": "treo cờ/thả diều; tấn công ai; mở toang; trôi qua nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "focus",
+      "meaning": "focus on; the focus of; in focus/out of focus; focus group",
+      "example": "Let’s focus on the task at hand. The main focus of the meeting was safety.",
+      "translation": "tập trung vào; tiêu điểm của...; rõ/mờ; nhóm thảo luận",
+      "count": 0
+    },
+    {
+      "word": "fold",
+      "meaning": "fold sth in half/two; fold sth neatly/carefully; fold flat",
+      "example": "Fold the paper in half. Please fold your clothes neatly.",
+      "translation": "gấp đôi; gấp gọn/gấp cẩn thận; gấp phẳng",
+      "count": 0
+    },
+    {
+      "word": "follow",
+      "meaning": "follow sb's advice; follow sb's argument; follow sb's lead; follow sb's example; as follows; follow suit",
+      "example": "He followed her advice and succeeded. The team followed suit after the leader’s move.",
+      "translation": "nghe lời ai; hiểu luận điểm; theo sau; noi gương; như sau; làm theo",
+      "count": 0
+    },
+    {
+      "word": "form",
+      "meaning": "form an impression of; take/assume the form of; in the form of; application form; good/bad form",
+      "example": "I formed a good impression of her. Please complete this application form.",
+      "translation": "hình thành ấn tượng; có hình dạng...; dưới dạng...; mẫu đơn; cách hành xử tốt/xấu",
+      "count": 0
+    },
+    {
+      "word": "foundation",
+      "meaning": "lay the foundations; foundation course; foundation stone",
+      "example": "They laid the foundations for future success. I’m taking a foundation course in art.",
+      "translation": "đặt nền móng; khóa học cơ sở; viên đá nền tảng",
+      "count": 0
+    },
+    {
+      "word": "free",
+      "meaning": "set sb free; let sb go free; walk free; free sb from sth; free to do; free and easy; feel free",
+      "example": "They were finally set free. Feel free to contact us anytime.",
+      "translation": "thả ai tự do; thả ai; tự do đi lại; giải thoát; tự do làm gì; thoải mái; cứ tự nhiên",
+      "count": 0
+    },
+    {
+      "word": "fresh",
+      "meaning": "fresh air; fresh-faced; fresh start; fresh from; fresh out of; fresh water",
+      "example": "Let’s go outside for some fresh air. She’s fresh from university.",
+      "translation": "không khí trong lành; tươi tắn; khởi đầu mới; vừa mới từ; vừa hết; nước ngọt",
+      "count": 0
+    },
+    {
+      "word": "friend",
+      "meaning": "be/friend sb; close/good/great friend; mutual friend; circle of friends; friends with sb",
+      "example": "He’s a close friend of mine. We met through a mutual friend.",
+      "translation": "kết bạn; bạn thân; bạn chung; vòng bạn bè; là bạn với ai",
+      "count": 0
+    },
+    {
+      "word": "generation",
+      "meaning": "the older/younger generation; generation gap; generation X; future generations",
+      "example": "There’s a clear generation gap in values. We must protect the environment for future generations.",
+      "translation": "thế hệ già/trẻ; khoảng cách thế hệ; thế hệ X; thế hệ tương lai",
+      "count": 0
+    },
+    {
+      "word": "consequence",
+      "meaning": "accept/face the consequences; serious/disastrous/negative consequences; direct consequence of; in consequence of; of no/little consequence",
+      "example": "You must face the consequences of your actions. The accident was a direct consequence of poor planning. His opinion is of no consequence to me.",
+      "translation": "chấp nhận/hứng chịu hậu quả; hậu quả nghiêm trọng; hậu quả trực tiếp; vì lý do; không quan trọng",
+      "count": 0
+    },
+    {
+      "word": "consideration",
+      "meaning": "take into consideration; give consideration to; show consideration for; under consideration; for consideration; out of consideration for",
+      "example": "We must take all factors into consideration before deciding. She always shows consideration for others. Your suggestion is under consideration.",
+      "translation": "cân nhắc; xem xét; quan tâm tới; được xem xét; để cân nhắc; vì cân nhắc tới ai",
+      "count": 0
+    },
+    {
+      "word": "course",
+      "meaning": "in the course of; course of action/events",
+      "example": "In the course of the investigation, new evidence came to light. We must decide the best course of action.",
+      "translation": "trong suốt quá trình; diễn biến hành động/sự kiện",
+      "count": 0
+    },
+    {
+      "word": "crime",
+      "meaning": "commit/permit/witness/solve a crime; fight/combat crime; crime rate; organised crime",
+      "example": "He committed a serious crime last year. The government is taking steps to combat organised crime. The city’s crime rate has dropped.",
+      "translation": "thực hiện/cho phép/chứng kiến/giải quyết tội ác; chống tội phạm; tỷ lệ tội phạm; tội phạm có tổ chức",
+      "count": 0
+    },
+    {
+      "word": "cry",
+      "meaning": "cry with pain/happiness/laughter; cry over/about; cry for help; cry your eyes/heart out; have a good cry; burst into tears",
+      "example": "She burst into tears at the news. He cried for help when he fell. I needed to have a good cry after the breakup.",
+      "translation": "khóc vì...; kêu cứu; khóc nhiều; khóc thỏa thích; bật khóc",
+      "count": 0
+    },
+    {
+      "word": "date",
+      "meaning": "date from; date back to; keep sth up to date; set/fix a date; go on/make a date with sb; at a later/future date; to date",
+      "example": "The building dates back to the 18th century. Please keep your records up to date. We haven’t set a date for the wedding yet.",
+      "translation": "bắt đầu xuất hiện từ; có từ khi; cập nhật; chọn ngày; hẹn hò; một ngày trong tương lai; đến nay",
+      "count": 0
+    },
+    {
+      "word": "day",
+      "meaning": "make sb’s day; by day; any day now; from day to day; day by day; day off; day trip",
+      "example": "The kind words really made my day. He works by day and studies by night. We're planning a day trip to the countryside.",
+      "translation": "khiến ai đó hạnh phúc; ban ngày; sắp tới; từng ngày; ngày nghỉ; chuyến đi trong ngày",
+      "count": 0
+    },
+    {
+      "word": "dead",
+      "meaning": "go dead; drop dead; dead silence; dead tired; dead and gone; dead ahead",
+      "example": "The phone line suddenly went dead. I was dead tired after the hike. There was dead silence in the room.",
+      "translation": "tắt/ngừng hoạt động; đột ngột chết; im lặng tuyệt đối; mệt lả; biến mất; ngay phía trước mặt",
+      "count": 0
+    },
+    {
+      "word": "deal",
+      "meaning": "deal in; deal with; deal a blow to; get a good deal on; give sb a good deal; great deal of sth",
+      "example": "She deals in antiques. We need to deal with this problem quickly. He got a good deal on his new car.",
+      "translation": "buôn bán; giải quyết; giáng đòn; mua giá tốt; cho thỏa thuận tốt; rất nhiều",
+      "count": 0
+    },
+    {
+      "word": "decide",
+      "meaning": "decide on sb/sth; decide against; decide in favour of; decide for yourself; decision to do",
+      "example": "They decided against buying the house. You need to decide for yourself. We made the decision to expand the business.",
+      "translation": "quyết định chọn; quyết định không; quyết định ủng hộ; tự quyết định; quyết định làm gì",
+      "count": 0
+    },
+    {
+      "word": "about",
+      "meaning": "partly/mainly/all about; do sth about; about to do",
+      "example": "She was about to leave when the phone rang. This book is all about courage and persistence. What are you going to do about the issue?",
+      "translation": "một phần/đa phần/toàn bộ về; làm gì để xử lý; sắp làm gì",
+      "count": 0
+    },
+    {
+      "word": "access",
+      "meaning": "have/gain/provide access to; Internet access; wheelchair access",
+      "example": "Students have access to all library materials online. Wheelchair access is available at the entrance. Only members can gain access to the archive.",
+      "translation": "có/đạt được/cung cấp sự tiếp cận; truy cập Internet; lối đi xe lăn",
+      "count": 0
+    },
+    {
+      "word": "account",
+      "meaning": "account for; give an account of; take into account; on account of; by all accounts; on sb’s account",
+      "example": "He gave an account of his experience to the class. We must take weather conditions into account. By all accounts, she’s a talented writer.",
+      "translation": "chiếm; kể lại; tính đến; bởi vì; theo những gì thu thập; theo ý kiến ai",
+      "count": 0
+    },
+    {
+      "word": "act",
+      "meaning": "in good/bad faith; out of desperation/necessity; act on sb’s advice/orders/behalf; act out of; act the part/role of; act like; act your age; in the act of doing",
+      "example": "He was caught in the act of stealing. She acted on her lawyer’s advice. They acted out of desperation.",
+      "translation": "hành vi thiện/chưa thiện; hành động tuyệt vọng/cần thiết; hành động dựa vào lời khuyên; vì lý do gì; đóng vai; cư xử như; cư xử đúng tuổi; đang làm gì thì bị bắt gặp",
+      "count": 0
+    },
+    {
+      "word": "age",
+      "meaning": "act your age; under age; old age; working/retirement age; age limit; age bracket/group; in Stone/Bronze/Iron Age",
+      "example": "She retired at the age of 65. He's not allowed in; he's under age. We studied tools from the Bronze Age.",
+      "translation": "hành động đúng tuổi; chưa đủ tuổi; tuổi già; độ tuổi đi làm/nghỉ hưu; giới hạn tuổi; nhóm tuổi; thời kỳ Đồ Đá/Đồng/Sắt",
+      "count": 0
+    },
+    {
+      "word": "ages",
+      "meaning": "take/spend ages (doing); ages ago; seems/feels like ages",
+      "example": "I spent ages trying to fix that bug before I finally gave up. They moved here ages ago and still love it. It feels like ages since we last spoke. She thinks it’s been ages since her last vacation.",
+      "translation": "tốn nhiều thời gian; rất lâu về trước; có vẻ đã lâu lắm rồi",
+      "count": 0
+    },
+    {
+      "word": "answer",
+      "meaning": "answer to sb; give sb an answer; answer sb’s prayers; answer the description of; have a lot to answer for",
+      "example": "Could you please answer my question about the API design? He finally answered her prayers by approving the budget. His work answers the description of an ideal solution. The manager will have a lot to answer for if the project fails.",
+      "translation": "trả lời ai đó; đáp lại lời; đáp lại lời cầu nguyện; rất giống với; chịu trách nhiệm về",
+      "count": 0
+    },
+    {
+      "word": "argument",
+      "meaning": "argument (with sb); win/lose an argument; argument about/over; argument for/against; without an argument",
+      "example": "They had an argument about which framework to use. She won the argument by presenting clear data. There’s a strong argument for adopting microservices. We resolved the issue without an argument.",
+      "translation": "cãi vã với ai; thắng/thua tranh cãi; tranh luận về; lập luận ủng hộ/chống; không cần bàn cãi",
+      "count": 0
+    },
+    {
+      "word": "arm",
+      "meaning": "arm sb with; arm yourself against; take up arms; lay down arms; arms control",
+      "example": "The guide armed us with all the necessary credentials. They taught us how to arm ourselves against cyber attacks. Rebels decided to lay down arms and negotiate. An international treaty on arms control was signed.",
+      "translation": "trang bị cho ai; trang bị cho bản thân; chuẩn bị chiến đấu; vứt bỏ vũ khí; kiểm soát vũ khí",
+      "count": 0
+    },
+    {
+      "word": "art",
+      "meaning": "art of doing; art deco; art gallery; art house",
+      "example": "He mastered the art of debugging complex code. The building’s façade is a beautiful example of art deco. Let's visit the new art gallery this weekend. They screened an indie film at the local art house.",
+      "translation": "nghệ thuật/kỹ thuật làm việc gì; trang trí nghệ thuật; phòng trưng bày nghệ thuật; phim nghệ thuật",
+      "count": 0
+    },
+    {
+      "word": "ask",
+      "meaning": "ask yourself; ask sb a favour; ask sb over/round; ask sb in; asking for trouble; if you ask me",
+      "example": "Ask yourself what the user really needs from this feature. Could I ask you a favour and review my pull request? She asked him over for afternoon tea. If you ask me, we should refactor this module.",
+      "translation": "tự hỏi bản thân; nhờ ai giúp đỡ; mời đến nhà; mời vào nhà; chắc chắn gặp rắc rối; theo tôi",
+      "count": 0
+    },
+    {
+      "word": "associate",
+      "meaning": "associate sth with",
+      "example": "Most people associate JavaScript with web development. He associates deadlines with unnecessary stress. Don’t associate code quality solely with performance.",
+      "translation": "liên kết cái gì với",
+      "count": 0
+    },
+    {
+      "word": "authority",
+      "meaning": "have the authority to do; grant sb the authority to do; local authority",
+      "example": "Only the admin has the authority to modify user roles. The board granted her the authority to approve budgets. Please consult the local authority for compliance guidelines. He assumed authority over the new deployment process.",
+      "translation": "có thẩm quyền làm gì; trao quyền cho ai; chính quyền địa phương",
+      "count": 0
+    },
+    {
+      "word": "back",
+      "meaning": "back into sth; back onto sth; back out of",
+      "example": "He accidentally backed into the server rack. The car backed onto the loading dock. She refused to back out of her commitment. We need someone to back us up on this proposal.",
+      "translation": "lùi vào chỗ nào; lùi lên trên; chống lưng/ủng hộ ai làm gì",
+      "count": 0
+    },
+    {
+      "word": "bad",
+      "meaning": "go bad; bad for sb; bad at sth; bad blood",
+      "example": "Don’t eat that milk—it’s gone bad. Smoking is bad for your health. He’s bad at estimating project timelines. There’s some bad blood between those two teams.",
+      "translation": "thiu/hỏng; có hại cho ai; kém về cái gì; mối quan hệ xấu",
+      "count": 0
+    },
+    {
+      "word": "balance",
+      "meaning": "strike a balance; upset/restore the balance; balance between; off balance",
+      "example": "We need to strike a balance between speed and quality. A sudden spike in traffic upset the balance of the system. There’s a fine balance between innovation and risk. The unexpected outage threw the team off balance.",
+      "translation": "tìm cân bằng; phá vỡ/khôi phục cân bằng; cân bằng giữa; mất thăng bằng",
+      "count": 0
+    },
+    {
+      "word": "basis",
+      "meaning": "on a basis; on a daily/temporary basis; on the basis of",
+      "example": "We review performance on a monthly basis. The feature is enabled on a temporary basis. Decisions are made on the basis of user feedback.",
+      "translation": "trên cơ sở; hàng ngày/tạm thời; dựa trên cơ sở",
+      "count": 0
+    },
+    {
+      "word": "behaviour",
+      "meaning": "behaviour towards; antisocial/violent behaviour; exemplary behaviour",
+      "example": "His behaviour towards colleagues was exemplary. The test revealed some antisocial behaviour in the AI agent. Good behaviour is rewarded in our performance reviews.",
+      "translation": "hành vi đối với; hành vi chống đối/bạo lực; hành vi gương mẫu",
+      "count": 0
+    },
+    {
+      "word": "belief",
+      "meaning": "express belief(s); contrary to popular belief; firm belief",
+      "example": "The CEO expressed her firm belief in the project’s success. Contrary to popular belief, code reviews improve productivity. He couldn’t hide his belief in the new framework.",
+      "translation": "bộc lộ niềm tin; ngược với niềm tin chung; niềm tin vững chắc",
+      "count": 0
+    },
+    {
+      "word": "bend",
+      "meaning": "bend sth into; round the bend; bend the rules",
+      "example": "She bent the metal rod into a perfect circle. Waiting in line all day drove me round the bend. Managers sometimes bend the rules to meet deadlines.",
+      "translation": "uốn cong thành gì; quá tức giận; nới lỏng quy tắc",
+      "count": 0
+    },
+    {
+      "word": "best",
+      "meaning": "make the best of; at your best; best of my ability; best friend",
+      "example": "We need to make the best of this opportunity. He performed at his best under pressure. I’ll help you to the best of my ability. She’s been my best friend since college.",
+      "translation": "tận dụng tốt nhất; ở trạng thái tốt nhất; theo khả năng tốt nhất; bạn thân nhất",
+      "count": 0
+    },
+    {
+      "word": "bet",
+      "meaning": "bet (sth) on; make a bet; safe bet",
+      "example": "I’d bet on JavaScript remaining popular for years. He made a bet with his friend about the release date. Opting for thorough tests is a safe bet.",
+      "translation": "đánh cược; đặt cược; điều chắc chắn thành công",
+      "count": 0
+    },
+    {
+      "word": "better",
+      "meaning": "get better; better off; better next time; for better or (for worse)",
+      "example": "I hope the system gets better after this update. You’ll be better off using a dedicated database. Maybe we’ll have better luck next time. For better or worse, this is the final design.",
+      "translation": "trở nên tốt hơn; khấm khá hơn; lần sau sẽ tốt hơn; dù tốt dù xấu",
+      "count": 0
+    },
+    {
+      "word": "big",
+      "meaning": "make a big thing out of; make it big; big of sb; big on; big business; big-hearted; big name; big game",
+      "example": "They made a big thing out of the minor mistake. She hopes to make it big in Silicon Valley. It was big of you to donate so much. He’s really big on open-source software.",
+      "translation": "làm quá lên; thành công nhanh; đã tốt khi làm gì; rất thích; doanh nghiệp lớn; hào hiệp; nhiều tiền; sự kiện quan trọng",
+      "count": 0
+    },
+    {
+      "word": "block",
+      "meaning": "block sb’s way; block of flats/apartment block; high-rise block; writer’s block",
+      "example": "The coach blocked their way onto the field. She lives in a new apartment block. That high-rise block dominates the skyline. He suffered from writer’s block all week.",
+      "translation": "chặn đường; tòa chung cư; tòa nhà cao tầng; rào cản tâm lý",
+      "count": 0
+    },
+    {
+      "word": "book",
+      "meaning": "read sb like a book; (do) by the book; book about/on; a closed book; open book; in my book; sb’s good/bad books",
+      "example": "I can read you like a book after all these years. She always does things by the book. He recommended a great book on algorithms. His behavior is definitely in my bad books.",
+      "translation": "hiểu rõ ai; làm đúng chuẩn; sách về; điều bí ẩn; người dễ hiểu; theo tôi; hài lòng/khó chịu với ai",
+      "count": 0
+    },
+    {
+      "word": "born",
+      "meaning": "born to do; born on/in; born into; born and bred; born-again; newborn",
+      "example": "She was born to do complex data analysis. I was born in Hanoi in 1990. He was born into a family of engineers. They are proud of their born-and-bred roots.",
+      "translation": "sinh ra để làm; sinh vào ngày/nơi nào; sinh ra trong gia đình; sinh ra và lớn lên; tái sinh; sơ sinh",
+      "count": 0
+    },
+    {
+      "word": "bottom",
+      "meaning": "come bottom; get to the bottom of; the bottom drops/falls out of; bottom line",
+      "example": "Our team came bottom in the hackathon. We need to get to the bottom of this bug. Suddenly the bottom fell out of the market. The bottom line is that we need more testing.",
+      "translation": "đứng cuối; tìm nguyên nhân; giảm sâu; điểm mấu chốt",
+      "count": 0
+    },
+    {
+      "word": "brain",
+      "meaning": "pick sb’s brain(s); rack your brain(s); brains behind; brainless; brainstorm; brainwave",
+      "example": "Can I pick your brains about this architecture? I’ve been racking my brain for hours. She is the brain behind our new feature. We had a productive brainstorm session yesterday.",
+      "translation": "hỏi ý ai; vắt óc; người đứng sau; ngu ngốc; động não; ý tưởng chợt đến",
+      "count": 0
+    },
+    {
+      "word": "break",
+      "meaning": "break a habit; break with tradition; take/have/need a break; lunch/coffee break",
+      "example": "I finally broke my habit of checking email at night. They decided to break with tradition this year. Let’s take a break and grab coffee. We only have a fifteen-minute break left.",
+      "translation": "phá thói quen; phá truyền thống; nghỉ giải lao; giờ nghỉ trưa/cà phê",
+      "count": 0
+    },
+    {
+      "word": "brick",
+      "meaning": "bricks and mortar; brick wall; bricklayer",
+      "example": "They opened a bricks-and-mortar store downtown. We built a small brick wall in the courtyard. The bricklayer finished the job early.",
+      "translation": "cửa hàng thực; tường gạch; thợ nề",
+      "count": 0
+    },
+    {
+      "word": "certain",
+      "meaning": "know/say for certain; certain to do; make certain; certain of/about; a certain (amount of sth)",
+      "example": "I can’t say for certain when the release will be. You’re certain to succeed with that plan. Please make certain the tests pass. We need a certain amount of RAM for this VM.",
+      "translation": "chắc chắn; chắc chắn làm; đảm bảo; chắc chắn về; một lượng nhất định",
+      "count": 0
+    },
+    {
+      "word": "chance",
+      "meaning": "take a chance; leave to chance; by chance; by any chance; second chance; last chance; pure chance; there’s every/no chance that",
+      "example": "I decided to take a chance and rewrite the module. Don’t leave it to chance—write unit tests. We met by chance at the conference. There’s every chance we’ll finish early.",
+      "translation": "đánh liều; mặc kệ; tình cờ; liệu có phải không; cơ hội thứ hai/cuối; ngẫu nhiên; có/không có cơ hội",
+      "count": 0
+    },
+    {
+      "word": "change",
+      "meaning": "change from sth to sth; change sth into; change sth for; change for the better/worse; change your mind; change the subject; make a change; undergo a change",
+      "example": "We need to change from HTTP to HTTPS. He changed his idea into a working prototype. They changed the plan for the better. After reflection, she changed her mind.",
+      "translation": "đổi từ... sang; biến thành; đổi lấy; thay đổi tốt hơn/tệ hơn; đổi ý; đổi chủ đề; tạo sự thay đổi; trải qua thay đổi",
+      "count": 0
+    },
+    {
+      "word": "charge",
+      "meaning": "charge sb with; charge sb for; take charge; put sb in charge; overall charge",
+      "example": "They charged her with overseeing the new API. We were charged for extra storage. She took charge of the deployment. The CTO was put in charge of security.",
+      "translation": "buộc tội ai; tính tiền ai; chịu trách nhiệm; trao quyền; toàn quyền",
+      "count": 0
+    },
+    {
+      "word": "child",
+      "meaning": "as a child; only child; child of; childcare; child abuse; child’s play",
+      "example": "As a child, I loved playing video games. He was an only child in his family. Childcare services are expanding. That puzzle is child’s play for us.",
+      "translation": "khi còn nhỏ; con một; con của; chăm sóc trẻ; lạm dụng trẻ em; trò trẻ con",
+      "count": 0
+    },
+    {
+      "word": "choice",
+      "meaning": "make a choice; exercise choice; have no choice; choice between; informed choice; wide choice; obvious choice",
+      "example": "It’s time to make a choice about the framework. Users can exercise choice in their settings. We had no choice but to postpone. There’s a wide choice of libraries available.",
+      "translation": "đưa ra lựa chọn; bầu chọn; không có lựa chọn; lựa chọn giữa; lựa chọn dựa trên thông tin; nhiều lựa chọn; lựa chọn hiển nhiên",
+      "count": 0
+    },
+    {
+      "word": "choose",
+      "meaning": "choose from; choose between; choose sb/sth as; choose sb/sth out of; choose to do; pick and choose; nothing to choose between",
+      "example": "You can choose from several templates. We had to choose between speed and accuracy. They chose her as team lead. There was nothing to choose between the two solutions.",
+      "translation": "chọn ra từ; chọn giữa; chọn làm; chọn trong nhóm; lựa chọn làm gì; cân nhắc kỹ và chọn; không có gì để chọn",
+      "count": 0
+    },
+    {
+      "word": "class",
+      "meaning": "class sb/sth as; social class; working/middle/upper class; ruling class; class system; class war",
+      "example": "They classed the data points as anomalies. Discussions about social class remain relevant. He grew up in a working-class family. The ruling class resisted the reforms.",
+      "translation": "phân loại; tầng lớp xã hội; lao động/trung lưu/thượng lưu; giai cấp thống trị; hệ thống giai cấp; mâu thuẫn giai cấp",
+      "count": 0
+    },
+    {
+      "word": "clean",
+      "meaning": "give sth a (good) clean; make a clean break; clean and tidy; a clean slate; clean sweep",
+      "example": "Let’s give this codebase a good clean. The team made a clean break from legacy. Keep your workspace clean and tidy. We started with a clean slate after the audit.",
+      "translation": "lau dọn sạch sẽ; cắt đứt hoàn toàn; sạch sẽ gọn gàng; khởi đầu mới; dọn sạch không cần thiết",
+      "count": 0
+    },
+    {
+      "word": "clear",
+      "meaning": "make/get sth clear; make yourself clear; have a clear conscience; clear in your mind; clear as a bell; clear as mud; clear evidence; clear case of",
+      "example": "She made her expectations perfectly clear. He has a clear conscience about the decision. The objective was clear in my mind. That explanation was clear as a bell.",
+      "translation": "làm rõ; nói rõ ý; lương tâm trong sạch; hiểu rõ; rõ ràng; khó hiểu; bằng chứng rõ ràng; trường hợp rõ ràng",
+      "count": 0
+    },
+    {
+      "word": "clock",
+      "meaning": "set a clock; watch the clock; against the clock; around the clock; clockwise; clockwork",
+      "example": "Don’t forget to set the clock before sleeping. We’re racing against the clock to finish. The server runs around the clock. The gears turned like clockwork.",
+      "translation": "đặt báo thức; đếm thời gian; chạy đua thời gian; suốt ngày đêm; theo chiều kim đồng hồ; bộ máy đồng hồ",
+      "count": 0
+    },
+    {
+      "word": "come",
+      "meaning": "come to a conclusion/decision; come to power; come into view; come as a shock; come true",
+      "example": "We came to a conclusion after reviewing logs. The new party came to power last year. The mountain peak finally came into view. His dream to launch the app came true.",
+      "translation": "đi tới kết luận/quyết định; lên nắm quyền; hiện ra trước mắt; gây sốc; trở thành hiện thực",
+      "count": 0
+    },
+    {
+      "word": "common",
+      "meaning": "have sth in common; common for sb/sth to do; common language; the common people; common practice",
+      "example": "We have much in common regarding coding standards. It’s common for teams to hold daily stand-ups. English serves as a common language in tech. Code reviews are now common practice.",
+      "translation": "có điểm chung; khá phổ biến; ngôn ngữ chung; người dân; thực hành phổ biến",
+      "count": 0
+    },
+    {
+      "word": "conclusion",
+      "meaning": "bring sth to a conclusion; come to/reach a conclusion; jump/leap to conclusions; in conclusion; foregone conclusion",
+      "example": "Let’s bring this discussion to a conclusion. They reached a conclusion after testing. Don’t jump to conclusions too quickly. In conclusion, we recommend a staging environment.",
+      "translation": "đưa đến kết luận; đi đến kết luận; vội kết luận; kết lại; kết quả đương nhiên",
+      "count": 0
+    }
+  ],    
+  "word formation": [
+    {
+      "word": "judge",
+      "meaning": "judgement (noun) /ˈdʒʌdʒmənt/; judiciary (noun) /dʒuˈdɪʃəri/; judiciousness (noun) /dʒuˈdɪʃəsnəs/; judicious (adj) /dʒuˈdɪʃəs/; judicial (adj) /dʒuˈdɪʃl/; judgmental (adj) /ˈdʒʌdʒˌmentl/; judiciously (adv) /dʒuˈdɪʃəsli/",
+      "example": "Her judgement was questioned during the board meeting; The judiciary plays a critical role in maintaining law and order; His judiciousness guided the company through a difficult decision; She made a judicious investment at the right time; The judicial process can be complex and time-consuming; It's unfair to be so judgmental without knowing the facts; She answered the tough question judiciously and calmly",
+      "translation": "sự phán xét; bộ máy tư pháp; sự sáng suốt; khôn ngoan; (thuộc) tòa án; mang tính phán xét; một cách khôn ngoan",
+      "count": 0
+    },
+    {
+      "word": "know",
+      "meaning": "acknowledge (verb) /əkˈnɒlɪdʒ/; acknowledgement (noun) /əkˈnɒlɪdʒmənt/; knowledge (noun) /ˈnɒlɪdʒ/; knowledgeable (adj) /ˈnɒlɪdʒəbl/; acknowledged (adj) /əkˈnɒlɪdʒd/; unacknowledged (adj) /ˌʌnəkˈnɒlɪdʒd/; knowing (adj) /ˈnəʊɪŋ/; knowingly (adv) /ˈnəʊɪŋli/",
+      "example": "He openly acknowledged his mistake during the interview; The award was a form of acknowledgement for her work; She has deep knowledge of European history; He’s highly knowledgeable about finance; His contributions were quietly acknowledged; Their effort remained unacknowledged by the public; She gave a knowing look during the conversation; He knowingly avoided the main issue",
+      "translation": "công nhận; sự công nhận; tri thức; uyên bác; được công nhận; không được công nhận; thận trọng; một cách hiểu biết",
+      "count": 0
+    },
+    {
+      "word": "land",
+      "meaning": "landing (noun) /ˈlændɪŋ/; landed (adj) /ˈlændɪd/; landless (adj) /ˈlændləs/; land (verb) /ˈlænd/",
+      "example": "The helicopter made a safe landing; They come from landed nobility; The landless workers demanded reform; We expect to land at noon",
+      "translation": "việc đổ bộ, hạ cánh; đã có đất đai; không có đất; hạ cánh",
+      "count": 0
+    },
+    {
+      "word": "large",
+      "meaning": "enlarge (verb) /ɪnˈlɑːdʒ/; enlargement (noun) /ɪnˈlɑːdʒmənt/; largely (adv) /ˈlɑːdʒli/",
+      "example": "They plan to enlarge the museum next year; The enlargement of the image revealed new details; The campaign was largely successful",
+      "translation": "mở rộng; sự mở rộng; phần lớn",
+      "count": 0
+    },
+    {
+      "word": "last",
+      "meaning": "outlast (verb) /ˌaʊtˈlɑːst/; lasting (adj) /ˈlɑːstɪŋ/; everlasting (adj) /ˌevəˈlɑːstɪŋ/; lastly (adv) /ˈlɑːstli/",
+      "example": "She managed to outlast her competitors in the race; Their friendship had a lasting impact on him; They promised everlasting loyalty; Lastly, let me thank the entire team",
+      "translation": "tồn tại lâu hơn; bền vững; vĩnh viễn; cuối cùng thì",
+      "count": 0
+    },
+    {
+      "word": "leisure",
+      "meaning": "leisure (noun) /ˈleʒə(r)/; leisurely (adv) /ˈleʒəli/",
+      "example": "He enjoys reading in his leisure time; They strolled leisurely along the riverside",
+      "translation": "nhàn hạ; một cách chậm rãi",
+      "count": 0
+    },
+    {
+      "word": "logic",
+      "meaning": "logical (adj) /ˈlɒdʒɪkl/; illogical (adj) /ɪˈlɒdʒɪkl/; logically (adv) /ˈlɒdʒɪkli/; illogically (adv) /ɪˈlɒdʒɪkli/",
+      "example": "Your suggestion is completely logical; That argument seems illogical to me; She explained her decision logically; He reacted illogically under stress",
+      "translation": "hợp lý; không hợp lý; một cách hợp lý; một cách không hợp lý",
+      "count": 0
+    },
+    {
+      "word": "long",
+      "meaning": "prolong (verb) /prəˈlɒŋ/; lengthen (verb) /ˈleŋθn/; long (adj) /lɒŋ/; longevity (noun) /lɒnˈdʒevəti/; longhand (noun) /ˈlɒŋhænd/; longing (noun/adj) /ˈlɒŋɪŋ/; longingly (adv) /ˈlɒŋɪŋli/; lengthy (adj) /ˈleŋkθi/; prolonged (adj) /prəˈlɒŋd/; lengthways (adv) /ˈleŋkθweɪz/; lengthwise (adv) /ˈleŋkθwaɪz/",
+      "example": "The storm may prolong the delay; They tried to lengthen the ladder; The road is long and winding; His longevity impressed the doctors; She wrote the note in longhand; He had a longing for home; She gazed longingly at the cake; The meeting was unusually lengthy; The illness became prolonged over months; Cut the paper lengthways for better folding; Fold it lengthwise to fit the envelope",
+      "translation": "kéo dài; kéo dài; dài; sự trường thọ; chữ viết tay; sự khao khát; một cách khao khát; dài dòng; kéo dài thêm; theo chiều dọc; theo chiều dọc",
+      "count": 0
+    },
+    {
+      "word": "lot",
+      "meaning": "allot (verb) /əˈlɒt/; allotment (noun) /əˈlɒtmənt/",
+      "example": "The teacher will allot each student a topic; Everyone received their allotment of materials",
+      "translation": "phân công; sự phân công",
+      "count": 0
+    },
+    {
+      "word": "loyal",
+      "meaning": "loyalty (noun) /ˈlɔɪəlti/; disloyalty (noun) /dɪsˈlɔɪəlti/; loyally (adv) /ˈlɔɪəli/; disloyally (adv) /dɪsˈlɔɪəli/",
+      "example": "Their loyalty never wavered during hard times; Disloyalty can ruin relationships quickly; He stood by his team loyally; She acted disloyally by leaking the report",
+      "translation": "trung thành; không trung thành; một cách trung thành; một cách không trung thành",
+      "count": 0
+    },
+    {
+      "word": "magnify",
+      "meaning": "magnificence (noun) /mæɡˈnɪfɪsns/; magnification (noun) /ˌmæɡnɪfɪˈkeɪʃn/; magnificent (adj) /mæɡˈnɪfɪsnt/; magnificently (adv) /mæɡˈnɪfɪsntli/",
+      "example": "The hall was decorated with grandeur and magnificence; Use higher magnification for sharper detail; The castle looked magnificent in the sunset; She was magnificently dressed in gold and red",
+      "translation": "sự nguy nga; sự phóng đại; tráng lệ; một cách tráng lệ",
+      "count": 0
+    },
+    {
+      "word": "major",
+      "meaning": "majorette (noun) /ˌmeɪdʒəˈret/",
+      "example": "The majorette twirled her baton as the crowd cheered",
+      "translation": "nữ đội trưởng diễu hành",
+      "count": 0
+    },
+    {
+      "word": "manage",
+      "meaning": "mismanage (verb) /ˌmɪsˈmænɪdʒ/; management (noun) /ˈmænɪdʒmənt/; manager (noun) /ˈmænɪdʒə(r)/; mismanagement (noun) /ˌmɪsˈmænɪdʒmənt/; unmanageable (adj) /ˌʌnˈmænɪdʒəbl/; mismanaged (adj) /ˌmɪsˈmænɪdʒd/; managerial (adj/adv) /ˌmænəˈdʒɪəriəli/",
+      "example": "He mismanaged the team's budget and caused delays; She is responsible for HR management; The manager handled the crisis well; Mismanagement led to the project's failure; The situation became completely unmanageable; Those accounts were severely mismanaged; She demonstrated strong managerial judgment",
+      "translation": "quản lý kém; quản lý; người quản lý; sự quản lý kém; không thể quản lý; bị quản lý kém; thuộc quản lý",
+      "count": 0
+    },
+    {
+      "word": "manufacture",
+      "meaning": "manufacturer (noun) /ˌmænjuˈfæktʃərə(r)/; manufacturing (noun) /ˌmænjuˈfæktʃərɪŋ/",
+      "example": "The manufacturer improved safety standards this year; Manufacturing has shifted to automated systems",
+      "translation": "nhà sản xuất; sự sản xuất",
+      "count": 0
+    },
+    {
+      "word": "match",
+      "meaning": "matchmaker (noun) /ˈmætʃmeɪkə(r)/; matchmaking (noun) /ˈmætʃmeɪkɪŋ/; matchstick (noun) /ˈmætʃstɪk/; matchwood (noun) /ˈmætʃwʊd/; matchbook (noun) /ˈmætʃbʊk/; matchless (adj) /ˈmætʃləs/; matching (adj) /ˈmætʃɪŋ/; unmatched (adj) /ʌnˈmætʃt/",
+      "example": "She became a professional matchmaker in her town; Matchmaking apps are popular these days; He struck a matchstick to light the candle; The explosion shattered the table into matchwood; I found an old matchbook in the drawer; Her performance was truly matchless; They wore matching sweaters to the event; His skills were unmatched by any competitor",
+      "translation": "bà mối; công việc mối lái; que diêm; gỗ diêm; hộp diêm; vô song; hợp; không sánh bằng",
+      "count": 0
+    },
+    {
+      "word": "material",
+      "meaning": "materialise (verb) /məˈtɪəriəlaɪz/; materialism (noun) /məˈtɪəriəlɪzəm/; materialistic (adj) /məˌtɪəriəˈlɪstɪk/; immaterial (adj) /ˌɪməˈtɪəriəl/; materially (adv) /məˈtɪəriəli/",
+      "example": "His ideas failed to materialise despite early support; She criticized the rise of materialism in society; He’s very materialistic when it comes to gifts; That detail is immaterial to the discussion; They were materially supported by donations",
+      "translation": "cụ thể hóa; chủ nghĩa duy vật; nặng về vật chất; không quan trọng; một cách hữu hình",
+      "count": 0
+    },
+    {
+      "word": "mature",
+      "meaning": "maturity (noun) /məˈtjʊərəti/; immaturity (noun) /ˌɪməˈtjʊərəti/; maturation (noun) /ˌmætʃuˈreɪʃn/; immature (adj) /ˌɪməˈtjʊə(r)/",
+      "example": "She showed great maturity in her decision-making; His immaturity caused unnecessary tension; The fruit undergoes natural maturation over time; His jokes were immature and inappropriate",
+      "translation": "sự trưởng thành; sự thiếu trưởng thành; sự chín, trưởng thành; non nớt",
+      "count": 0
+    },
+    {
+      "word": "mean",
+      "meaning": "meaning (noun) /ˈmiːnɪŋ/; meaningfulness (noun) /ˈmiːnɪŋflnəs/; meaningless (adj) /ˈmiːnɪŋləs/; meaningfully (adv) /ˈmiːnɪŋfli/",
+      "example": "The meaning of the poem is debated; They questioned the meaningfulness of the gesture; That reply seemed meaningless; He looked at her meaningfully and said nothing",
+      "translation": "ý nghĩa; sự có ý nghĩa; vô nghĩa; một cách có ý nghĩa",
+      "count": 0
+    },
+    {
+      "word": "metal",
+      "meaning": "metallic (adj) /məˈtælɪk/; metallurgy (noun) /məˈtælədʒi/",
+      "example": "The cover has a metallic texture; He pursued a career in metallurgy after graduation",
+      "translation": "(thuộc) kim loại; ngành luyện kim",
+      "count": 0
+    },
+    {
+      "word": "might",
+      "meaning": "mighty (adj) /ˈmaɪti/; mightily (adv) /ˈmaɪtəli/",
+      "example": "The mighty storm shook the entire coast; She worked mightily to overcome the challenge",
+      "translation": "mạnh, hùng cường; một cách đầy quyền lực",
+      "count": 0
+    },
+    {
+      "word": "minor",
+      "meaning": "minority (noun) /maɪˈnɒrəti/",
+      "example": "The law was designed to protect the rights of the minority",
+      "translation": "thiểu số",
+      "count": 0
+    },
+    {
+      "word": "mobile",
+      "meaning": "mobilise (verb) /məʊbəlaɪz/; immobilise (verb) /ɪməʊbəlaɪz/; mobility (noun) /məʊˈbɪləti/; immobility (noun) /ɪməʊˈbɪləti/; mobilisation (noun) /məʊbəlaɪˈzeɪʃn/; immobile (adj) /ɪˈməʊbaɪl/",
+      "example": "The government decided to mobilise resources for relief; The injury will immobilise him temporarily; Social mobility varies across countries; Her illness caused prolonged immobility; Mobilisation efforts began before sunrise; He stayed immobile during the procedure",
+      "translation": "huy động; làm bất động; sự chuyển động; sự bất động; sự huy động; bất động",
+      "count": 0
+    },
+    {
+      "word": "modern",
+      "meaning": "modernise (verb) /ˈmɒdənaɪz/; modernisation (noun) /ˌmɒdənaɪˈzeɪʃn/; modernism (noun) /ˈmɒdənɪzəm/; modernist (noun) /ˈmɒdənɪst/",
+      "example": "They plan to modernise the railway system; The modernisation of the factory will increase efficiency; Modernism had a strong influence on 20th-century art; He’s a well-known modernist writer",
+      "translation": "hiện đại hóa; sự hiện đại hóa; chủ nghĩa hiện đại; người theo chủ nghĩa hiện đại",
+      "count": 0
+    },
+    {
+      "word": "mode",
+      "meaning": "modality (noun) /məʊˈdæləti/",
+      "example": "Learning modality varies among individuals",
+      "translation": "trình hiện đại",
+      "count": 0
+    },
+    {
+      "word": "moment",
+      "meaning": "momentary (adj) /ˈməʊməntri/; momentarily (adv) /ˌməʊmənˈterəli/",
+      "example": "There was a momentary delay in the transmission; She paused momentarily before responding",
+      "translation": "chốc lát; ngay tức khắc",
+      "count": 0
+    },
+    {
+      "word": "moral",
+      "meaning": "moralise (verb) /ˈmɒrəlaɪz/; demoralise (verb) /dɪˈmɒrəlaɪz/; morality (noun) /məˈræləti/; immorality (noun) /ɪməˈræləti/; moralist (noun) /ˈmɒrəlɪst/; morale (noun) /məˈrɑːl/; moral (adj/adv) /ˈmɒrəl(i)/; immoral (adj/adv) /ɪˈmɒrəl(i)/",
+      "example": "He tends to moralise every small issue; The bad news seemed to demoralise the team; Morality is essential in education; The novel explores themes of immorality; She's known as a strict moralist; Team morale improved after the announcement; They acted morally despite pressure; It was an immoral decision",
+      "translation": "lên lớp dạy đời; làm mất tinh thần; đạo đức; trái đạo đức; nhà đạo đức học; nhuệ khí; phù hợp đạo đức; không phù hợp đạo đức",
+      "count": 0
+    },
+    {
+      "word": "motion",
+      "meaning": "motionless (adj) /ˈməʊʃnləs/",
+      "example": "He stood motionless as the verdict was read",
+      "translation": "bất động",
+      "count": 0
+    },
+    {
+      "word": "motive",
+      "meaning": "motivate (verb) /ˈməʊtɪveɪt/; demotivate (verb) /diːˈməʊtɪveɪt/; motivator (noun) /ˈməʊtɪveɪtə(r)/; motivation (noun) /ˌməʊtɪˈveɪʃn/; demotivation (noun) /diːˌməʊtɪˈveɪʃn/; motivating (adj) /ˈməʊtɪveɪtɪŋ/; demotivating (adj) /diːˈməʊtɪveɪtɪŋ/; motivational (adj) /ˌməʊtɪˈveɪʃənl/",
+      "example": "Teachers must find ways to motivate their students; Repetitive tasks can demotivate staff quickly; A bonus can be a powerful motivator; Motivation levels dropped during the crisis; There was widespread demotivation across departments; It was a truly motivating speech; The lack of results was demotivating; Her motivational speech lifted everyone's spirits",
+      "translation": "thúc đẩy; tước bỏ động lực; yếu tố thúc đẩy; sự động lực; sự thiếu động lực; có tính thúc đẩy; làm giảm động lực; có sức truyền cảm hứng",
+      "count": 0
+    },
+    {
+      "word": "mount",
+      "meaning": "surmount (verb) /səˈmaʊnt/; mountain (noun) /ˈmaʊntən/; mountaineering (noun) /ˌmaʊntəˈnɪərɪŋ/; surmountable (adj) /səˈmaʊntəbl/; insurmountable (adj) /ɪnsəˈmaʊntəbl/; mountainous (adj) /ˈmaʊntənəs/",
+      "example": "They managed to surmount all the obstacles; He dreams of climbing every major mountain; Mountaineering takes years of preparation; The problem is surmountable with effort; The challenge felt insurmountable at first; They live in a mountainous region",
+      "translation": "vượt qua; núi; môn leo núi; có thể vượt qua; không thể vượt qua; thuộc vùng núi",
+      "count": 0
+    },
+    {
+      "word": "move",
+      "meaning": "mover (noun) /ˈmuːvə(r)/; movement (noun) /ˈmuːvmənt/; movable (adj) /ˈmuːvəbl/; immovable (adj) /ɪˈmuːvəbl/",
+      "example": "He’s a fast mover in business; The movement gained support nationwide; These chairs are easily movable; That cabinet is completely immovable",
+      "translation": "động cơ, lực; sự chuyển động; có thể di chuyển; không thể di chuyển",
+      "count": 0
+    },
+    {
+      "word": "mystery",
+      "meaning": "mystify (verb) /ˈmɪstɪfaɪ/; mystification (noun) /ˌmɪstɪfɪˈkeɪʃn/; mysterious (adj) /mɪˈstɪəriəs/; mysteriously (adv) /mɪˈstɪəriəsli/",
+      "example": "The technical explanation mystified the audience; His sudden absence led to mystification; The island has a mysterious charm; She mysteriously disappeared without a trace",
+      "translation": "làm hoang mang; sự hoang mang; bí ẩn; một cách bí ẩn",
+      "count": 0
+    },
+    {
+      "word": "neglect",
+      "meaning": "negligence (noun) /ˈneɡlɪdʒəns/; negligible (adj) /ˈneɡlɪdʒəbl/; neglectful (adj) /nɪˈɡlektfl/; neglectfully (adv) /nɪˈɡlektfəli/",
+      "example": "His negligence led to serious consequences; The damage was considered negligible; She was neglectful of her duties; He acted neglectfully toward the animals",
+      "translation": "tính cẩu thả; không đáng kể; tắc trách; một cách tắc trách",
+      "count": 0
+    },
+    {
+      "word": "new",
+      "meaning": "renew (verb) /rɪˈnjuː/; renewal (noun) /rɪˈnjuːəl/; newness (noun) /ˈnjuːnəs/; renewable (adj) /rɪˈnjuːəbl/; anew (adv) /əˈnjuː/",
+      "example": "They decided to renew their lease for another year; The software requires annual renewal; He appreciated the newness of the experience; This is a renewable energy source; Let’s start anew and forget the past",
+      "translation": "làm mới lại; sự làm mới lại; tính mới mẻ; có thể đổi mới; lại, một lần nữa",
+      "count": 0
+    },
+    {
+      "word": "object",
+      "meaning": "objective (noun) /əbˈdʒektɪv/; objection (noun) /əbˈdʒekʃn/; objectivity (noun) /ˌɒbdʒekˈtɪvəti/; objector (noun) /əbˈdʒektə(r)/; objectionable (adj) /əbˈdʒekʃənəbl/; unobjectionable (adj) /ʌnəbˈdʒekʃənəbl/",
+      "example": "Our main objective is to improve results; The lawyer raised an objection; She was praised for her objectivity; The objector interrupted the hearing; That statement is objectionable; His comments were completely unobjectionable",
+      "translation": "mục tiêu; sự phản đối; tính khách quan; người phản đối; không thể chấp nhận; có thể chấp nhận",
+      "count": 0
+    },
+    {
+      "word": "observe",
+      "meaning": "objectively (adv) /əbˈdʒektɪvli/; observation (noun) /ˌɒbzəˈveɪʃn/; observance (noun) /əbˈzɜːvəns/; observer (noun) /əbˈzɜːvə(r)/; observatory (noun) /əbˈzɜːvətəri/; observable (adj) /əbˈzɜːvəbl/; observant (adj) /əbˈzɜːvənt/; observably (adv) /əbˈzɜːvəbli/",
+      "example": "She spoke objectively about the incident; Accurate observation is key in science; Strict observance of the rules is expected; An observer reported the incident; The observatory monitors space activity; The change was easily observable; He's an observant detective; The results improved observably after the change",
+      "translation": "một cách khách quan; sự quan sát; sự tuân thủ; người quan sát; đài quan sát; dễ thấy; tinh mắt; một cách dễ thấy",
+      "count": 0
+    },
+    {
+      "word": "obsess",
+      "meaning": "obsession (noun) /əbˈseʃn/; obsessed (adj) /əbˈsest/; obsessive (adj) /əbˈsesɪv/; obsessively (adv) /əbˈsesɪvli/",
+      "example": "Her obsession with cleanliness affected her life; He’s obsessed with achieving perfection; She shows obsessive attention to detail; He obsessively checks his phone every few minutes",
+      "translation": "sự ám ảnh; bị ám ảnh; ám ảnh; một cách ám ảnh",
+      "count": 0
+    },
+    {
+      "word": "place",
+      "meaning": "replace /rɪˈpleɪs/; placement /ˈpleɪsmənt/; placing /ˈpleɪsɪŋ/; replacement /rɪˈpleɪsmənt/; (ir)replaceable /(ˌɪr)rɪˈpleɪsəbl/",
+      "example": "They replaced the damaged vase. The company handled the placement process efficiently. She focused on the careful placing of artworks. He’s a suitable replacement. This antique clock is irreplaceable.",
+      "translation": "thay thế; sự sắp xếp; không thể thay thế",
+      "count": 0
+    },
+    {
+      "word": "play",
+      "meaning": "replay /ˈriːpleɪ/; overplay /ˌəʊvəˈpleɪ/; downplay /ˌdaʊnˈpleɪ/; player /ˈpleɪə(r)/; playful(ly) /ˈpleɪfl(i)/",
+      "example": "The match will be replayed tomorrow. She tends to overplay her emotions. He tried to downplay the mistake. The player scored twice. They exchanged playful banter.",
+      "translation": "chơi lại; cường điệu; làm giảm; người chơi; đùa bỡn",
+      "count": 0
+    },
+    {
+      "word": "portion",
+      "meaning": "apportion /əˈpɔːʃn/",
+      "example": "Profits were apportioned among the team members.",
+      "translation": "phân chia",
+      "count": 0
+    },
+    {
+      "word": "power",
+      "meaning": "empower /ɪmˈpaʊə(r)/; overpower /ˌəʊvəˈpaʊə(r)/; empowerment /ɪmˈpaʊəmənt/; powerlessness /ˈpaʊələsnəs/; powerful(ly) /ˈpaʊəfl(i)/; powerless(ly) /ˈpaʊələsli/",
+      "example": "The policy empowers local councils. They were overpowered by the wind. Empowerment builds confidence. She expressed powerlessness in her role. He argued powerfully. They watched powerlessly as the fire spread.",
+      "translation": "trao quyền; áp đảo; sự bất lực; một cách mạnh mẽ; một cách bất lực",
+      "count": 0
+    },
+    {
+      "word": "prefer",
+      "meaning": "preference /ˈprefrəns/; preferable /ˈprefrəbl/; preferred /prɪˈfɜːd/; preferential /ˌprefəˈrenʃl/; preferably /ˈprefrəbli/",
+      "example": "Do you have any food preferences? Public transport is preferable during peak hours. She picked her preferred option. They received preferential treatment. Preferably, submit your form online.",
+      "translation": "sở thích; được ưa thích; ưu đãi; một cách tốt hơn",
+      "count": 0
+    },
+    {
+      "word": "prejudice",
+      "meaning": "(un)prejudiced /(ˌʌn)ˈpredʒədɪst/",
+      "example": "Many are prejudiced by media influence. She is refreshingly unprejudiced.",
+      "translation": "có thành kiến; không thành kiến",
+      "count": 0
+    },
+    {
+      "word": "prevent",
+      "meaning": "prevention /prɪˈvenʃn/; preventive /prɪˈventɪv/; (un)preventable /(ˌʌn)prɪˈventəbl/",
+      "example": "Better prevention could reduce disease rates. They implemented preventive steps. The damage was preventable.",
+      "translation": "phòng ngừa; ngăn chặn; có thể ngăn chặn",
+      "count": 0
+    },
+    {
+      "word": "print",
+      "meaning": "reprint /ˈriːprɪnt/; printing /ˈprɪntɪŋ/; printer /ˈprɪntə(r)/; printout /ˈprɪntaʊt/; imprint /ˈɪmprɪnt/; printed /ˈprɪntɪd/; (un)printable /(ʌn)ˈprɪntəbl/",
+      "example": "They decided to reprint the book. Printing was delayed due to a jam. The printer ran out of ink. I saved a copy of the printout. Her smile left an imprint. This document is already printed. That comment was unprintable.",
+      "translation": "tái bản; bản in; máy in; ấn dấu; không thể in được",
+      "count": 0
+    },
+    {
+      "word": "probable",
+      "meaning": "(im)probability /(ɪm)ˌprɒbəˈbɪləti/; improbable /ɪmˈprɒbəbl/; (im)probably /(ɪm)ˈprɒbəbli/",
+      "example": "The probability of success is high. Such events are highly improbable. It will probably arrive today. It probably won’t matter much.",
+      "translation": "khả năng; không chắc xảy ra; một cách có/không chắc",
+      "count": 0
+    },
+    {
+      "word": "process",
+      "meaning": "processor /ˈprəʊsesə(r)/; processing /ˈprəʊsesɪŋ/; processed /ˈprəʊsest/",
+      "example": "The processor handles tasks quickly. Image processing is complex. Processed food lacks nutrients.",
+      "translation": "bộ xử lý; xử lý; chế biến",
+      "count": 0
+    },
+    {
+      "word": "produce",
+      "meaning": "producer /prəˈdjuːsə(r)/; product /ˈprɒdʌkt/; productivity /ˌprɒdʌkˈtɪvəti/; production /prəˈdʌkʃn/; counterproductive /ˌkaʊntəprəˈdʌktɪv/; (un)productive(ly) /(ˌʌn)prəˈdʌktɪv(li)/",
+      "example": "The producer financed the film. This is a new product. Productivity rose this quarter. Production has increased. That method is counterproductive. They worked productively all day.",
+      "translation": "nhà sản xuất; sản phẩm; năng suất; phản tác dụng; không hiệu quả",
+      "count": 0
+    },
+    {
+      "word": "progress",
+      "meaning": "progression /prəˈɡreʃn/; progressive(ly) /prəˈɡresɪv(li)/",
+      "example": "His progression was rapid. The disease progressed progressively.",
+      "translation": "sự tiến bộ; một cách tiến bộ",
+      "count": 0
+    },
+    {
+      "word": "provoke",
+      "meaning": "provocation /ˌprɒvəˈkeɪʃn/; provocative(ly) /prəˈvɒkətɪv(li)/",
+      "example": "There was no provocation for the attack. She spoke provocatively to get attention.",
+      "translation": "sự khiêu khích; một cách khiêu khích",
+      "count": 0
+    },
+    {
+      "word": "public",
+      "meaning": "publicise /ˈpʌblɪsaɪz/; publicity /pʌbˈlɪsəti/; publication /ˌpʌblɪˈkeɪʃn/; publicist /ˈpʌblɪsɪst/; publicised /ˈpʌblɪsaɪzd/; (un)publicised /ʌnˈpʌblɪsaɪzd/",
+      "example": "They publicised the update. The campaign gained publicity. The publication was a bestseller. The publicist issued a press release. Their plans were widely publicised. The changes remain unpublicised.",
+      "translation": "công bố; sự chú ý; xuất bản; chuyên gia truyền thông",
+      "count": 0
+    },
+    {
+      "word": "pursue",
+      "meaning": "pursuer /pəˈsjuːə(r)/",
+      "example": "The pursuer continued through the crowd.",
+      "translation": "người theo đuổi",
+      "count": 0
+    },
+    {
+      "word": "quality",
+      "meaning": "qualitative(ly), /ˈkwɒlɪtətɪv(li)/: (một cách) định tính;",
+      "example": "The results were qualitatively better;",
+      "translation": "chất lượng",
+      "count": 0
+    },
+    {
+      "word": "race",
+      "meaning": "racist, /ˈreɪsɪst/: người phân biệt chủng tộc; racial(ly), /ˈreɪʃl(i)/: (về) chủng tộc; interracial, /ˌɪntəˈreɪʃl/: giữa các chủng tộc;",
+      "example": "He was accused of being a racist; They debated racial issues; It was an interracial marriage;",
+      "translation": "chủng tộc",
+      "count": 0
+    },
+    {
+      "word": "rapid",
+      "meaning": "rapidly, /ˈræpɪdli/: một cách nhanh chóng;",
+      "example": "Technology is evolving rapidly;",
+      "translation": "nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "rational",
+      "meaning": "rationalise, /ˈræʃnəlaɪz/: hợp lý hóa; rationalisation, /ˌræʃnəlaɪˈzeɪʃn/: sự hợp lý hóa; rationalist, /ˈræʃnəlɪst/: người theo chủ nghĩa duy lý; rationalism, /ˈræʃnəlɪzəm/: chủ nghĩa duy lý; (ir)rationality, /(ɪ)ˌræʃnəˈlæti/: (không) hợp lý; (ir)rational(ly), /(ɪ)ˈræʃnəli/: (một cách) (không) hợp lý;",
+      "example": "We need to rationalise spending; The plan's rationalisation was approved; He's a rationalist; She believes in rationalism; His decision lacked rationality; You acted irrationally;",
+      "translation": "hợp lý",
+      "count": 0
+    },
+    {
+      "word": "reason",
+      "meaning": "reasonableness, /ˈriːznəblnəs/: sự có lý; (un)reasonable, /ʌnˈriːznəbl/: (không) hợp lý; (un)reasonably, /ʌnˈriːznəbli/: (một cách) (không) hợp lý;",
+      "example": "He showed reasonableness in negotiation; That’s unreasonable! She reacted unreasonably;",
+      "translation": "lý do",
+      "count": 0
+    },
+    {
+      "word": "regret",
+      "meaning": "regrettable, /rɪˈɡretəbl/: đáng tiếc; regrettably, /rɪˈɡretəbli/: thật đáng tiếc là; regretful(ly), /rɪˈɡretfl(i)/: (một cách) hối tiếc;",
+      "example": "It was a regrettable mistake; Regrettably, we must cancel; She looked at him regretfully;",
+      "translation": "hối tiếc",
+      "count": 0
+    },
+    {
+      "word": "occur",
+      "meaning": "recur, /rɪˈkɜː(r)/: tái diễn; occurrence, /əˈkʌrəns/: sự xuất hiện; recurrence, /rɪˈkʌrəns/: sự tái diễn; recurring, /rɪˈkɜːrɪŋ/: lặp đi lặp lại;",
+      "example": "Headaches may recur frequently; The occurrence was unusual; We want to prevent recurrence; It's a recurring problem;",
+      "translation": "xảy ra",
+      "count": 0
+    },
+    {
+      "word": "office",
+      "meaning": "officiate, /əˈfɪʃieɪt/: làm lễ, chủ trì; official(dom), /əˈfɪʃl/: làm nhiệm vụ, chính thức; officer, /ˈɒfɪsə(r)/: viên chức; officious, /əˈfɪʃəs/: lắm lời, không chính thức; (un)official(ly), /(ˌʌn)əˈfɪʃəli/: (không) chính thức;",
+      "example": "He officiated the ceremony; The official attended the meeting; The officer gave instructions; He was being officious; The decision is unofficial;",
+      "translation": "văn phòng",
+      "count": 0
+    },
+    {
+      "word": "opinion",
+      "meaning": "opinionated, /əˈpɪnjəneɪtɪd/: cứng đầu, ngoan cố;",
+      "example": "She’s very opinionated and won’t listen;",
+      "translation": "ý kiến",
+      "count": 0
+    },
+    {
+      "word": "parent",
+      "meaning": "parenting, /ˈpeərəntɪŋ/: việc làm cha mẹ; parentage, /ˈpeərəntɪdʒ/: tư cách làm cha mẹ; parenthood, /ˈpeərəntʊd/: bậc cha mẹ; parental(ly), /pəˈrentl(i)/: (thuộc) cha mẹ;",
+      "example": "Good parenting is important; His parentage is unknown; Parenthood changes people; They acted parentally;",
+      "translation": "cha mẹ",
+      "count": 0
+    },
+    {
+      "word": "pass",
+      "meaning": "(im)passable, /(ˌɪm)ˈpɑːsəbl/: (không) thể đi qua; passing, /ˈpɑːsɪŋ/: sự qua đi; passable, /ˈpɑːsəbl/: có thể đi qua; impatient, /ɪmˈpeɪʃnt/: không kiên nhẫn; (im)patient(ly), /(ɪm)ˈpeɪʃntli/: (một cách) (không) kiên nhẫn;",
+      "example": "The road is impassable due to snow; His passing was sudden; The trail is passable now; She’s an impatient person; He waited patiently;",
+      "translation": "đi qua",
+      "count": 0
+    },
+    {
+      "word": "pay",
+      "meaning": "overpay, /ˌəʊvəˈpeɪ/: trả quá nhiều tiền; underpay, /ˌʌndəˈpeɪ/: trả lương quá thấp; repay, /rɪˈpeɪ/: trả lại; overpayment, /ˌəʊvəˈpeɪmənt/: trả vượt mức; underpayment, /ˌʌndəˈpeɪmənt/: trả lương thấp; repayment, /rɪˈpeɪmənt/: sự trả lại; payback, /ˈpeɪbæk/: lợi tức; payee, /ˌpeɪˈiː/: người nhận tiền; payer, /ˈpeɪə(r)/: người trả tiền; payload, /ˈpeɪləʊd/: tải trọng; payoff, /ˈpeɪɒf/: tiền bồi dưỡng; payable, /ˈpeɪəbl/: phải trả; payroll, /ˈpeɪrəʊl/: bảng lương; payslip, /ˈpeɪslɪp/: phiếu lương; overpaid, /ˌəʊvəˈpeɪd/: được trả quá cao; underpaid, /ˌʌndəˈpeɪd/: bị trả quá thấp;",
+      "example": "They overpay their employees; Many teachers are underpaid; I’ll repay the loan soon; His overpayment was refunded; The underpayment caused issues; The repayment is due tomorrow; She got her payback; The payee was verified; The payer is responsible; The payload is too heavy; He received a payoff; The invoice is payable next week; Check your payroll account; I lost my payslip; He’s definitely overpaid; Nurses are often underpaid;",
+      "translation": "trả",
+      "count": 0
+    },
+    {
+      "word": "perceive",
+      "meaning": "perception, /pəˈsepʃn/; perceptiveness, /pəˈseptɪvnəs/; (im)perceptible, /(ɪm)ˈpɜːsəptəbl/; (im)perceptively, /(ɪm)ˈpɜːsəptɪvli/",
+      "example": "Her perception differed from others. His perceptiveness impressed the team. The sound was barely perceptible. She observed perceptively.",
+      "translation": "sự nhận thức; khả năng nhận thức; (không) thể cảm nhận được; (một cách) (không) nhạy bén",
+      "count": 0
+    },
+    {
+      "word": "perfect",
+      "meaning": "perfection, /pəˈfekʃn/; perfectionist, /pəˈfekʃənɪst/; perfectionism, /pəˈfekʃənɪzəm/; perfectible, /pəˈfektəbl/; perfectly, /ˈpɜːfɪktli/; imperfect(ly), /ɪmˈpɜːfɪkt(li)/",
+      "example": "He pursued perfection tirelessly. She's known as a perfectionist. Perfectionism slowed her progress. This model is perfectible. Everything worked perfectly. The surface is imperfect.",
+      "translation": "sự hoàn hảo; người cầu toàn; chủ nghĩa hoàn hảo; có thể hoàn thiện; một cách hoàn hảo; (một cách) không hoàn hảo",
+      "count": 0
+    },
+    {
+      "word": "period",
+      "meaning": "periodical, /ˌpɪəriˈɒdɪkl/; periodically, /ˌpɪəriˈɒdɪkli/",
+      "example": "She subscribes to a periodical. We update the policy periodically.",
+      "translation": "tạp chí định kỳ; một cách định kỳ",
+      "count": 0
+    },
+    {
+      "word": "permit",
+      "meaning": "permission, /pəˈmɪʃn/; permissiveness, /pəˈmɪsɪvnəs/; permissive, /pəˈmɪsɪv/; permissible, /pəˈmɪsəbl/",
+      "example": "He lacked permission to enter. Her permissiveness caused issues. It's a permissive environment. That behavior isn’t permissible.",
+      "translation": "sự cho phép; tính dễ dãi; dễ dãi; có thể chấp nhận",
+      "count": 0
+    },
+    {
+      "word": "persist",
+      "meaning": "persistence, /pəˈsɪstəns/; persistent(ly), /pəˈsɪstəntli/",
+      "example": "Her persistence won him over. He emailed persistently for updates.",
+      "translation": "sự kiên trì; (một cách) kiên trì",
+      "count": 0
+    },
+    {
+      "word": "person",
+      "meaning": "personalise, /ˈpɜːsənaɪz/; impersonate, /ɪmˈpɜːsəneɪt/; personality, /ˌpɜːsəˈnæləti/; personnel, /ˌpɜːsəˈnel/; interpersonal, /ˌɪntəˈpɜːsənl/; (im)personal(ly), /(ˌɪm)ˈpɜːsənəli/",
+      "example": "Users can personalise their dashboard. He impersonated a celebrity. Her personality is warm. All personnel must attend. Interpersonal skills matter. Don’t take it personally.",
+      "translation": "cá nhân hóa; giả danh; tính cách; nhân sự; giữa các cá nhân; (một cách) (không) cụ thể, riêng tư",
+      "count": 0
+    },
+    {
+      "word": "persuade",
+      "meaning": "dissuade, /dɪˈsweɪd/; persuasion, /pəˈsweɪʒn/; persuasive(ly), /pəˈsweɪsɪv(li)/",
+      "example": "They tried to dissuade him. Her persuasion succeeded. He spoke persuasively.",
+      "translation": "ngăn cản, thuyết phục từ bỏ; sự thuyết phục; (một cách) thuyết phục",
+      "count": 0
+    },
+    {
+      "word": "phrase",
+      "meaning": "rephrase, /ˌriːˈfreɪz/; paraphrase, /ˈpærəfreɪz/; phrasing, /ˈfreɪzɪŋ/; phraseology, /ˌfreɪziˈɒlədʒi/",
+      "example": "Could you rephrase the question? Try paraphrasing this idea. The phrasing was awkward. His phraseology was complex.",
+      "translation": "diễn đạt bằng cách khác; diễn giải, diễn đạt; cách phân nhịp; ngữ cú, cách nói viết",
+      "count": 0
+    },
+    {
+      "word": "fold",
+      "meaning": "enfold, /ɪnˈfəʊld/; unfold, /ʌnˈfəʊld/; folder, /ˈfəʊldə(r)/; (un)folding, /(ʌn)ˈfəʊldɪŋ/; foldaway, /ˈfəʊldəweɪ/",
+      "example": "She enfolded the scarf gently. Events began to unfold. Place it in the folder. This is a folding design. The foldaway table is handy.",
+      "translation": "gấp nếp, bọc lại; mở ra, bày ra; thư mục; (không) gấp lại được; gấp/kép lại được",
+      "count": 0
+    },
+    {
+      "word": "fortune",
+      "meaning": "misfortune, /ˌmɪsˈfɔːtʃuːn/; (un)fortunate(ly), /(ʌn)ˈfɔːtʃənət(li)/; fortuitous(ly), /fɔːˈtjuːɪtəs(li)/",
+      "example": "They met by misfortune. Fortunately, he escaped. She won fortuitously.",
+      "translation": "điều không may; (một cách) (không) may mắn; tình cờ, ngẫu nhiên",
+      "count": 0
+    },
+    {
+      "word": "fruit",
+      "meaning": "fruitfulness, /ˈfruːtflnəs/; fruitlessness, /ˈfruːtləsnəs/; fruition, /fruːˈɪʃn/; fruitful(ly), /ˈfruːtfl(i)/; fruitless(ly), /ˈfruːtləsli/",
+      "example": "The orchard shows fruitfulness. The plan ended in fruitlessness. Their ideas came to fruition. They negotiated fruitfully. He waited fruitlessly.",
+      "translation": "sự sai quả, khả năng thành công; sự không ra quả; sự kết trái, sự hưởng; (một cách) thành công; (một cách) vô ích",
+      "count": 0
+    },
+    {
+      "word": "future",
+      "meaning": "futurist, /ˈfjuːtʃərɪst/; futuristic(ally), /ˌfjuːtʃəˈrɪstɪk(ə)li)/",
+      "example": "A futurist envisioned space cities. The gadget works futuristically.",
+      "translation": "người theo thuyết vị lai; (một cách) thuộc về tương lai",
+      "count": 0
+    },
+    {
+      "word": "go",
+      "meaning": "undergo, /ˌʌndəˈɡəʊ/; went, /went/; for(e)go, /fəˈɡəʊ/; for(e)went, /fəˈwent/; for(e)gone, /fəˈɡɒn/; ongoing, /ˈɒnɡəʊɪŋ/; outgoing, /ˈaʊtɡəʊɪŋ/",
+      "example": "She had to undergo treatment. He went out early. They forego luxuries. The result was foregone. Talks are ongoing. He's outgoing and cheerful.",
+      "translation": "trải qua; quá khứ của go; đi trước; quá khứ của forego; quá khứ phân từ của forego; đang diễn ra; cởi mở",
+      "count": 0
+    },
+    {
+      "word": "good",
+      "meaning": "goods, /ɡʊdz/; goodness, /ˈɡʊdnəs/; goodwill, /ˌɡʊdˈwɪl/; goody/goodie, /ˈɡʊdi/",
+      "example": "The shop sells various goods. She is full of goodness. Their gesture showed goodwill. He played the goody in the tale.",
+      "translation": "hàng hóa; lòng tốt; thiện chí; người tốt",
+      "count": 0
+    },
+    {
+      "word": "govern",
+      "meaning": "misgovern, /ˌmɪsˈɡʌvn/; government, /ˈɡʌvənmənt/; governor, /ˈɡʌvənə(r)/; governess, /ˈɡʌvənəs/; governing, /ˈɡʌvnɪŋ/; governmental, /ˌɡʌvənˈmentl/; ungovernable, /ʌnˈɡʌvənəbl/",
+      "example": "They misgoverned the province. The government responded quickly. A new governor was elected. She worked as a governess. That’s the governing rule. Governmental bodies acted. The protest was ungovernable.",
+      "translation": "cai trị sai; chính phủ; thống đốc; cô giáo; có quyền cai trị; thuộc chính phủ; không thể kiểm soát",
+      "count": 0
+    },
+    {
+      "word": "hand",
+      "meaning": "handle (verb) /ˈhændl/; handler (noun) /ˈhændlə(r)/; handling (noun) /ˈhændlɪŋ/; handout (noun) /ˈhændaʊt/; handover (noun) /ˈhændəʊvə(r)/; handful (noun) /ˈhændfʊl/; handmade (adj) /ˌhændˈmeɪd/; underhand (adj) /ˌʌndəˈhænd/",
+      "example": "She handled multiple tasks without complaints; The handler kept the animal calm throughout the event; Safe handling of chemicals is required in this lab; Each participant received a handout at the start; The handover to the new manager was smooth; He grabbed a handful of sand; These necklaces are all handmade by local artisans; Their underhand tactics were eventually exposed",
+      "translation": "xử lý; người điều khiển; cách xử lý; tài liệu phát ra; sự bàn giao; một nắm tay; đồ do tay làm; lén lút",
+      "count": 0
+    },
+    {
+      "word": "hard",
+      "meaning": "handy (adj) /ˈhændi/; hardship (noun) /ˈhɑːdʃɪp/; hardness (noun) /ˈhɑːdnəs/; hardy (adj) /ˈhɑːdi/",
+      "example": "This screwdriver is very handy for minor repairs; They overcame years of hardship together; Test the hardness of the metal before using it; These flowers are hardy and survive the cold",
+      "translation": "có ích, tiện tay; sự gian khổ; độ cứng; chịu khó, bền",
+      "count": 0
+    },
+    {
+      "word": "hear",
+      "meaning": "overhear (verb) /ˌəʊvəˈhɪə(r)/; hearing (noun) /ˈhɪərɪŋ/; hearsay (noun) /ˈhɪəseɪ/",
+      "example": "He overheard them planning a surprise; Her hearing was tested at the clinic; Don’t make decisions based on hearsay",
+      "translation": "nghe lỏm; thính giác; tin đồn",
+      "count": 0
+    },
+    {
+      "word": "high",
+      "meaning": "heighten (verb) /ˈhaɪtn/; highbrow (adj) /ˈhaɪbraʊ/; highly (adv) /ˈhaɪli/; highlight (verb) /ˈhaɪlaɪt/; height (noun) /haɪt/; heights (noun) /haɪts/",
+      "example": "Security measures were heightened during the event; The gallery displays highbrow works of art; She is highly regarded by her colleagues; The report highlights recent achievements; The tower’s height makes it visible for miles; Many people are afraid of heights",
+      "translation": "làm cao thêm; xa rời thực tế; ở mức độ cao; làm nổi bật; chiều cao; đỉnh cao",
+      "count": 0
+    },
+    {
+      "word": "history",
+      "meaning": "historian (noun) /hɪˈstɔːriən/; historic (adj) /hɪˈstɒrɪk/; historical(ly) (adj/adv) /hɪˈstɒrɪkl(i)/",
+      "example": "A historian studied ancient artifacts; It was a historic match for the team; Historically, the region has faced many challenges",
+      "translation": "nhà sử học; mang tính lịch sử; (một cách) thuộc lịch sử",
+      "count": 0
+    },
+    {
+      "word": "house",
+      "meaning": "housing (noun) /ˈhaʊzɪŋ/; household(er) (noun) /ˈhaʊshəʊld(ə)/; houseful (noun) /ˈhaʊsfʊl/",
+      "example": "Affordable housing is needed in cities; The householder welcomed the inspectors; There was a houseful of relatives for the holiday",
+      "translation": "nhà ở; hộ gia đình; đầy một nhà",
+      "count": 0
+    },
+    {
+      "word": "human",
+      "meaning": "humanise (verb) /ˈhjuːmənaɪz/; humanity (noun) /hjuːˈmænəti/; humanism (noun) /ˈhjuːmənɪzəm/; humanist (noun) /ˈhjuːmənɪst/; humanities (noun) /hjuːˈmænətiz/; humanitarian (noun) /hjuːˌmænɪˈteəriən/; humane (adj) /hjuːˈmeɪn/; humanly (adv) /ˈhjuːmənli/",
+      "example": "Leaders try to humanise workplace policies; Humanity has achieved remarkable progress; She is an expert in humanism; The humanist advocated for equal rights; He teaches the humanities at university; A humanitarian worked tirelessly during the crisis; The organization takes a humane approach; It’s not humanly possible to finish so soon",
+      "translation": "nhân hóa; nhân loại; chủ nghĩa nhân đạo; người theo chủ nghĩa nhân đạo; các môn nhân văn; người nhân đạo; nhân văn; từ góc độ con người",
+      "count": 0
+    },
+    {
+      "word": "ideal",
+      "meaning": "idealise (verb) /aɪˈdɪəlaɪz/; idealism (noun) /ˈaɪdiəlɪzəm/; idealisation (noun) /ˌaɪdɪələˈzeɪʃn/; idealist (noun) /ˈaɪdiəlɪst/; idealistic (adj) /ˌaɪdiəˈlɪstɪk/; idealised (adj) /ˈaɪdiəlaɪzd/; ideally (adv) /aɪˈdɪəli/",
+      "example": "Don’t idealise the past; Her idealism inspired those around her; The novel is a romantic idealisation of youth; He’s an idealist at heart; She offered an idealistic perspective; The movie portrayed an idealised version of history; Ideally, meetings should be short",
+      "translation": "lý tưởng hóa; chủ nghĩa lý tưởng; sự lý tưởng hóa; người theo chủ nghĩa lý tưởng; duy tâm; được lý tưởng hóa; một cách lý tưởng",
+      "count": 0
+    },
+    {
+      "word": "illusion",
+      "meaning": "disillusion (verb/noun) /ˌdɪsɪˈluːʒn/; disillusionment (noun) /ˌdɪsɪˈluːʒnmənt/; disillusioned (adj) /ˌdɪsɪˈluːʒnd/; illusory (adj) /ɪˈluːsəri/",
+      "example": "Travel can disillusion people about stereotypes; His disillusionment became clear after the meeting; She grew disillusioned with politics; The promise of easy money proved illusory",
+      "translation": "sự vỡ mộng; sự làm vỡ mộng; bị vỡ mộng; ảo tưởng, viển vông",
+      "count": 0
+    },
+    {
+      "word": "imagine",
+      "meaning": "imagination (noun) /ɪˌmædʒɪˈneɪʃn/; imaginings (noun) /ɪˈmædʒɪnɪŋz/; imaginative(ly) (adj/adv) /ɪˈmædʒɪnətɪv(li)/; (un)imaginative(ly) (adj/adv) /(ʌn)ɪˈmædʒɪnətɪv(li)/",
+      "example": "Children’s imagination knows no bounds; Her imaginings inspired her artwork; He solved the problem imaginatively; The story was written unimaginatively",
+      "translation": "trí tưởng tượng; những hình dung; (một cách) giàu trí tưởng tượng; (một cách) (không) giàu trí tưởng tượng",
+      "count": 0
+    },
+    {
+      "word": "imitate",
+      "meaning": "imitation (noun) /ˌɪmɪˈteɪʃn/; imitator (noun) /ˈɪmɪteɪtə(r)/; imitative (adj) /ˈɪmɪtətɪv/; inimitable (adj) /ɪˈnɪmɪtəbl/",
+      "example": "This purse is only an imitation; The comedian was a skilled imitator; Her work is imitative of modern trends; His performance was inimitable",
+      "translation": "sự bắt chước; kẻ bắt chước; có tính bắt chước; không thể bắt chước được",
+      "count": 0
+    },
+    {
+      "word": "imply",
+      "meaning": "implicate (verb) /ˈɪmplɪkeɪt/; implication (noun) /ˌɪmplɪˈkeɪʃn/; implicit(ly) (adj/adv) /ɪmˈplɪsɪt(li)/",
+      "example": "The investigation implicated several people; The implication was never stated openly; She agreed implicitly to the terms",
+      "translation": "lôi kéo, dính líu; sự liên can; (một cách) ngầm định",
+      "count": 0
+    },
+    {
+      "word": "impress",
+      "meaning": "impression (noun) /ɪmˈpreʃn/; (un)impressiveness (noun) /(ʌn)ɪmˈpresɪvnəs/; impressionist (noun) /ɪmˈpreʃənɪst/; impressionable (adj) /ɪmˈpreʃənəbl/; impressionistic (adj) /ˌɪmpreʃəˈnɪstɪk/; (un)impressive(ly) (adj/adv) /(ʌn)ɪmˈpresɪvli/",
+      "example": "The teacher left a lasting impression; The design lacked impressiveness; She is a well-known impressionist; Young students can be impressionable; The review was impressionistic rather than factual; He performed impressively on stage",
+      "translation": "ấn tượng; sự (không) ấn tượng; người theo trường phái ấn tượng; dễ bị ảnh hưởng; thuộc trường phái ấn tượng; (một cách) (không) gây ấn tượng",
+      "count": 0
+    },
+    {
+      "word": "improve",
+      "meaning": "improvement (noun) /ɪmˈpruːvmənt/; improvable (adj) /ɪmˈpruːvəbl/; improved (adj) /ɪmˈpruːvd/",
+      "example": "She made steady improvement throughout the year; The process is improvable with feedback; This is an improved version of the software",
+      "translation": "sự cải thiện; có thể cải thiện; được cải thiện",
+      "count": 0
+    },
+    {
+      "word": "incident",
+      "meaning": "incidence (noun) /ˈɪnsɪdəns/",
+      "example": "There has been a high incidence of theft in this area",
+      "translation": "tần suất, tỉ lệ mắc phải",
+      "count": 0
+    },
+    {
+      "word": "coincide",
+      "meaning": "coincidence (noun) /kəʊˈɪnsɪdəns/; coincidental(ly) (adj/adv) /kəʊˌɪnsɪˈdentl(i)/",
+      "example": "Their arrival was pure coincidence; They met coincidentally at a café",
+      "translation": "sự trùng hợp; (một cách) ngẫu nhiên",
+      "count": 0
+    },
+    {
+      "word": "indicate",
+      "meaning": "indication (noun) /ˌɪndɪˈkeɪʃn/; indicator (noun) /ˈɪndɪkeɪtə(r)/; indicative (adj) /ɪnˈdɪkətɪv/",
+      "example": "A rash can be an indication of illness; The indicator showed a full battery; The growth is indicative of recovery",
+      "translation": "sự biểu thị; tín hiệu; chỉ ra",
+      "count": 0
+    },
+    {
+      "word": "individual",
+      "meaning": "individualise (verb) /ˌɪndɪˈvɪdʒuəlaɪz/; individualism (noun) /ɪnˈdɪvɪdʒuəlɪzəm/; individuality (noun) /ˌɪndɪˌvɪdʒuˈæləti/; individualist (noun) /ɪnˈdɪvɪdʒuəlɪst/; individualistic (adj) /ˌɪndɪˌvɪdʒuəˈlɪstɪk/",
+      "example": "Teachers try to individualise assignments; Her belief in individualism shaped her philosophy; His individuality makes him stand out; She is known as an individualist in the workplace; The design is very individualistic",
+      "translation": "cá nhân hóa; chủ nghĩa cá nhân; cá tính; người theo chủ nghĩa cá nhân; mang tính cá nhân",
+      "count": 0
+    },
+    {
+      "word": "influence",
+      "meaning": "influential (adj) /ˌɪnfluˈenʃl/",
+      "example": "She has become an influential leader in her field",
+      "translation": "có ảnh hưởng lớn",
+      "count": 0
+    },
+    {
+      "word": "inhabit",
+      "meaning": "inhabitant (noun) /ɪnˈhæbɪtənt/; habitat (noun) /ˈhæbɪtæt/; habitation (noun) /ˌhæbɪˈteɪʃn/; (un)inhabitable (adj) /ʌnˈhæbɪtəbl/",
+      "example": "The island is home to many inhabitants; The panda’s habitat is shrinking; The building has been unfit for habitation for years; This desert is uninhabitable",
+      "translation": "cư dân; môi trường sống; nơi ở; (không) thể ở được",
+      "count": 0
+    },
+    {
+      "word": "inherit",
+      "meaning": "inheritance (noun) /ɪnˈherɪtəns/; heritage (noun) /ˈherɪtɪdʒ/; hereditary (adj) /həˈredɪtəri/",
+      "example": "He received a large inheritance; Vietnamese water puppetry is a unique heritage; The disorder is hereditary",
+      "translation": "sự thừa kế; di sản; truyền từ đời này sang đời khác",
+      "count": 0
+    },
+    {
+      "word": "insist",
+      "meaning": "insistence (noun) /ɪnˈsɪstəns/; insistent (adj) /ɪnˈsɪstənt/",
+      "example": "Their insistence led to a review of the policy; She was insistent that we stay longer",
+      "translation": "sự khăng khăng; khăng khăng",
+      "count": 0
+    },
+    {
+      "word": "instinct",
+      "meaning": "instinctive(ly) (adj/adv) /ɪnˈstɪŋktɪv(li)/",
+      "example": "He instinctively shielded his eyes from the light",
+      "translation": "một cách theo bản năng",
+      "count": 0
+    },
+    {
+      "word": "institute",
+      "meaning": "institutionalise (verb) /ˌɪnstɪˈtjuːʃənəlaɪz/; institution (noun) /ˌɪnstɪˈtjuːʃn/; institutional (adj) /ˌɪnstɪˈtjuːʃənl/; institutionalised (adj) /ˌɪnstɪˈtjuːʃnəlaɪzd/",
+      "example": "The company decided to institutionalise regular training; He works for a respected institution; They face institutional barriers to change; This custom is now institutionalised in the law",
+      "translation": "thể chế hóa; tổ chức; thuộc tổ chức; được thể chế hóa",
+      "count": 0
+    },
+    {
+      "word": "intend",
+      "meaning": "intention (noun) /ɪnˈtenʃn/; (un)intended (adj) /(ʌn)ɪnˈtendɪd/; (un)intentional(ly) (adj/adv) /(ʌn)ɪnˈtenʃən(ə)li/",
+      "example": "He announced his intention to retire; The side effects were unintended; She acted intentionally to avoid confusion",
+      "translation": "ý định; (không) cố ý; (một cách) (không) có chủ đích",
+      "count": 0
+    },
+    {
+      "word": "intimate",
+      "meaning": "intimacy (noun) /ˈɪntɪməsi/; intimately (adv) /ˈɪntɪmətli/",
+      "example": "There is great intimacy in their friendship; They know each other intimately",
+      "translation": "sự thân mật; một cách thân mật",
+      "count": 0
+    },
+    {
+      "word": "job",
+      "meaning": "jobbing (adj) /ˈdʒɒbɪŋ/; jobless (adj) /ˈdʒɒbləs/",
+      "example": "He took up jobbing tasks to cover expenses; The factory closure left many families jobless",
+      "translation": "làm việc vặt; thất nghiệp",
+      "count": 0
+    },
+    {
+      "word": "electric",
+      "meaning": "electrify (v) /ɪˈlektrɪfaɪ/; electrician (n) /ɪˌlekˈtrɪʃn/; electricity (n) /ɪˌlekˈtrɪsəti/; electrified (adj) /ɪˈlektrɪfaɪd/; electrifying (adj) /ɪˈlektrɪfaɪɪŋ/; electrical (adj) /ɪˈlektrɪkl/",
+      "example": "They plan to electrify the entire village soon; The electrician finished wiring the new house; A sudden surge of electricity caused the lights to flicker; The fence was fully electrified for safety; The performance had an electrifying energy; An electrical fault caused the outage",
+      "translation": "làm nhiễm điện; thợ điện; điện; đã nhiễm điện; đầy hứng khởi; (thuộc) điện",
+      "count": 0
+    },
+    {
+      "word": "elude",
+      "meaning": "elusiveness (n) /ɪˈluːsɪvnəs/; elusive (adj) /ɪˈluːsɪv/",
+      "example": "The elusiveness of the suspect frustrated investigators; She gave him an elusive answer and left the room",
+      "translation": "tính lảng tránh; khó nắm bắt",
+      "count": 0
+    },
+    {
+      "word": "employ",
+      "meaning": "employment (n) /ɪmˈplɔɪmənt/; unemployment (n) /ˌʌnɪmˈplɔɪmənt/; underemployment (n) /ˌʌndərɪmˈplɔɪmənt/; employer (n) /ɪmˈplɔɪə(r)/; employee (n) /ˌemplɔɪˈiː/; employed (adj) /ɪmˈplɔɪd/; unemployed (adj) /ˌʌnɪmˈplɔɪd/; employable (adj) /ɪmˈplɔɪəbl/; unemployable (adj) /ˌʌnɪmˈplɔɪəbl/",
+      "example": "She searched for stable employment in the city; Rising unemployment has become a concern for local leaders; Underemployment remains an issue in many rural areas; The employer interviewed several candidates for the role; Each employee received new training; She felt more employed after accepting a second job; He has been unemployed for months; With her skills, she is highly employable; Chronic illness can make someone unemployable",
+      "translation": "việc làm; thất nghiệp; thiếu việc; người sử dụng lao động; nhân viên; có việc; thất nghiệp; có thể tuyển dụng; không thể tuyển dụng",
+      "count": 0
+    },
+    {
+      "word": "end",
+      "meaning": "endure (v) /ɪnˈdjʊə(r)/; endurance (n) /ɪnˈdjʊərəns/; endurable (adj) /ɪnˈdjʊərəbl/; unendurable (adj) /ʌnˈendɪrəbəl/; unending (adj) /ʌnˈendɪŋ/; ending (n) /ˈendɪŋ/; endless (adj) /ˈendləs/; endlessly (adv) /ˈendləsli/",
+      "example": "They must endure harsh conditions to succeed; Endurance is required to complete a marathon; The pain was barely endurable for him; Such noise is simply unendurable at night; The unending rain flooded the village; The movie’s ending surprised everyone; He stared at the endless rows of books; She talked endlessly about her plans",
+      "translation": "chịu đựng; sức bền; có thể chịu đựng; không thể chịu đựng được; không có hồi kết; sự kết thúc; vô tận; một cách vô tận",
+      "count": 0
+    },
+    {
+      "word": "envy",
+      "meaning": "enviable (adj) /ˈenviəbl/; unenviable (adj) /ʌnˈenviəbl/; enviably (adv) /ˈenviəbli/; unenviably (adv) /ʌnˈenviəbli/; envious (adj) /ˈenviəs/; enviously (adv) /ˈenviəsli/",
+      "example": "He has an enviable reputation in his field; The position was unenviable due to heavy stress; She lived enviably close to the beach; The job was unenviably complicated; She was envious of her friend’s success; He watched enviously as the winner took the prize",
+      "translation": "đáng ghen tị; không đáng ghen tị; một cách đáng ghen tị; một cách không đáng ghen tị; ghen tị; một cách ghen tị",
+      "count": 0
+    },
+    {
+      "word": "erode",
+      "meaning": "erosion (n) /ɪˈrəʊʒn/",
+      "example": "Erosion gradually wore away the old stone bridge",
+      "translation": "sự xói mòn",
+      "count": 0
+    },
+    {
+      "word": "erupt",
+      "meaning": "eruption (n) /ɪˈrʌpʃn/",
+      "example": "The sudden eruption startled everyone nearby",
+      "translation": "sự phun trào",
+      "count": 0
+    },
+    {
+      "word": "event",
+      "meaning": "eventuality (n) /ɪˌventʃuˈæləti/; eventful (adj) /ɪˈventfl/; uneventful (adj) /ʌnɪˈventfl/; eventual (adj) /ɪˈventʃuəl/; eventually (adv) /ɪˈventʃuəli/",
+      "example": "The company planned for every possible eventuality; It was an eventful year in technology; Their trip was uneventful and relaxing; The eventual results were announced; Eventually, everyone agreed on a solution",
+      "translation": "tình huống có thể xảy ra; nhiều sự kiện; không có nhiều sự kiện; cuối cùng; cuối cùng",
+      "count": 0
+    },
+    {
+      "word": "evolve",
+      "meaning": "evolution (n) /ˌiːvəˈluːʃn/; evolutionary (adj) /ˌiːvəˈluːʃənəri/; evolving (adj) /ɪˈvɒlvɪŋ/",
+      "example": "Evolution has shaped life on Earth; This is an evolutionary adaptation in birds; The company is an evolving leader in AI",
+      "translation": "sự tiến hóa; (thuộc) tiến hóa; đang tiến hóa",
+      "count": 0
+    },
+    {
+      "word": "example",
+      "meaning": "exemplify (v) /ɪɡˈzemplɪfaɪ/; exemplification (n) /ɪɡˌzemplɪfɪˈkeɪʃn/; exemplary (adj) /ɪɡˈzempləri/",
+      "example": "Her actions exemplify dedication to her team; The case was cited as an exemplification of success; He set an exemplary standard for his peers",
+      "translation": "minh họa; sự minh họa; mẫu mực",
+      "count": 0
+    },
+    {
+      "word": "exclaim",
+      "meaning": "exclamation (n) /ˌekskləˈmeɪʃn/; exclamatory (adj) /eksˈklæmətri/",
+      "example": "Her exclamation drew everyone’s attention; He used an exclamatory tone in his reply",
+      "translation": "câu cảm thán; mang tính cảm thán",
+      "count": 0
+    },
+    {
+      "word": "expect",
+      "meaning": "expectation (n) /ˌekspekˈteɪʃn/; expectancy (n) /ɪkˈspektənsi/; expectant (adj) /ɪkˈspektənt/; expectantly (adv) /ɪkˈspektəntli/; expected (adj) /ɪkˈspektɪd/; unexpected (adj) /ʌnɪkˈspektɪd/; expectedly (adv) /ɪkˈspektɪdli/; unexpectedly (adv) /ʌnɪkˈspektɪdli/",
+      "example": "Their expectation was to finish early; There was a sense of expectancy in the air; She gave him an expectant look; He waited expectantly for the results; The expected outcome was positive; The unexpected delay disrupted plans; The event ended expectedly well; She left unexpectedly without a word",
+      "translation": "sự mong đợi; sự chờ đợi; mong chờ; một cách mong chờ; được mong đợi; không ngờ tới; một cách mong đợi; một cách bất ngờ",
+      "count": 0
+    },
+    {
+      "word": "explain",
+      "meaning": "explanation (n) /ˌekspləˈneɪʃn/; explanatory (adj) /ɪkˈsplænətri/; unexplained (adj) /ˌʌnɪkˈspleɪnd/; explicable (adj) /ˈeksplɪkəbl/; inexplicable (adj) /ɪnˈeksplɪkəbl/; inexplicably (adv) /ˌɪnɪkˈsplɪkəbli/",
+      "example": "She gave a thorough explanation in class; The diagram had several explanatory notes; The illness remains unexplained; The reason is fully explicable now; His absence is inexplicable; The lights flickered inexplicably all evening",
+      "translation": "sự giải thích; mang tính giải thích; không rõ nguyên nhân; có thể giải thích; không thể giải thích; một cách không thể giải thích",
+      "count": 0
+    },
+    {
+      "word": "express",
+      "meaning": "expression (n) /ɪkˈspreʃn/; expressiveness (n) /ɪkˈspreʃɪvnəs/; expressionism (n) /ɪkˈspreʃənɪzəm/; expressionist (n) /ɪkˈspreʃənɪst/; expressive (adj) /ɪkˈspresɪv/; expressionless (adj) /ɪkˈspreʃnləs/; expressionless (n) /ɪkˈspreʃnləsnəs/; expressively (adv) /ɪkˈspresɪvli/",
+      "example": "Her expression changed as she listened; His face showed real expressiveness; She studied expressionism in college; The artist is a well-known expressionist; His voice was expressive during the performance; He sat with an expressionless gaze; The cold expressionlessness unsettled her; She nodded expressively",
+      "translation": "sự biểu lộ; tính diễn cảm; chủ nghĩa biểu hiện; người theo chủ nghĩa biểu hiện; có tính biểu cảm; vô cảm; sự vô cảm; một cách biểu cảm",
+      "count": 0
+    },
+    {
+      "word": "extend",
+      "meaning": "extension (n) /ɪkˈstenʃn/; extent (n) /ɪkˈstent/; extended (adj) /ɪkˈstendɪd/; unextended (adj) /ʌnɪkˈstendɪd/; extensible (adj) /ɪkˈstensəbl/; inextensible (adj) /ɪnɪkˈstensəbl/",
+      "example": "They built an extension on their home; The extent of the changes surprised many; They enjoyed an extended holiday abroad; The warranty is unextended for older models; This cable is fully extensible; The material proved inextensible under stress",
+      "translation": "sự mở rộng; mức độ; được mở rộng; không được mở rộng; có thể kéo dài; không thể kéo dài",
+      "count": 0
+    },
+    {
+      "word": "extinct",
+      "meaning": "extinction (n) /ɪkˈstɪŋkʃn/",
+      "example": "Many endangered species face extinction if trends continue",
+      "translation": "sự tuyệt chủng",
+      "count": 0
+    },
+    {
+      "word": "familiar",
+      "meaning": "familiarise (v) /fəˈmɪliəraɪz/; familiarity (n) /fəˌmɪliˈærəti/; unfamiliarity (n) /ʌnfəˌmɪliˈærəti/; unfamiliar (adj) /ˌʌnfəˈmɪliə(r)/; familiarly (adv) /fəˈmɪliəli/",
+      "example": "He tried to familiarise himself with the software; Her familiarity with the city made navigation easy; His unfamiliarity with local customs was clear; The area felt unfamiliar after so many years; She spoke familiarly to the group",
+      "translation": "làm cho quen; sự quen thuộc; sự không quen thuộc; không quen thuộc; một cách thân mật",
+      "count": 0
+    },
+    {
+      "word": "favour",
+      "meaning": "favouritism (n) /ˈfeɪvərɪtɪzəm/; favourite (n) /ˈfeɪvərɪt/; favourable (adj) /ˈfeɪvərəbl/; unfavourable (adj) /ʌnˈfeɪvərəbl/; favourably (adv) /ˈfeɪvərəbli/; unfavourably (adv) /ʌnˈfeɪvərəbli/",
+      "example": "He was accused of favouritism at work; She is my favourite colleague; The weather was favourable for hiking; The results were unfavourable to our plan; The news was received favourably; The proposal was unfavourably reviewed by management",
+      "translation": "sự thiên vị; người yêu thích; có thiện chí; không thuận lợi; một cách thuận lợi; một cách không thuận lợi",
+      "count": 0
+    },
+    {
+      "word": "finite",
+      "meaning": "infinity (n) /ɪnˈfɪnəti/; infinitive (n) /ɪnˈfɪnətɪv/; infinite (adj) /ˈɪnfɪnət/; infinitely (adv) /ˈɪnfɪnətli/; infinitesimal (adj) /ˌɪnfɪnɪˈtesɪml/; infinitesimally (adv) /ˌɪnfɪnɪˈtesɪməli/",
+      "example": "Space is sometimes described as reaching infinity; Use the infinitive form in this sentence; The resources are not infinite; Her patience is infinitely greater than mine; The error margin was infinitesimal; Their chances decreased infinitesimally over time",
+      "translation": "vô cực; động từ nguyên mẫu; vô hạn; một cách vô hạn; cực nhỏ; một cách cực nhỏ",
+      "count": 0
+    },
+    {
+      "word": "flexible",
+      "meaning": "flexibility (n) /ˌfleksəˈbɪləti/; inflexibility (n) /ɪnˌfleksəˈbɪləti/; inflexible (adj) /ɪnˈfleksəbl/",
+      "example": "Flexibility in approach can be an advantage; His inflexibility caused problems in negotiations; The rules were too inflexible for exceptions",
+      "translation": "tính linh hoạt; tính cứng nhắc; cứng nhắc",
+      "count": 0
+    },
+    {
+      "word": "character",
+      "meaning": "characterise (v) /ˈkærəktəraɪz/; characterisation (n) /ˌkærəktəraɪˈzeɪʃn/; characteristic (adj) /ˌkærəktəˈrɪstɪk/; uncharacteristic (adj) /ʌnˌkærəktəˈrɪstɪk/; characterless (adj) /ˈkærəktələs/",
+      "example": "We can characterise the novel as suspenseful; Her characterisation of the role impressed critics; That response was characteristic of him; His lateness was uncharacteristic; The building looked characterless after renovations",
+      "translation": "mô tả; sự mô tả; đặc trưng; không đặc trưng; không có bản sắc",
+      "count": 0
+    },
+    {
+      "word": "charity",
+      "meaning": "charitableness (n) /ˈtʃærətəblnəs/; charitable (adj) /ˈtʃærətəbl/; uncharitable (adj) /ʌnˈtʃærətəbl/; charitably (adv) /ˈtʃærətəbli/; uncharitably (adv) /ʌnˈtʃærətəbli/",
+      "example": "Her charitableness was widely respected; They ran a charitable event for children; His remarks were uncharitable towards his rivals; She donated charitably each year; He commented uncharitably about the error",
+      "translation": "lòng nhân ái; có lòng nhân ái; không có lòng nhân ái; một cách nhân ái; một cách không nhân ái",
+      "count": 0
+    },
+    {
+      "word": "choose",
+      "meaning": "chose (v) /tʃəʊz/; chosen (adj) /ˈtʃəʊzn/; choice (n) /tʃɔɪs/; choosy (adj) /ˈtʃuːzi/",
+      "example": "He chose to move abroad for work; She is the chosen leader of the team; The choice was difficult to make; He is quite choosy about his food",
+      "translation": "đã chọn; được chọn; sự lựa chọn; kén chọn",
+      "count": 0
+    },
+    {
+      "word": "class",
+      "meaning": "outclass (v) /ˌaʊtˈklɑːs/; declassify (v) /ˈdiːˈklæsɪfaɪ/; classify (v) /ˈklæsɪfaɪ/; classics (n) /ˈklæsɪks/; classifieds (n) /ˈklæsɪfaɪdz/; classification (n) /ˌklæsɪfɪˈkeɪʃn/; classlessness (n) /ˈklɑːsləsnəs/; classmate (n) /ˈklɑːsmeɪt/; classroom (n) /ˈklɑːsruːm/; classwork (n) /ˈklɑːswɜːk/; classy (adj) /ˈklɑːsi/",
+      "example": "She managed to outclass all her competitors; The report was declassified last year; They classify animals by species; He loves reading the classics; He found a job in the classifieds; The process of classification took months; They promoted classlessness in society; Her classmate helped her with the project; The classroom was filled with laughter; His classwork was always complete; That’s a classy restaurant downtown",
+      "translation": "vượt trội; giải mật; phân loại; tác phẩm kinh điển; mục rao vặt; sự phân loại; không giai cấp; bạn cùng lớp; phòng học; bài học trên lớp; sang trọng",
+      "count": 0
+    },
+    {
+      "word": "collect",
+      "meaning": "collect (v) /kəˈlekt/; collector (n) /kəˈlektə(r)/; collection (n) /kəˈlekʃn/; collectable (adj) /kəˈlektəbl/; collected (adj) /kəˈlektɪd/; collective (adj) /kəˈlektɪv/; collectively (adv) /kəˈlektɪvli/",
+      "example": "He began to collect coins as a child; The collector displayed rare paintings; The museum’s collection grew every year; These coins are highly collectable; The collected data was analyzed; It was a collective effort by the team; The changes were made collectively",
+      "translation": "thu thập; người sưu tầm; bộ sưu tập; có thể sưu tầm; được thu thập; tập thể; một cách tập thể",
+      "count": 0
+    },
+    {
+      "word": "come",
+      "meaning": "overcome (v) /ˌəʊvəˈkʌm/; comeback (n) /ˈkʌmbæk/; newcomer (n) /ˈnjuːˌkʌmə(r)/; outcome (n) /ˈaʊtkʌm/; income (n) /ˈɪnkʌm/; coming (adj) /ˈkʌmɪŋ/; oncoming (adj) /ˈɒnkʌmɪŋ/; incoming (adj) /ˈɪnkʌmɪŋ/",
+      "example": "He worked hard to overcome the setback; The band staged an impressive comeback; The newcomer was warmly welcomed; The outcome was better than expected; Her income increased after the promotion; The coming weeks will be busy; Watch for oncoming traffic; The incoming message was urgent",
+      "translation": "vượt qua; sự trở lại; người mới đến; kết quả; thu nhập; sắp tới; đang đến; mới đến",
+      "count": 0
+    },
+    {
+      "word": "compete",
+      "meaning": "competition (n) /ˌkɒmpəˈtɪʃn/; competitor (n) /kəmˈpetɪtə(r)/; competitiveness (n) /kəmˈpetətɪvnəs/; competitive (adj) /kəmˈpetətɪv/; uncompetitive (adj) /ʌnˈkɒmpətɪtɪv/; competitively (adv) /kəmˈpetətɪvli/; uncompetitively (adv) /ʌnˈkɒmpətɪtɪvli/",
+      "example": "She entered the annual competition with excitement; Every competitor trained for months; The company’s competitiveness led to growth; They offered competitive salaries to attract talent; The price is uncompetitive in the market; She sold her products competitively; They priced uncompetitively and lost customers",
+      "translation": "cuộc thi; đối thủ; tính cạnh tranh; cạnh tranh; không cạnh tranh; một cách cạnh tranh; một cách không cạnh tranh",
+      "count": 0
+    },
+    {
+      "word": "concept",
+      "meaning": "conceptualise (v) /kənˈseptʃuəlaɪz/; concept (n) /ˈkɒnsept/; conception (n) /kənˈsepʃn/; conceivable (adj) /kənˈsiːvəbl/; inconceivable (adj) /ɪnkənˈsiːvəbl/; conceivably (adv) /kənˈsiːvəbli/; inconceivably (adv) /ɪnkənˈsiːvəbli/",
+      "example": "He tried to conceptualise the process; The concept was easy to grasp; Her conception of the plan was innovative; That’s a conceivable solution; The alternative is inconceivable to most; It could conceivably happen; The system failed inconceivably fast",
+      "translation": "khái niệm hóa; khái niệm; quan niệm; có thể tưởng tượng; không thể tưởng tượng; một cách có thể tưởng tượng; một cách không thể tưởng tượng",
+      "count": 0
+    },
+    {
+      "word": "confuse",
+      "meaning": "confusion (n) /kənˈfjuːʒn/; confused (adj) /kənˈfjuːzd/; confusing (adj) /kənˈfjuːzɪŋ/; confusingly (adv) /kənˈfjuːzɪŋli/",
+      "example": "The instructions led to confusion among students; He looked confused during the test; The map is confusing to visitors; The information was presented confusingly",
+      "translation": "sự nhầm lẫn; bối rối; gây nhầm lẫn; một cách gây nhầm lẫn",
+      "count": 0
+    },
+    {
+      "word": "connect",
+      "meaning": "disconnect (v) /ˌdɪskəˈnekt/; reconnect (v) /ˌriːkəˈnekt/; interconnect (v) /ˌɪntəkəˈnekt/; interconnection (n) /ˌɪntəkəˈnekʃn/; connection (n) /kəˈnekʃn/; disconnection (n) /ˌdɪskəˈnekʃn/; reconnection (n) /ˌriːkəˈnekʃn/; connector (n) /kəˈnektə(r)/",
+      "example": "He needed to disconnect the power before repairs; The technician will reconnect the lines tomorrow; The devices interconnect seamlessly; The interconnection was tested; The internet connection dropped; A sudden disconnection ended the call; The reconnection was successful; The cable uses a standard connector",
+      "translation": "ngắt kết nối; kết nối lại; kết nối lẫn nhau; sự liên kết; kết nối; ngắt kết nối; kết nối lại; đầu nối",
+      "count": 0
+    },
+    {
+      "word": "conserve",
+      "meaning": "conservation (n) /ˌkɒnsəˈveɪʃn/; conservationist (n) /ˌkɒnsəˈveɪʃənɪst/; conservative (adj) /kənˈsɜːvətɪv/; conservatively (adv) /kənˈsɜːvətɪvli/",
+      "example": "Wildlife conservation is crucial for biodiversity; The conservationist spoke at the event; He dressed in a conservative manner; The estimate was conservatively low",
+      "translation": "sự bảo tồn; nhà bảo tồn; bảo thủ; một cách bảo thủ",
+      "count": 0
+    },
+    {
+      "word": "consider",
+      "meaning": "consideration (n) /kənˌsɪdəˈreɪʃn/; considered (adj) /kənˈsɪdəd/; considering (prep) /kənˈsɪdərɪŋ/; considerable (adj) /kənˈsɪdərəbl/; inconsiderable (adj) /ɪnkənˈsɪdərəbl/; considerably (adv) /kənˈsɪdərəbli/",
+      "example": "Your consideration is appreciated; She gave a considered reply; Considering the rain, we stayed home; There was a considerable delay; The change was inconsiderable; Prices rose considerably last year",
+      "translation": "sự cân nhắc; được xem là; xét đến; đáng kể; không đáng kể; một cách đáng kể",
+      "count": 0
+    },
+    {
+      "word": "content",
+      "meaning": "content (n) /ˈkɒntent/; discontent (n) /dɪsˈkɒntent/; contented (adj) /kənˈtentɪd/; discontented (adj) /dɪsˈkɒntentɪd/",
+      "example": "The book’s content was engaging; The decision led to discontent; She felt contented after the meal; Many were discontented with the changes",
+      "translation": "nội dung; bất mãn; hài lòng; không hài lòng",
+      "count": 0
+    },
+    {
+      "word": "continue",
+      "meaning": "discontinue (v) /ˌdɪskənˈtɪnjuː/; continuation (n) /kənˌtɪnjuˈeɪʃn/; continuity (n) /ˌkɒntɪˈnjuːəti/; continual (adj) /kənˈtɪnjuəl/; continuous (adj) /kənˈtɪnjuəs/; continually (adv) /kənˈtɪnjuəli/; continuously (adv) /kənˈtɪnjuəsli/",
+      "example": "They decided to discontinue the service; The continuation of the series was popular; The film lacked continuity; There were continual interruptions; Continuous rain delayed the match; He checked his phone continually; The machine operated continuously",
+      "translation": "ngừng lại; sự tiếp tục; tính liên tục; liên tục; liên tục; một cách liên tục; một cách liên tục",
+      "count": 0
+    },
+    {
+      "word": "convert",
+      "meaning": "conversion (n) /kənˈvɜːʃn/; convertible (adj) /kənˈvɜːtəbl/",
+      "example": "Their conversion to a new system took months; The couch is convertible into a bed",
+      "translation": "sự chuyển đổi; có thể chuyển đổi",
+      "count": 0
+    },
+    {
+      "word": "convince",
+      "meaning": "conviction (n) /kənˈvɪkʃn/; convinced (adj) /kənˈvɪnst/; unconvinced (adj) /ʌnkənˈvɪnst/; convincing (adj) /kənˈvɪnsɪŋ/; unconvincing (adj) /ʌnkənˈvɪnsɪŋ/; convincingly (adv) /kənˈvɪnsɪŋli/; unconvincingly (adv) /ʌnkənˈvɪnsɪŋli/",
+      "example": "Her conviction was clear during the speech; She appeared convinced by the evidence; He seemed unconvinced by the proposal; The argument was convincing; The excuse was unconvincing; She answered convincingly; He spoke unconvincingly about the reasons",
+      "translation": "sự tin chắc; bị thuyết phục; không bị thuyết phục; có sức thuyết phục; không có sức thuyết phục; một cách thuyết phục; một cách không thuyết phục",
+      "count": 0
+    },
+    {
+      "word": "crime",
+      "meaning": "decriminalise (v) /ˈkrɪmɪnəlaɪz/; criminal (n) /ˈkrɪmɪnl/; criminality (n) /ˌkrɪmɪˈnæləti/; criminally (adv) /ˈkrɪmɪnəli/",
+      "example": "The country chose to decriminalise certain offenses; The criminal was quickly arrested; Criminality is on the rise in the region; The law was broken criminally",
+      "translation": "không hình sự hóa; tội phạm; sự phạm tội; một cách phạm pháp",
+      "count": 0
+    },
+    {
+      "word": "decide",
+      "meaning": "decision (n) /dɪˈsɪʒn/; decider (n) /dɪˈsaɪdə(r)/; decisiveness (n) /dɪˈsaɪsɪvnəs/; decisive (adj) /dɪˈsaɪsɪv/; indecisive (adj) /ɪndɪˈsaɪsɪv/; decisively (adv) /dɪˈsaɪsɪvli/",
+      "example": "She made a quick decision; The game’s decider was tense; Decisiveness is vital for leaders; His action was decisive; He was indecisive about the offer; She acted decisively in the crisis",
+      "translation": "quyết định; trận quyết định; sự quyết đoán; quyết đoán; thiếu quyết đoán; một cách quyết đoán",
+      "count": 0
+    },
+    {
+      "word": "declare",
+      "meaning": "declaration (n) /ˌdekləˈreɪʃn/; declared (adj) /dɪˈkleəd/; undeclared (adj) /ʌndɪˈkleəd/",
+      "example": "The minister made a formal declaration; It was a declared conflict; He held an undeclared amount of money",
+      "translation": "tuyên bố; được công bố; không công bố",
+      "count": 0
+    },
+    {
+      "word": "deep",
+      "meaning": "deepen (v) /ˈdiːpən/; depth (n) /depθ/; deeply (adv) /ˈdiːpli/",
+      "example": "The discussion helped deepen their understanding; The lake’s depth surprised divers; She was deeply grateful for the help",
+      "translation": "làm sâu thêm; độ sâu; một cách sâu sắc",
+      "count": 0
+    },
+    {
+      "word": "define",
+      "meaning": "definition (n) /ˌdefɪˈnɪʃn/; defined (adj) /dɪˈfaɪnd/; definitive (adj) /dɪˈfɪnətɪv/; definitely (adv) /ˈdefɪnətli/; indefinite (adj) /ɪnˈdefɪnət/; indefinitely (adv) /ɪnˈdefɪnətli/",
+      "example": "He gave a precise definition in class; The project’s scope was clearly defined; The committee issued a definitive statement; The event will definitely happen; The deadline is indefinite for now; The plans were postponed indefinitely",
+      "translation": "định nghĩa; được xác định; dứt khoát; một cách chắc chắn; không xác định; một cách không xác định",
+      "count": 0
+    },
+    {
+      "word": "dense",
+      "meaning": "density (n) /ˈdensəti/; independence (n) /ˌɪndɪˈpendəns/; dependence (n) /dɪˈpendəns/; dependent (adj) /dɪˈpendənt/; independent (adj) /ˌɪndɪˈpendənt/; dependently (adv) /dɪˈpendəntli/; independently (adv) /ˌɪndɪˈpendəntli/",
+      "example": "The population density is high in the city; They celebrated their independence; His dependence on others decreased; She is still dependent on her parents; He became fully independent after college; They lived dependently for years; She solved the issue independently",
+      "translation": "mật độ; độc lập; sự phụ thuộc; phụ thuộc; độc lập; một cách phụ thuộc; một cách độc lập",
+      "count": 0
+    },
+    {
+      "word": "derive",
+      "meaning": "derivation (n) /ˌderɪˈveɪʃn/; derivative (n/adj) /dɪˈrɪvətɪv/",
+      "example": "The derivation of the word is Latin; That formula is a derivative of the original",
+      "translation": "nguồn gốc; bắt nguồn từ",
+      "count": 0
+    },
+    {
+      "word": "desire",
+      "meaning": "desirable (adj) /dɪˈzaɪərəbl/; undesirable (adj) /ʌndɪˈzaɪərəbl/; desire (n) /dɪˈzaɪə(r)/; desired (adj) /dɪˈzaɪəd/; desirably (adv) /dɪˈzaɪərəbli/; undesirably (adv) /ʌndɪˈzaɪərəbli/",
+      "example": "The property is in a desirable area; The job conditions were undesirable; She felt a strong desire to travel; The desired outcome was achieved; He was desirably qualified; The weather turned undesirably hot",
+      "translation": "đáng ao ước; không đáng ao ước; mong muốn; được mong muốn; một cách mong muốn; một cách không mong muốn",
+      "count": 0
+    },
+    {
+      "word": "destroy",
+      "meaning": "destroyer (n) /dɪˈstrɔɪə(r)/; destruction (n) /dɪˈstrʌkʃn/; indestructible (adj) /ˌɪndɪˈstrʌktəbl/; destructive (adj) /dɪˈstrʌktɪv/; destructively (adv) /dɪˈstrʌktɪvli/",
+      "example": "The destroyer sailed into port; The fire caused great destruction; The safe was indestructible; The criticism was destructive; He acted destructively during the argument",
+      "translation": "tàu khu trục; sự phá hủy; không thể phá hủy; phá hoại; một cách phá hoại",
+      "count": 0
+    },
+    {
+      "word": "distant",
+      "meaning": "equidistant (adj) /ˌekwɪˈdɪstənt/; distantly (adv) /ˈdɪstəntli/",
+      "example": "The houses are equidistant from the main road; She smiled distantly at her friend",
+      "translation": "cách đều nhau; một cách xa cách",
+      "count": 0
+    },
+    {
+      "word": "do",
+      "meaning": "overdo (v) /ˌəʊvəˈduː/; outdo (v) /ˌaʊtˈduː/; redo (v) /ˌriːˈduː/; undo (v) /ʌnˈduː/; did (v) /dɪd/; done (adj) /dʌn/; doing (n) /ˈduːɪŋ/; doings (n) /ˈduːɪŋz/",
+      "example": "Be careful not to overdo the exercise; She managed to outdo her competitors; Please redo the calculations; He tried to undo the knot; He did his best to help; The work is done for the day; What are you doing now? Strange doings were reported",
+      "translation": "làm quá sức; làm giỏi hơn; làm lại; hoàn tác; đã làm; đã xong; hành động; hành vi",
+      "count": 0
+    },
+    {
+      "word": "dominate",
+      "meaning": "domineer (v) /ˌdɒmɪˈnɪə(r)/; domination (n) /ˌdɒmɪˈneɪʃn/; dominance (n) /ˈdɒmɪnəns/; predominant (adj) /prɪˈdɒmɪnənt/; dominant (adj) /ˈdɒmɪnənt/; dominating (adj) /ˈdɒmɪneɪtɪŋ/; predominantly (adv) /prɪˈdɒmɪnəntli/",
+      "example": "He tends to domineer in meetings; The team’s domination was evident; Their dominance in the market continues; The predominant color was blue; She has a dominant personality; His presence was dominating; The staff was predominantly young",
+      "translation": "áp đặt; sự thống trị; sự trội hơn; vượt trội; thống trị; có tính thống trị; chủ yếu",
+      "count": 0
+    },
+    {
+      "word": "doubt",
+      "meaning": "doubter (n) /ˈdaʊtə(r)/; doubtful (adj) /ˈdaʊtfl/; undoubted (adj) /ʌnˈdaʊtɪd/; doubtfully (adv) /ˈdaʊtfl(i)/; undoubtedly (adv) /ʌnˈdaʊtɪdli/",
+      "example": "He is a doubter by nature; The plan is doubtful at best; She is an undoubted talent; He answered doubtfully; She is undoubtedly skilled",
+      "translation": "người nghi ngờ; đáng ngờ; không nghi ngờ; một cách nghi ngờ; một cách không nghi ngờ",
+      "count": 0
+    },
+    {
+      "word": "draw",
+      "meaning": "withdraw (v) /wɪðˈdrɔː/; withdrew (v) /wɪðˈdruː/; drawn (adj) /drɔːn/; withdrawal (n) /wɪðˈdrɔːəl/; drawing (n) /ˈdrɔːɪŋ/; overdraft (n) /ˈəʊvədrɑːft/; overdrawn (adj) /ˌəʊvəˈdrɔːn/; withdrawable (adj) /wɪðˈdrɔːəbl/",
+      "example": "She plans to withdraw from the contest; He withdrew his name from the list; The curtains were drawn at dusk; The withdrawal of troops took weeks; Her drawing was praised; He paid off his overdraft; The account is overdrawn; The funds are withdrawable at any time",
+      "translation": "rút lui; đã rút lui; được kéo; sự rút lui; bản vẽ; thấu chi; bị quá hạn; có thể rút",
+      "count": 0
+    },
+    {
+      "word": "duty",
+      "meaning": "dutiful (adj) /ˈdjuːtɪfl/; dutifully (adv) /ˈdjuːtɪfli/",
+      "example": "He was always dutiful in his tasks; She listened dutifully to instructions",
+      "translation": "có trách nhiệm; một cách có trách nhiệm",
+      "count": 0
+    },
+    {
+      "word": "ecology",
+      "meaning": "ecologist (n) /ɪˈkɒlədʒɪst/; ecological (adj) /ˌiːkəˈlɒdʒɪkl/; ecologically (adv) /ˌiːkəˈlɒdʒɪkli/",
+      "example": "The ecologist studied rare plants; They made an ecological assessment; The system was designed ecologically",
+      "translation": "nhà sinh thái học; thuộc sinh thái; một cách sinh thái",
+      "count": 0
+    },
+    {
+      "word": "edit",
+      "meaning": "edition (n) /ɪˈdɪʃn/; editor (n) /ˈedɪtə(r)/; editorship (n) /ˈedɪtəʃɪp/; edited (adj) /ˈedɪtɪd/; unedited (adj) /ʌnˈedɪtɪd/; editorial (adj) /ˌedɪˈtɔːriəl/; editorially (adv) /ˌedɪˈtɔːriəli/",
+      "example": "She read the latest edition; The editor revised the article; He held the editorship for years; The edited film was released; The footage is unedited; The editorial policy was strict; The article was editorially approved",
+      "translation": "phiên bản; biên tập viên; công việc biên tập; đã chỉnh sửa; chưa chỉnh sửa; thuộc biên tập; một cách biên tập",
+      "count": 0
+    },
+    {
+      "word": "effect",
+      "meaning": "effectiveness (n) /ɪˈfektɪvnəs/; ineffectiveness (n) /ɪnɪˈfektɪvnəs/; effectual (adj) /ɪˈfektʃuəl/; ineffectual (adj) /ɪnɪˈfektʃuəl/; effective (adj) /ɪˈfektɪv/; ineffective (adj) /ɪnɪˈfektɪv/; effectively (adv) /ɪˈfektɪvli/; ineffectively (adv) /ɪnɪˈfektɪvli/",
+      "example": "We measured the treatment’s effectiveness; The plan’s ineffectiveness was clear; This is an effectual remedy; The method was ineffectual for most; The new system is effective; The old tools were ineffective; She responded effectively; The work was done ineffectively",
+      "translation": "sự hiệu quả; không hiệu quả; có hiệu lực; không hiệu lực; hiệu quả; không hiệu quả; một cách hiệu quả; một cách không hiệu quả",
+      "count": 0
+    },
+    {
+      "word": "relate",
+      "meaning": "relation (n) /rɪˈleɪʃn/; relationship (n) /rɪˈleɪʃnʃɪp/; related (adj) /rɪˈleɪtɪd/; unrelated (adj) /ʌnˈreɪtɪd/; relative (adj) /ˈrelətɪv/; relatively (adv) /ˈrelətɪvli/",
+      "example": "They had a strong relation to each other; Their relationship lasted years; The topics are closely related; The issues are unrelated; She is a relative of mine; The task is relatively simple",
+      "translation": "mối quan hệ; mối quan hệ; có liên quan; không liên quan; tương đối; một cách tương đối",
+      "count": 0
+    },
+    {
+      "word": "relax",
+      "meaning": "relaxation (n) /ˌriːlækˈseɪʃn/; relaxing (adj) /rɪˈlæksɪŋ/",
+      "example": "Music helps with relaxation after work; The vacation was very relaxing",
+      "translation": "sự thư giãn; thư giãn",
+      "count": 0
+    },
+    {
+      "word": "repair",
+      "meaning": "repairman (n) /rɪˈpeəmæn/; repairer (n) /rɪˈpeərə/; reparation (n) /ˌrepəˈreɪʃn/; repair (n) /rɪˈpeə/; irreparable (adj) /ɪˈrepərəbl/; irreparably (adv) /ɪˈrepərəbli/",
+      "example": "The repairman fixed the leak; She hired a skilled repairer; The damages needed reparation; The repair was completed on time; The vase was irreparable; The damage was irreparably done",
+      "translation": "thợ sửa chữa; người sửa chữa; sự sửa chữa; sự sửa chữa; không thể sửa; một cách không thể sửa",
+      "count": 0
+    },
+    {
+      "word": "reside",
+      "meaning": "residence (n) /ˈrezɪdns/; resident (n) /ˈrezɪdənt/; residing (adj) /rɪˈzaɪdɪŋ/; residential (adj) /ˌrezɪˈdenʃl/; residentially (adv) /ˌrezɪˈdenʃəli/",
+      "example": "His residence was easy to find; The residents gathered for a meeting; She is currently residing in Paris; The area is mostly residential; The area is residentially zoned",
+      "translation": "nhà ở; cư dân; cư trú; thuộc nhà ở; một cách thuộc về nhà ở",
+      "count": 0
+    },
+    {
+      "word": "resolve",
+      "meaning": "resolution (n) /ˌrezəˈluːʃn/; irresolution (n) /ˌɪrˌrezəˈluːʃn/; resolved (adj) /rɪˈzɒlvd/; unresolved (adj) /ʌnˈrɪˈzɒlvd/; resolute (adj) /ˈrezəluːt/; irresolute (adj) /ɪˈrezəluːt/; resolutely (adv) /ˈrezəluːtli/",
+      "example": "Their resolution was passed unanimously; His irresolution led to delays; She remained resolved to finish; The conflict remained unresolved; He gave a resolute answer; Her response was irresolute; She acted resolutely under pressure",
+      "translation": "sự giải quyết; thiếu quyết đoán; được giải quyết; chưa được giải quyết; kiên quyết; thiếu kiên quyết; một cách kiên quyết",
+      "count": 0
+    },
+    {
+      "word": "respond",
+      "meaning": "response (n) /rɪˈspɒns/; respondent (n) /rɪˈspɒndənt/; responsive (adj) /rɪˈspɒnsɪv/; unresponsive (adj) /ˌʌnˈspɒnsɪv/; responsively (adv) /rɪˈspɒnsɪvli/; unresponsively (adv) /ˌʌnˈspɒnsɪvli/",
+      "example": "His response was immediate; The respondent filled the survey; She is highly responsive to feedback; The device is unresponsive; He nodded responsively; She answered unresponsively",
+      "translation": "phản hồi; người trả lời; đáp ứng; không đáp ứng; một cách đáp ứng; một cách không đáp ứng",
+      "count": 0
+    },
+    {
+      "word": "rest",
+      "meaning": "restlessness (n) /ˈrestləsnəs/; unrest (n) /ʌnˈrest/; restive (adj) /ˈrestɪv/; restful (adj) /ˈrestfl/; restful (adv) /ˈrestfli/; restless (adj) /ˈrestləs/; restlessly (adv) /ˈrestləsli/",
+      "example": "He suffered from restlessness at night; Political unrest spread quickly; The child grew restive during the trip; The park was restful and quiet; She sat restfully in the shade; The night was restless; She slept restlessly",
+      "translation": "sự bồn chồn; bất ổn; bồn chồn; yên tĩnh; một cách yên tĩnh; không yên; một cách không yên",
+      "count": 0
+    },
+    {
+      "word": "result",
+      "meaning": "resultant (adj) /rɪˈzʌltənt/; resulting (adj) /rɪˈzʌltɪŋ/",
+      "example": "The resultant loss was significant; The resulting confusion delayed the project",
+      "translation": "như kết quả; xảy ra do",
+      "count": 0
+    },
+    {
+      "word": "revolt",
+      "meaning": "revolutionise (v) /ˌrevəˈluːʃənaɪz/; revolution (n) /ˌrevəˈluːʃn/; revolutionary (adj) /ˌrevəˈluːʃənəri/; revolting (adj) /rɪˈvəʊltɪŋ/",
+      "example": "The invention will revolutionise the industry; The revolution led to reforms; She had a revolutionary approach; The smell was revolting",
+      "translation": "cách mạng hóa; cách mạng; mang tính cách mạng; gây phản cảm",
+      "count": 0
+    },
+    {
+      "word": "rhythm",
+      "meaning": "rhythmic (adj) /ˈrɪðmɪk/; rhythmical (adj) /ˈrɪðmɪkəl/; rhythmically (adv) /ˈrɪðmɪkli/",
+      "example": "The drummer’s rhythmic beats energized the crowd; The movement was rhythmical and smooth; She danced rhythmically",
+      "translation": "có nhịp điệu; mang tính nhịp điệu; một cách nhịp nhàng",
+      "count": 0
+    },
+    {
+      "word": "rigid",
+      "meaning": "rigidity (n) /rɪˈdʒɪdəti/; rigidly (adv) /ˈrɪdʒɪdli/",
+      "example": "The rigidity of the rule surprised many; He adhered rigidly to the plan",
+      "translation": "sự cứng nhắc; một cách cứng nhắc",
+      "count": 0
+    },
+    {
+      "word": "risk",
+      "meaning": "risky (adj) /ˈrɪski/",
+      "example": "That was a risky investment for the company",
+      "translation": "mạo hiểm",
+      "count": 0
+    },
+    {
+      "word": "surround",
+      "meaning": "surroundings (noun) /səˈraʊndɪŋz/; roundabout (noun) /ˈraʊndəbaʊt/; surrounding (adj) /səˈraʊndɪŋ/; roundly (adv) /ˈraʊndli/",
+      "example": "She enjoyed the peaceful surroundings near the lake; At the roundabout, take the second exit; The surrounding area is known for its vineyards; He was roundly praised for his honesty",
+      "translation": "vùng xung quanh; vòng xuyến; bao quanh; một cách thẳng thắn",
+      "count": 0
+    },
+    {
+      "word": "sane",
+      "meaning": "sanity (noun) /ˈsænəti/; insanity (noun) /ɪnˈsænəti/; insane (adj) /ɪnˈseɪn/; insanely (adv) /ɪnˈseɪnli/",
+      "example": "She managed to keep her sanity despite the stress; Years of isolation led to his insanity; That was an insane risk to take; The mountain trail was insanely difficult to climb",
+      "translation": "sự tỉnh táo; sự điên loạn; điên rồ; một cách điên rồ",
+      "count": 0
+    },
+    {
+      "word": "satisfy",
+      "meaning": "satisfactory (adj) /ˌsætɪsˈfæktəri/; unsatisfactory (adj) /ˌʌnˌsætɪsˈfæktəri/; satisfied (adj) /ˈsætɪsfaɪd/; dissatisfied (adj) /dɪsˈsætɪsfaɪd/; satisfying (adj) /ˈsætɪsfaɪɪŋ/; unsatisfying (adj) /ʌnˈsætɪsfaɪɪŋ/; satisfaction (noun) /ˌsætɪsˈfækʃn/",
+      "example": "The results were satisfactory for everyone; The answer was unsatisfactory to the manager; She felt satisfied with her progress; Many customers were dissatisfied after the update; Completing the project was satisfying; The explanation was unsatisfying; He expressed satisfaction at the outcome",
+      "translation": "đủ tốt; không đủ tốt; hài lòng; không hài lòng; thỏa mãn; không thỏa mãn; sự hài lòng",
+      "count": 0
+    },
+    {
+      "word": "say",
+      "meaning": "gainsay (verb) /ˌɡeɪnˈseɪ/; saying (noun) /ˈseɪɪŋ/; unsaid (adj) /ʌnˈsed/",
+      "example": "No one could gainsay her achievements; There's a saying that honesty is the best policy; Much was left unsaid between them",
+      "translation": "phản đối; câu nói; chưa được nói ra",
+      "count": 0
+    },
+    {
+      "word": "seem",
+      "meaning": "seeming (adj) /ˈsiːmɪŋ/; seemingly (adv) /ˈsiːmɪŋli/",
+      "example": "His seeming confidence impressed the panel; She was seemingly unaffected by the criticism",
+      "translation": "có vẻ; một cách có vẻ",
+      "count": 0
+    },
+    {
+      "word": "select",
+      "meaning": "deselect (verb) /ˌdiːsɪˈlekt/; selection (noun) /sɪˈlekʃn/; selective (adj) /sɪˈlektɪv/; selectively (adv) /sɪˈlektɪvli/",
+      "example": "You may deselect unwanted options in the menu; The selection of candidates was fair; She is very selective about her reading; He listens selectively to advice",
+      "translation": "bỏ chọn; sự lựa chọn; có chọn lọc; một cách chọn lọc",
+      "count": 0
+    },
+    {
+      "word": "self",
+      "meaning": "selfishness (noun) /ˈselfɪʃnəs/; unselfishness (noun) /ʌnˈselfɪʃnəs/; selfishly (adv) /ˈselfɪʃli/; unselfishly (adv) /ʌnˈselfɪʃli/; selfless (adj) /ˈselfləs/; selflessly (adv) /ˈselfləsli/",
+      "example": "His selfishness caused problems in the group; Her unselfishness inspired her friends; He acted selfishly during negotiations; She shared her time unselfishly; The nurse was known for her selfless dedication; Volunteers worked selflessly to help others",
+      "translation": "sự ích kỷ; sự không ích kỷ; ích kỷ; không ích kỷ; vị tha; một cách vị tha",
+      "count": 0
+    },
+    {
+      "word": "sense",
+      "meaning": "desensitise (verb) /ˈdesəntaɪz/; sensitivity (noun) /sɛnsəˈtɪvəti/; insensitivity (noun) /ɪnˌsɛnsəˈtɪvəti/; hypersensitivity (noun) /ˌhaɪpəsensəˈtɪvəti/; sensibility (noun) /ˌsensəˈbɪləti/; senseless (adj) /ˈsensləs/; senselessness (noun) /ˈsensləsnəs/; sensuality (noun) /ˌsenʃuˈæləti/; sensuousness (noun) /ˈsenʃuəsnəs/; sensor (noun) /ˈsensər/; hypersensitive (adj) /ˌhaɪpəˈsensətɪv/; oversensitive (adj) /ˌəʊvəsensətɪv/; nonsense (noun) /ˈnɒnsens/; sensory (adj) /ˈsensəri/",
+      "example": "The treatment helped desensitise her to pain; Sensitivity to others is an important skill; His insensitivity upset many people; Some children have hypersensitivity to noise; Her artistic sensibility was remarkable; The comment was senseless in that context; The senselessness of the act shocked everyone; The novel explored themes of sensuality; The music's sensuousness was appreciated; The sensor activated the alarm; He is hypersensitive to criticism; She can be oversensitive about feedback; That statement is pure nonsense; The test measured sensory responses",
+      "translation": "làm giảm nhạy cảm; sự nhạy cảm; sự thiếu nhạy cảm; sự quá nhạy cảm; sự nhạy cảm; vô nghĩa; sự vô nghĩa; ham muốn nhục dục; sự kích thích giác quan; cảm biến; quá nhạy cảm; quá nhạy cảm; vô lý; thuộc giác quan",
+      "count": 0
+    },
+    {
+      "word": "sense",
+      "meaning": "sensible (adj) /ˈsensəbl/; nonsensical (adj) /ˌnɒnˈsensɪkl/; sensibly (adv) /ˈsensəbli/; sensitive (adj) /ˈsensətɪv/; insensitive (adj) /ɪnˈsensətɪv/; sensitively (adv) /ˈsensətɪvli/; insensitively (adv) /ɪnˈsensətɪvli/; sensational (adj) /senˈseɪʃənl/; insensational (adj) /ɪnˈsɛnseɪʃənl/; sensationally (adv) /senˈseɪʃənəli/; insensationally (adv) /ɪnˈsɛnseɪʃənəli/; sensual (adj) /ˈsenʃuəl/; sensually (adv) /ˈsenʃuəli/; sensuous (adj) /ˈsenʃuəs/; sensuously (adv) /ˈsenʃuəsli/",
+      "example": "She made a sensible choice in the situation; His argument was nonsensical; She responded sensibly to the news; He is sensitive to criticism; He appeared insensitive to others' feelings; She replied sensitively to the question; He answered insensitively in the meeting; The story was sensational in the media; The event was considered insensational by critics; The play was sensationally received; The news was insensationally covered; The artwork has a sensual appeal; The fragrance was described sensually; The fabric felt sensuous; The music played sensuously in the background",
+      "translation": "khôn ngoan; vô lý; một cách hợp lý; nhạy cảm; không nhạy cảm; một cách nhạy cảm; một cách không nhạy cảm; gây xúc động; không gây xúc động; một cách gây xúc động; một cách không gây xúc động; gợi cảm; một cách gợi cảm; kích thích giác quan; một cách kích thích giác quan",
+      "count": 0
+    },
+    {
+      "word": "separate",
+      "meaning": "separation (noun) /ˌsepəˈreɪʃn/; separable (adj) /ˈseprəbl/; inseparable (adj) /ɪnˈseprəbl/; separated (adj) /ˈsepəreɪtɪd/; separately (adv) /ˈseprətli/",
+      "example": "Their separation lasted over a year; These two ideas are separable in theory; The twins have always been inseparable; The couple are now separated; The items were shipped separately",
+      "translation": "sự chia cách; có thể tách rời; không thể tách rời; đã ly thân; một cách riêng biệt",
+      "count": 0
+    },
+    {
+      "word": "shelf",
+      "meaning": "shelve (verb) /ʃelv/; shelves (noun) /ʃelvz/; shelving (noun) /ˈʃelvɪŋ/",
+      "example": "She decided to shelve the proposal for now; The shelves were organized by color; The garage needed new shelving for tools",
+      "translation": "xếp lên kệ; giá sách; vật liệu làm kệ",
+      "count": 0
+    },
+    {
+      "word": "signify",
+      "meaning": "significance (noun) /sɪɡˈnɪfɪkəns/; insignificance (noun) /ɪnˌsɪɡˈnɪfɪkəns/; significantly (adv) /sɪɡˈnɪfɪkəntli/; insignificantly (adv) /ɪnˌsɪɡˈnɪfɪkəntli/",
+      "example": "The change had great significance for the team; The issue was of utter insignificance; Profits increased significantly last year; The error insignificantly affected the results",
+      "translation": "sự quan trọng; sự không quan trọng; một cách đáng kể; một cách không đáng kể",
+      "count": 0
+    },
+    {
+      "word": "slip",
+      "meaning": "slippage (noun) /ˈslɪpɪdʒ/; slippery (adj) /ˈslɪpəri/",
+      "example": "The project suffered from budget slippage; The path became slippery after the rain",
+      "translation": "sự trượt giá; trơn trượt",
+      "count": 0
+    },
+    {
+      "word": "soft",
+      "meaning": "soften (verb) /ˈsɒfn/; softener (noun) /ˈsɒfənər/; softly (adv) /ˈsɒftli/",
+      "example": "Let the butter soften before mixing; Add fabric softener to the wash; She sang softly to the baby",
+      "translation": "làm mềm; chất làm mềm; một cách nhẹ nhàng",
+      "count": 0
+    },
+    {
+      "word": "solid",
+      "meaning": "solidify (verb) /səˈlɪdɪfaɪ/; solidity (noun) /səˈlɪdəti/",
+      "example": "Allow the solution to solidify overnight; The structure was praised for its solidity",
+      "translation": "làm cứng lại; sự vững chắc",
+      "count": 0
+    },
+    {
+      "word": "space",
+      "meaning": "spacing (noun) /ˈspeɪsɪŋ/; spaciousness (noun) /ˈspeɪʃəsnəs/; spacious (adj) /ˈspeɪʃəs/; spaciously (adv) /ˈspeɪʃəsli/",
+      "example": "Adjust the spacing between paragraphs; The spaciousness of the hall impressed guests; Their new apartment is spacious; The room is spaciously decorated",
+      "translation": "sự giãn cách; sự rộng rãi; rộng rãi; một cách rộng rãi",
+      "count": 0
+    },
+    {
+      "word": "speak",
+      "meaning": "spoke (verb) /spəʊk/; speech (noun) /spiːtʃ/; speaker (noun) /ˈspiːkər/; spokesman (noun) /ˈspəʊksmən/; spokeswoman (noun) /ˈspəʊkswʊmən/; spokeswomen (noun) /ˈspəʊkswɪmɪn/; spokesperson (noun) /ˈspəʊkspɜːsn/",
+      "example": "He spoke on behalf of the committee; Her speech captivated the audience; The speaker addressed a large crowd; The company's spokesman issued a statement; The spokeswoman answered questions; The spokeswomen attended the conference; The spokesperson clarified the issue",
+      "translation": "nói; bài phát biểu; diễn giả; người phát ngôn (nam); người phát ngôn (nữ); các nữ phát ngôn viên; người phát ngôn",
+      "count": 0
+    },
+    {
+      "word": "speak",
+      "meaning": "spokespeople (noun) /ˈspəʊksˌpiːpl/; outspokenness (noun) /ˌaʊtˈspəʊkənnəs/; spoken (adj) /ˈspəʊkən/; unspoken (adj) /ʌnˈspəʊkən/; speechless (adj) /ˈspiːtʃləs/; unspeakable (adj) /ʌnˈspiːkəbl/; unspeakably (adv) /ʌnˈspiːkəbli/; outspoken (adj) /ˌaʊtˈspəʊkən/; outspokenly (adv) /ˌaʊtˈspəʊkənli/",
+      "example": "The spokespeople gave interviews after the event; His outspokenness was admired by many; The agreement was spoken clearly; Some worries remained unspoken between them; She was speechless with surprise; The tragedy was unspeakable; The disaster was unspeakably tragic; She is known for her outspoken comments; He spoke out outspokenly about injustice",
+      "translation": "các phát ngôn viên; sự thẳng thắn; được nói ra; chưa được nói ra; không nói nên lời; không thể diễn tả; cực kỳ; thẳng thắn; một cách thẳng thắn",
+      "count": 0
+    },
+    {
+      "word": "speed",
+      "meaning": "sped (verb) /sped/; speeding (noun) /ˈspiːdɪŋ/; speedy (adj) /ˈspiːdi/; speedily (adv) /ˈspiːdɪli/",
+      "example": "He sped away from the scene quickly; He was fined for speeding in the city; The team delivered a speedy response; The paperwork was processed speedily",
+      "translation": "đã chạy nhanh; lái xe quá tốc độ; nhanh chóng; một cách nhanh chóng",
+      "count": 0
+    },
+    {
+      "word": "sport",
+      "meaning": "sportsman (noun) /ˈspɔːtsmən/; sportswoman (noun) /ˈspɔːtsˌwʊmən/; sportsperson (noun) /ˈspɔːtspɜːsn/; sportsmanship (noun) /ˈspɔːtsmənʃɪp/; sports (noun) /spɔːts/; sporting (adj) /ˈspɔːtɪŋ/; sporty (adj) /ˈspɔːti/",
+      "example": "He is a renowned sportsman; She is a skilled sportswoman; The sportsperson broke the record; They showed good sportsmanship after losing; He is interested in many sports; The event had a sporting atmosphere; He wore a sporty jacket to the event",
+      "translation": "vận động viên nam; vận động viên nữ; vận động viên; tinh thần thể thao; các môn thể thao; (thuộc) thể thao; thích thể thao",
+      "count": 0
+    },
+    {
+      "word": "stable",
+      "meaning": "stabilise (verb) /ˈsteɪbəlaɪz/; destabilise (verb) /ˌdiːˈsteɪbəlaɪz/; stability (noun) /stəˈbɪləti/; instability (noun) /ˌɪnstəˈbɪləti/; stabiliser (noun) /ˈsteɪbəlaɪzər/; stabilising (adj) /ˈsteɪbəlaɪzɪŋ/; destabilising (adj) /ˌdiːˈsteɪbəlaɪzɪŋ/",
+      "example": "The medicine helped stabilise her condition; The conflict could destabilise the region; Economic stability is crucial; Political instability threatens growth; The aircraft is equipped with a stabiliser; Meditation has a stabilising effect; The crisis was destabilising for the market",
+      "translation": "làm ổn định; làm mất ổn định; sự ổn định; sự bất ổn định; thiết bị ổn định; mang tính ổn định; mang tính gây bất ổn",
+      "count": 0
+    },
+    {
+      "word": "stand",
+      "meaning": "withstand (verb) /wɪðˈstænd/; withstood (verb) /wɪðˈstʊd/; standing (noun) /ˈstændɪŋ/; upstanding (adj) /ʌpˈstændɪŋ/; outstanding (adj) /aʊtˈstændɪŋ/; notwithstanding (prep) /ˌnɒtwɪðˈstændɪŋ/",
+      "example": "These walls can withstand strong winds; She withstood criticism bravely; His standing in the community is high; He is known as an upstanding citizen; Her achievements are outstanding; Notwithstanding the rain, the game continued",
+      "translation": "chịu đựng; đã chịu đựng; vị thế; thẳng thắn; nổi bật; mặc dù",
+      "count": 0
+    },
+    {
+      "word": "state",
+      "meaning": "restate (verb) /ˌriːˈsteɪt/; overstate (verb) /ˌəʊvəˈsteɪt/; understate (verb) /ˌʌndəˈsteɪt/; statement (noun) /ˈsteɪtmənt/; understatement (noun) /ˌʌndəˈsteɪtmənt/; overstated (adj) /ˌəʊvəˈsteɪtɪd/; understated (adj) /ˌʌndəˈsteɪtɪd/",
+      "example": "She decided to restate her proposal to make it clearer; The article tends to overstate the problem; He tried to understate his involvement; The statement was released by the company this morning; Calling it a setback is an understatement given the losses; The benefits were overstated in the advertisement; The risks were understated in the report",
+      "translation": "nói lại; phóng đại; nói giảm; bản tuyên bố; cách nói giảm; bị phóng đại; bị giảm nhẹ",
+      "count": 0
+    },
+    {
+      "word": "steady",
+      "meaning": "unsteady (adj) /ʌnˈstedi/; unsteadily (adv) /ʌnˈstedəli/; steadily (adv) /ˈstedəli/",
+      "example": "The unsteady ladder made him nervous; She walked unsteadily across the ice; He worked steadily throughout the night",
+      "translation": "không ổn định; một cách không ổn định; một cách đều đặn",
+      "count": 0
+    },
+    {
+      "word": "stimulate",
+      "meaning": "stimulation (noun) /ˌstɪmjʊˈleɪʃn/; stimulant (noun) /ˈstɪmjələnt/; stimulus (noun) /ˈstɪmjələs/; stimuli (noun, plural) /ˈstɪmjʊlaɪ/; stimulating (adj) /ˈstɪmjəleɪtɪŋ/; stimulated (adj) /ˈstɪmjəleɪtɪd/",
+      "example": "Mental stimulation keeps the mind active; Caffeine is a popular stimulant; Praise can be a strong stimulus for improvement; The laboratory tested how various stimuli affect reaction; The conversation was stimulating and inspiring; She felt stimulated by the lively debate",
+      "translation": "sự kích thích; chất kích thích; tác nhân kích thích; các tác nhân kích thích; gây hứng khởi; được kích thích",
+      "count": 0
+    },
+    {
+      "word": "strong",
+      "meaning": "strengthen (verb) /ˈstreŋθn/; strength (noun) /streŋθ/; stronghold (noun) /ˈstrɒŋhəʊld/; strongly (adv) /ˈstrɒŋli/",
+      "example": "They plan to strengthen the local economy; His physical strength is impressive; The fortress was a stronghold for the resistance; She strongly opposed the new policy",
+      "translation": "làm mạnh lên; sức mạnh; thành trì; một cách mạnh mẽ",
+      "count": 0
+    },
+    {
+      "word": "structure",
+      "meaning": "infrastructure (noun) /ˈɪnfrəstrʌktʃə/; structurally (adv) /ˈstrʌktʃərəli/; unstructured (adj) /ʌnˈstrʌktʃərd/",
+      "example": "The city invested heavily in infrastructure; Structurally, the bridge is very sound; The meeting was unstructured and lacked direction",
+      "translation": "cơ sở hạ tầng; về mặt cấu trúc; không có cấu trúc",
+      "count": 0
+    },
+    {
+      "word": "substance",
+      "meaning": "substantiation (noun) /səbˌstænʃiˈeɪʃn/; substantiate (verb) /səbˈstænʃieɪt/; insubstantial (adj) /ˌɪnsəbˈstænʃl/; substantially (adv) /səbˈstænʃəli/",
+      "example": "The lawyer provided further substantiation for his claim; Please substantiate your answer with evidence; The argument was insubstantial and unconvincing; Costs have increased substantially this year",
+      "translation": "sự chứng minh; chứng minh; không đáng kể; một cách đáng kể",
+      "count": 0
+    },
+    {
+      "word": "suggest",
+      "meaning": "suggestion (noun) /səˈdʒestʃn/; suggested (adj) /səˈdʒestɪd/; suggestive (adj) /səˈdʒestɪv/; suggestibly (adv) /səˈdʒestəbl/",
+      "example": "He made a useful suggestion during the meeting; The changes were suggested by the committee; Her comments were suggestive of something hidden; Children are often suggestibly influenced by advertisements",
+      "translation": "sự đề xuất; được đề xuất; mang tính gợi ý; dễ bị ảnh hưởng",
+      "count": 0
+    },
+    {
+      "word": "sympathy",
+      "meaning": "sympathise (verb) /ˈsɪmpəθaɪz/; sympathiser (noun) /ˈsɪmpəθaɪzər/; unsympathetic (adj) /ˌʌnsɪmpəˈθetɪk/; sympathetically (adv) /sɪmpəˈθetɪkli/",
+      "example": "I always try to sympathise with those in trouble; She is a well-known sympathiser of environmental causes; The judge seemed unsympathetic to his explanation; He listened sympathetically to her story",
+      "translation": "đồng cảm; người ủng hộ; không đồng cảm; một cách cảm thông",
+      "count": 0
+    },
+    {
+      "word": "talk",
+      "meaning": "talker (noun) /ˈtɔːkər/; talkie (noun) /ˈtɔːki/; talkback (noun) /ˈtɔːkbæk/; talkative (adj) /ˈtɔːkətɪv/",
+      "example": "He is not much of a talker in meetings; They watched a classic talkie on TV; The radio show encourages talkback from listeners; She is very talkative with friends",
+      "translation": "người nói; phim nói; phản hồi; nhiều chuyện",
+      "count": 0
+    },
+    {
+      "word": "tend",
+      "meaning": "tendency (noun) /ˈtendənsi/",
+      "example": "There is a tendency for people to check their phones frequently",
+      "translation": "xu hướng",
+      "count": 0
+    },
+    {
+      "word": "terror",
+      "meaning": "terrorise (verb) /ˈterəraɪz/; terrify (verb) /ˈterəfaɪ/; terrorist (noun) /ˈterərɪst/; terrorism (noun) /ˈterərɪzəm/; terror (noun) /ˈterər/; terrible (adj) /ˈterəbl/; terrific (adj) /təˈrɪfɪk/; terrifying (adj) /ˈterəfaɪɪŋ/; terrified (adj) /ˈterəfaɪd/; terribly (adv) /ˈterəbli/",
+      "example": "The group tried to terrorise the population; Thunderstorms always terrify the dog; The terrorist was arrested at the airport; The country faces ongoing terrorism; She was filled with terror after the accident; The food tasted terrible; His work is terrific; It was a terrifying rollercoaster ride; He is terrified of heights; She was terribly late for the interview",
+      "translation": "khủng bố; làm khiếp sợ; kẻ khủng bố; chủ nghĩa khủng bố; nỗi kinh hoàng; tồi tệ; tuyệt vời; gây kinh hãi; sợ hãi; rất",
+      "count": 0
+    },
+    {
+      "word": "think",
+      "meaning": "thought (noun) /θɔːt/; thinker (noun) /ˈθɪŋkər/; thinking (noun) /ˈθɪŋkɪŋ/; thoughtfulness (noun) /ˈθɔːtfəlnəs/; thoughtlessness (noun) /ˈθɔːtləsnəs/; unthinkable (adj) /ʌnˈθɪŋkəbl/; thoughtful (adj) /ˈθɔːtfl/; thoughtless (adj) /ˈθɔːtləs/; thoughtfully (adv) /ˈθɔːtfl(i)/; thoughtlessly (adv) /ˈθɔːtləsli/",
+      "example": "The idea came to him as a sudden thought; She is regarded as a deep thinker; His way of thinking is very logical; Her thoughtfulness cheered me up; His thoughtlessness upset the team; It was unthinkable to cancel the trip; That was a thoughtful gesture; It was a thoughtless mistake; He replied thoughtfully; She spoke thoughtlessly about the topic",
+      "translation": "ý nghĩ; nhà tư tưởng; sự suy nghĩ; sự chu đáo; sự vô tâm; không thể nghĩ tới; chu đáo; thiếu suy nghĩ; một cách chu đáo; một cách thiếu suy nghĩ",
+      "count": 0
+    },
+    {
+      "word": "threat",
+      "meaning": "threaten (verb) /ˈθretn/; threatened (adj) /ˈθretənd/; threateningly (adv) /ˈθretnɪŋli/",
+      "example": "They threatened to reveal the secret; Several species are threatened by pollution; She looked at him threateningly",
+      "translation": "đe dọa; bị đe dọa; một cách đe dọa",
+      "count": 0
+    },
+    {
+      "word": "time",
+      "meaning": "mistime (verb) /ˌmɪsˈtaɪm/; timer (noun) /ˈtaɪmər/; timing (noun) /ˈtaɪmɪŋ/; overtime (noun) /ˈəʊvətaɪm/; timetable (noun) /ˈtaɪmteɪbl/; timelessness (noun) /ˈtaɪmləsnəs/; untimely (adj) /ˈʌnˈtaɪmli/; timely (adj) /ˈtaɪmli/; timelessly (adv) /ˈtaɪmləsli/",
+      "example": "He mistimed his arrival and missed the meeting; Set the timer for ten minutes; Her timing was perfect in the race; He often works overtime to finish projects; The timetable was updated last week; The painting has a sense of timelessness; The actor's untimely death shocked fans; The response was timely and effective; The song remains timelessly popular",
+      "translation": "định thời gian sai; đồng hồ bấm giờ; thời gian; làm thêm giờ; thời gian biểu; sự vượt thời gian; không đúng lúc; đúng lúc; một cách vượt thời gian",
+      "count": 0
+    },
+    {
+      "word": "transit",
+      "meaning": "transition (noun) /trænˈzɪʃn/; transitory (adj) /ˈtrænzətri/; transitional (adj) /trænˈzɪʃənl/; transitionally (adv) /trænˈzɪʃnəli/",
+      "example": "The team is going through a difficult transition; Temporary jobs are often transitory; There will be a transitional phase next year; Roles changed transitionally as the company grew",
+      "translation": "sự chuyển đổi; tạm thời; chuyển tiếp; một cách chuyển tiếp",
+      "count": 0
+    },
+    {
+      "word": "type",
+      "meaning": "typeset (verb) /ˈtaɪpset/; typecast (verb) /ˈtaɪpkɑːst/; typify (verb) /ˈtɪpɪfaɪ/; typist (noun) /ˈtaɪpɪst/; typewriter (noun) /ˈtaɪpraɪtər/; typeface (noun) /ˈtaɪpfeɪs/; typesetting (noun) /ˈtaɪpsetɪŋ/; typesetter (noun) /ˈtaɪpsetər/; typewritten (adj) /ˈtaɪprɪtn/; typically (adv) /ˈtɪpɪkl(i)/",
+      "example": "He learned how to typeset newspaper pages; She was typecast as the villain in movies; The building typifies the style of the era; The typist finished the report quickly; My grandfather owned a typewriter; This typeface is easy to read; Typesetting has become digital today; The typesetter made several adjustments; The contract was typewritten and signed; She typically arrives early to meetings",
+      "translation": "sắp chữ; đóng khung; là điển hình; người đánh máy; máy đánh chữ; kiểu chữ; sự sắp chữ; thợ sắp chữ; được đánh máy; một cách điển hình",
+      "count": 0
+    },
+    {
+      "word": "up",
+      "meaning": "uppermost (adj) /ˈʌpəməʊst/; upright (adj) /ˈʌpraɪt/; upwards (adv) /ˈʌpwəd(z)/; upwardly (adv) /ˈʌpwədli/",
+      "example": "The uppermost shelf holds the rarely used items; Please keep your back upright; The balloon drifted upwards into the sky; Salaries have moved upwardly over the last year",
+      "translation": "cao nhất; thẳng đứng; lên trên; một cách tăng lên",
+      "count": 0
+    },
+    {
+      "word": "use",
+      "meaning": "abuse (verb) /əˈbjuːz/; misuse (verb) /ˌmɪsˈjuːz/; reuse (verb) /ˌriːˈjuːz/; overuse (verb) /ˌəʊvəˈjuːz/; user (noun) /ˈjuːzər/; usefulness (noun) /ˈjuːsfəlnəs/; usage (noun) /ˈjuːsɪdʒ/; uselessness (noun) /ˈjuːsləsnəs/; unused (adj) /ˌʌnˈjuːzd/; unusable (adj) /ˈjuːzəbl/; reusable (adj) /ˌriːˈjuːzəbl/; abused (adj) /əˈbjuːzd/; abusively (adv) /əˈbjuːsɪvli/; usefully (adv) /ˈjuːsfəli/",
+      "example": "Never abuse your authority at work; Don't misuse chemicals in the lab; It's smart to reuse shopping bags; Overuse of antibiotics can cause problems; The app has many regular users; The usefulness of this tool is obvious; Usage of the word has changed; The product’s uselessness became apparent; The coupon was left unused; The equipment is unusable after the accident; These bottles are reusable; The abused pet was rescued; He spoke abusively to the staff; She acted usefully during the crisis",
+      "translation": "lạm dụng; dùng sai; tái sử dụng; dùng quá mức; người dùng; tính hữu dụng; cách sử dụng; sự vô dụng; chưa dùng; không thể dùng; có thể tái sử dụng; bị lạm dụng; một cách lạm dụng; một cách hữu ích",
+      "count": 0
+    },
+    {
+      "word": "value",
+      "meaning": "revalue (verb) /ˌriːˈvæljuː/; overvalue (verb) /ˌəʊvəˈvæljuː/; evaluate (verb) /ɪˈvæljueɪt/; evaluation (noun) /ˌɪvæljuˈeɪʃn/; overvaluation (noun) /ˌəʊvərˌvæljuˈeɪʃn/; valuer (noun) /ˈvæljuər/; valuables (noun, plural) /ˈvæljəblz/; invaluable (adj) /ɪnˈvæljuəbl/; valueless (adj) /ˈvæljuləs/",
+      "example": "The bank decided to revalue its currency; Investors often overvalue new technology; Managers need to evaluate employee performance; The evaluation will take two weeks; There is a risk of overvaluation in the housing market; A valuer was called to assess the property; Keep your valuables locked away; Her support was invaluable during the crisis; The broken phone is now valueless",
+      "translation": "định giá lại; đánh giá quá cao; đánh giá; sự đánh giá; sự định giá quá cao; người định giá; vật có giá trị; vô giá; không có giá trị",
+      "count": 0
+    },
+    {
+      "word": "weigh",
+      "meaning": "weight (noun) /weɪt/; weightlifter (noun) /ˈweɪtlɪftər/; weightlifting (noun) /ˈweɪtlɪftɪŋ/; weightiness (noun) /ˈweɪtinəs/; overweight (adj) /ˌəʊvəˈweɪt/; underweight (adj) /ˌʌndəˈweɪt/; weighted (adj) /ˈweɪtɪd/; weightlessness (noun) /ˈweɪtləsnəs/; weighty (adj) /ˈweɪti/",
+      "example": "He checks his weight every morning; The weightlifter broke a world record; Weightlifting requires strong muscles; Her words carried weightiness in the discussion; Doctors advise patients who are overweight to exercise; She is slightly underweight for her age; The dice were weighted for fairness; Astronauts experience weightlessness in space; It was a weighty issue for the board",
+      "translation": "cân nặng; vận động viên cử tạ; môn cử tạ; sự quan trọng; thừa cân; thiếu cân; có trọng lượng; trạng thái không trọng lượng; nghiêm trọng",
+      "count": 0
+    },
+    {
+      "word": "wild",
+      "meaning": "wilderness (noun) /ˈwɪldənəs/; wildlife (noun) /ˈwaɪldlaɪf/; wildness (noun) /ˈwaɪldnəs/; wildly (adv) /ˈwaɪldli/",
+      "example": "They camped in the wilderness for a week; The reserve protects local wildlife; The wildness of the party surprised everyone; He laughed wildly at the joke",
+      "translation": "vùng hoang dã; động vật hoang dã; sự hoang dã; một cách điên cuồng",
+      "count": 0
+    },
+    {
+      "word": "wise",
+      "meaning": "wisdom (noun) /ˈwɪzdəm/; wisely (adv) /ˈwaɪzli/; unwisely (adv) /ʌnˈwaɪzli/",
+      "example": "He is admired for his wisdom; She wisely chose to save her money; He spent his money unwisely on unnecessary things",
+      "translation": "sự khôn ngoan; một cách khôn ngoan; một cách không khôn ngoan",
+      "count": 0
+    },
+    {
+      "word": "reword",
+      "meaning": "reword (verb) /ˌriːˈwɜːd/; wording (noun) /ˈwɜːdɪŋ/; wordplay (noun) /ˈwɜːdpleɪ/; wordy (adj) /ˈwɜːdi/; worded (adj) /ˈwɜːdɪd/; wordlessly (adv) /ˈwɜːdləsli/",
+      "example": "Please reword the introduction for clarity; The legal wording was complicated; His jokes rely on clever wordplay; The essay was too wordy and repetitive; The message was carefully worded; She watched the scene wordlessly",
+      "translation": "diễn đạt lại; cách diễn đạt; chơi chữ; dài dòng; được soạn thảo; một cách không nói nên lời",
+      "count": 0
+    },
+    {
+      "word": "work",
+      "meaning": "rework (verb) /ˌriːˈwɜːk/; overwork (verb) /ˌəʊvəˈwɜːk/; worker (noun) /ˈwɜːkər/; works (noun, plural) /wɜːks/; workplace (noun) /ˈwɜːkpleɪs/; working (noun) /ˈwɜːkɪŋ/; unworkable (adj) /ʌnˈwɜːkəbl/",
+      "example": "We need to rework the draft before submitting; She often overworks herself at her job; The worker finished his shift; His collected works are published worldwide; The workplace must meet safety standards; The working of this device is simple; The proposal is unworkable in practice",
+      "translation": "làm lại; làm việc quá sức; công nhân; tác phẩm; nơi làm việc; hoạt động; không khả thi",
+      "count": 0
+    },
+    {
+      "word": "worth",
+      "meaning": "worthlessness (noun) /ˈwɜːθləsnəs/; worthy (adj) /ˈwɜːði/; worthless (adj) /ˈwɜːθləs/; worthwhile (adj) /ˌwɜːθˈwaɪl/",
+      "example": "She struggled with feelings of worthlessness; He is a worthy opponent in chess; The device became worthless after it broke; The project was worthwhile despite challenges",
+      "translation": "sự vô giá trị; xứng đáng; vô giá trị; đáng giá",
+      "count": 0
+    },
+    {
+      "word": "write",
+      "meaning": "rewrite (verb) /ˌriːˈraɪt/; wrote (verb, past) /rəʊt/; written (adj) /ˈrɪtn/; writings (noun, plural) /ˈraɪtɪŋz/; writer (noun) /ˈraɪtər/; unwritten (adj) /ʌnˈrɪtn/",
+      "example": "She had to rewrite the report after feedback; He wrote a letter to his friend; The instructions were clearly written; His writings inspire many readers; She became a successful writer; Some rules are unwritten but understood",
+      "translation": "viết lại; đã viết; được viết; bài viết; nhà văn; không được viết ra",
+      "count": 0
+    },
+    {
+      "word": "young",
+      "meaning": "youngster (noun) /ˈjʌŋstər/; youth (noun) /juːθ/; youthful (adj) /ˈjuːθfl/",
+      "example": "The youngster excelled in school; He spent his youth traveling the world; Her style is very youthful",
+      "translation": "người trẻ; tuổi trẻ; trẻ trung",
+      "count": 0
+    },
+    {
+      "word": "zeal",
+      "meaning": "zealot (noun) /ˈzelət/; zealously (adv) /ˈzeləsli/",
+      "example": "A zealot will defend their beliefs passionately; She worked zealously to complete the project",
+      "translation": "người cuồng tín; một cách sốt sắng",
+      "count": 0
+    },
+    {
+      "word": "avoid",
+      "meaning": "avoidance (noun) /əˈvɔɪdəns/; unavoidable (adj) /əˈvɔɪdəbl/; unavoidably (adv) /ˌʌnəˈvɔɪdəbli/",
+      "example": "His avoidance of responsibility was obvious; Delays were unavoidable due to the storm; The flight was unavoidably canceled by weather",
+      "translation": "sự tránh né; không thể tránh; một cách không thể tránh",
+      "count": 0
+    },
+    {
+      "word": "awe",
+      "meaning": "awfulness (noun) /ˈɔːflnəs/; awesomeness (noun) /ˈɔːsəmnəs/; awestruck (adj) /ˈɔːstrʌk/; awfully (adv) /ˈɔːfəli/; awesomely (adv) /ˈɔːsəmli/",
+      "example": "The awfulness of the scene was shocking; The team's awesomeness impressed everyone; She stood awestruck at the mountain view; The room was awfully quiet; The band played awesomely at the concert",
+      "translation": "sự kinh khủng; sự tuyệt vời; kinh ngạc; một cách kinh khủng; một cách tuyệt vời",
+      "count": 0
+    },
+    {
+      "word": "believe",
+      "meaning": "disbelieve (verb) /ˌdɪsbɪˈliːv/; belief (noun) /bɪˈliːf/; believer (noun) /bɪˈliːvər/; unbelievable (adj) /ˌʌnbɪˈliːvəbl/; disbelievingly (adv) /ˌdɪsbɪˈliːvɪŋli/",
+      "example": "She disbelieves in ghosts; His belief in justice is strong; He is a true believer in equal rights; The story sounded unbelievable; She looked at him disbelievingly",
+      "translation": "không tin; niềm tin; người tin tưởng; không thể tin được; một cách không tin",
+      "count": 0
+    },
+    {
+      "word": "benefit",
+      "meaning": "beneficiary (noun) /ˌbenɪˈfɪʃəri/; beneficial (adj) /ˌbenɪˈfɪʃl/; beneficially (adv) /ˌbenɪˈfɪʃəli/",
+      "example": "The beneficiary received the payment after the settlement; A balanced diet is beneficial to long-term health; The new policy was applied beneficially in rural areas",
+      "translation": "người hưởng lợi; có lợi; một cách có lợi",
+      "count": 0
+    },
+    {
+      "word": "brief",
+      "meaning": "debriefing (noun) /ˈbriːfɪŋ/; brevity (noun) /ˈbrevəti/; briefs (noun) /briːfs/; briefly (adv) /ˈbriːfli/",
+      "example": "The debriefing covered every detail of the operation; The presentation was praised for its brevity; He packed several briefs for the trip; She spoke briefly at the meeting",
+      "translation": "cuộc thẩm vấn; sự ngắn gọn; quần lót nam; một cách ngắn gọn",
+      "count": 0
+    },
+    {
+      "word": "brilliant",
+      "meaning": "brilliance (noun) /ˈbrɪljəns/; brilliantly (adv) /ˈbrɪljəntli/",
+      "example": "Her brilliance shone through in the challenging interview; He solved the puzzle brilliantly under pressure",
+      "translation": "sự tài giỏi; một cách xuất sắc",
+      "count": 0
+    },
+    {
+      "word": "broad",
+      "meaning": "broaden (verb) /ˈbrɔːdn/; breadth (noun) /bredθ/; broadly (adv) /ˈbrɔːdli/",
+      "example": "Travelling helps broaden your perspective; The river had impressive breadth after the storm; The proposal was broadly supported across teams",
+      "translation": "mở rộng; chiều rộng; một cách rộng rãi",
+      "count": 0
+    },
+    {
+      "word": "capable",
+      "meaning": "capability (noun) /ˌkeɪpəˈbɪləti/; incapable (adj) /ɪnˈkeɪpəbl/",
+      "example": "The company has the capability to expand globally; He is incapable of dishonesty",
+      "translation": "khả năng; không có khả năng",
+      "count": 0
+    },
+    {
+      "word": "cause",
+      "meaning": "causation (noun) /kɔːˈzeɪʃn/; causal (adj) /ˈkɔːzl/; causative (adj) /ˈkɔːzətɪv/",
+      "example": "The investigation focused on the causation of the fire; There is a causal relationship between diet and health; Poor hygiene is a causative factor in disease",
+      "translation": "nguyên nhân; thuộc về nhân quả; là nguyên nhân gây ra",
+      "count": 0
+    },
+    {
+      "word": "change",
+      "meaning": "exchange (noun) /ɪksˈtʃeɪndʒ/; changeover (noun) /ˈtʃeɪndʒəʊvə/; unchanging (adj) /ʌnˈtʃeɪndʒɪŋ/; changeable (adj) /ˈtʃeɪndʒəbl/; interchangeable (adj) /ˌɪntəˈtʃeɪndʒəbl/",
+      "example": "Currency exchange is required when traveling abroad; The factory completed the changeover in record time; His attitude toward his friends remained unchanging; The schedule is changeable depending on demand; These two parts are completely interchangeable",
+      "translation": "sự trao đổi; sự chuyển đổi; không thay đổi; có thể thay đổi; có thể thay thế cho nhau",
+      "count": 0
+    },
+    {
+      "word": "approve",
+      "meaning": "disapprove (verb) /ˌdɪsəˈpruːv/; approval (noun) /əˈpruːvəl/; disapproval (noun) /ˌdɪsəˈpruːvəl/; approved (adj) /əˈpruːvd/; disapproved (adj) /ˌdɪsəˈpruːvd/; approvingly (adv) /əˈpruːvɪŋli/; disapprovingly (adv) /ˌdɪsəˈpruːvɪŋli/",
+      "example": "Her parents disapprove of the decision; The project received final approval yesterday; His actions were met with disapproval; The policy is now officially approved; Their request was disapproved after review; She nodded approvingly at the suggestion; He looked disapprovingly at the messy room",
+      "translation": "không tán thành; sự phê duyệt; sự không đồng tình; được thông qua; bị bác bỏ; một cách tán thành; một cách không tán thành",
+      "count": 0
+    },
+    {
+      "word": "architect",
+      "meaning": "architecture (noun) /ˈɑːkɪtektʃə/; architecturally (adv) /ˌɑːkɪˈtektʃərəli/",
+      "example": "The museum is an example of modern architecture; The district is architecturally unique compared to others",
+      "translation": "kiến trúc; về mặt kiến trúc",
+      "count": 0
+    },
+    {
+      "word": "argue",
+      "meaning": "argument (noun) /ˈɑːɡjumənt/; argumentative (adj) /ˌɑːɡjumənˈtetɪv/; arguable (adj) /ˈɑːɡjuəbl/; unarguable (adj) /ʌnˈɑːɡjuəbl/; arguably (adv) /ˈɑːɡjuəbli/",
+      "example": "Their argument lasted into the night; He has an argumentative nature at meetings; That claim is only arguable with more evidence; The outcome is unarguable based on the data; She is arguably the most experienced candidate",
+      "translation": "sự tranh luận; thích tranh cãi; có thể tranh cãi; không thể tranh cãi; có thể cho là",
+      "count": 0
+    },
+    {
+      "word": "arrange",
+      "meaning": "rearrange (verb) /ˌriːəˈreɪndʒ/; arrangement (noun) /əˈreɪndʒmənt/; rearrangement (noun) /ˌriːəˈreɪndʒmənt/; arranged (adj) /əˈreɪndʒd/",
+      "example": "They plan to rearrange the furniture next week; The travel arrangement included all meals; The rearrangement made the process more efficient; Everything was arranged before the event",
+      "translation": "sắp xếp lại; sự sắp xếp; sự sắp xếp lại; đã được sắp xếp",
+      "count": 0
+    },
+    {
+      "word": "art",
+      "meaning": "arts (noun) /ɑːts/; artfulness (noun) /ˈɑːtfəlnəs/; artificiality (noun) /ˌɑːtɪˌfɪʃiˈæləti/; artist (noun) /ˈɑːtɪst/; artistic (adj) /ɑːˈtɪstɪk/; artistically (adv) /ɑːˈtɪstɪkli/; artificial (adj) /ˌɑːtɪˈfɪʃl/; artificially (adv) /ˌɑːtɪˈfɪʃəli/; artful (adj) /ˈɑːtfəl/; artfully (adv) /ˈɑːtfəli/; artless (adj) /ˈɑːtləs/; artlessly (adv) /ˈɑːtləsli/",
+      "example": "She has always enjoyed the arts; The magician performed with great artfulness; The artificiality of the product was obvious; The artist displayed new work last month; His approach is artistic and innovative; The room was decorated artistically; The flower looked artificial in the bouquet; The cake was artificially sweetened; It was an artful maneuver during negotiations; She responded artfully in conversation; The answer was charmingly artless; He admitted his mistake artlessly",
+      "translation": "nghệ thuật; sự khéo léo; tính chất nhân tạo; nghệ sĩ; thuộc về nghệ thuật; một cách nghệ thuật; nhân tạo; một cách nhân tạo; khéo léo; một cách khéo léo; ngây thơ; một cách ngây thơ",
+      "count": 0
+    },
+    {
+      "word": "assess",
+      "meaning": "reassess (verb) /ˌriːəˈses/; assessment (noun) /əˈsesmənt/; reassessment (noun) /ˌriːəˈsesmənt/; assessor (noun) /əˈsesər/; assessed (adj) /əˈsest/",
+      "example": "The school will reassess the program next year; The assessment was completed in May; The reassessment revealed new priorities; The assessor visited the site on Friday; The house was assessed for taxes",
+      "translation": "đánh giá lại; sự đánh giá; sự đánh giá lại; người đánh giá; đã được đánh giá",
+      "count": 0
+    },
+    {
+      "word": "associate",
+      "meaning": "dissociate (verb) /dɪˈsəʊʃieɪt/; association (noun) /əˌsəʊsiˈeɪʃn/; associate (noun) /əˈsəʊʃiət/; associated (adj) /əˈsəʊsieɪtɪd/",
+      "example": "She tried to dissociate herself from the incident; The association organized the conference; He’s a senior associate at the firm; The risks are associated with poor planning",
+      "translation": "tách rời; hiệp hội; cộng sự; có liên quan",
+      "count": 0
+    },
+    {
+      "word": "assume",
+      "meaning": "assumption (noun) /əˈsʌmpʃn/; assuming (conj) /əˈsjuːmɪŋ/; unassuming (adj) /ˌʌnəˈsjuːmɪŋ/; assumed (adj) /əˈsjuːmd/",
+      "example": "That is a dangerous assumption to make; Assuming the weather stays clear, we’ll go hiking; His unassuming attitude made him well-liked; She used an assumed name in the story",
+      "translation": "giả định; giả sử; khiêm tốn; giả tạo",
+      "count": 0
+    },
+    {
+      "word": "attach",
+      "meaning": "reattach (verb) /ˌriːəˈtætʃ/; attachment (noun) /əˈtætʃmənt/; unattached (adj) /ʌnəˈtætʃt/",
+      "example": "She had to reattach the loose part before the meeting; The email contained an important attachment for review; He remained unattached throughout the project, working independently",
+      "translation": "đính kèm lại; tệp đính kèm; không gắn bó",
+      "count": 0
+    },
+    {
+      "word": "available",
+      "meaning": "availability (noun) /əˌveɪləˈbɪləti/; unavailability (noun) /ʌnəˌveɪləˈbɪləti/",
+      "example": "The availability of resources was confirmed early; Internet unavailability caused a delay in the online training",
+      "translation": "sự sẵn có; sự không sẵn có",
+      "count": 0
+    },
+    {
+      "word": "access",
+      "meaning": "accessibility (noun) /ˌæk.ses.əˈbɪl.ə.ti/; accessible (adj) /əkˈsesəbl/; inaccessible (adj) /ˌɪn.əkˈses.ə.bəl/",
+      "example": "The accessibility of public spaces has improved; The library is accessible to all students; This document is inaccessible without proper clearance",
+      "translation": "khả năng tiếp cận; có thể tiếp cận; không thể tiếp cận",
+      "count": 0
+    },
+    {
+      "word": "act",
+      "meaning": "enact (verb) /ɪˈnækt/; react (verb) /riˈækt/; counteract (verb) /ˌkaʊntərˈækt/; interact (verb) /ˌɪntərˈækt/; transact (verb) /trænˈzækt/; overact (verb) /ˌəʊvərˈækt/; overreact (verb) /ˌəʊvəriˈækt/; deactivate (verb) /diːˈæktɪveɪt/; reactivate (verb) /riˈæktɪveɪt/; acting (adj) /ˈæktɪŋ/; actor (noun) /ˈæktər/; actress (noun) /ˈæktrəs/; action (noun) /ˈækʃən/; inactivity (noun) /ˌɪn.ækˈtɪv.ə.ti/; radioactivity (noun) /ˌreɪ.di.əʊ.ækˈtɪv.ə.ti/; transaction (noun) /trænˈzækʃən/; activist (noun) /ˈæktɪvɪst/; activism (noun) /ˈæktɪvɪzəm/; interaction (noun) /ˌɪntərˈækʃən/; overreaction (noun) /ˌəʊvəriˈækʃən/; overacting (noun) /ˌəʊvərˈæktɪŋ/; reactionary (adj) /riˈækʃənəri/; reactor (noun) /riˈæktər/; transactional (adj) /trænˈzækʃənl/; active (adj) /ˈæktɪv/; hyperactive (adj) /ˌhaɪ.pərˈæk.tɪv/; radioactive (adj) /ˌreɪ.di.əʊˈæk.tɪv/; overactive (adj) /ˌəʊvərˈæktɪv/; actively (adv) /ˈæk.tɪvli/; inactively (adv) /ˈɪn.æk.tɪvli/",
+      "example": "The new policy was enacted last year; She reacted calmly to the unexpected news; The antidote can counteract the poison’s effect; Students often interact with each other in group projects; They transact business primarily online; He tends to overact in dramatic roles; Please don’t overreact to minor setbacks; The device was deactivated after use; The security system can be reactivated remotely; The acting manager called an emergency meeting; The actor received critical acclaim; The actress starred in a popular series; Decisive action is needed in an emergency; Prolonged inactivity can affect your health; The team measured radioactivity in soil samples; The transaction was completed successfully; The activist organized several events; Environmental activism has grown rapidly; Positive interaction improves team morale; His overreaction surprised everyone; Overacting can ruin a performance; The policy attracted criticism from reactionary groups; The reactor was safely shut down; The new software uses transactional emails; She remains active despite her age; The child is extremely hyperactive; Radioactive waste must be stored carefully; His glands are overactive; He contributed actively to the discussion; The engine ran inactively for months",
+      "translation": "ban hành; phản ứng; chống lại; tương tác; giao dịch; diễn quá mức; phản ứng thái quá; tắt; kích hoạt lại; tạm quyền; nam diễn viên; nữ diễn viên; hành động; sự không hoạt động; chất phóng xạ; giao dịch; nhà hoạt động; chủ nghĩa hoạt động; sự tương tác; sự phản ứng thái quá; sự diễn quá mức; phản động; lò phản ứng; mang tính giao dịch; năng động; hiếu động; phóng xạ; hoạt động quá mức; một cách năng động; một cách không hoạt động",
+      "count": 0
+    },
+    {
+      "word": "adapt",
+      "meaning": "adaptation (noun) /ˌædæpˈteɪʃən/; adaptor (noun) /əˈdæptər/; adaptable (adj) /əˈdæptəbl/",
+      "example": "The adaptation of the story became a successful play; He bought a new adaptor for his laptop; She is highly adaptable to new working environments",
+      "translation": "sự thích nghi; bộ chuyển đổi; có thể thích nghi",
+      "count": 0
+    },
+    {
+      "word": "add",
+      "meaning": "addendum (noun) /əˈdendəm/; addenda (noun) /əˈdendə/; additive (noun) /ˈædətɪv/; additional (adj) /əˈdɪʃənl/; additionally (adv) /əˈdɪʃənli/",
+      "example": "An addendum was issued with the latest update; The report contains several addenda; This product is free from harmful additives; Additional resources were provided for the project; Additionally, he offered his support",
+      "translation": "phụ lục; các phụ lục; chất phụ gia; bổ sung; ngoài ra",
+      "count": 0
+    },
+    {
+      "word": "adequate",
+      "meaning": "adequacy (noun) /ˈædɪkwəsi/; inadequacy (noun) /ɪnˈædɪkwəsi/; inadequate (adj) /ɪnˈædɪkwət/; adequately (adv) /ˈædɪkwətli/; inadequately (adv) /ɪnˈædɪkwətli/",
+      "example": "There are concerns about the adequacy of the data; His lack of experience revealed his inadequacy; The current staff is inadequate for the workload; The machine operates adequately in most conditions; The work was inadequately supervised",
+      "translation": "sự đầy đủ; sự thiếu hụt; không đủ; một cách đầy đủ; một cách không đầy đủ",
+      "count": 0
+    },
+    {
+      "word": "adjust",
+      "meaning": "readjust (verb) /ˌriː.əˈdʒʌst/; adjustment (noun) /əˈdʒʌstmənt/; adjustable (adj) /əˈdʒʌstəbl/",
+      "example": "He had to readjust after moving to a new city; The adjustment improved the results; This seat is fully adjustable for comfort",
+      "translation": "điều chỉnh lại; sự điều chỉnh; có thể điều chỉnh",
+      "count": 0
+    },
+    {
+      "word": "admire",
+      "meaning": "admiration (noun) /ˌædməˈreɪʃən/; admirer (noun) /ədˈmaɪərər/; admirable (adj) /ˈædmərəbl/; admirably (adv) /ˈædmərəbli/; admiringly (adv) /ədˈmaɪərɪŋli/",
+      "example": "He earned admiration for his honesty; She discovered a secret admirer at work; His admirable efforts were noticed; She solved the problem admirably; He looked at her admiringly after the performance",
+      "translation": "sự ngưỡng mộ; người ngưỡng mộ; đáng ngưỡng mộ; một cách đáng ngưỡng mộ; một cách ngưỡng mộ",
+      "count": 0
+    },
+    {
+      "word": "aggression",
+      "meaning": "aggressiveness (noun) /əˈɡresɪvnəs/; aggressor (noun) /əˈɡresər/; aggressive (adj) /əˈɡresɪv/; aggressively (adv) /əˈɡresɪvli/",
+      "example": "His aggressiveness worried the team; The aggressor was quickly apprehended; She has an aggressive negotiation style; He drove aggressively through traffic",
+      "translation": "tính hung hăng; kẻ tấn công; hung hăng; một cách hung hăng",
+      "count": 0
+    },
+    {
+      "word": "alter",
+      "meaning": "alteration (noun) /ˌɔːltəˈreɪʃən/; alterable (adj) /ˈɔːltərəbl/; unaltered (adj) /ʌnˈɔːltəd/; alternate (adj) /ˈɔːltərnət/; alternative (noun) /ɔːlˈtɜːnətɪv/",
+      "example": "There was a minor alteration to the design; The contract terms are alterable upon request; The results remained unaltered after testing; The schedule follows alternate days; We discussed an alternative to the current plan",
+      "translation": "sự thay đổi; có thể thay đổi; không thay đổi; luân phiên; phương án thay thế",
+      "count": 0
+    },
+    {
+      "word": "analyse",
+      "meaning": "analysis (noun) /əˈnæləsɪs/; analyst (noun) /ˈænəlɪst/; analytical (adj) /ˌænəˈlɪtɪkl/",
+      "example": "We performed a detailed analysis of the results; The analyst predicted a positive trend; She has a highly analytical mind",
+      "translation": "sự phân tích; nhà phân tích; (thuộc) phân tích",
+      "count": 0
+    },
+    {
+      "word": "antique",
+      "meaning": "antiquity (noun) /ænˈtɪkwəti/; antiquated (adj) /ˈæntɪkweɪtɪd/",
+      "example": "The gallery displays artifacts from antiquity; That equipment is considered antiquated now",
+      "translation": "thời cổ đại; lỗi thời",
+      "count": 0
+    },
+    {
+      "word": "appear",
+      "meaning": "disappear (verb) /ˌdɪsəˈpɪər/; reappear (verb) /ˌriːəˈpɪə(r)/; disappearance (noun) /ˌdɪsəˈpɪərəns/; reappearance (noun) /ˌriːəˈpɪərəns/; apparition (noun) /ˌæpəˈrɪʃn/; apparent (adj) /əˈpærənt/; apparently (adv) /əˈpærəntli/",
+      "example": "The painting seemed to disappear under new light; He may reappear in the next episode; Her disappearance was reported immediately; His reappearance surprised everyone; They claimed to see an apparition in the hallway; The cause of the issue is not apparent; Apparently, the results were misreported",
+      "translation": "biến mất; xuất hiện lại; sự biến mất; sự xuất hiện lại; bóng ma; rõ ràng; có vẻ như",
+      "count": 0
+    },
+    {
+      "word": "apply",
+      "meaning": "reapply (verb) /ˌriːəˈplaɪ/; misapply (verb) /ˌmɪsəˈplaɪ/; applicant (noun) /ˈæplɪkənt/; application (noun) /ˌæplɪˈkeɪʃn/; applicability (noun) /ˌæplɪkəˈbɪləti/; inapplicability (noun) /ˌɪnˌæplɪkəˈbɪləti/; applicable (adj) /ˈæplɪkəbl/; inapplicable (adj) /ɪnˈæplɪkəbl/; applied (adj) /əˈplaɪd/; misapplied (adj) /ˌmɪsəˈplaɪd/",
+      "example": "She will reapply for the position next year; The funds were misapplied by the manager; Each applicant must complete the form; The application deadline is Friday; This concept has broad applicability; Its inapplicability was soon clear; The rule is applicable in most cases; That standard is inapplicable here; This is an applied field of study; The method was misapplied in practice",
+      "translation": "nộp lại; áp dụng sai; người nộp đơn; đơn xin; khả năng áp dụng; không thể áp dụng; có thể áp dụng; không thể áp dụng; (thuộc) ứng dụng; bị áp dụng sai",
+      "count": 0
+    },
+    {
+      "word": "appreciate",
+      "meaning": "appreciation (noun) /əˌpriːʃiˈeɪʃn/; appreciable (adj) /əˈpriːʃəbl/; appreciably (adv) /əˈpriːʃəbli/; appreciative (adj) /əˈpriːʃətɪv/; unappreciative (adj) /ʌnəˈpriːʃətɪv/; appreciatively (adv) /əˈpriːʃətɪvli/; unappreciatively (adv) /ʌnəˈpriːʃətɪvli/",
+      "example": "His work earned widespread appreciation; The price increase was appreciable; The company grew appreciably last year; The team was very appreciative of her help; He was unappreciative of their support; She smiled appreciatively at the gift; He listened unappreciatively to the feedback",
+      "translation": "sự cảm kích; đáng kể; một cách đáng kể; biết ơn; không biết ơn; một cách biết ơn; một cách không biết ơn",
+      "count": 0
+    }   
+  ]
+}

--- a/src/data/defaultVocabulary.ts
+++ b/src/data/defaultVocabulary.ts
@@ -1,9 +1,4 @@
-import { SheetData } from "@/types/vocabulary";
-//import { SheetData } from "@/data/defaultVocabulary";
+import data from './defaultVocabulary.json';
+import { SheetData } from '@/types/vocabulary';
 
-export const DEFAULT_VOCABULARY_DATA: SheetData = 
-//import { SheetData } from "@/data/defaultVocabulary";
-//export const DEFAULT_VOCABULARY_DATA: SheetData = 
-{
-  
-}
+export const DEFAULT_VOCABULARY_DATA = data as SheetData;

--- a/src/services/vocabulary/VocabularyDataManager.ts
+++ b/src/services/vocabulary/VocabularyDataManager.ts
@@ -72,62 +72,17 @@ export class VocabularyDataManager {
   mergeImportedData(importedData: SheetData): void {
     this.importer.mergeImportedData(importedData, this.data);
   }
-  
+
   loadDefaultVocabulary(): boolean {
     try {
       console.log("Loading default vocabulary data");
-      
-      // Try to fetch the updated default vocabulary from public directory
-      fetch('/defaultVocabulary.json')
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(`Failed to fetch default vocabulary: ${response.status}`);
-          }
-          return response.json();
-        })
-        .then(fetchedData => {
-          console.log("Successfully loaded default vocabulary from JSON file");
-          console.log("Fetched data preview:", Object.keys(fetchedData).map(key => 
-            `${key}: ${fetchedData[key]?.length || 0} words`
-          ));
-          
-          // Process data to ensure all fields have proper types
-          this.data = this.dataProcessor.processDataTypes(fetchedData);
-          this.storage.saveData(this.data);
-          
-          // Notify listeners about vocabulary change
-          this.notifyVocabularyChange();
-        })
-        .catch(error => {
-          console.warn("Failed to load from JSON file, using embedded default data:", error);
-          
-          // Use the embedded default data as fallback
-          console.log("Using embedded default vocabulary data");
-          this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
-          this.storage.saveData(this.data);
-          
-          console.log("Embedded data loaded:", Object.keys(this.data).map(key => 
-            `${key}: ${this.data[key]?.length || 0} words`
-          ));
-          
-          // Notify listeners about vocabulary change
-          this.notifyVocabularyChange();
-        });
-      
+      this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
+      this.storage.saveData(this.data);
+      this.notifyVocabularyChange();
       return true;
     } catch (error) {
       console.error("Failed to load default vocabulary:", error);
-      
-      // Last resort fallback - use embedded data synchronously
-      try {
-        this.data = this.dataProcessor.processDataTypes(DEFAULT_VOCABULARY_DATA);
-        this.storage.saveData(this.data);
-        this.notifyVocabularyChange();
-        return true;
-      } catch (fallbackError) {
-        console.error("Critical error: Failed to load any vocabulary data:", fallbackError);
-        return false;
-      }
+      return false;
     }
   }
   

--- a/src/utils/allWords.ts
+++ b/src/utils/allWords.ts
@@ -1,23 +1,21 @@
 import type { VocabularyWord } from '@/types/vocabulary';
+import { DEFAULT_VOCABULARY_DATA } from '@/data/defaultVocabulary';
+
 export type WordEntry = VocabularyWord;
 
 let cachedWords: WordEntry[] | null = null;
 
-async function fetchAllWords(): Promise<WordEntry[]> {
-  if (cachedWords) return cachedWords;
-  const res = await fetch('/defaultVocabulary.json');
-  if (!res.ok) {
-    throw new Error(`Failed to fetch vocabulary (${res.status})`);
+function loadWords(): WordEntry[] {
+  if (!cachedWords) {
+    cachedWords = Object.entries(DEFAULT_VOCABULARY_DATA).flatMap(([category, words]) =>
+      (words || []).map((w) => ({ ...w, category }))
+    );
   }
-  const data: Record<string, WordEntry[]> = await res.json();
-  cachedWords = Object.entries(data).flatMap(([category, words]) =>
-    words.map((w) => ({ ...w, category }))
-  );
   return cachedWords;
 }
 
-export async function loadAllWords(): Promise<WordEntry[]> {
-  const words = await fetchAllWords();
+export function loadAllWords(): WordEntry[] {
+  const words = loadWords();
   console.info(`QuickSearch: loaded ${words.length} words`);
   return words;
 }


### PR DESCRIPTION
## Summary
- inline default vocabulary JSON via build-time import
- load default vocabulary synchronously without fetch
- provide synchronous allWords loader using embedded data

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb0f7fdc832f8d0f00bf689efc7c