### PR TITLE
feat: fallback to full list when no daily words

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -102,6 +102,13 @@ export const useVocabularyDataLoader = (
           todayWords = Array.from(map.values());
         }
 
+        if (todayWords.length === 0) {
+          console.log(
+            '[DATA-LOADER] No daily selection available, falling back to full list'
+          );
+          todayWords = allWords;
+        }
+
         setWordList(todayWords);
         setHasData(todayWords.length > 0);
 


### PR DESCRIPTION
## Summary
- fallback to full word list when today's selection is empty and log this scenario

## Testing
- `npm test -- --run` *(fails: process produced excessive output and did not complete in time)*
- `npm run lint` *(fails: 52 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4030bb8cc832f84dca12dcf9ddcb3