### PR TITLE
feat: build daily selection from all vocabulary sheets

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -73,10 +73,13 @@ export const useVocabularyDataLoader = (
 
     console.log('[DATA-LOADER] Loading initial vocabulary data');
 
-    const loadData = () => {
+    const loadData = async () => {
       clearStartTimer();
       try {
-        const allWords = vocabularyService.getWordList();
+        if (!vocabularyService.hasData()) {
+          await vocabularyService.loadDefaultVocabulary();
+        }
+        const allWords = vocabularyService.getAllWords();
         console.log(`[DATA-LOADER] Loaded ${allWords.length} words`);
 
         const selection =
@@ -155,13 +158,13 @@ export const useVocabularyDataLoader = (
       }
     };
 
-    loadData();
+    void loadData();
 
     // Subscribe to vocabulary changes
     const handleVocabularyChange = () => {
       console.log('[DATA-LOADER] Vocabulary data changed, reloading');
       clearAutoAdvanceTimer(); // Clear timer when data changes
-      loadData();
+      void loadData();
     };
 
     vocabularyService.addVocabularyChangeListener(handleVocabularyChange);

--- a/src/services/vocabulary/VocabularyService.ts
+++ b/src/services/vocabulary/VocabularyService.ts
@@ -38,6 +38,11 @@ export class VocabularyService {
     const currentSheet = this.sheetOperations.getCurrentSheetName();
     return this.dataManager.getWordList(currentSheet);
   }
+
+  // NEW: Method to get all words across every sheet
+  getAllWords(): VocabularyWord[] {
+    return this.sheetOptions.flatMap(sheet => this.dataManager.getWordList(sheet));
+  }
   
   // FIXED: Method to add a vocabulary change listener
   addVocabularyChangeListener(listener: VocabularyChangeListener): void {

--- a/tests/useVocabularyDataLoaderAllSheets.test.ts
+++ b/tests/useVocabularyDataLoaderAllSheets.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useVocabularyDataLoader } from '@/hooks/vocabulary-controller/core/useVocabularyDataLoader';
+import { VocabularyWord } from '@/types/vocabulary';
+import { vocabularyService } from '@/services/vocabularyService';
+import { learningProgressService } from '@/services/learningProgressService';
+import { getTodayLastWord } from '@/utils/lastWordStorage';
+
+vi.mock('@/services/vocabularyService', () => ({
+  vocabularyService: {
+    getAllWords: vi.fn(),
+    addVocabularyChangeListener: vi.fn(),
+    removeVocabularyChangeListener: vi.fn(),
+    loadDefaultVocabulary: vi.fn(),
+    hasData: vi.fn().mockReturnValue(false)
+  }
+}));
+
+vi.mock('@/services/learningProgressService', () => ({
+  learningProgressService: {
+    getTodaySelection: vi.fn().mockReturnValue(null),
+    forceGenerateDailySelection: vi.fn().mockReturnValue(null)
+  }
+}));
+
+vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
+vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn()
+};
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+const getTodayLastWordMock = getTodayLastWord as unknown as vi.Mock;
+
+describe('useVocabularyDataLoader all sheets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+    getTodayLastWordMock.mockReturnValue(undefined);
+  });
+
+  it('generates daily selection from multiple categories on first load', async () => {
+    const words: VocabularyWord[] = [
+      { word: 'a', meaning: '', example: '', category: 'c1', count: 1 },
+      { word: 'b', meaning: '', example: '', category: 'c2', count: 1 }
+    ];
+    vocabularyService.getAllWords.mockReturnValue(words);
+    vocabularyService.loadDefaultVocabulary.mockResolvedValue(true);
+
+    const setWordList = vi.fn();
+    const setHasData = vi.fn();
+    const setCurrentIndex = vi.fn();
+
+    renderHook(() =>
+      useVocabularyDataLoader(setWordList, setHasData, setCurrentIndex, 0, 'v', vi.fn())
+    );
+
+    await waitFor(() => {
+      expect(vocabularyService.loadDefaultVocabulary).toHaveBeenCalled();
+      expect(learningProgressService.forceGenerateDailySelection).toHaveBeenCalledWith(words, 'light');
+      expect(setWordList).toHaveBeenCalledWith(words);
+    });
+  });
+});
+

--- a/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
+++ b/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
@@ -11,10 +11,12 @@ import { getTodayLastWord } from '@/utils/lastWordStorage';
 
 vi.mock('@/services/vocabularyService', () => ({
   vocabularyService: {
-    getWordList: vi.fn(),
+    getAllWords: vi.fn(),
     getCurrentSheetName: vi.fn(),
     addVocabularyChangeListener: vi.fn(),
-    removeVocabularyChangeListener: vi.fn()
+    removeVocabularyChangeListener: vi.fn(),
+    loadDefaultVocabulary: vi.fn(),
+    hasData: vi.fn().mockReturnValue(true)
   }
 }));
 
@@ -55,7 +57,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
       { word: 'a', meaning: '', example: '', category: 'c', count: 1 },
       { word: 'b', meaning: '', example: '', category: 'c', count: 1 }
     ];
-    vocabularyService.getWordList.mockReturnValue(words);
+    vocabularyService.getAllWords.mockReturnValue(words);
     vocabularyService.getCurrentSheetName.mockReturnValue('c');
 
     const now = new Date('2024-01-01T10:00:00Z').getTime();
@@ -89,7 +91,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
       { word: 'a', meaning: '', example: '', category: 'c', count: 1 },
       { word: 'b', meaning: '', example: '', category: 'c', count: 1 }
     ];
-    vocabularyService.getWordList.mockReturnValue(words);
+    vocabularyService.getAllWords.mockReturnValue(words);
     vocabularyService.getCurrentSheetName.mockReturnValue('c');
 
     const now = new Date('2024-01-01T10:00:00Z').getTime();
@@ -123,7 +125,7 @@ describe('useVocabularyDataLoader nextAllowedTime handling', () => {
       { word: 'a', meaning: '', example: '', category: 'c', count: 1 },
       { word: 'b', meaning: '', example: '', category: 'c', count: 1 }
     ];
-    vocabularyService.getWordList.mockReturnValue(words);
+    vocabularyService.getAllWords.mockReturnValue(words);
     vocabularyService.getCurrentSheetName.mockReturnValue('c');
 
     const now = new Date('2024-01-01T10:00:00Z').getTime();


### PR DESCRIPTION
## Summary
- add `getAllWords` to `VocabularyService` to aggregate words across all sheets
- load default vocabulary then use `getAllWords` in `useVocabularyDataLoader`
- verify multi-sheet selection with new unit test

## Testing
- `npx vitest run tests/useVocabularyDataLoaderAllSheets.test.ts tests/useVocabularyDataLoaderNextAllowedTime.test.ts`
- `CI=1 npm test` *(fails: channel closed)*
- `npm run lint` *(fails: Unexpected any, empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_68a421b0c838832f82984b7e100ca823