### PR TITLE
feat: remember last vocabulary sheet

### DIFF
--- a/src/services/vocabulary/VocabularySheetOperations.ts
+++ b/src/services/vocabulary/VocabularySheetOperations.ts
@@ -13,22 +13,23 @@ export class VocabularySheetOperations {
     this.sheetOptions = sheetOptions;
     this.wordNavigation = new WordNavigation(dataManager.getData(), this.sheetOptions);
     
-    // Set default sheet to "phrasal verbs" instead of "All words"
-    let initialSheet = "phrasal verbs";
-    
-    // Get initial sheet name from localStorage if available
+    // Try to restore last used sheet from localStorage
+    let restoredSheet: string | null = null;
     try {
       const storedStates = localStorage.getItem(BUTTON_STATES_KEY);
       if (storedStates) {
         const parsedStates = JSON.parse(storedStates);
         if (parsedStates.currentCategory && this.sheetOptions.includes(parsedStates.currentCategory)) {
-          initialSheet = parsedStates.currentCategory;
-          console.log(`Restored sheet name from localStorage: ${initialSheet}`);
+          restoredSheet = parsedStates.currentCategory;
+          console.log(`Restored sheet name from localStorage: ${restoredSheet}`);
         }
       }
     } catch (error) {
       console.error("Error reading sheet name from localStorage:", error);
     }
+
+    // Use restored sheet if available, otherwise fall back to first sheet option
+    const initialSheet = restoredSheet ?? this.sheetOptions[0];
     
     this.wordNavigation.setCurrentSheetName(initialSheet);
     this.wordNavigation.shuffleCurrentSheet();

--- a/tests/vocabularySheetOperations.test.ts
+++ b/tests/vocabularySheetOperations.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { VocabularySheetOperations } from '@/services/vocabulary/VocabularySheetOperations';
+import { BUTTON_STATES_KEY } from '@/utils/storageKeys';
+
+const createOps = (sheetOptions: string[]) => {
+  const mockManager = {
+    getData: () => ({}),
+    notifyVocabularyChange: () => {}
+  } as any;
+  return new VocabularySheetOperations(mockManager, sheetOptions);
+};
+
+// Simple in-memory localStorage mock
+const createLocalStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    }
+  } as Storage;
+};
+
+describe('VocabularySheetOperations initial sheet', () => {
+  beforeEach(() => {
+    Object.defineProperty(global, 'localStorage', { value: createLocalStorage(), writable: true });
+  });
+
+  it('restores category from localStorage when available', () => {
+    localStorage.setItem(BUTTON_STATES_KEY, JSON.stringify({ currentCategory: 'idioms' }));
+    const ops = createOps(['idioms', 'phrasal verbs']);
+    expect(ops.getCurrentSheetName()).toBe('idioms');
+  });
+
+  it('falls back to first sheet option when no stored category exists', () => {
+    const ops = createOps(['idioms', 'phrasal verbs']);
+    expect(ops.getCurrentSheetName()).toBe('idioms');
+  });
+});


### PR DESCRIPTION
## Summary
- restore last used sheet from localStorage and fall back to the first available sheet
- add tests covering sheet restoration and default selection

## Testing
- `npx vitest run tests/vocabularySheetOperations.test.ts`
- `npm run lint` *(fails: Unexpected any and empty block statements)*
- `npm test -- --run` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a421b52340832fbc3cbd5f7018e0d6