### PR TITLE
Stop speech instantly when muting playback

### DIFF
--- a/src/hooks/vocabulary-playback/core/usePlaybackControls.ts
+++ b/src/hooks/vocabulary-playback/core/usePlaybackControls.ts
@@ -48,6 +48,8 @@ export const usePlaybackControls = (cancelSpeech: () => void, playCurrentWord: (
       unifiedSpeechController.setMuted(newMuted);
 
       if (newMuted) {
+        cancelSpeech();
+        playCurrentWord();
         toast.info("Audio playback muted");
       } else {
         if (!paused) {
@@ -58,7 +60,7 @@ export const usePlaybackControls = (cancelSpeech: () => void, playCurrentWord: (
 
       return newMuted;
     });
-  }, [paused, playCurrentWord]);
+  }, [paused, playCurrentWord, cancelSpeech]);
   
   // Function to toggle pause with full speech handling
   const togglePause = useCallback(() => {

--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -252,15 +252,17 @@ class RealSpeechService {
   setMuted(muted: boolean): void {
     if (this.currentUtterance) {
       this.currentUtterance.volume = muted ? 0 : 1;
-      // Force the speech engine to apply the new volume immediately by
-      // briefly pausing and resuming. The resume is deferred to the next
-      // task to ensure the volume change takes effect before speaking
-      // continues.
+
       if (window.speechSynthesis?.speaking) {
-        window.speechSynthesis.pause();
-        setTimeout(() => {
-          window.speechSynthesis.resume();
-        }, 0);
+        if (muted) {
+          window.speechSynthesis.cancel();
+          window.speechSynthesis.speak(this.currentUtterance);
+        } else {
+          window.speechSynthesis.pause();
+          setTimeout(() => {
+            window.speechSynthesis.resume();
+          }, 0);
+        }
       }
     }
   }

--- a/tests/realSpeechServiceMute.test.ts
+++ b/tests/realSpeechServiceMute.test.ts
@@ -12,6 +12,8 @@ describe('realSpeechService mute control', () => {
       speaking: false,
       pause: vi.fn(),
       resume: vi.fn(),
+      cancel: vi.fn(),
+      speak: vi.fn(),
     };
   });
 
@@ -38,5 +40,17 @@ describe('realSpeechService mute control', () => {
     expect(window.speechSynthesis.resume).not.toHaveBeenCalled();
     vi.runAllTimers();
     expect(window.speechSynthesis.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels and restarts speech when muting mid-utterance', () => {
+    const fakeUtterance = { volume: 1 } as unknown as SpeechSynthesisUtterance;
+    (realSpeechService as any).currentUtterance = fakeUtterance;
+    (window.speechSynthesis as any).speaking = true;
+
+    realSpeechService.setMuted(true);
+
+    expect(fakeUtterance.volume).toBe(0);
+    expect(window.speechSynthesis.cancel).toHaveBeenCalledTimes(1);
+    expect(window.speechSynthesis.speak).toHaveBeenCalledWith(fakeUtterance);
   });
 });

--- a/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
+++ b/tests/useSimpleVocabularyPlaybackMuteToggle.test.ts
@@ -61,6 +61,9 @@ describe('useSimpleVocabularyPlayback mute toggling', () => {
     expect(setMutedMock).toHaveBeenLastCalledWith(true);
     expect(playWordMock).toHaveBeenCalledTimes(2);
     expect(playWordMock.mock.calls[1][0].word).toBe('alpha');
+    const muteOrder = setMutedMock.mock.invocationCallOrder.at(-1)!;
+    const playOrder = playWordMock.mock.invocationCallOrder.at(-1)!;
+    expect(muteOrder).toBeLessThan(playOrder);
 
     act(() => {
       result.current.goToNext();


### PR DESCRIPTION
## Summary
- Cancel any active utterance and replay current word when muting
- Silence speech engine immediately on mute to avoid audio tails
- Add tests for mute behavior and speech service restart

## Testing
- `npm test tests/realSpeechServiceMute.test.ts tests/useSimpleVocabularyPlaybackMuteToggle.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a42c61b7bc832fb9f3ec2bddb6bd50