### PR TITLE
feat: adjust mute control sequence

### DIFF
--- a/src/hooks/vocabulary-playback/core/usePlaybackControls.ts
+++ b/src/hooks/vocabulary-playback/core/usePlaybackControls.ts
@@ -45,13 +45,14 @@ export const usePlaybackControls = (cancelSpeech: () => void, playCurrentWord: (
     console.log('Toggle mute called');
     setMuted(prev => {
       const newMuted = !prev;
-      unifiedSpeechController.setMuted(newMuted);
 
       if (newMuted) {
         cancelSpeech();
+        unifiedSpeechController.setMuted(true);
         playCurrentWord();
         toast.info("Audio playback muted");
       } else {
+        unifiedSpeechController.setMuted(false);
         if (!paused) {
           playCurrentWord();
           toast.success("Audio playback resumed");


### PR DESCRIPTION
## Summary
- cancel speech before muting and immediately replay current word muted
- unmute sets speech controller before resuming playback

## Testing
- `npx vitest run`
- `npx eslint src/hooks/vocabulary-playback/core/usePlaybackControls.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a43879f454832fb1bbbf6cd8cd2e8b