### PR TITLE
Cancel speech on mute without restart

### DIFF
--- a/src/services/speech/realSpeechService.ts
+++ b/src/services/speech/realSpeechService.ts
@@ -256,7 +256,6 @@ class RealSpeechService {
       if (window.speechSynthesis?.speaking) {
         if (muted) {
           window.speechSynthesis.cancel();
-          window.speechSynthesis.speak(this.currentUtterance);
         } else {
           window.speechSynthesis.pause();
           setTimeout(() => {

--- a/tests/realSpeechServiceMute.test.ts
+++ b/tests/realSpeechServiceMute.test.ts
@@ -42,7 +42,7 @@ describe('realSpeechService mute control', () => {
     expect(window.speechSynthesis.resume).toHaveBeenCalledTimes(1);
   });
 
-  it('cancels and restarts speech when muting mid-utterance', () => {
+  it('cancels speech when muting mid-utterance', () => {
     const fakeUtterance = { volume: 1 } as unknown as SpeechSynthesisUtterance;
     (realSpeechService as any).currentUtterance = fakeUtterance;
     (window.speechSynthesis as any).speaking = true;
@@ -51,6 +51,6 @@ describe('realSpeechService mute control', () => {
 
     expect(fakeUtterance.volume).toBe(0);
     expect(window.speechSynthesis.cancel).toHaveBeenCalledTimes(1);
-    expect(window.speechSynthesis.speak).toHaveBeenCalledWith(fakeUtterance);
+    expect(window.speechSynthesis.speak).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Prevent restarting speech when muting by canceling after setting volume to zero
- Update mute tests to expect cancellation only

## Testing
- `npm test tests/realSpeechServiceMute.test.ts`
- `npm run lint` *(fails: 95 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a4387e8138832fae9b057c68d254da