### PR TITLE
Cancel speech before muting playback

### DIFF
--- a/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
+++ b/src/hooks/vocabulary-playback/useSimpleVocabularyPlayback.ts
@@ -25,7 +25,7 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
   const { currentIndex, currentWord, advanceToNext, goToPrevious, goToWord } = useSimpleWordNavigation(wordList);
   
   // Word playback
-  const { playWord, isSpeaking } = useSimpleWordPlayback(
+  const { playWord, stopPlayback: cancelSpeech, isSpeaking } = useSimpleWordPlayback(
     selectedVoice,
     findVoice,
     advanceToNext,
@@ -89,13 +89,19 @@ export const useSimpleVocabularyPlayback = (wordList: VocabularyWord[]) => {
     const newMuted = !muted;
     console.log(`[SIMPLE-VOCABULARY] ✓ Toggling mute: ${newMuted}`);
     setMuted(newMuted);
-    unifiedSpeechController.setMuted(newMuted);
 
-    if (newMuted && currentWord) {
-      console.log('[SIMPLE-VOCABULARY] Restarting current word while muted');
-      playWord(currentWord);
+    if (newMuted) {
+      cancelSpeech();
+      unifiedSpeechController.setMuted(true);
+
+      if (currentWord) {
+        console.log('[SIMPLE-VOCABULARY] Restarting current word while muted');
+        playWord(currentWord);
+      }
+    } else {
+      unifiedSpeechController.setMuted(false);
     }
-  }, [muted, currentWord, playWord]);
+  }, [muted, currentWord, playWord, cancelSpeech]);
 
   const togglePause = useCallback(() => {
     const newPaused = !paused;


### PR DESCRIPTION
## Summary
- Cancel current speech before muting in `useSimpleVocabularyPlayback` to avoid residual audio and replay silently.
- Extend mute toggle test to verify cancellation occurs before muting and replay ordering.

## Testing
- `npm test tests/useSimpleVocabularyPlaybackMuteToggle.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a43881a7a4832fac7ae7c94f1d645b