### PR TITLE
Fix status after updating word progress

### DIFF
--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -121,7 +121,8 @@ export class LearningProgressService {
       progress.isLearned = true;
       progress.reviewCount += 1;
       progress.nextReviewDate = this.calculateNextReviewDate(progress.reviewCount);
-      progress.status = 'due';
+      progress.status =
+        progress.nextReviewDate > today ? 'not_due' : 'due';
       progress.nextAllowedTime = new Date().toISOString();
       
       progressMap.set(wordKey, progress);


### PR DESCRIPTION
## Summary
- ensure `updateWordProgress` marks future reviews as `not_due`
- test that freshly reviewed words are removed from due list until the scheduled date

## Testing
- `npm test -- --run`
- `npx vitest run tests/learningProgress.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a5f6e88a20832f9f96a526321bee2b