### PR TITLE
Expose global word search

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -85,6 +85,7 @@ const VocabularyAppWithLearning: React.FC = () => {
     setWordToReset(null);
   };
 
+  // Opens the global search modal, optionally pre-filling with a word
   const openSearch = (word: string = '') => {
     setSearchWord(word);
     setIsSearchOpen(true);

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
 import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
+import WordSearchModal from './vocabulary-app/WordSearchModal';
 
 const VocabularyAppWithLearning: React.FC = () => {
   useDailyUsageTracker('default');
@@ -18,6 +19,8 @@ const VocabularyAppWithLearning: React.FC = () => {
   const [summaryOpen, setSummaryOpen] = useState(false);
   const [isMarkAsNewDialogOpen, setIsMarkAsNewDialogOpen] = useState(false);
   const [wordToReset, setWordToReset] = useState<string | null>(null);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchWord, setSearchWord] = useState('');
 
   const {
     dailySelection,
@@ -80,6 +83,11 @@ const VocabularyAppWithLearning: React.FC = () => {
     }
     setIsMarkAsNewDialogOpen(false);
     setWordToReset(null);
+  };
+
+  const openSearch = (word: string = '') => {
+    setSearchWord(word);
+    setIsSearchOpen(true);
   };
 
   const learningSection = (
@@ -188,6 +196,7 @@ const VocabularyAppWithLearning: React.FC = () => {
             markCurrentWordLearned(word);
           }}
           additionalContent={learningSection}
+          onOpenSearch={openSearch}
         />
       </div>
       <MarkAsNewDialog
@@ -196,6 +205,7 @@ const VocabularyAppWithLearning: React.FC = () => {
         onConfirm={handleMarkAsNew}
         word={wordToReset || ''}
       />
+      <WordSearchModal isOpen={isSearchOpen} onClose={() => setIsSearchOpen(false)} searchWord={searchWord} />
     </>
   );
 };

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -29,6 +29,7 @@ interface ContentWithDataNewProps {
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
   additionalContent?: React.ReactNode;
+  onOpenSearch?: (word?: string) => void;
 }
 
 const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
@@ -51,7 +52,8 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenEditWordModal,
   playCurrentWord,
   onMarkWordLearned,
-  additionalContent
+  additionalContent,
+  onOpenSearch
 }) => {
   const editingWordData = useMemo(
     () => (
@@ -80,10 +82,11 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         handleManualNext={handleManualNext}
         displayTime={displayTime}
         selectedVoiceName={selectedVoiceName}
-      onOpenAddModal={handleOpenAddWordModal}
-      onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
-      playCurrentWord={playCurrentWord}
-      onMarkWordLearned={onMarkWordLearned}
+        onOpenAddModal={handleOpenAddWordModal}
+        onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
+        playCurrentWord={playCurrentWord}
+        onMarkWordLearned={onMarkWordLearned}
+        onOpenSearch={onOpenSearch}
       />
 
       {additionalContent}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -17,9 +17,10 @@ interface VocabularyAppContainerNewProps {
   onMarkWordLearned?: (word: string) => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
+  onOpenSearch?: (word?: string) => void;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent, onOpenSearch }) => {
   // Use stable state management
   const {
     currentWord,
@@ -190,11 +191,12 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ o
             handleSaveWord={handleSaveWord}
             isEditMode={isEditMode}
             wordToEdit={wordToEdit}
-            handleOpenAddWordModal={handleOpenAddWordModal}
-            handleOpenEditWordModal={handleOpenEditWordModal}
-            onMarkWordLearned={onMarkWordLearned}
-            additionalContent={additionalContent}
-          />
+          handleOpenAddWordModal={handleOpenAddWordModal}
+          handleOpenEditWordModal={handleOpenEditWordModal}
+          onMarkWordLearned={onMarkWordLearned}
+          additionalContent={additionalContent}
+          onOpenSearch={onOpenSearch}
+        />
         </div>
       </VocabularyLayout>
     </DebugInfoContext.Provider>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -7,7 +7,6 @@ import { useSpeechRate } from '@/hooks/useSpeechRate';
 import { toast } from 'sonner';
 import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
-import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
@@ -27,6 +26,7 @@ interface VocabularyControlsColumnProps {
   selectedVoiceName: string;
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
+  onOpenSearch: (word?: string) => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,7 +41,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenEditModal,
   selectedVoiceName,
   playCurrentWord,
-  onMarkWordLearned
+  onMarkWordLearned,
+  onOpenSearch
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
@@ -91,15 +92,12 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
     }
   };
 
-  const [isSearchOpen, setIsSearchOpen] = React.useState(false);
   const [isMarkAsLearnedDialogOpen, setIsMarkAsLearnedDialogOpen] = React.useState(false);
   const [wordToMark, setWordToMark] = React.useState('');
   const learnedSoundRef = React.useRef<HTMLAudioElement | null>(null);
   React.useEffect(() => {
     learnedSoundRef.current = new Audio('/beep2.wav');
   }, []);
-  const openSearch = () => setIsSearchOpen(true);
-  const closeSearch = () => setIsSearchOpen(false);
 
   const handleMarkAsLearnedClick = () => {
     setWordToMark(currentWord?.word || '');
@@ -172,7 +170,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       <Button
         variant="outline"
         size="sm"
-        onClick={openSearch}
+        onClick={() => onOpenSearch()}
         className="h-8 w-8 p-0"
         title="Quick Search"
         aria-label="Quick Search"
@@ -193,8 +191,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
           <CheckCircle size={16} />
         </Button>
       )}
-      
-      <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
       
       <MarkAsLearnedDialog
         isOpen={isMarkAsLearnedDialogOpen}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -21,6 +21,7 @@ interface VocabularyMainNewProps {
   showWordCount?: boolean;
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
+  onOpenSearch?: (word?: string) => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -39,6 +40,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   showWordCount = false,
   playCurrentWord,
   onMarkWordLearned,
+  onOpenSearch = () => {},
   }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -73,6 +75,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
             selectedVoiceName={selectedVoiceName}
             playCurrentWord={playCurrentWord}
             onMarkWordLearned={onMarkWordLearned}
+            onOpenSearch={onOpenSearch}
           />
         </div>
       </div>

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -13,13 +13,14 @@ import { findVoice } from '@/hooks/vocabulary-playback/speech-playback/findVoice
 interface WordSearchModalProps {
   isOpen: boolean;
   onClose: () => void;
+  searchWord?: string;
 }
 
-const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) => {
+const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose, searchWord = '' }) => {
   const wordsRef = useRef<VocabularyWord[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState('');
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(searchWord);
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [results, setResults] = useState<VocabularyWord[]>([]);
   const [selectedWord, setSelectedWord] = useState<VocabularyWord | null>(null);
@@ -47,6 +48,12 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose }) =>
         });
     }
   }, [isOpen, loading]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery(searchWord);
+    }
+  }, [isOpen, searchWord]);
 
   const highlightMatch = (text: string) => {
     const normalized = query.trim().toLowerCase();

--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -13,6 +13,7 @@ import { findVoice } from '@/hooks/vocabulary-playback/speech-playback/findVoice
 interface WordSearchModalProps {
   isOpen: boolean;
   onClose: () => void;
+  // Word to pre-populate the search field with
   searchWord?: string;
 }
 


### PR DESCRIPTION
## Summary
- centralize word search modal in VocabularyAppWithLearning and expose `openSearch`
- plumb `onOpenSearch` through app container and main components
- use shared open search handler in controls column

## Testing
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `npm run lint` *(fails: 98 problems (56 errors, 42 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a665808dd4832f8f0c3af00a507411