### PR TITLE
Centralize search modal handling

### DIFF
--- a/src/components/VocabularyApp.tsx
+++ b/src/components/VocabularyApp.tsx
@@ -1,10 +1,14 @@
 
-import { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import VocabularyAppContainerNew from "./vocabulary-app/VocabularyAppContainerNew";
 import { vocabularyService } from '@/services/vocabularyService';
 import ToastProvider from './vocabulary-app/ToastProvider';
+import WordSearchModal from './vocabulary-app/WordSearchModal';
 
 const VocabularyApp = () => {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchWord, setSearchWord] = useState('');
+
   useEffect(() => {
     const load = async () => {
       if (!vocabularyService.hasData()) {
@@ -14,11 +18,21 @@ const VocabularyApp = () => {
     };
     load();
   }, []);
+
+  const openSearch = (word?: string) => {
+    setSearchWord(word || '');
+    setIsSearchOpen(true);
+  };
   
   return (
     <>
       <ToastProvider />
-      <VocabularyAppContainerNew />
+      <VocabularyAppContainerNew onOpenSearch={openSearch} />
+      <WordSearchModal
+        isOpen={isSearchOpen}
+        initialQuery={searchWord}
+        onClose={() => setIsSearchOpen(false)}
+      />
     </>
   );
 };

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -75,8 +75,8 @@ const VocabularyAppWithLearning: React.FC = () => {
 
   const learnedWords = getLearnedWords();
 
-  const openSearch = (word: string) => {
-    setSearchWord(word);
+  const openSearch = (word?: string) => {
+    setSearchWord(word || '');
     setIsSearchOpen(true);
   };
 
@@ -204,6 +204,7 @@ const VocabularyAppWithLearning: React.FC = () => {
             markCurrentWordLearned(word);
           }}
           additionalContent={learningSection}
+          onOpenSearch={openSearch}
         />
       </div>
       <MarkAsNewDialog

--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -28,6 +28,7 @@ interface ContentWithDataNewProps {
   handleOpenEditWordModal: (word: VocabularyWord) => void;
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
+  onOpenSearch: (word?: string) => void;
   additionalContent?: React.ReactNode;
 }
 
@@ -51,6 +52,7 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   handleOpenEditWordModal,
   playCurrentWord,
   onMarkWordLearned,
+  onOpenSearch,
   additionalContent
 }) => {
   const editingWordData = useMemo(
@@ -80,10 +82,11 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
         handleManualNext={handleManualNext}
         displayTime={displayTime}
         selectedVoiceName={selectedVoiceName}
-      onOpenAddModal={handleOpenAddWordModal}
-      onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
-      playCurrentWord={playCurrentWord}
-      onMarkWordLearned={onMarkWordLearned}
+        onOpenAddModal={handleOpenAddWordModal}
+        onOpenEditModal={() => handleOpenEditWordModal(displayWord)}
+        playCurrentWord={playCurrentWord}
+        onMarkWordLearned={onMarkWordLearned}
+        onOpenSearch={onOpenSearch}
       />
 
       {additionalContent}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -17,9 +17,10 @@ interface VocabularyAppContainerNewProps {
   onMarkWordLearned?: (word: string) => void;
   initialWords?: VocabularyWord[];
   additionalContent?: React.ReactNode;
+  onOpenSearch: (word?: string) => void;
 }
 
-const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent }) => {
+const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ onMarkWordLearned, initialWords, additionalContent, onOpenSearch }) => {
   // Use stable state management
   const {
     currentWord,
@@ -194,6 +195,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({ o
             handleOpenEditWordModal={handleOpenEditWordModal}
             onMarkWordLearned={onMarkWordLearned}
             additionalContent={additionalContent}
+            onOpenSearch={onOpenSearch}
           />
         </div>
       </VocabularyLayout>

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -7,7 +7,6 @@ import { useSpeechRate } from '@/hooks/useSpeechRate';
 import { toast } from 'sonner';
 import AddWordButton from './AddWordButton';
 import EditWordButton from './EditWordButton';
-import WordSearchModal from './WordSearchModal';
 import { VocabularyWord } from '@/types/vocabulary';
 import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
@@ -27,6 +26,7 @@ interface VocabularyControlsColumnProps {
   selectedVoiceName: string;
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
+  onOpenSearch: (word?: string) => void;
 }
 
 const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
@@ -41,7 +41,8 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   onOpenEditModal,
   selectedVoiceName,
   playCurrentWord,
-  onMarkWordLearned
+  onMarkWordLearned,
+  onOpenSearch
 }) => {
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
@@ -91,15 +92,12 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
     }
   };
 
-  const [isSearchOpen, setIsSearchOpen] = React.useState(false);
   const [isMarkAsLearnedDialogOpen, setIsMarkAsLearnedDialogOpen] = React.useState(false);
   const [wordToMark, setWordToMark] = React.useState('');
   const learnedSoundRef = React.useRef<HTMLAudioElement | null>(null);
   React.useEffect(() => {
     learnedSoundRef.current = new Audio('/beep2.wav');
   }, []);
-  const openSearch = () => setIsSearchOpen(true);
-  const closeSearch = () => setIsSearchOpen(false);
 
   const handleMarkAsLearnedClick = () => {
     setWordToMark(currentWord?.word || '');
@@ -172,7 +170,7 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       <Button
         variant="outline"
         size="sm"
-        onClick={openSearch}
+        onClick={() => onOpenSearch()}
         className="h-8 w-8 p-0"
         title="Quick Search"
         aria-label="Quick Search"
@@ -193,8 +191,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
           <CheckCircle size={16} />
         </Button>
       )}
-      
-      <WordSearchModal isOpen={isSearchOpen} onClose={closeSearch} />
       
       <MarkAsLearnedDialog
         isOpen={isMarkAsLearnedDialogOpen}

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -21,6 +21,7 @@ interface VocabularyMainNewProps {
   showWordCount?: boolean;
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
+  onOpenSearch: (word?: string) => void;
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -39,6 +40,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   showWordCount = false,
   playCurrentWord,
   onMarkWordLearned,
+  onOpenSearch,
   }) => {
   const { backgroundColor } = useBackgroundColor();
 
@@ -73,6 +75,7 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
             selectedVoiceName={selectedVoiceName}
             playCurrentWord={playCurrentWord}
             onMarkWordLearned={onMarkWordLearned}
+            onOpenSearch={onOpenSearch}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `openSearch` helper in app components and pass to `VocabularyAppContainerNew`
- Plumb new `onOpenSearch` prop through container, content, main and controls
- Invoke `onOpenSearch` from magnifier button and drop local WordSearchModal

## Testing
- `npm test -- --run`
- `npm run lint --silent` *(produced very verbose output)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a8a393ac832fb006e2cfdf41b30c