### PR TITLE
Normalize search queries before searching

### DIFF
--- a/src/components/VocabularyApp.tsx
+++ b/src/components/VocabularyApp.tsx
@@ -4,6 +4,8 @@ import VocabularyAppContainerNew from "./vocabulary-app/VocabularyAppContainerNe
 import { vocabularyService } from '@/services/vocabularyService';
 import ToastProvider from './vocabulary-app/ToastProvider';
 import WordSearchModal from './vocabulary-app/WordSearchModal';
+import { normalizeQuery } from '@/utils/text/normalizeQuery';
+import { toast } from 'sonner';
 
 const VocabularyApp = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -20,7 +22,12 @@ const VocabularyApp = () => {
   }, []);
 
   const openSearch = (word?: string) => {
-    setSearchWord(word || '');
+    const normalized = normalizeQuery(word || '');
+    if (word && normalized === '') {
+      toast.warning('Please enter a valid search query.');
+      return;
+    }
+    setSearchWord(normalized);
     setIsSearchOpen(true);
   };
   

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
 import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
+import { normalizeQuery } from '@/utils/text/normalizeQuery';
 
 const VocabularyAppWithLearning: React.FC = () => {
   useDailyUsageTracker('default');
@@ -76,7 +77,12 @@ const VocabularyAppWithLearning: React.FC = () => {
   const learnedWords = getLearnedWords();
 
   const openSearch = (word?: string) => {
-    setSearchWord(word || '');
+    const normalized = normalizeQuery(word || '');
+    if (word && normalized === '') {
+      toast.warning('Please enter a valid search query.');
+      return;
+    }
+    setSearchWord(normalized);
     setIsSearchOpen(true);
   };
 

--- a/src/utils/text/normalizeQuery.ts
+++ b/src/utils/text/normalizeQuery.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize search query by trimming, removing diacritics,
+ * and whitelisting allowed characters.
+ */
+export const normalizeQuery = (input: string): string => {
+  if (!input) return '';
+  return input
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9\s'-]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+export default normalizeQuery;


### PR DESCRIPTION
## Summary
- add `normalizeQuery` util to trim, strip diacritics and limit allowed characters
- validate user search input across VocabularyApp and search modal
- show inline warning when sanitized query is empty

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any & empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c37bd300832f9eaab087d3cfdc99