### PR TITLE
feat: add GA4 analytics wrappers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,14 +19,6 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HQ5Q01TG2L"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-HQ5Q01TG2L');
-    </script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -19,14 +19,6 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HQ5Q01TG2L"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-HQ5Q01TG2L');
-    </script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '@/components/ui/popover';
 import { Gauge } from 'lucide-react';
+import { trackSpeechRateChange } from '@/lib/analytics/events';
 
 interface SpeechRateControlProps {
   rate: number;
@@ -15,13 +16,7 @@ const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange })
 
   const handleChange = (v: number) => {
     onChange(v);
-    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-      window.gtag('event', 'speech_rate_change', {
-        event_category: 'interaction',
-        event_label: `${v}x`,
-        value: v
-      });
-    }
+    trackSpeechRateChange(v);
     setOpen(false); // close popup after selecting rate
   };
 

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -5,6 +5,15 @@ import { Button } from '@/components/ui/button';
 import { Volume2, VolumeX, Pause, Play, SkipForward } from 'lucide-react';
 import { VoiceSelection } from '@/hooks/vocabulary-playback/useVoiceSelection';
 import parseWordAnnotations from '@/utils/text/parseWordAnnotations';
+import {
+  trackWordView,
+  trackMute,
+  trackUnmute,
+  trackPlay,
+  trackPause,
+  trackNextWord,
+  trackCycleVoice
+} from '@/lib/analytics/events';
 
 interface VocabularyCardProps {
   word: string;
@@ -52,12 +61,13 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   useEffect(() => {
     if (word) {
       localStorage.setItem('currentDisplayedWord', word);
+      trackWordView(word, category);
     }
-    
+
     return () => {
       localStorage.removeItem('currentDisplayedWord');
     };
-  }, [word]);
+  }, [word, category]);
 
   // Parse word to separate types and phonetics
   const wordParts = word.split(/\s*\(([^)]+)\)/);
@@ -66,33 +76,23 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
   const phoneticPart = wordParts.length > 2 ? wordParts.slice(2).join(' ').trim() : '';
   const { main, annotations } = parseWordAnnotations(word);
 
-  const trackEvent = (name: string, label: string, value?: number) => {
-    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-      window.gtag('event', name, {
-        event_category: 'interaction',
-        event_label: label,
-        ...(typeof value === 'number' ? { value } : {})
-      });
-    }
-  };
-
   const handleMuteClick = () => {
-    trackEvent(isMuted ? 'unmute' : 'mute', isMuted ? 'Unmute' : 'Mute');
+    isMuted ? trackUnmute() : trackMute();
     onToggleMute();
   };
 
   const handlePauseClick = () => {
-    trackEvent(isPaused ? 'play' : 'pause', isPaused ? 'Play' : 'Pause');
+    isPaused ? trackPlay() : trackPause();
     onTogglePause();
   };
 
   const handleNextClick = () => {
-    trackEvent('next_word', 'Next');
+    trackNextWord();
     onNextWord();
   };
 
   const handleCycleVoiceClick = () => {
-    trackEvent('cycle_voice', nextVoiceLabel);
+    trackCycleVoice(nextVoiceLabel);
     onCycleVoice();
   };
 

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -12,6 +12,14 @@ import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 import { MarkAsLearnedDialog } from '@/components/MarkAsLearnedDialog';
+import {
+  trackMute,
+  trackUnmute,
+  trackPlay,
+  trackPause,
+  trackNextWord,
+  trackCycleVoice
+} from '@/lib/analytics/events';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -47,31 +55,21 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   const { speechRate, setSpeechRate } = useSpeechRate();
   const { allVoices } = useVoiceContext();
   
-  const trackEvent = (name: string, label: string, value?: number) => {
-    if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
-      window.gtag('event', name, {
-        event_category: 'interaction',
-        event_label: label,
-        ...(typeof value === 'number' ? { value } : {})
-      });
-    }
-  };
-
   const handleToggleMute = () => {
     onToggleMute();
-    trackEvent(isMuted ? 'unmute' : 'mute', isMuted ? 'Unmute' : 'Mute');
+    isMuted ? trackUnmute() : trackMute();
     toast(isMuted ? 'Audio unmuted' : 'Audio muted');
   };
 
   const handleTogglePause = () => {
     onTogglePause();
-    trackEvent(isPaused ? 'play' : 'pause', isPaused ? 'Play' : 'Pause');
+    isPaused ? trackPlay() : trackPause();
     toast(isPaused ? 'Playback resumed' : 'Playback paused');
   };
 
   const handleNextWord = () => {
     onNextWord();
-    trackEvent('next_word', 'Next Word');
+    trackNextWord();
   };
 
   const handleCycleVoice = () => {
@@ -80,12 +78,11 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
       return;
     }
     onCycleVoice();
-    trackEvent('cycle_voice', selectedVoiceName);
+    trackCycleVoice(selectedVoiceName);
   };
 
   const handleRateChange = (r: number) => {
     setSpeechRate(r);
-    trackEvent('speech_rate_change', `${r}x`, r);
     unifiedSpeechController.stop();
     if (!isMuted && !isPaused) {
       playCurrentWord();

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,45 @@
+import { trackEvent } from './ga4';
+
+export interface AnalyticsEventParams {
+  event_category?: string;
+  event_label?: string;
+  value?: number;
+  [key: string]: any;
+}
+
+export const trackWordView = (word: string, category?: string) => {
+  trackEvent('word_view', {
+    event_category: 'content',
+    event_label: word,
+    ...(category ? { category } : {})
+  });
+};
+
+export const trackMute = () =>
+  trackEvent('mute', { event_category: 'interaction', event_label: 'Mute' });
+
+export const trackUnmute = () =>
+  trackEvent('unmute', { event_category: 'interaction', event_label: 'Unmute' });
+
+export const trackPlay = () =>
+  trackEvent('play', { event_category: 'interaction', event_label: 'Play' });
+
+export const trackPause = () =>
+  trackEvent('pause', { event_category: 'interaction', event_label: 'Pause' });
+
+export const trackNextWord = () =>
+  trackEvent('next_word', { event_category: 'interaction', event_label: 'Next Word' });
+
+export const trackCycleVoice = (label: string) =>
+  trackEvent('cycle_voice', { event_category: 'interaction', event_label: label });
+
+export const trackSpeechRateChange = (rate: number) =>
+  trackEvent('speech_rate_change', {
+    event_category: 'interaction',
+    event_label: `${rate}x`,
+    value: rate
+  });
+
+export const trackPageView = (path: string) =>
+  trackEvent('page_view', { page_path: path });
+

--- a/src/lib/analytics/ga4.ts
+++ b/src/lib/analytics/ga4.ts
@@ -1,0 +1,66 @@
+import type { AnalyticsEventParams } from './events';
+
+interface InitOptions {
+  dedupeTTL?: number;
+}
+
+let initialized = false;
+let dedupeTTL = 30_000; // default 30s
+const sentEvents = new Map<string, number>();
+let cleanupTimer: number | undefined;
+
+function loadScript(measurementId: string) {
+  if (document.getElementById('ga4-script')) return;
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+  script.id = 'ga4-script';
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(...args: any[]) {
+    window.dataLayer.push(args);
+  }
+  // @ts-ignore
+  window.gtag = window.gtag || gtag;
+  window.gtag('js', new Date());
+  window.gtag('config', measurementId);
+}
+
+function cleanup() {
+  const now = Date.now();
+  for (const [key, ts] of sentEvents) {
+    if (now - ts > dedupeTTL) sentEvents.delete(key);
+  }
+}
+
+export function initAnalytics(measurementId: string, options: InitOptions = {}) {
+  if (initialized || !measurementId) return;
+  dedupeTTL = options.dedupeTTL ?? dedupeTTL;
+  loadScript(measurementId);
+  cleanupTimer = window.setInterval(cleanup, dedupeTTL);
+  initialized = true;
+}
+
+function shouldSend(key: string) {
+  const now = Date.now();
+  const last = sentEvents.get(key);
+  if (last && now - last < dedupeTTL) return false;
+  sentEvents.set(key, now);
+  return true;
+}
+
+export function trackEvent(name: string, params?: AnalyticsEventParams) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  const key = `${name}:${JSON.stringify(params || {})}`;
+  if (!shouldSend(key)) return;
+  window.gtag('event', name, params);
+}
+
+declare global {
+  interface Window {
+    dataLayer: any[];
+    gtag: (...args: any[]) => void;
+  }
+}
+

--- a/src/lib/analytics/usePageView.ts
+++ b/src/lib/analytics/usePageView.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { trackPageView } from './events';
+
+export default function usePageView(path: string) {
+  useEffect(() => {
+    if (path) {
+      trackPageView(path);
+    }
+  }, [path]);
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { initAnalytics } from '@/lib/analytics/ga4';
 
 // Disable console logs in production for better performance
 if (import.meta.env.PROD) {
@@ -13,6 +14,21 @@ if (import.meta.env.PROD) {
 const rootElement = document.getElementById("root");
 if (!rootElement) {
   throw new Error('Root element not found');
+}
+
+const measurementId = import.meta.env.VITE_GA4_MEASUREMENT_ID as string | undefined;
+const ttl = Number(import.meta.env.VITE_GA4_DEDUPE_TTL_MS);
+if (measurementId && typeof window !== 'undefined') {
+  try {
+    const consent = localStorage.getItem('analytics-consent');
+    if (consent === 'granted') {
+      initAnalytics(measurementId, {
+        dedupeTTL: isNaN(ttl) ? undefined : ttl
+      });
+    }
+  } catch {
+    // ignore
+  }
 }
 
 createRoot(rootElement).render(<App />);


### PR DESCRIPTION
## Summary
- add GA4 analytics loader with TTL-based dedupe
- provide typed tracking helpers and page view hook
- initialize analytics on consent and replace legacy gtag calls

## Testing
- `npm test`
- `npm run lint` *(fails: no-explicit-any, no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68bba9b69614832f8a864a89d2d03819