### PR TITLE
feat: add Supabase Phase 1 write-through schema

### DIFF
--- a/docs/supabase-phase1-high-priority.sql
+++ b/docs/supabase-phase1-high-priority.sql
@@ -1,0 +1,99 @@
+-- identity already exists:
+-- table public.nicknames(id uuid pk default gen_random_uuid(), name text unique not null, created_at timestamptz default now());
+-- RLS enabled; anon insert allowed (from prior step).
+
+-- 1) resume_state (per category + today)
+create table if not exists public.resume_state (
+  name text not null,               -- nickname
+  category text not null default 'all',
+  last_word_key text,               -- todayLastWord.word or lastWordByCategory[category]
+  last_seen_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (name, category)
+);
+
+-- 2) learning_progress (per word)
+create table if not exists public.learning_progress (
+  name text not null,
+  word_key text not null,
+  category text,
+  status smallint,                  -- enum-like 0..n
+  review_count int default 0,
+  next_review_at timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key (name, word_key)
+);
+
+-- 3) daily_selection (1 row/day)
+create table if not exists public.daily_selection (
+  name text not null,
+  day date not null,
+  selection_json jsonb not null,    -- compact array/object
+  updated_at timestamptz not null default now(),
+  primary key (name, day)
+);
+
+-- 4) learning_time (aggregated per day)
+create table if not exists public.learning_time (
+  name text not null,
+  day date not null,
+  duration_ms bigint not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (name, day)
+);
+
+-- 5) word_counts (per word counter)
+create table if not exists public.word_counts (
+  name text not null,
+  word_key text not null,
+  count int not null default 0,
+  last_shown_at timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key (name, word_key)
+);
+
+-- Indexing (cheap but helpful)
+create index if not exists idx_progress_name_updated on public.learning_progress(name, updated_at desc);
+create index if not exists idx_time_name_day on public.learning_time(name, day);
+create index if not exists idx_selection_name_day on public.daily_selection(name, day);
+
+-- Minimal RLS: enable and allow anon upsert for Phase-1 (write-only). No SELECT policies.
+alter table public.resume_state enable row level security;
+alter table public.learning_progress enable row level security;
+alter table public.daily_selection enable row level security;
+alter table public.learning_time enable row level security;
+alter table public.word_counts enable row level security;
+
+-- INSERT and UPDATE for anon/auth (Phase-1; not secure, acceptable for non-PII prototype).
+do $$ begin
+  perform 1;
+  exception when others then null;
+end $$;
+
+create policy if not exists "p1_resume_ins" on public.resume_state
+for insert to anon, authenticated with check (true);
+create policy if not exists "p1_resume_upd" on public.resume_state
+for update to anon, authenticated using (true) with check (true);
+
+create policy if not exists "p1_prog_ins" on public.learning_progress
+for insert to anon, authenticated with check (true);
+create policy if not exists "p1_prog_upd" on public.learning_progress
+for update to anon, authenticated using (true) with check (true);
+
+create policy if not exists "p1_sel_ins" on public.daily_selection
+for insert to anon, authenticated with check (true);
+create policy if not exists "p1_sel_upd" on public.daily_selection
+for update to anon, authenticated using (true) with check (true);
+
+create policy if not exists "p1_time_ins" on public.learning_time
+for insert to anon, authenticated with check (true);
+create policy if not exists "p1_time_upd" on public.learning_time
+for update to anon, authenticated using (true) with check (true);
+
+create policy if not exists "p1_wc_ins" on public.word_counts
+for insert to anon, authenticated with check (true);
+create policy if not exists "p1_wc_upd" on public.word_counts
+for update to anon, authenticated using (true) with check (true);
+
+-- NOTE: We intentionally do NOT create SELECT policies in Phase-1 (no reads from client).
+-- Later, when Auth is added, replace these permissive policies with user-scoped RLS.

--- a/src/lib/sync/pushers.ts
+++ b/src/lib/sync/pushers.ts
@@ -1,0 +1,32 @@
+import { getSupabaseClient } from '../supabaseClient';
+
+export async function upsertResume(name: string, rows: Array<{category: string; last_word_key: string|null; last_seen_at?: string}>) {
+  const supabase = getSupabaseClient();
+  const payload = rows.map(r => ({ name, ...r, updated_at: new Date().toISOString() }));
+  // onConflict columns must match PK
+  return supabase.from('resume_state').upsert(payload, { onConflict: 'name,category' });
+}
+
+export async function upsertProgress(name: string, rows: Array<{word_key: string; category?: string|null; status?: number|null; review_count?: number; next_review_at?: string|null}>) {
+  const supabase = getSupabaseClient();
+  const payload = rows.map(r => ({ name, ...r, updated_at: new Date().toISOString() }));
+  return supabase.from('learning_progress').upsert(payload, { onConflict: 'name,word_key' });
+}
+
+export async function upsertDailySelection(name: string, dayISO: string, selection: unknown) {
+  const supabase = getSupabaseClient();
+  const row = { name, day: dayISO.slice(0,10), selection_json: selection, updated_at: new Date().toISOString() };
+  return supabase.from('daily_selection').upsert(row, { onConflict: 'name,day' });
+}
+
+export async function upsertLearningTime(name: string, rows: Array<{dayISO: string; duration_ms: number}>) {
+  const supabase = getSupabaseClient();
+  const payload = rows.map(r => ({ name, day: r.dayISO.slice(0,10), duration_ms: Math.max(0, Math.floor(r.duration_ms)), updated_at: new Date().toISOString() }));
+  return supabase.from('learning_time').upsert(payload, { onConflict: 'name,day' });
+}
+
+export async function upsertWordCounts(name: string, rows: Array<{word_key: string; count: number; last_shown_at?: string}>) {
+  const supabase = getSupabaseClient();
+  const payload = rows.map(r => ({ name, ...r, updated_at: new Date().toISOString() }));
+  return supabase.from('word_counts').upsert(payload, { onConflict: 'name,word_key' });
+}

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -1,0 +1,24 @@
+import type { LearningProgress, DailySelection } from '@/types/learning';
+
+export type LastWordMap = Record<string, string>;
+
+export interface TodayLastWord {
+  date: string;
+  index: number;
+  word: string;
+  category?: string;
+}
+
+export type LearningProgressMap = Record<string, LearningProgress>;
+
+export type LearningTimeRecord = Record<string, number>;
+
+export interface WordCountEntry {
+  word: string;
+  count: number;
+  lastShown: string;
+}
+
+export type WordCountMap = Record<string, WordCountEntry>;
+
+export type { DailySelection };


### PR DESCRIPTION
## Summary
- add SQL for high-priority Supabase tables and permissive RLS policies
- scaffold sync types for localStorage and Supabase
- implement client-side upsert helpers for each table

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test -- --run` (fails: process terminated before completion)
- `npm run lint` (fails: lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68c7d32db320832fa29fee6f7f7087b8