### PR TITLE
feat: canonical nicknames

### DIFF
--- a/src/components/NicknameGate.tsx
+++ b/src/components/NicknameGate.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getSupabaseClient } from '../lib/supabaseClient';
-import { getNicknameLocal, validateNickname, NICKNAME_LS_KEY } from '../lib/nickname';
+import { getNicknameLocal, validateDisplayName, NICKNAME_LS_KEY } from '../lib/nickname';
 import { ensureAuth } from '../lib/auth/ensureAuth';
 
 type UIState = {
@@ -10,10 +10,12 @@ type UIState = {
   value: string;
   pending: boolean;
   error?: string;
+  showClaim?: boolean;
+  claimCode: string;
 };
 
 export default function NicknameGate() {
-  const [s, setS] = useState<UIState>({ ready: false, show: false, value: '', pending: false });
+  const [s, setS] = useState<UIState>({ ready: false, show: false, value: '', pending: false, showClaim: false, claimCode: '' });
 
   // On first client render, decide whether to show the modal
   useEffect(() => {
@@ -33,31 +35,88 @@ export default function NicknameGate() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const nick = s.value.trim();
-    const localErr = validateNickname(nick);
-    if (localErr) { setS(p => ({ ...p, error: localErr })); return; }
+    const errMsg = validateDisplayName(nick);
+    if (errMsg) { setS(p => ({ ...p, pending: false, error: errMsg })); return; }
 
     setS(p => ({ ...p, pending: true, error: undefined }));
     const supabase = getSupabaseClient();
     const { userId } = await ensureAuth();
-    const { error } = await supabase
+
+    const up = await supabase
       .from('nicknames')
-      .upsert({ user_id: userId, name: nick }, { onConflict: 'user_id' });
-    if (error) {
-      // Friendly messages
-      const msg = (error.code === '42501' || /row-level security/i.test(error.message))
-        ? 'Sign-in failed or RLS blocked the insert. Please refresh and try again.'
-        : (error.code === '23505' ? 'This nickname is already taken. Try another.' : error.message);
-      setS(s => ({ ...s, pending: false, error: msg }));
+      .upsert({ user_id: userId, display_name: nick }, { onConflict: 'user_id' });
+
+    if (!up.error) {
+      const rc = await supabase.rpc('rotate_claim_code', { p_display_name: nick });
+      const code = rc.data || '';
+      alert(code ? `Your claim code: ${code}` : 'Nickname saved.');
+      localStorage.setItem('lazyVoca.nickname', nick);
+      try { (await import('../lib/sync/flushLocalToServer')).flushLocalToServer(nick); } catch {}
+      try { (await import('../lib/storage/migrateLocalVocabToDb')).migrateLocalVocabToDb?.(); } catch {}
+      setS({ ready: true, show: false, value: nick, pending: false, showClaim: false, claimCode: '' });
       return;
     }
 
-    // success: save locally and close
+    if (up.error.code === '23505' || /unique|duplicate/i.test(up.error.message)) {
+      setS(p => ({ ...(p as any), pending: false, error: undefined, showClaim: true, claimCode: '' }));
+      return;
+    }
+    setS(p => ({ ...p, pending: false, error: up.error.message }));
+  };
+
+  const onClaim = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const nick = s.value.trim();
+    const code = s.claimCode.trim();
+    if (!code) { setS(p => ({ ...p, error: 'Enter claim code.' })); return; }
+    setS(p => ({ ...p, pending: true, error: undefined }));
+    const supabase = getSupabaseClient();
+    await ensureAuth();
+    const r = await supabase.rpc('claim_nickname', { p_display_name: nick, p_code: code });
+    if (r.error) {
+      setS(p => ({ ...p, pending: false, error: r.error.message }));
+      return;
+    }
+    if (!r.data) {
+      setS(p => ({ ...p, pending: false, error: 'Invalid claim code.' }));
+      return;
+    }
+    const rc = await supabase.rpc('rotate_claim_code', { p_display_name: nick });
+    const newCode = rc.data || '';
+    alert(newCode ? `Your claim code: ${newCode}` : 'Nickname claimed.');
     localStorage.setItem('lazyVoca.nickname', nick);
-    // Trigger optional background syncs if available
     try { (await import('../lib/sync/flushLocalToServer')).flushLocalToServer(nick); } catch {}
     try { (await import('../lib/storage/migrateLocalVocabToDb')).migrateLocalVocabToDb?.(); } catch {}
-    setS(p => ({ ...p, show: false, pending: false }));
+    setS({ ready: true, show: false, value: nick, pending: false, showClaim: false, claimCode: '' });
   };
+
+  const BLOCKED_CHARS_HELP = "< > \" ' ` $ \\ { } | ;";
+
+  if (s.showClaim) {
+    return (
+      <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 9999 }}>
+        <form onSubmit={onClaim} style={{ width: 360, padding: 20, borderRadius: 12, background: '#fff', boxShadow: '0 10px 30px rgba(0,0,0,0.25)', fontFamily: 'system-ui, sans-serif' }}>
+          <h3 style={{ margin: 0 }}>Claim nickname</h3>
+          <p style={{ marginTop: 6, color: '#555', fontSize: 14 }}>
+            Enter the claim code to transfer “{s.value}” to you.
+          </p>
+          <input
+            autoFocus
+            value={s.claimCode}
+            onChange={(e) => setS(p => ({ ...p, claimCode: e.target.value, error: undefined }))}
+            placeholder="6-digit code"
+            maxLength={6}
+            disabled={s.pending}
+            style={{ width: '100%', padding: '10px 12px', fontSize: 14, borderRadius: 8, border: '1px solid #ccc' }}
+          />
+          {s.error && <div style={{ color: '#c00', marginTop: 8, fontSize: 13 }}>{s.error}</div>}
+          <button type="submit" disabled={s.pending} style={{ marginTop: 12, width: '100%', padding: '10px 12px', borderRadius: 8, border: 'none', background: '#111', color: '#fff', fontWeight: 600 }}>
+            {s.pending ? 'Claiming…' : 'Claim nickname'}
+          </button>
+        </form>
+      </div>
+    );
+  }
 
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 9999 }}>
@@ -70,11 +129,14 @@ export default function NicknameGate() {
           autoFocus
           value={s.value}
           onChange={(e) => setS(p => ({ ...p, value: e.target.value, error: undefined }))}
-          placeholder="e.g., hunter_123"
-          maxLength={24}
+          placeholder="e.g., Mi mi U"
+          maxLength={40}
           disabled={s.pending}
           style={{ width: '100%', padding: '10px 12px', fontSize: 14, borderRadius: 8, border: '1px solid #ccc' }}
         />
+        <div style={{ marginTop: 4, fontSize: 12, color: '#777' }}>
+          Names are matched case-insensitively and ignore spaces. Allowed: most characters; blocked: {BLOCKED_CHARS_HELP}
+        </div>
         {s.error && <div style={{ color: '#c00', marginTop: 8, fontSize: 13 }}>{s.error}</div>}
         <button type="submit" disabled={s.pending} style={{ marginTop: 12, width: '100%', padding: '10px 12px', borderRadius: 8, border: 'none', background: '#111', color: '#fff', fontWeight: 600 }}>
           {s.pending ? 'Saving…' : 'Save nickname'}

--- a/src/lib/nickname.ts
+++ b/src/lib/nickname.ts
@@ -8,10 +8,17 @@ export function setNicknameLocal(v: string) {
   try { localStorage.setItem(NICKNAME_LS_KEY, v); } catch {}
 }
 
-export function validateNickname(n: string): string | null {
-  const v = n.trim();
+export function toCanonical(s: string): string {
+  return s.normalize('NFKC').toLowerCase().replace(/\s+/g, '');
+}
+
+const BAD_CHARS = /[<>"'`$\\{}|;]|[\u0000-\u001F]/;
+
+export function validateDisplayName(s: string): string | null {
+  const v = s.trim();
   if (v.length < 3) return 'Nickname must be at least 3 characters.';
-  if (v.length > 24) return 'Nickname must be at most 24 characters.';
-  if (!/^[A-Za-z0-9_-]+$/.test(v)) return 'Use letters, numbers, "_" or "-".';
+  if (v.length > 40) return 'Nickname must be at most 40 characters.';
+  if (BAD_CHARS.test(v)) return 'Nickname contains blocked characters.';
+  // allow anything else (including spaces & emoji)
   return null;
 }

--- a/supabase/nicknames.sql
+++ b/supabase/nicknames.sql
@@ -1,0 +1,95 @@
+-- 1) Columns: display_name + generated canonical (unique)
+create extension if not exists pgcrypto;
+
+-- Ensure table exists (keep your existing id pk)
+create table if not exists public.nicknames (
+  id bigserial primary key,
+  user_id uuid unique,
+  display_name text not null,
+  name_canonical text generated always as (
+    lower(regexp_replace(display_name, '\s+', '', 'g'))
+  ) stored,
+  claim_code_hash text,
+  created_at timestamptz not null default now()
+);
+
+-- Backfill / migrate if you previously had "name"
+do $$
+begin
+  if exists (select 1 from information_schema.columns
+             where table_schema='public' and table_name='nicknames' and column_name='name') then
+    alter table public.nicknames
+      alter column name drop not null;
+    update public.nicknames set display_name = coalesce(display_name, name) where display_name is null;
+    alter table public.nicknames drop column if exists name;
+  end if;
+end $$;
+
+-- Uniqueness on canonical
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname='nicknames_name_canonical_key') then
+    alter table public.nicknames add constraint nicknames_name_canonical_key unique (name_canonical);
+  end if;
+end $$;
+
+alter table public.nicknames enable row level security;
+
+-- Tight RLS (auth users can touch their row)
+drop policy if exists "nick_ins_upd_self" on public.nicknames;
+drop policy if exists "nick_upd_self"     on public.nicknames;
+drop policy if exists "nick_select_self"  on public.nicknames;
+
+create policy "nick_ins_upd_self"
+on public.nicknames for insert to authenticated
+with check (user_id = auth.uid());
+
+create policy "nick_upd_self"
+on public.nicknames for update to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "nick_select_self"
+on public.nicknames for select to authenticated
+using (user_id = auth.uid());
+
+-- 2) RPCs aware of canonical
+
+-- rotate_claim_code(display_name): returns plaintext code once
+create or replace function public.rotate_claim_code(p_display_name text)
+returns text
+language plpgsql security definer set search_path = public as $$
+declare code text;
+begin
+  code := lpad((floor(random()*1000000))::int::text, 6, '0');
+  update public.nicknames
+     set claim_code_hash = crypt(code, gen_salt('bf'))
+   where user_id = auth.uid()
+     and name_canonical = lower(regexp_replace(p_display_name, '\s+', '', 'g'));
+  if not found then
+    raise exception 'nickname not owned by caller';
+  end if;
+  return code;
+end $$;
+
+revoke all on function public.rotate_claim_code(text) from public;
+grant execute on function public.rotate_claim_code(text) to authenticated;
+
+-- claim_nickname(display_name, code): transfer ownership by code
+create or replace function public.claim_nickname(p_display_name text, p_code text)
+returns boolean
+language plpgsql security definer set search_path = public as $$
+begin
+  update public.nicknames
+     set user_id = auth.uid()
+   where name_canonical = lower(regexp_replace(p_display_name, '\s+', '', 'g'))
+     and claim_code_hash is not null
+     and crypt(p_code, claim_code_hash) = claim_code_hash;
+  return found;
+end $$;
+
+revoke all on function public.claim_nickname(text, text) from public;
+grant execute on function public.claim_nickname(text, text) to authenticated;
+
+-- refresh API cache
+notify pgrst, 'reload schema';

--- a/tests/nickname.test.ts
+++ b/tests/nickname.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { toCanonical, validateDisplayName } from '../src/lib/nickname';
+
+describe('nickname helpers', () => {
+  it('canonicalizes case and whitespace', () => {
+    expect(toCanonical('Mi mi U')).toBe('mimiu');
+    expect(toCanonical('MIMIU')).toBe('mimiu');
+  });
+
+  it('validates blocked characters', () => {
+    expect(validateDisplayName('valid name')).toBeNull();
+    expect(validateDisplayName('bad$name')).toBe('Nickname contains blocked characters.');
+  });
+});


### PR DESCRIPTION
## Summary
- add supabase SQL patch for canonical nicknames and claim/rotate RPCs
- allow flexible display names with canonicalization and validation helpers
- update NicknameGate for canonical uniqueness and claim flow
- add tests for nickname helpers

## Testing
- `npx vitest run tests/nickname.test.ts`
- `npm run lint` *(fails: Unexpected any, empty block statements)*

------
https://chatgpt.com/codex/tasks/task_e_68c816067750832f8a106c582a9cc8b0