### PR TITLE
Implement case-insensitive nickname service

### DIFF
--- a/src/components/NicknameGate.tsx
+++ b/src/components/NicknameGate.tsx
@@ -1,8 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { getSupabaseClient } from '../lib/supabaseClient';
 import { getNicknameLocal, validateDisplayName, NICKNAME_LS_KEY } from '../lib/nickname';
-import { ensureAuth } from '../lib/auth/ensureAuth';
+import { sanitizeDisplay, normalizeNickname, getNicknameByKey, upsertNickname } from '@/services/nicknameService';
 
 type UIState = {
   ready: boolean;    // localStorage checked
@@ -10,12 +9,10 @@ type UIState = {
   value: string;
   pending: boolean;
   error?: string;
-  showClaim?: boolean;
-  claimCode: string;
 };
 
 export default function NicknameGate() {
-  const [s, setS] = useState<UIState>({ ready: false, show: false, value: '', pending: false, showClaim: false, claimCode: '' });
+  const [s, setS] = useState<UIState>({ ready: false, show: false, value: '', pending: false });
 
   // On first client render, decide whether to show the modal
   useEffect(() => {
@@ -39,84 +36,24 @@ export default function NicknameGate() {
     if (errMsg) { setS(p => ({ ...p, pending: false, error: errMsg })); return; }
 
     setS(p => ({ ...p, pending: true, error: undefined }));
-    const supabase = getSupabaseClient();
-    const { userId } = await ensureAuth();
+    const display = sanitizeDisplay(nick);
+    const key = normalizeNickname(display);
 
-    const up = await supabase
-      .from('nicknames')
-      .upsert({ user_id: userId, display_name: nick }, { onConflict: 'user_id' });
+    try {
+      const existing = await getNicknameByKey(key);
+      const chosen = existing ?? await upsertNickname(display);
 
-    if (!up.error) {
-      const rc = await supabase.rpc('rotate_claim_code', { p_display_name: nick });
-      const code = rc.data || '';
-      alert(code ? `Your claim code: ${code}` : 'Nickname saved.');
-      localStorage.setItem('lazyVoca.nickname', nick);
-      try { (await import('../lib/sync/flushLocalToServer')).flushLocalToServer(nick); } catch {}
+      localStorage.setItem(NICKNAME_LS_KEY, chosen.name);
+      try { (await import('../lib/sync/flushLocalToServer')).flushLocalToServer(chosen.name); } catch {}
       try { (await import('../lib/storage/migrateLocalVocabToDb')).migrateLocalVocabToDb?.(); } catch {}
-      setS({ ready: true, show: false, value: nick, pending: false, showClaim: false, claimCode: '' });
-      return;
-    }
 
-    if (up.error.code === '23505' || /unique|duplicate/i.test(up.error.message)) {
-      setS(p => ({ ...(p as any), pending: false, error: undefined, showClaim: true, claimCode: '' }));
-      return;
+      setS({ ready: true, show: false, value: chosen.name, pending: false });
+    } catch (err: any) {
+      setS(p => ({ ...p, pending: false, error: err.message || 'Failed to save nickname' }));
     }
-    setS(p => ({ ...p, pending: false, error: up.error.message }));
-  };
-
-  const onClaim = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const nick = s.value.trim();
-    const code = s.claimCode.trim();
-    if (!code) { setS(p => ({ ...p, error: 'Enter claim code.' })); return; }
-    setS(p => ({ ...p, pending: true, error: undefined }));
-    const supabase = getSupabaseClient();
-    await ensureAuth();
-    const r = await supabase.rpc('claim_nickname', { p_display_name: nick, p_code: code });
-    if (r.error) {
-      setS(p => ({ ...p, pending: false, error: r.error.message }));
-      return;
-    }
-    if (!r.data) {
-      setS(p => ({ ...p, pending: false, error: 'Invalid claim code.' }));
-      return;
-    }
-    const rc = await supabase.rpc('rotate_claim_code', { p_display_name: nick });
-    const newCode = rc.data || '';
-    alert(newCode ? `Your claim code: ${newCode}` : 'Nickname claimed.');
-    localStorage.setItem('lazyVoca.nickname', nick);
-    try { (await import('../lib/sync/flushLocalToServer')).flushLocalToServer(nick); } catch {}
-    try { (await import('../lib/storage/migrateLocalVocabToDb')).migrateLocalVocabToDb?.(); } catch {}
-    setS({ ready: true, show: false, value: nick, pending: false, showClaim: false, claimCode: '' });
   };
 
   const BLOCKED_CHARS_HELP = "< > \" ' ` $ \\ { } | ;";
-
-  if (s.showClaim) {
-    return (
-      <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 9999 }}>
-        <form onSubmit={onClaim} style={{ width: 360, padding: 20, borderRadius: 12, background: '#fff', boxShadow: '0 10px 30px rgba(0,0,0,0.25)', fontFamily: 'system-ui, sans-serif' }}>
-          <h3 style={{ margin: 0 }}>Claim nickname</h3>
-          <p style={{ marginTop: 6, color: '#555', fontSize: 14 }}>
-            Enter the claim code to transfer “{s.value}” to you.
-          </p>
-          <input
-            autoFocus
-            value={s.claimCode}
-            onChange={(e) => setS(p => ({ ...p, claimCode: e.target.value, error: undefined }))}
-            placeholder="6-digit code"
-            maxLength={6}
-            disabled={s.pending}
-            style={{ width: '100%', padding: '10px 12px', fontSize: 14, borderRadius: 8, border: '1px solid #ccc' }}
-          />
-          {s.error && <div style={{ color: '#c00', marginTop: 8, fontSize: 13 }}>{s.error}</div>}
-          <button type="submit" disabled={s.pending} style={{ marginTop: 12, width: '100%', padding: '10px 12px', borderRadius: 8, border: 'none', background: '#111', color: '#fff', fontWeight: 600 }}>
-            {s.pending ? 'Claiming…' : 'Claim nickname'}
-          </button>
-        </form>
-      </div>
-    );
-  }
 
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 9999 }}>

--- a/src/services/nicknameService.ts
+++ b/src/services/nicknameService.ts
@@ -1,0 +1,37 @@
+import { getSupabaseClient } from '@/lib/supabaseClient';
+
+// Lowercase + remove spaces for the unique key
+export function normalizeNickname(s: string) {
+  return s.toLowerCase().replace(/\s+/g, '');
+}
+
+// Optional: block risky display chars (doesn't affect key)
+export function sanitizeDisplay(s: string) {
+  return s.replace(/[<>"'`$(){}\[\];]/g, '').trim();
+}
+
+export async function getNicknameByKey(key: string) {
+  const supabase = getSupabaseClient();
+  const { data, error } = await supabase
+    .from('nicknames')
+    .select('id, name')
+    .eq('user_unique_key', key)
+    .maybeSingle();
+  if (error) throw error;
+  return data ?? null;
+}
+
+export async function upsertNickname(display: string) {
+  const supabase = getSupabaseClient();
+  const key = normalizeNickname(display);
+  const { data, error } = await supabase
+    .from('nicknames')
+    .upsert(
+      { name: display, user_unique_key: key },
+      { onConflict: 'user_unique_key' }
+    )
+    .select('id, name')
+    .single();
+  if (error) throw error;
+  return data!;
+}


### PR DESCRIPTION
## Summary
- Add nickname service with helpers to sanitize, normalize, lookup, and upsert nicknames by `user_unique_key`
- Refactor nickname modal to use service and store chosen name locally

## Testing
- `npm test` *(fails: Missing Supabase env vars NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY)*
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c829025e50832fbd31a2d79d621cbf