### PR TITLE
Add lazy Supabase helper with user warning

### DIFF
--- a/src/lib/db/learned.ts
+++ b/src/lib/db/learned.ts
@@ -1,7 +1,8 @@
-import { supabase } from './supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from './supabase';
 import type { LearnedWord } from '@/core/models';
 
-async function getUserId(): Promise<string> {
+async function getUserId(supabase: SupabaseClient): Promise<string> {
   const { data: sessionData, error } = await supabase.auth.getSession();
   if (error) throw error;
   let user = sessionData.session?.user;
@@ -14,7 +15,9 @@ async function getUserId(): Promise<string> {
 }
 
 export async function getLearned(): Promise<LearnedWord[]> {
-  const user_id = await getUserId();
+  const supabase = getSupabaseClient();
+  if (!supabase) return [];
+  const user_id = await getUserId(supabase);
   const { data, error } = await supabase
     .from('learned_words')
     .select('*')
@@ -24,7 +27,9 @@ export async function getLearned(): Promise<LearnedWord[]> {
 }
 
 export async function upsertLearned(wordId: string, inReview: boolean): Promise<void> {
-  const user_id = await getUserId();
+  const supabase = getSupabaseClient();
+  if (!supabase) return;
+  const user_id = await getUserId(supabase);
   const { error } = await supabase
     .from('learned_words')
     .upsert(
@@ -35,7 +40,9 @@ export async function upsertLearned(wordId: string, inReview: boolean): Promise<
 }
 
 export async function setReview(wordId: string, inReview: boolean): Promise<void> {
-  const user_id = await getUserId();
+  const supabase = getSupabaseClient();
+  if (!supabase) return;
+  const user_id = await getUserId(supabase);
   const { error } = await supabase
     .from('learned_words')
     .update({ in_review_queue: inReview, learned_at: new Date().toISOString() })

--- a/src/lib/db/preferences.ts
+++ b/src/lib/db/preferences.ts
@@ -1,7 +1,8 @@
-import { supabase } from './supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from './supabase';
 import type { UserPreferences } from '@/core/models';
 
-async function getUserId(): Promise<string> {
+async function getUserId(supabase: SupabaseClient): Promise<string> {
   const { data: sessionData, error } = await supabase.auth.getSession();
   if (error) throw error;
   let user = sessionData.session?.user;
@@ -22,7 +23,9 @@ const DEFAULT_PREFS: UserPreferences = {
 };
 
 export async function getPreferences(): Promise<UserPreferences> {
-  const user_id = await getUserId();
+  const supabase = getSupabaseClient();
+  if (!supabase) return DEFAULT_PREFS;
+  const user_id = await getUserId(supabase);
   const { data, error } = await supabase
     .from('user_preferences')
     .select('*')
@@ -46,7 +49,9 @@ export async function getPreferences(): Promise<UserPreferences> {
 }
 
 export async function savePreferences(p: Partial<UserPreferences>): Promise<void> {
-  const user_id = await getUserId();
+  const supabase = getSupabaseClient();
+  if (!supabase) return;
+  const user_id = await getUserId(supabase);
   const { data: existing } = await supabase
     .from('user_preferences')
     .select('*')

--- a/src/lib/db/profiles.ts
+++ b/src/lib/db/profiles.ts
@@ -1,8 +1,12 @@
-import { supabase } from './supabase';
+import { getSupabaseClient } from './supabase';
 import { canonNickname, isNicknameAllowed } from '@/core/nickname';
 
-export async function ensureProfile(nickname: string): Promise<{ user_id: string; nickname: string }> {
+export async function ensureProfile(
+  nickname: string
+): Promise<{ user_id: string; nickname: string } | null> {
   if (!isNicknameAllowed(nickname)) throw new Error('Invalid nickname');
+  const supabase = getSupabaseClient();
+  if (!supabase) return null;
   const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
   if (sessionError) throw sessionError;
   let user = sessionData.session?.user;

--- a/src/lib/db/supabase.ts
+++ b/src/lib/db/supabase.ts
@@ -1,10 +1,79 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+let client: SupabaseClient | null = null;
+let hasShownMissingMessage = false;
 
-if (!url || !anon) {
-  throw new Error('Missing Supabase env vars NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+function readImportMetaEnv(key: string): string | undefined {
+  try {
+    return ((import.meta as unknown as { env?: Record<string, string | undefined> })?.env ?? {})[key];
+  } catch {
+    return undefined;
+  }
 }
 
-export const supabase = createClient(url, anon);
+function readProcessEnv(key: string): string | undefined {
+  return typeof process !== 'undefined' ? process.env?.[key] : undefined;
+}
+
+function showMissingEnvMessage() {
+  if (hasShownMissingMessage) return;
+  hasShownMissingMessage = true;
+  const message =
+    'Cloud sync features are disabled because Supabase credentials are missing. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable them.';
+
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    console.warn(message);
+    return;
+  }
+
+  const renderMessage = () => {
+    if (document.getElementById('supabase-env-warning')) return;
+    const banner = document.createElement('div');
+    banner.id = 'supabase-env-warning';
+    banner.textContent = message;
+    banner.style.position = 'fixed';
+    banner.style.bottom = '1.5rem';
+    banner.style.left = '50%';
+    banner.style.transform = 'translateX(-50%)';
+    banner.style.zIndex = '2147483647';
+    banner.style.background = '#fff7ed';
+    banner.style.color = '#7c2d12';
+    banner.style.padding = '0.9rem 1.4rem';
+    banner.style.borderRadius = '0.75rem';
+    banner.style.border = '1px solid rgba(124, 45, 18, 0.2)';
+    banner.style.boxShadow = '0 10px 25px rgba(0, 0, 0, 0.1)';
+    banner.style.fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+    banner.style.fontSize = '0.95rem';
+    banner.style.maxWidth = '90%';
+    banner.style.textAlign = 'center';
+    banner.style.pointerEvents = 'none';
+    banner.style.lineHeight = '1.4';
+    document.body?.appendChild(banner);
+    window.setTimeout(() => {
+      banner.remove();
+    }, 12000);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', renderMessage, { once: true });
+  } else {
+    renderMessage();
+  }
+}
+
+function resolveSupabaseConfig() {
+  const url = readImportMetaEnv('VITE_SUPABASE_URL') ?? readProcessEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anon = readImportMetaEnv('VITE_SUPABASE_ANON_KEY') ?? readProcessEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  return { url, anon };
+}
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (client) return client;
+  const { url, anon } = resolveSupabaseConfig();
+  if (!url || !anon) {
+    showMissingEnvMessage();
+    return null;
+  }
+  client = createClient(url, anon);
+  return client;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,28 +1,12 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-
-let client: SupabaseClient | null = null;
-
-function viteEnv(k: string) {
-  try {
-    return (import.meta as any).env?.[k];
-  } catch {
-    return undefined;
-  }
-}
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient as getDbSupabaseClient } from './db/supabase';
 
 export function getSupabaseClient(): SupabaseClient {
-  if (client) return client;
-  const url =
-    viteEnv('VITE_SUPABASE_URL') ||
-    process.env.NEXT_PUBLIC_SUPABASE_URL ||
-    process.env.REACT_APP_SUPABASE_URL ||
-    '';
-  const anon =
-    viteEnv('VITE_SUPABASE_ANON_KEY') ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    process.env.REACT_APP_SUPABASE_ANON_KEY ||
-    '';
-  if (!url || !anon) throw new Error(`Missing Supabase envs`);
-  client = createClient(url, anon);
+  const client = getDbSupabaseClient();
+  if (!client) {
+    throw new Error(
+      'Supabase credentials are missing. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable cloud sync.'
+    );
+  }
   return client;
 }


### PR DESCRIPTION
## Summary
- create a lazy Supabase helper that reads Vite env vars and displays a friendly banner when configuration is missing
- update database helpers to request the client lazily and fall back safely when Supabase is unavailable
- reuse the shared helper for `getSupabaseClient` so other modules get the same configuration handling

## Testing
- npm run lint *(fails: repository has existing lint violations unrelated to this change)*
- npm test *(fails: Supabase network calls require credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c82f9795a4832f9922d303cc2f1880