### PR TITLE
feat: default daily option to light

### DIFF
--- a/tests/markWordLearnedRemovesTodayWord.test.tsx
+++ b/tests/markWordLearnedRemovesTodayWord.test.tsx
@@ -2,10 +2,22 @@
  * @vitest-environment jsdom
  */
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
 import { VocabularyWord } from '@/types/vocabulary';
+import { getPreferences, savePreferences } from '@/lib/db/preferences';
+
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: 'light'
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
 
 describe('markWordLearned', () => {
   beforeEach(() => {

--- a/tests/useLearningProgressAutoDailyOption.test.tsx
+++ b/tests/useLearningProgressAutoDailyOption.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useLearningProgress } from '@/hooks/useLearningProgress';
+import type { VocabularyWord } from '@/types/vocabulary';
+import type { DailySelection } from '@/types/learning';
+import { learningProgressService } from '@/services/learningProgressService';
+import { getPreferences, savePreferences } from '@/lib/db/preferences';
+
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: null
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('@/services/learningProgressService', () => ({
+  learningProgressService: {
+    getTodaySelection: vi.fn().mockReturnValue(null),
+    forceGenerateDailySelection: vi.fn(),
+    getProgressStats: vi.fn().mockReturnValue({
+      total: 0,
+      learning: 0,
+      new: 0,
+      due: 0,
+      learned: 0
+    }),
+    updateWordProgress: vi.fn(),
+    getWordProgress: vi.fn(),
+    getLearnedWords: vi.fn().mockReturnValue([]),
+    markWordLearned: vi.fn(),
+    markWordAsNew: vi.fn()
+  }
+}));
+
+describe('useLearningProgress daily option default', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to light when daily_option is missing', async () => {
+    const words: VocabularyWord[] = [
+      { word: 'apple', meaning: '', example: '', category: 'fruit' }
+    ];
+    const selection: DailySelection = {
+      newWords: [],
+      reviewWords: [],
+      totalCount: 0,
+      severity: 'light'
+    };
+    (learningProgressService.forceGenerateDailySelection as vi.Mock).mockReturnValue(selection);
+
+    renderHook(() => useLearningProgress(words));
+
+    await waitFor(() => {
+      expect(getPreferences).toHaveBeenCalled();
+      expect(learningProgressService.forceGenerateDailySelection).toHaveBeenCalledWith(words, 'light');
+      expect(savePreferences).toHaveBeenCalledWith({ daily_option: 'light' });
+    });
+  });
+});
+

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -7,6 +7,18 @@ import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
 import { VocabularyWord } from '@/types/vocabulary';
 import { LearningProgress, DailySelection } from '@/types/learning';
+import { getPreferences, savePreferences } from '@/lib/db/preferences';
+
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: 'light'
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
 
 describe('useLearningProgress due reviews', () => {
   const dueWord: VocabularyWord = { word: 'apple', meaning: '', example: '', category: 'fruit' };

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -5,6 +5,18 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
+import { getPreferences, savePreferences } from '@/lib/db/preferences';
+
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: 'light'
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
 
 describe('useLearningProgress', () => {
   it('provides learned stat from service', () => {

--- a/tests/useVocabularyDataLoaderAllSheets.test.ts
+++ b/tests/useVocabularyDataLoaderAllSheets.test.ts
@@ -8,6 +8,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { learningProgressService } from '@/services/learningProgressService';
 import { getTodayLastWord } from '@/utils/lastWordStorage';
+import { getPreferences, savePreferences } from '@/lib/db/preferences';
 
 vi.mock('@/services/vocabularyService', () => ({
   vocabularyService: {
@@ -28,6 +29,16 @@ vi.mock('@/services/learningProgressService', () => ({
 
 vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
 vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: null
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
 
 const localStorageMock = {
   getItem: vi.fn(),
@@ -64,6 +75,8 @@ describe('useVocabularyDataLoader all sheets', () => {
 
     await waitFor(() => {
       expect(vocabularyService.loadDefaultVocabulary).toHaveBeenCalled();
+      expect(getPreferences).toHaveBeenCalled();
+      expect(savePreferences).toHaveBeenCalledWith({ daily_option: 'light' });
       expect(learningProgressService.forceGenerateDailySelection).toHaveBeenCalledWith(words, 'light');
       expect(setWordList).toHaveBeenCalledWith(words);
     });

--- a/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
+++ b/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
@@ -29,6 +29,16 @@ vi.mock('@/services/learningProgressService', () => ({
 
 vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
 vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
+vi.mock('@/lib/db/preferences', () => ({
+  getPreferences: vi.fn().mockResolvedValue({
+    favorite_voice: null,
+    speech_rate: null,
+    is_muted: false,
+    is_playing: true,
+    daily_option: 'light'
+  }),
+  savePreferences: vi.fn().mockResolvedValue(undefined)
+}));
 
 const localStorageMock = {
   getItem: vi.fn(),


### PR DESCRIPTION
## Summary
- default to light daily severity when user preference missing
- persist chosen daily option
- cover preference defaulting in tests

## Testing
- `npm run lint` (fails: Unexpected any)
- `npm test` (fails: fetch failed ENETUNREACH)
- `npx vitest run tests/useLearningProgressAutoDailyOption.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c84c439fa0832f89db236f7f717b69