### PR TITLE
Use user_unique_key for preferences

### DIFF
--- a/src/lib/db/preferences.ts
+++ b/src/lib/db/preferences.ts
@@ -1,18 +1,6 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabaseClient } from './supabase';
 import type { UserPreferences } from '@/core/models';
-
-async function getUserId(supabase: SupabaseClient): Promise<string> {
-  const { data: sessionData, error } = await supabase.auth.getSession();
-  if (error) throw error;
-  let user = sessionData.session?.user;
-  if (!user) {
-    const { data, error: anonError } = await supabase.auth.signInAnonymously();
-    if (anonError || !data.user) throw anonError || new Error('anonymous sign-in failed');
-    user = data.user;
-  }
-  return user.id;
-}
+import { ensureUserKey } from '@/lib/progress/srsSyncByUserKey';
 
 const DEFAULT_PREFS: UserPreferences = {
   favorite_voice: null,
@@ -25,17 +13,18 @@ const DEFAULT_PREFS: UserPreferences = {
 export async function getPreferences(): Promise<UserPreferences> {
   const supabase = getSupabaseClient();
   if (!supabase) return DEFAULT_PREFS;
-  const user_id = await getUserId(supabase);
+  const user_unique_key = await ensureUserKey();
+  if (!user_unique_key) return DEFAULT_PREFS;
   const { data, error } = await supabase
     .from('user_preferences')
     .select('*')
-    .eq('user_id', user_id)
+    .eq('user_unique_key', user_unique_key)
     .maybeSingle();
   if (error) throw error;
   if (!data) {
     const { error: upsertError } = await supabase
       .from('user_preferences')
-      .upsert({ user_id, ...DEFAULT_PREFS });
+      .upsert({ user_unique_key, ...DEFAULT_PREFS });
     if (upsertError) throw upsertError;
     return DEFAULT_PREFS;
   }
@@ -51,15 +40,16 @@ export async function getPreferences(): Promise<UserPreferences> {
 export async function savePreferences(p: Partial<UserPreferences>): Promise<void> {
   const supabase = getSupabaseClient();
   if (!supabase) return;
-  const user_id = await getUserId(supabase);
+  const user_unique_key = await ensureUserKey();
+  if (!user_unique_key) return;
   const { data: existing } = await supabase
     .from('user_preferences')
     .select('*')
-    .eq('user_id', user_id)
+    .eq('user_unique_key', user_unique_key)
     .maybeSingle();
   const merged = { ...DEFAULT_PREFS, ...existing, ...p };
   const { error } = await supabase
     .from('user_preferences')
-    .upsert({ user_id, ...merged, updated_at: new Date().toISOString() });
+    .upsert({ user_unique_key, ...merged, updated_at: new Date().toISOString() });
   if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- replace the local getUserId helper with ensureUserKey for retrieving the current user key
- query and upsert user_preferences records by user_unique_key instead of user_id

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ee783998832fbced8074be13e2f2