### PR TITLE
Persist speech rate in local storage

### DIFF
--- a/src/hooks/useSpeechRate.tsx
+++ b/src/hooks/useSpeechRate.tsx
@@ -1,24 +1,19 @@
 import { useEffect, useState } from 'react';
 import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getSpeechRate as getStoredSpeechRate, setSpeechRate as setStoredSpeechRate } from '@/lib/localPreferences';
 
 export const useSpeechRate = () => {
   const [speechRate, setSpeechRate] = useState<number>(DEFAULT_SPEECH_RATE);
 
   useEffect(() => {
-    getPreferences()
-      .then(p => {
-        if (typeof p.speech_rate === 'number') {
-          setSpeechRate(p.speech_rate);
-        }
-      })
-      .catch(console.error);
+    const storedRate = getStoredSpeechRate();
+    if (typeof storedRate === 'number') {
+      setSpeechRate(storedRate);
+    }
   }, []);
 
   useEffect(() => {
-    savePreferences({ speech_rate: speechRate }).catch(err => {
-      console.error('Error saving speech rate', err);
-    });
+    setStoredSpeechRate(speechRate);
   }, [speechRate]);
 
   return { speechRate, setSpeechRate };

--- a/src/lib/localPreferences.ts
+++ b/src/lib/localPreferences.ts
@@ -1,0 +1,26 @@
+const SPEECH_RATE_KEY = 'lv_speech_rate';
+
+const hasLocalStorage = (): boolean =>
+  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+export const getSpeechRate = (): number | null => {
+  if (!hasLocalStorage()) return null;
+  try {
+    const raw = window.localStorage.getItem(SPEECH_RATE_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+export const setSpeechRate = (rate: number): void => {
+  if (!hasLocalStorage()) return;
+  if (!Number.isFinite(rate)) return;
+  try {
+    window.localStorage.setItem(SPEECH_RATE_KEY, String(rate));
+  } catch {
+    // ignore write errors
+  }
+};

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,22 +1,13 @@
 import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getSpeechRate as getStoredSpeechRate, setSpeechRate as setStoredSpeechRate } from '@/lib/localPreferences';
 
-let cachedRate = DEFAULT_SPEECH_RATE;
-
-// Load initial rate
-getPreferences()
-  .then(p => {
-    if (typeof p.speech_rate === 'number') {
-      cachedRate = p.speech_rate;
-    }
-  })
-  .catch(() => {});
+let cachedRate = getStoredSpeechRate() ?? DEFAULT_SPEECH_RATE;
 
 export const getSpeechRate = (): number => cachedRate;
 
 export const setSpeechRate = (rate: number): void => {
   cachedRate = rate;
-  void savePreferences({ speech_rate: rate });
+  setStoredSpeechRate(rate);
 };
 
 export const getSpeechPitch = (): number => 1.0;


### PR DESCRIPTION
## Summary
- add local preference helpers for speech rate using localStorage
- update the speech rate hook to load and persist values through the new helpers
- update core speech settings to reuse the helpers and remove Supabase usage

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68c90cbd1000832f8e057cddd61e89ad