### PR TITLE
Persist mute preference locally

### DIFF
--- a/src/hooks/audio/useAudioMuteEffect.tsx
+++ b/src/hooks/audio/useAudioMuteEffect.tsx
@@ -1,12 +1,11 @@
-
 import { useEffect } from 'react';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
-import { savePreferences } from '@/lib/db/preferences';
+import { setIsMuted } from '@/utils/localPreferences';
 
 export const useAudioMuteEffect = (mute: boolean) => {
   // Effect specifically for mute changes
   useEffect(() => {
-    savePreferences({ is_muted: mute }).catch(() => {});
+    setIsMuted(mute);
     unifiedSpeechController.setMuted(mute);
   }, [mute]);
 };

--- a/src/hooks/useMuteToggle.tsx
+++ b/src/hooks/useMuteToggle.tsx
@@ -1,16 +1,16 @@
-
 import { useState, useCallback, useEffect } from 'react';
-import { savePreferences } from '@/lib/db/preferences';
+import { getIsMuted, setIsMuted } from '@/utils/localPreferences';
 
 export const useMuteToggle = (
   isMuted: boolean,
   handleToggleMute: () => void
 ) => {
-  const [mute, setMute] = useState(isMuted);
+  const [mute, setMute] = useState(() => getIsMuted());
 
   // Sync with parent mute state
   useEffect(() => {
     setMute(isMuted);
+    setIsMuted(isMuted);
   }, [isMuted]);
 
   // Toggle mute without restarting speech or clearing timers
@@ -19,9 +19,7 @@ export const useMuteToggle = (
     setMute(!mute);
     handleToggleMute();
 
-    savePreferences({ is_muted: !mute }).catch(err =>
-      console.error('Error saving mute state', err),
-    );
+    setIsMuted(!mute);
   }, [mute, handleToggleMute]);
 
   return { mute, toggleMute };

--- a/src/utils/localPreferences.ts
+++ b/src/utils/localPreferences.ts
@@ -1,0 +1,20 @@
+const MUTE_KEY = 'lv_is_muted';
+
+export function getIsMuted(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(MUTE_KEY) === 'true';
+  } catch (error) {
+    console.error('Error reading mute state from localStorage:', error);
+    return false;
+  }
+}
+
+export function setIsMuted(muted: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(MUTE_KEY, muted ? 'true' : 'false');
+  } catch (error) {
+    console.error('Error saving mute state to localStorage:', error);
+  }
+}

--- a/src/utils/speech/core/speechPlayerUtils.ts
+++ b/src/utils/speech/core/speechPlayerUtils.ts
@@ -1,6 +1,5 @@
-
-// Preferences handled server-side
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
+import { getIsMuted } from '@/utils/localPreferences';
 
 // Store the current text being spoken for sync checking
 export function setCurrentTextBeingSpoken(processedText: string) {
@@ -12,8 +11,7 @@ export function setCurrentTextBeingSpoken(processedText: string) {
 }
 
 export function isMutedFromLocalStorage(): boolean {
-  // Prefer server-side preferences
-  return false;
+  return getIsMuted();
 }
 
 export function loadVoices(): SpeechSynthesisVoice[] {


### PR DESCRIPTION
## Summary
- add utilities to get and set the mute preference in localStorage
- initialize the mute toggle hook from the saved preference and persist updates through the new helpers
- ensure audio mute effects and the speech player respect the locally stored mute state

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c90d18dcc8832fa547b8123b89b61a