### PR TITLE
Use local storage for favorite voice selection

### DIFF
--- a/src/hooks/useVoiceContext.tsx
+++ b/src/hooks/useVoiceContext.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import { toast } from 'sonner';
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getFavoriteVoice, setFavoriteVoice } from '@/lib/preferences/localPreferences';
+
 export interface VoiceContext {
   allVoices: SpeechSynthesisVoice[];
   selectedVoiceName: string;
@@ -20,18 +20,15 @@ export const useVoiceContext = (): VoiceContext => {
         .filter(v => v.lang && v.lang.toLowerCase().startsWith('en'));
       logAvailableVoices(voices);
       setAllVoices(voices);
-      getPreferences()
-        .then(p => {
-          const preferred = voices.find(v => v.name === p.favorite_voice);
-          if (preferred) {
-            setSelectedVoiceName(preferred.name);
-          } else if (voices.length > 0) {
-            setSelectedVoiceName(voices[0].name);
-          }
-        })
-        .catch(() => {
-          if (voices.length > 0) setSelectedVoiceName(voices[0].name);
-        });
+      const favorite = getFavoriteVoice();
+      const preferred = favorite
+        ? voices.find(v => v.name === favorite)
+        : undefined;
+      if (preferred) {
+        setSelectedVoiceName(preferred.name);
+      } else if (voices.length > 0) {
+        setSelectedVoiceName(voices[0].name);
+      }
     };
 
     window.speechSynthesis.addEventListener('voiceschanged', loadVoices);
@@ -44,9 +41,7 @@ export const useVoiceContext = (): VoiceContext => {
 
   useEffect(() => {
     if (selectedVoiceName) {
-      savePreferences({ favorite_voice: selectedVoiceName }).catch(err =>
-        console.error('Error saving voice preference', err),
-      );
+      setFavoriteVoice(selectedVoiceName);
     }
   }, [selectedVoiceName]);
 
@@ -56,9 +51,7 @@ export const useVoiceContext = (): VoiceContext => {
     const nextIndex = (index + 1) % allVoices.length;
     const nextVoice = allVoices[nextIndex];
     setSelectedVoiceName(nextVoice.name);
-    savePreferences({ favorite_voice: nextVoice.name }).catch(err =>
-      console.error('Error saving voice preference', err),
-    );
+    setFavoriteVoice(nextVoice.name);
   };
 
   return { allVoices, selectedVoiceName, setSelectedVoiceName, cycleVoice };

--- a/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyControls.ts
@@ -5,7 +5,7 @@ import { vocabularyService } from '@/services/vocabularyService';
 import { SpeechState } from '@/services/speech/core/SpeechState';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 import { toast } from 'sonner';
-import { savePreferences } from '@/lib/db/preferences';
+import { setFavoriteVoice } from '@/lib/preferences/localPreferences';
 
 /**
  * Vocabulary control actions
@@ -54,7 +54,7 @@ export const useVocabularyControls = (
     const nextIndex = (currentIndex + 1) % allVoices.length;
     const nextVoice = allVoices[nextIndex];
     setSelectedVoiceName(nextVoice.name);
-    savePreferences({ favorite_voice: nextVoice.name }).catch(console.error);
+    setFavoriteVoice(nextVoice.name);
     unifiedSpeechController.stop();
     toast.success(`Voice changed to ${nextVoice.name} (${nextVoice.lang})`);
   }, [allVoices, selectedVoiceName, setSelectedVoiceName]);

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -1,9 +1,9 @@
-
 import { useEffect, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { learningProgressService } from '@/services/learningProgressService';
 import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { setFavoriteVoice } from '@/lib/preferences/localPreferences';
 import { getTodayLastWord } from '@/utils/lastWordStorage';
 import type { SeverityLevel } from '@/types/learning';
 
@@ -34,9 +34,7 @@ export const useVocabularyDataLoader = (
   };
   // Persist selected voice whenever it changes
   useEffect(() => {
-    savePreferences({ favorite_voice: selectedVoiceName }).catch(err =>
-      console.error('Error saving voice', err),
-    );
+    setFavoriteVoice(selectedVoiceName);
   }, [selectedVoiceName]);
 
   // Load initial data

--- a/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
+++ b/src/hooks/vocabulary-playback/core/useVoiceManagement.ts
@@ -1,9 +1,8 @@
-
 import { useState, useEffect, useCallback } from 'react';
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
 import { VoiceSelection } from '../useVoiceSelection';
 import { toast } from 'sonner';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getFavoriteVoice, setFavoriteVoice } from '@/lib/preferences/localPreferences';
 
 /**
  * Hook for managing voice selection and finding appropriate voices
@@ -28,12 +27,11 @@ export const useVoiceManagement = () => {
   
   // Load initial voice settings
   useEffect(() => {
-    getPreferences()
-      .then(p => {
-        const idx = allVoiceOptions.findIndex(v => v.label === p.favorite_voice);
-        if (idx >= 0) setVoiceIndex(idx);
-      })
-      .catch(err => console.error('Error loading voice preference', err));
+    const favorite = getFavoriteVoice();
+    if (favorite) {
+      const idx = allVoiceOptions.findIndex(v => v.label === favorite);
+      if (idx >= 0) setVoiceIndex(idx);
+    }
 
     // Also try to preload voices
     const loadVoicesAndNotify = () => {
@@ -122,9 +120,7 @@ export const useVoiceManagement = () => {
       );
       
       const voiceName = allVoiceOptions[nextIndex].label;
-      savePreferences({ favorite_voice: voiceName }).catch(err =>
-        console.error('Error saving voice preference', err),
-      );
+      setFavoriteVoice(voiceName);
       
       // Notify the user
       toast.success(`Voice changed to ${allVoiceOptions[nextIndex].label}`);

--- a/src/hooks/vocabulary-playback/useVoiceSelection.tsx
+++ b/src/hooks/vocabulary-playback/useVoiceSelection.tsx
@@ -1,8 +1,6 @@
-
 import { useState, useEffect } from 'react';
 import { logAvailableVoices } from '@/utils/speech/debug/logVoices';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
-
+import { getFavoriteVoice, setFavoriteVoice } from '@/lib/preferences/localPreferences';
 
 export type VoiceOption = {
   label: string;
@@ -86,24 +84,20 @@ export const useVoiceSelection = () => {
         
         setVoices(voiceOptions);
 
-        getPreferences()
-          .then(p => {
-            const storedName = p.favorite_voice;
-            const matched = storedName
-              ? voiceOptions.find(v => v.voice?.name === storedName)
-              : null;
-            if (matched) {
-              setVoiceIndex(matched.index);
-              setSelectedVoice({
-                label: matched.label,
-                region: matched.region,
-                gender: matched.gender,
-                index: matched.index,
-              });
-              console.log(`Restored voice preference: ${matched.voice?.name}`);
-            }
-          })
-          .catch(err => console.error('Error loading voice preference', err));
+        const storedName = getFavoriteVoice();
+        const matched = storedName
+          ? voiceOptions.find(v => v.voice?.name === storedName)
+          : null;
+        if (matched) {
+          setVoiceIndex(matched.index);
+          setSelectedVoice({
+            label: matched.label,
+            region: matched.region,
+            gender: matched.gender,
+            index: matched.index,
+          });
+          console.log(`Restored voice preference: ${matched.voice?.name}`);
+        }
       }
     };
 
@@ -130,9 +124,7 @@ export const useVoiceSelection = () => {
   useEffect(() => {
     const voiceName = voices[voiceIndex]?.voice?.name;
     if (voiceName) {
-      savePreferences({ favorite_voice: voiceName }).catch(err =>
-        console.error('Error saving voice preference', err),
-      );
+      setFavoriteVoice(voiceName);
     }
   }, [voiceIndex, voices]);
   
@@ -151,9 +143,7 @@ export const useVoiceSelection = () => {
 
     const voiceName = voices[nextVoice.index]?.voice?.name;
     if (voiceName) {
-      savePreferences({ favorite_voice: voiceName }).catch(err =>
-        console.error('Error saving voice preference', err),
-      );
+      setFavoriteVoice(voiceName);
     }
   };
   

--- a/src/lib/preferences/localPreferences.ts
+++ b/src/lib/preferences/localPreferences.ts
@@ -1,0 +1,30 @@
+const FAVORITE_VOICE_KEY = 'lv_favorite_voice';
+
+export function getFavoriteVoice(): string | null {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(FAVORITE_VOICE_KEY);
+  } catch (error) {
+    console.error('Error reading favorite voice from localStorage', error);
+    return null;
+  }
+}
+
+export function setFavoriteVoice(name: string | null): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    if (name) {
+      window.localStorage.setItem(FAVORITE_VOICE_KEY, name);
+    } else {
+      window.localStorage.removeItem(FAVORITE_VOICE_KEY);
+    }
+  } catch (error) {
+    console.error('Error saving favorite voice to localStorage', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add local preferences helpers to store the favorite voice in localStorage
- update voice-related hooks to initialize and persist selections via the local helper functions

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c90d1b1b78832fa4b50d62a0db52f8