### PR TITLE
fix: restore speech rate hook and preferences helpers

### DIFF
--- a/src/hooks/useSpeechRate.tsx
+++ b/src/hooks/useSpeechRate.tsx
@@ -1,35 +1,29 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
-  getSpeechVoicePreference,
-  setSpeechVoicePreference,
-} from '@/utils/localPreferences';
-import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
+  getSpeechRate as getStoredSpeechRate,
+  setSpeechRate as setStoredSpeechRate,
+} from '@/utils/speech/core/speechSettings';
 
-export const useSpeechVoiceEffect = (
-  handleVoiceChange: (voice: string) => void
-) => {
-  // Load stored preference
-  const [voice, setVoice] = useState(() => getSpeechVoicePreference());
+/**
+ * Hook for managing the speech synthesis rate.
+ *
+ * The current rate is persisted to local storage via the speech settings
+ * helper so it can be restored across sessions.
+ */
+export const useSpeechRate = () => {
+  // initialise from stored preference or fall back to default value from settings
+  const [speechRate, setSpeechRateState] = useState(() => getStoredSpeechRate());
 
-  // Apply saved voice on initial mount
+  // ensure state stays in sync with any external changes
   useEffect(() => {
-    const stored = getSpeechVoicePreference();
-    if (stored) unifiedSpeechController.setVoice(stored);
+    setSpeechRateState(getStoredSpeechRate());
   }, []);
 
-  // Persist voice choice and update controller whenever it changes
-  useEffect(() => {
-    setSpeechVoicePreference(voice);
-    unifiedSpeechController.setVoice(voice);
-  }, [voice]);
+  const setSpeechRate = useCallback((rate: number) => {
+    setSpeechRateState(rate);
+    setStoredSpeechRate(rate);
+  }, []);
 
-  const handleChange = useCallback(
-    (newVoice: string) => {
-      setVoice(newVoice);
-      handleVoiceChange(newVoice);
-    },
-    [handleVoiceChange],
-  );
-
-  return { voice, handleChange };
+  return { speechRate, setSpeechRate };
 };
+

--- a/src/lib/preferences/localPreferences.ts
+++ b/src/lib/preferences/localPreferences.ts
@@ -1,4 +1,44 @@
+import type { UserPreferences } from '@/core/models';
+
+const PREF_KEY = 'lv_preferences';
 const FAVORITE_VOICE_KEY = 'lv_favorite_voice';
+
+const defaultPrefs: UserPreferences = {
+  favorite_voice: null,
+  speech_rate: null,
+  is_muted: false,
+  is_playing: true,
+  daily_option: null,
+};
+
+export async function getLocalPreferences(): Promise<UserPreferences> {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return { ...defaultPrefs };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(PREF_KEY);
+    const stored = raw ? JSON.parse(raw) : {};
+    return { ...defaultPrefs, ...stored } as UserPreferences;
+  } catch (error) {
+    console.error('Error reading local preferences from localStorage', error);
+    return { ...defaultPrefs };
+  }
+}
+
+export async function saveLocalPreferences(prefs: Partial<UserPreferences>): Promise<void> {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    const current = await getLocalPreferences();
+    const merged = { ...current, ...prefs };
+    window.localStorage.setItem(PREF_KEY, JSON.stringify(merged));
+  } catch (error) {
+    console.error('Error saving local preferences to localStorage', error);
+  }
+}
 
 export function getFavoriteVoice(): string | null {
   if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
@@ -28,3 +68,4 @@ export function setFavoriteVoice(name: string | null): void {
     console.error('Error saving favorite voice to localStorage', error);
   }
 }
+


### PR DESCRIPTION
## Summary
- add `useSpeechRate` hook backed by speech settings
- introduce local preference utilities for reading and saving user settings

## Testing
- `npm run lint` *(fails: Unexpected any, Empty block statement)*
- `npm test` *(fails: JavaScript heap out of memory)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c921512b4c832f8f228a08b3999d47