### PR TITLE
Enhance Lovable message fetch reliability

### DIFF
--- a/src/lovable.ts
+++ b/src/lovable.ts
@@ -1,5 +1,75 @@
 // Utilities for speech playback and API integration
 
+import { toast as defaultToast } from '@/hooks/use-toast';
+
+const DEFAULT_RETRY_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 500;
+const DEFAULT_BROADCAST_CHANNEL = 'lovable:latest-message';
+const DEFAULT_BROADCAST_FAILURE_THRESHOLD = 3;
+
+type ToastInvoker = typeof defaultToast;
+type ToastPayload = Parameters<ToastInvoker>[0];
+
+type Logger = Pick<Console, 'warn' | 'error'>;
+
+type LovableBroadcastFailureReason = 'unsupported' | 'init-error' | 'post-message-error';
+type LovableBroadcastDisableReason = 'manual' | 'threshold' | 'unsupported' | 'init-error';
+
+export interface LovableBroadcastFailureContext {
+  channelName: string;
+  projectId: string;
+  failureCount: number;
+  reason: LovableBroadcastFailureReason;
+  disable: (reason?: LovableBroadcastDisableReason) => void;
+}
+
+export interface LovableBroadcastDisabledInfo {
+  channelName: string;
+  projectId: string;
+  reason: LovableBroadcastDisableReason;
+  failureCount: number;
+  error?: unknown;
+}
+
+export interface LovableBroadcastOptions {
+  channelName?: string;
+  disabled?: boolean;
+  maxConsecutiveFailures?: number;
+  logger?: Logger;
+  onFailure?: (error: unknown, context: LovableBroadcastFailureContext) => void;
+  onDisabled?: (info: LovableBroadcastDisabledInfo) => void;
+}
+
+interface NormalizedBroadcastOptions {
+  channelName: string;
+  disabled: boolean;
+  maxConsecutiveFailures: number;
+  logger: Logger;
+  onFailure?: LovableBroadcastOptions['onFailure'];
+  onDisabled?: LovableBroadcastOptions['onDisabled'];
+}
+
+interface BroadcastState {
+  channel: BroadcastChannel | null;
+  disabled: boolean;
+  failureCount: number;
+  options: NormalizedBroadcastOptions;
+  lastProjectId?: string;
+}
+
+const broadcastStates = new Map<string, BroadcastState>();
+
+export interface FetchLatestMessageOptions {
+  retries?: number;
+  retryDelayMs?: number | ((attempt: number) => number);
+  toastOnHttpError?: boolean | Partial<ToastPayload>;
+  toastFn?: ToastInvoker;
+  logger?: Logger;
+  signal?: AbortSignal;
+  fetchImplementation?: typeof fetch;
+  broadcast?: boolean | LovableBroadcastOptions;
+}
+
 interface SpeechState {
   isMuted: boolean;
   voiceRegion: 'US' | 'UK' | 'AU';
@@ -19,8 +89,10 @@ function unlockSpeech() {
   }
 }
 
-document.addEventListener('click', unlockSpeech, { once: true });
-document.addEventListener('touchstart', unlockSpeech, { once: true });
+if (typeof document !== 'undefined') {
+  document.addEventListener('click', unlockSpeech, { once: true });
+  document.addEventListener('touchstart', unlockSpeech, { once: true });
+}
 
 export function executeSpeech(
   text: string,
@@ -45,19 +117,328 @@ export function executeSpeech(
   }
 }
 
-export async function fetchLatestMessage(projectId: string) {
-  try {
-    const res = await fetch(
-      `https://lovable-api.com/projects/${projectId}/latest-message`,
-      {
-        headers: { Accept: 'application/json' },
-        mode: 'cors'
-      }
+export async function fetchLatestMessage(
+  projectId: string,
+  options: FetchLatestMessageOptions = {}
+) {
+  return fetchLatestMessageWithOptions(projectId, options);
+}
+
+export function disableLovableBroadcast(
+  channelName: string = DEFAULT_BROADCAST_CHANNEL,
+  reason: LovableBroadcastDisableReason = 'manual'
+): boolean {
+  const state = broadcastStates.get(channelName);
+  if (!state) return false;
+  const projectId = state.lastProjectId ?? 'unknown';
+  return disableBroadcastState(state, projectId, reason);
+}
+
+function fetchLatestMessageWithOptions(
+  projectId: string,
+  {
+    retries = DEFAULT_RETRY_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    toastOnHttpError = true,
+    toastFn = defaultToast,
+    logger = console,
+    signal,
+    fetchImplementation,
+    broadcast
+  }: FetchLatestMessageOptions = {}
+): Promise<unknown | null> {
+  const fetchFn = fetchImplementation ?? globalThis.fetch;
+  if (typeof fetchFn !== 'function') {
+    logger.warn?.(
+      '[Lovable] fetchLatestMessage cannot run because the Fetch API is unavailable in this environment.'
     );
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
-  } catch (err) {
-    console.error('Failed to load latest message:', err);
-    return null;
+    return Promise.resolve(null);
   }
+
+  const normalizedBroadcast = normalizeBroadcastOptions(broadcast);
+  const attempts = Math.max(1, Math.floor(retries) + 1);
+  const url = `https://lovable-api.com/projects/${projectId}/latest-message`;
+
+  let lastError: unknown = null;
+  let hasShownHttpWarning = false;
+
+  const attemptFetch = async (attemptIndex: number): Promise<unknown | null> => {
+    const attemptNumber = attemptIndex + 1;
+    const isFinalAttempt = attemptNumber >= attempts;
+
+    try {
+      const response = await fetchFn(url, {
+        headers: { Accept: 'application/json' },
+        mode: 'cors',
+        signal
+      } as RequestInit);
+
+      if (response.status >= 400) {
+        if (!hasShownHttpWarning) {
+          notifyHttpError(
+            response.status,
+            projectId,
+            toastOnHttpError,
+            toastFn,
+            logger
+          );
+          hasShownHttpWarning = true;
+        } else {
+          logger.warn?.(
+            `[Lovable] Latest message request for project ${projectId} failed again with status ${response.status} (attempt ${attemptNumber}).`
+          );
+        }
+
+        if (!isFinalAttempt) {
+          await waitForRetry(retryDelayMs, attemptNumber);
+          return attemptFetch(attemptIndex + 1);
+        }
+        lastError = new Error(`HTTP ${response.status}`);
+        return null;
+      }
+
+      const data = await response.json();
+      if (normalizedBroadcast) {
+        maybeBroadcastLatestMessage(projectId, data, normalizedBroadcast);
+      }
+      return data;
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+      logger.warn?.(
+        `[Lovable] Latest message fetch attempt ${attemptNumber} failed for project ${projectId}.`,
+        error
+      );
+
+      if (!isFinalAttempt) {
+        await waitForRetry(retryDelayMs, attemptNumber);
+        return attemptFetch(attemptIndex + 1);
+      }
+    }
+
+    return null;
+  };
+
+  return attemptFetch(0).then(result => {
+    if (result === null && lastError) {
+      logger.error?.('Failed to load latest message:', lastError);
+    }
+    return result;
+  });
+}
+
+function notifyHttpError(
+  status: number,
+  projectId: string,
+  toastSetting: boolean | Partial<ToastPayload> | undefined,
+  toastFn: ToastInvoker | undefined,
+  logger: Logger
+) {
+  const message = `[Lovable] Latest message request for project ${projectId} failed with status ${status}.`;
+  let toastDisplayed = false;
+
+  if (toastSetting !== false && typeof window !== 'undefined' && typeof toastFn === 'function') {
+    const override = typeof toastSetting === 'object' && toastSetting !== null ? toastSetting : {};
+    try {
+      const payload: ToastPayload = {
+        title: override.title ?? 'Unable to fetch updates',
+        description:
+          override.description ??
+          `Lovable responded with status ${status}. We'll retry shortly.`,
+        variant: override.variant ?? 'destructive'
+      } as ToastPayload;
+      toastFn(payload);
+      toastDisplayed = true;
+    } catch (error) {
+      logger.warn?.('[Lovable] Failed to display toast notification for Lovable errors.', error);
+    }
+  }
+
+  logger.warn?.(message);
+
+  if (!toastDisplayed && toastSetting === false) {
+    return;
+  }
+}
+
+function normalizeBroadcastOptions(
+  broadcast: boolean | LovableBroadcastOptions | undefined
+): NormalizedBroadcastOptions | null {
+  if (broadcast === false) return null;
+
+  const options =
+    typeof broadcast === 'object' && broadcast !== null ? broadcast : ({} as LovableBroadcastOptions);
+
+  const maxFailuresRaw = options.maxConsecutiveFailures;
+  const maxConsecutiveFailures =
+    typeof maxFailuresRaw === 'number' && Number.isFinite(maxFailuresRaw) && maxFailuresRaw > 0
+      ? Math.floor(maxFailuresRaw)
+      : DEFAULT_BROADCAST_FAILURE_THRESHOLD;
+
+  return {
+    channelName: options.channelName ?? DEFAULT_BROADCAST_CHANNEL,
+    disabled: options.disabled ?? false,
+    maxConsecutiveFailures,
+    logger: options.logger ?? console,
+    onFailure: options.onFailure,
+    onDisabled: options.onDisabled
+  };
+}
+
+function getBroadcastState(options: NormalizedBroadcastOptions): BroadcastState {
+  let state = broadcastStates.get(options.channelName);
+  if (!state) {
+    state = {
+      channel: null,
+      disabled: false,
+      failureCount: 0,
+      options,
+      lastProjectId: undefined
+    };
+    broadcastStates.set(options.channelName, state);
+  } else {
+    state.options = options;
+  }
+  return state;
+}
+
+function disableBroadcastState(
+  state: BroadcastState,
+  projectId: string,
+  reason: LovableBroadcastDisableReason,
+  error?: unknown
+): boolean {
+  if (state.disabled) return false;
+  state.disabled = true;
+
+  if (state.channel) {
+    try {
+      state.channel.close();
+    } catch {
+      // ignore channel closing failures
+    }
+    state.channel = null;
+  }
+
+  state.options.logger.warn?.(
+    `[Lovable] Broadcast disabled for channel "${state.options.channelName}" (${reason}).`,
+    error
+  );
+
+  state.options.onDisabled?.({
+    channelName: state.options.channelName,
+    projectId,
+    reason,
+    failureCount: state.failureCount,
+    error
+  });
+
+  return true;
+}
+
+function maybeBroadcastLatestMessage(
+  projectId: string,
+  payload: unknown,
+  options: NormalizedBroadcastOptions
+) {
+  const state = getBroadcastState(options);
+  state.lastProjectId = projectId;
+
+  if (options.disabled || state.disabled) {
+    return;
+  }
+
+  const disable = (
+    reason: LovableBroadcastDisableReason = 'manual',
+    error?: unknown
+  ): boolean => disableBroadcastState(state, projectId, reason, error);
+
+  const handleFailure = (reason: LovableBroadcastFailureReason, error?: unknown) => {
+    state.failureCount += 1;
+    options.logger.warn?.(
+      `[Lovable] Broadcast message failed (${reason}) on channel "${options.channelName}" (failure #${state.failureCount}).`,
+      error
+    );
+
+    options.onFailure?.(error, {
+      channelName: options.channelName,
+      projectId,
+      failureCount: state.failureCount,
+      reason,
+      disable: disable
+    });
+
+    if (reason === 'unsupported' || reason === 'init-error') {
+      disable(reason, error);
+      return;
+    }
+
+    if (state.failureCount >= options.maxConsecutiveFailures) {
+      disable('threshold', error);
+    }
+  };
+
+  if (typeof globalThis === 'undefined' || typeof globalThis.BroadcastChannel === 'undefined') {
+    handleFailure('unsupported');
+    return;
+  }
+
+  if (!state.channel) {
+    try {
+      state.channel = new globalThis.BroadcastChannel(options.channelName);
+    } catch (error) {
+      handleFailure('init-error', error);
+      return;
+    }
+  }
+
+  try {
+    state.channel.postMessage({
+      projectId,
+      payload,
+      timestamp: Date.now()
+    });
+    state.failureCount = 0;
+  } catch (error) {
+    handleFailure('post-message-error', error);
+  }
+}
+
+function waitForRetry(delaySetting: number | ((attempt: number) => number), attemptNumber: number) {
+  const delayMs = computeRetryDelay(delaySetting, attemptNumber);
+  if (!delayMs || delayMs <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function computeRetryDelay(delaySetting: number | ((attempt: number) => number), attemptNumber: number) {
+  if (typeof delaySetting === 'function') {
+    const value = Number(delaySetting(attemptNumber));
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  }
+
+  const numericDelay = Number(delaySetting);
+  if (!Number.isFinite(numericDelay) || numericDelay <= 0) {
+    return 0;
+  }
+
+  return Math.round(numericDelay * Math.pow(2, attemptNumber - 1));
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!error) return false;
+  if (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    error.name === 'AbortError'
+  ) {
+    return true;
+  }
+  return typeof error === 'object' && (error as { name?: string }).name === 'AbortError';
 }

--- a/tests/fetchLatestMessage.test.ts
+++ b/tests/fetchLatestMessage.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { fetchLatestMessage } from '@/lovable';
+import type { LovableBroadcastDisabledInfo, LovableBroadcastFailureContext } from '@/lovable';
+
+interface MockResponse {
+  status: number;
+  json: ReturnType<typeof vi.fn>;
+}
+
+const createResponse = (status: number, body: unknown = {}): MockResponse => ({
+  status,
+  json: vi.fn().mockResolvedValue(body)
+});
+
+describe('fetchLatestMessage', () => {
+  const originalBroadcast = globalThis.BroadcastChannel;
+
+  afterEach(() => {
+    globalThis.BroadcastChannel = originalBroadcast;
+    vi.restoreAllMocks();
+  });
+
+  it('retries on HTTP errors until the request succeeds', async () => {
+    const first = createResponse(502);
+    const second = createResponse(503);
+    const successBody = { message: 'ok' };
+    const third = createResponse(200, successBody);
+
+    const fetchMock = vi
+      .fn<Parameters<typeof fetch>, Promise<MockResponse>>()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValueOnce(third);
+
+    const toastSpy = vi.fn();
+    const warnSpy = vi.fn();
+    const errorSpy = vi.fn();
+
+    const result = await fetchLatestMessage('project-1', {
+      retries: 3,
+      retryDelayMs: () => 0,
+      fetchImplementation: fetchMock as unknown as typeof fetch,
+      toastFn: toastSpy,
+      logger: { warn: warnSpy, error: errorSpy },
+      broadcast: false
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(toastSpy).not.toHaveBeenCalled();
+    expect(result).toEqual(successBody);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null after exhausting retries', async () => {
+    const failure = createResponse(500);
+    const fetchMock = vi.fn<Parameters<typeof fetch>, Promise<MockResponse>>().mockResolvedValue(failure);
+    const toastSpy = vi.fn();
+    const warnSpy = vi.fn();
+    const errorSpy = vi.fn();
+
+    const result = await fetchLatestMessage('project-2', {
+      retries: 1,
+      retryDelayMs: () => 0,
+      fetchImplementation: fetchMock as unknown as typeof fetch,
+      toastFn: toastSpy,
+      toastOnHttpError: false,
+      logger: { warn: warnSpy, error: errorSpy },
+      broadcast: false
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toBeNull();
+    expect(toastSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('Failed to load latest message:', expect.anything());
+  });
+
+  it('allows the broadcast to be disabled after repeated failures', async () => {
+    const channelName = `test-broadcast-${Date.now()}-${Math.random()}`;
+
+    class ThrowingBroadcastChannel {
+      static instances: ThrowingBroadcastChannel[] = [];
+      public readonly name: string;
+      public readonly postMessage = vi.fn(() => {
+        throw new Error('broadcast failure');
+      });
+      public readonly close = vi.fn();
+      constructor(name: string) {
+        this.name = name;
+        ThrowingBroadcastChannel.instances.push(this);
+      }
+      addEventListener() {}
+      removeEventListener() {}
+    }
+
+    globalThis.BroadcastChannel = ThrowingBroadcastChannel as unknown as typeof BroadcastChannel;
+
+    const fetchMock = vi
+      .fn<Parameters<typeof fetch>, Promise<MockResponse>>()
+      .mockResolvedValue({ status: 200, json: vi.fn().mockResolvedValue({ ok: true }) });
+
+    const disabledEvents: LovableBroadcastDisabledInfo[] = [];
+    const warnSpy = vi.fn();
+    const errorSpy = vi.fn();
+
+    const onFailure = vi.fn((_: unknown, context: LovableBroadcastFailureContext) => {
+      if (context.failureCount >= 2) {
+        context.disable();
+      }
+    });
+
+    const options = {
+      retries: 0,
+      retryDelayMs: () => 0,
+      fetchImplementation: fetchMock as unknown as typeof fetch,
+      toastOnHttpError: false,
+      logger: { warn: warnSpy, error: errorSpy },
+      broadcast: {
+        channelName,
+        maxConsecutiveFailures: 5,
+        onFailure,
+        onDisabled: (info: LovableBroadcastDisabledInfo) => disabledEvents.push(info),
+        logger: { warn: warnSpy, error: errorSpy }
+      }
+    } as const;
+
+    await fetchLatestMessage('project-3', options);
+    await fetchLatestMessage('project-3', options);
+
+    const channelInstance = ThrowingBroadcastChannel.instances[0];
+    expect(channelInstance).toBeDefined();
+    expect(channelInstance.postMessage).toHaveBeenCalledTimes(2);
+    expect(channelInstance.close).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledTimes(2);
+    expect(disabledEvents).toHaveLength(1);
+    expect(disabledEvents[0]?.reason).toBe('manual');
+
+    const callsAfterDisable = channelInstance.postMessage.mock.calls.length;
+
+    await fetchLatestMessage('project-3', options);
+
+    expect(channelInstance.postMessage).toHaveBeenCalledTimes(callsAfterDisable);
+  });
+});


### PR DESCRIPTION
## Summary
- add retry/backoff, toast notification, and error logging options to `fetchLatestMessage`
- provide broadcast channel management hooks so callers can disable multi-tab updates after repeated failures
- cover the new Lovable message handling flows with targeted unit tests

## Testing
- npx vitest run tests/fetchLatestMessage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c931baae88832f89d3ecadd5558fba