### PR TITLE
fix: remove duplicate user key retrieval

### DIFF
--- a/src/lib/sync/autoBackfillOnReload.ts
+++ b/src/lib/sync/autoBackfillOnReload.ts
@@ -288,9 +288,6 @@ export async function autoBackfillOnReload(): Promise<void> {
   const userKey = await ensureUserKey();
   if (!userKey) return;
 
-  const userKey = await ensureUserKey();
-  if (!userKey) return;
-
   const progress = extractLearningProgress();
   const counts = extractWordCounts();
   const dailySelection = extractDailySelection();


### PR DESCRIPTION
## Summary
- remove duplicate `userKey` retrieval in `autoBackfillOnReload`

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*
- `npm run lint` *(fails: 117 problems, 76 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c943b917ec832f9b88471c0a5a50f8