### PR TITLE
Resolve learned words before use

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -29,10 +29,10 @@ const VocabularyAppWithLearning: React.FC = () => {
     progressStats,
     generateDailyWords,
     markWordAsPlayed,
-    getLearnedWords,
     markWordLearned: markCurrentWordLearned,
     markWordAsNew,
-    todayWords
+    todayWords,
+    learnedWords
   } = useLearningProgress(allWords);
 
   // Load vocabulary data
@@ -75,7 +75,13 @@ const VocabularyAppWithLearning: React.FC = () => {
     };
   }, [markWordAsPlayed]);
 
-  const learnedWords = getLearnedWords();
+  const learnedWordsList = Array.isArray(learnedWords) ? learnedWords : [];
+
+  useEffect(() => {
+    if (dailySelection) {
+      setSummaryOpen(true);
+    }
+  }, [dailySelection]);
 
   const openSearch = (word?: string) => {
     const normalized = normalizeQuery(word || '');
@@ -163,10 +169,10 @@ const VocabularyAppWithLearning: React.FC = () => {
               )}
 
               <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Learned ({learnedWords.length})</h4>
+                <h4 className="font-medium text-gray-600">Learned ({learnedWordsList.length})</h4>
                 <div className="space-y-1 max-h-60 overflow-y-auto">
-                  {learnedWords.length > 0 ? (
-                    learnedWords.map((word, index) => (
+                  {learnedWordsList.length > 0 ? (
+                    learnedWordsList.map((word, index) => (
                       <div
                         key={index}
                         className="text-sm p-2 bg-gray-50 rounded border opacity-75 flex items-center justify-between"

--- a/tests/quickSearchView.test.tsx
+++ b/tests/quickSearchView.test.tsx
@@ -25,7 +25,8 @@ vi.mock('@/hooks/useLearningProgress', () => ({
     progressStats: { total: 0, learning: 0, new: 0, due: 0, learned: 1 },
     generateDailyWords: vi.fn(),
     markWordAsPlayed: vi.fn(),
-    getLearnedWords: () => [
+    refreshLearnedWords: vi.fn(),
+    learnedWords: [
       {
         word: 'end up /ˈend ʌp/ [intransitive]',
         category: 'phrases',


### PR DESCRIPTION
## Summary
- keep learned words in state within `useLearningProgress`, providing a refresh helper and updating stats when marking words learned
- update the vocabulary app wrapper to consume the synchronous learned word list and safely render the summary panel
- adjust related tests to the new hook contract and to exercise the updated rendering guards

## Testing
- npm run test -- tests/quickSearchView.test.tsx tests/vocabularyAppDueReviews.test.tsx tests/useLearningProgressAutoDailyOption.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca34c59784832f80949b8eff71ff10