### PR TITLE
Use local preferences storage

### DIFF
--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -3,7 +3,7 @@ import { learningProgressService } from '@/services/learningProgressService';
 import { DailySelection, SeverityLevel, LearningProgress } from '@/types/learning';
 import { VocabularyWord } from '@/types/vocabulary';
 import { buildTodaysWords } from '@/utils/todayWords';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 import { toWordId } from '@/lib/words/ids';
 import { markLearnedServerByKey } from '@/lib/progress/srsSyncByUserKey';
 
@@ -34,7 +34,7 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     const selection = learningProgressService.forceGenerateDailySelection(allWords, severity);
     setDailySelection(selection);
     refreshStats();
-    void savePreferences({ daily_option: severity });
+    void saveLocalPreferences({ daily_option: severity });
   }, [allWords, refreshStats]);
 
   const markWordAsPlayed = useCallback(
@@ -78,10 +78,10 @@ export const useLearningProgress = (allWords: VocabularyWord[]) => {
     const init = async () => {
       let severity: SeverityLevel = 'light';
       try {
-        const prefs = await getPreferences();
+        const prefs = await getLocalPreferences();
         severity = (prefs.daily_option as SeverityLevel) || 'light';
         if (!prefs.daily_option) {
-          await savePreferences({ daily_option: 'light' });
+          await saveLocalPreferences({ daily_option: 'light' });
         }
       } catch {
         // ignore preference loading errors

--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { learningProgressService } from '@/services/learningProgressService';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 import { setFavoriteVoice } from '@/lib/preferences/localPreferences';
 import { getTodayLastWord } from '@/utils/lastWordStorage';
 import type { SeverityLevel } from '@/types/learning';
@@ -78,10 +78,10 @@ export const useVocabularyDataLoader = (
 
         let severity: SeverityLevel = 'light';
         try {
-          const prefs = await getPreferences();
+          const prefs = await getLocalPreferences();
           severity = (prefs.daily_option as SeverityLevel) || 'light';
           if (!prefs.daily_option) {
-            await savePreferences({ daily_option: 'light' });
+            await saveLocalPreferences({ daily_option: 'light' });
           }
         } catch {
           // ignore preference loading errors

--- a/src/lib/db/preferences.ts
+++ b/src/lib/db/preferences.ts
@@ -1,6 +1,5 @@
-import { getSupabaseClient } from './supabase';
 import type { UserPreferences } from '@/core/models';
-import { ensureUserKey } from '@/lib/progress/srsSyncByUserKey';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
 const DEFAULT_PREFS: UserPreferences = {
   favorite_voice: null,
@@ -11,45 +10,10 @@ const DEFAULT_PREFS: UserPreferences = {
 };
 
 export async function getPreferences(): Promise<UserPreferences> {
-  const supabase = getSupabaseClient();
-  if (!supabase) return DEFAULT_PREFS;
-  const user_unique_key = await ensureUserKey();
-  if (!user_unique_key) return DEFAULT_PREFS;
-  const { data, error } = await supabase
-    .from('user_preferences')
-    .select('*')
-    .eq('user_unique_key', user_unique_key)
-    .maybeSingle();
-  if (error) throw error;
-  if (!data) {
-    const { error: upsertError } = await supabase
-      .from('user_preferences')
-      .upsert({ user_unique_key, ...DEFAULT_PREFS });
-    if (upsertError) throw upsertError;
-    return DEFAULT_PREFS;
-  }
-  return {
-    favorite_voice: data.favorite_voice,
-    speech_rate: data.speech_rate,
-    is_muted: data.is_muted,
-    is_playing: data.is_playing,
-    daily_option: data.daily_option,
-  };
+  const prefs = await getLocalPreferences();
+  return { ...DEFAULT_PREFS, ...prefs } as UserPreferences;
 }
 
 export async function savePreferences(p: Partial<UserPreferences>): Promise<void> {
-  const supabase = getSupabaseClient();
-  if (!supabase) return;
-  const user_unique_key = await ensureUserKey();
-  if (!user_unique_key) return;
-  const { data: existing } = await supabase
-    .from('user_preferences')
-    .select('*')
-    .eq('user_unique_key', user_unique_key)
-    .maybeSingle();
-  const merged = { ...DEFAULT_PREFS, ...existing, ...p };
-  const { error } = await supabase
-    .from('user_preferences')
-    .upsert({ user_unique_key, ...merged, updated_at: new Date().toISOString() });
-  if (error) throw error;
+  await saveLocalPreferences(p);
 }

--- a/tests/markWordLearnedRemovesTodayWord.test.tsx
+++ b/tests/markWordLearnedRemovesTodayWord.test.tsx
@@ -6,17 +6,21 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
 import { VocabularyWord } from '@/types/vocabulary';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
-vi.mock('@/lib/db/preferences', () => ({
-  getPreferences: vi.fn().mockResolvedValue({
+vi.mock('@/lib/progress/srsSyncByUserKey', () => ({
+  markLearnedServerByKey: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,
     speech_rate: null,
     is_muted: false,
     is_playing: true,
     daily_option: 'light'
   }),
-  savePreferences: vi.fn().mockResolvedValue(undefined)
+  saveLocalPreferences: vi.fn().mockResolvedValue(undefined)
 }));
 
 describe('markWordLearned', () => {

--- a/tests/useLearningProgressAutoDailyOption.test.tsx
+++ b/tests/useLearningProgressAutoDailyOption.test.tsx
@@ -7,17 +7,17 @@ import { useLearningProgress } from '@/hooks/useLearningProgress';
 import type { VocabularyWord } from '@/types/vocabulary';
 import type { DailySelection } from '@/types/learning';
 import { learningProgressService } from '@/services/learningProgressService';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
-vi.mock('@/lib/db/preferences', () => ({
-  getPreferences: vi.fn().mockResolvedValue({
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,
     speech_rate: null,
     is_muted: false,
     is_playing: true,
     daily_option: null
   }),
-  savePreferences: vi.fn().mockResolvedValue(undefined)
+  saveLocalPreferences: vi.fn().mockResolvedValue(undefined)
 }));
 
 vi.mock('@/services/learningProgressService', () => ({
@@ -59,9 +59,9 @@ describe('useLearningProgress daily option default', () => {
     renderHook(() => useLearningProgress(words));
 
     await waitFor(() => {
-      expect(getPreferences).toHaveBeenCalled();
+      expect(getLocalPreferences).toHaveBeenCalled();
       expect(learningProgressService.forceGenerateDailySelection).toHaveBeenCalledWith(words, 'light');
-      expect(savePreferences).toHaveBeenCalledWith({ daily_option: 'light' });
+      expect(saveLocalPreferences).toHaveBeenCalledWith({ daily_option: 'light' });
     });
   });
 });

--- a/tests/useLearningProgressDueReviews.test.tsx
+++ b/tests/useLearningProgressDueReviews.test.tsx
@@ -7,17 +7,17 @@ import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
 import { VocabularyWord } from '@/types/vocabulary';
 import { LearningProgress, DailySelection } from '@/types/learning';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
-vi.mock('@/lib/db/preferences', () => ({
-  getPreferences: vi.fn().mockResolvedValue({
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,
     speech_rate: null,
     is_muted: false,
     is_playing: true,
     daily_option: 'light'
   }),
-  savePreferences: vi.fn().mockResolvedValue(undefined)
+  saveLocalPreferences: vi.fn().mockResolvedValue(undefined)
 }));
 
 describe('useLearningProgress due reviews', () => {

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -5,17 +5,17 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
 import { learningProgressService } from '@/services/learningProgressService';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
-vi.mock('@/lib/db/preferences', () => ({
-  getPreferences: vi.fn().mockResolvedValue({
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,
     speech_rate: null,
     is_muted: false,
     is_playing: true,
     daily_option: 'light'
   }),
-  savePreferences: vi.fn().mockResolvedValue(undefined)
+  saveLocalPreferences: vi.fn().mockResolvedValue(undefined)
 }));
 
 describe('useLearningProgress', () => {

--- a/tests/useVocabularyDataLoaderAllSheets.test.ts
+++ b/tests/useVocabularyDataLoaderAllSheets.test.ts
@@ -8,7 +8,7 @@ import { VocabularyWord } from '@/types/vocabulary';
 import { vocabularyService } from '@/services/vocabularyService';
 import { learningProgressService } from '@/services/learningProgressService';
 import { getTodayLastWord } from '@/utils/lastWordStorage';
-import { getPreferences, savePreferences } from '@/lib/db/preferences';
+import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
 
 vi.mock('@/services/vocabularyService', () => ({
   vocabularyService: {
@@ -29,15 +29,16 @@ vi.mock('@/services/learningProgressService', () => ({
 
 vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
 vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
-vi.mock('@/lib/db/preferences', () => ({
-  getPreferences: vi.fn().mockResolvedValue({
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,
     speech_rate: null,
     is_muted: false,
     is_playing: true,
     daily_option: null
   }),
-  savePreferences: vi.fn().mockResolvedValue(undefined)
+  saveLocalPreferences: vi.fn().mockResolvedValue(undefined),
+  setFavoriteVoice: vi.fn()
 }));
 
 const localStorageMock = {
@@ -75,8 +76,8 @@ describe('useVocabularyDataLoader all sheets', () => {
 
     await waitFor(() => {
       expect(vocabularyService.loadDefaultVocabulary).toHaveBeenCalled();
-      expect(getPreferences).toHaveBeenCalled();
-      expect(savePreferences).toHaveBeenCalledWith({ daily_option: 'light' });
+      expect(getLocalPreferences).toHaveBeenCalled();
+      expect(saveLocalPreferences).toHaveBeenCalledWith({ daily_option: 'light' });
       expect(learningProgressService.forceGenerateDailySelection).toHaveBeenCalledWith(words, 'light');
       expect(setWordList).toHaveBeenCalledWith(words);
     });


### PR DESCRIPTION
## Summary
- update learning progress hooks to read and persist settings via the localPreferences helpers
- simplify the Supabase-backed preferences module to delegate to localStorage
- refresh associated tests to mock the local preferences API and accommodate async loading

## Testing
- bunx vitest run tests/useVocabularyDataLoaderNextAllowedTime.test.ts
- bunx vitest run tests/useVocabularyDataLoaderAllSheets.test.ts
- bunx vitest run tests/useLearningProgressAutoDailyOption.test.tsx tests/useLearningProgressDueReviews.test.tsx tests/useLearningProgressStats.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca5f9231e8832fbe9639170f53a583