### PR TITLE
Update auth gate to require stored passcode

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import { canonNickname } from '@/core/nickname';
 import { getSupabaseClient, requireSupabaseClient } from './supabaseClient';
 
 const SESSION_STORAGE_KEY = 'lazyVoca.session';
-const PASSCODE_STORAGE_KEY = 'lazyVoca.passcode';
+export const PASSCODE_STORAGE_KEY = 'lazyVoca.passcode';
 const AUTH_EMAIL_DOMAIN = 'app.local';
 const EXPIRATION_MARGIN_MS = 60_000;
 


### PR DESCRIPTION
## Summary
- read the stored passcode during AuthGate initialization to ensure the modal only hides once both nickname and passcode exist
- react to localStorage updates for nickname and passcode keys so clearing either key reopens the gate
- export the passcode storage key to share between the gate and auth utilities

## Testing
- `npm run lint` *(fails: existing lint violations throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68ca676cc7ac832f842e711a4fd45b4e