### PR TITLE
Ensure profile nickname updated during auth

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -9,6 +9,7 @@ import {
   upsertNickname,
 } from '@/services/nicknameService';
 import { ensureUserKey } from '@/lib/progress/srsSyncByUserKey';
+import { ensureProfile } from '@/lib/db/profiles';
 import {
   registerNicknameWithPasscode,
   signInWithPasscode,
@@ -158,6 +159,7 @@ export default function AuthGate() {
       const chosen = existing ?? (await upsertNickname(display));
 
       localStorage.setItem(NICKNAME_LS_KEY, chosen.name);
+      await ensureProfile(chosen.name);
       await ensureUserKey().catch(() => null);
       if (s.mode === 'create') {
         try {


### PR DESCRIPTION
## Summary
- import the profile helper into the auth gate flow
- sync the authenticated user's profile nickname after choosing a nickname

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca6bd1bb24832f9290ad31e8120720