### PR TITLE
Update nickname handling to use canonical fields

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -158,8 +158,8 @@ export default function AuthGate() {
       const existing = await getNicknameByKey(key);
       const chosen = existing ?? (await upsertNickname(display));
 
-      localStorage.setItem(NICKNAME_LS_KEY, chosen.name);
-      await ensureProfile(chosen.name);
+      localStorage.setItem(NICKNAME_LS_KEY, chosen.display_name);
+      await ensureProfile(chosen.display_name);
       await ensureUserKey().catch(() => null);
       if (s.mode === 'create') {
         try {
@@ -183,7 +183,7 @@ export default function AuthGate() {
       setS({
         ready: true,
         show: false,
-        nickname: chosen.name,
+        nickname: chosen.display_name,
         passcode: '',
         pending: false,
         mode: 'signin',


### PR DESCRIPTION
## Summary
- switch nickname service lookups to the new display_name/name_canonical fields and include the authenticated user id when saving
- update AuthGate to persist the returned display_name locally and feed it into ensureProfile

## Testing
- npm run lint (fails: numerous pre-existing lint issues in unrelated files)
- npm run test (fails: existing learningProgress service tests already red)


------
https://chatgpt.com/codex/tasks/task_e_68ca7785e368832fa8f89c1b0edab4e4