### PR TITLE
Switch nickname passcode RPCs to nicknames table

### DIFF
--- a/supabase/sql/2025-05-nickname-passcode.sql
+++ b/supabase/sql/2025-05-nickname-passcode.sql
@@ -1,0 +1,33 @@
+set search_path = public;
+
+-- Verify nickname + passcode
+create or replace function public.verify_nickname_passcode(
+    nickname text,
+    passcode int8
+)
+returns table(user_unique_key text)
+language sql
+security definer
+as $$
+  select n.user_unique_key
+  from public.nicknames n
+  where lower(replace(n.name,' ','')) = lower(replace(nickname,' ',''))
+    and n.passcode = passcode;
+$$;
+
+-- Set passcode for nickname
+create or replace function public.set_nickname_passcode(
+    nickname text,
+    passcode int8
+)
+returns void
+language sql
+security definer
+as $$
+  update public.nicknames
+  set passcode = set_nickname_passcode.passcode
+  where lower(replace(name,' ','')) = lower(replace(nickname,' ',''));
+$$;
+
+grant execute on function public.verify_nickname_passcode(text, int8) to anon, authenticated;
+grant execute on function public.set_nickname_passcode(text, int8) to anon, authenticated;


### PR DESCRIPTION
## Summary
- add Supabase SQL to provide verify_nickname_passcode and set_nickname_passcode RPCs on the public.nicknames table
- update the AuthGate nickname overlay to call the new RPCs and convert passcodes to numeric values before invoking Supabase

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8c534efc832fb3aed26f6b2e7826