### PR TITLE
Refactor nickname column usage

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -171,8 +171,8 @@ export default function AuthGate() {
       const existing = await getNicknameByKey(key);
       const chosen = existing ?? (await upsertNickname(display));
 
-      localStorage.setItem(NICKNAME_LS_KEY, chosen.display_name);
-      await ensureProfile(chosen.display_name);
+      localStorage.setItem(NICKNAME_LS_KEY, chosen.name);
+      await ensureProfile(chosen.name);
       await ensureUserKey().catch(() => null);
       if (s.mode === 'create') {
         try {
@@ -196,7 +196,7 @@ export default function AuthGate() {
       setS({
         ready: true,
         show: false,
-        nickname: chosen.display_name,
+        nickname: chosen.name,
         passcode: '',
         pending: false,
         mode: 'signin',


### PR DESCRIPTION
## Summary
- update Supabase nickname service to query the new name and user_unique_key columns and expose passcode in the return type
- adjust nickname upsert fallback and selections to use the real nickname column names
- update AuthGate to persist and reuse the nickname name field instead of the removed display_name

## Testing
- npm run lint *(fails: existing lint violations in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68caad10b93c832fac25776454985fe4