### PR TITLE
Refactor nickname profile handling

### DIFF
--- a/src/services/nicknameService.ts
+++ b/src/services/nicknameService.ts
@@ -12,8 +12,8 @@ export function normalizeNickname(s: string) {
   return s.toLowerCase().replace(/\s+/g, '');
 }
 
-// Optional: block risky display chars (doesn't affect key)
-export function sanitizeDisplay(s: string) {
+// Optional: block risky nickname chars (doesn't affect key)
+export function sanitizeNickname(s: string) {
   return s.replace(/[<>"'`$(){}\[\];]/g, '').trim();
 }
 
@@ -29,11 +29,11 @@ export async function getNicknameByKey(key: string): Promise<NicknameRecord | nu
   return (data as NicknameRecord | null) ?? null;
 }
 
-export async function upsertNickname(display: string): Promise<NicknameRecord> {
+export async function upsertNickname(name: string): Promise<NicknameRecord> {
   const supabase = getSupabaseClient();
-  const key = normalizeNickname(display);
+  const key = normalizeNickname(name);
   if (!supabase) {
-    return { id: key, name: display, user_unique_key: key, passcode: null };
+    return { id: key, name, user_unique_key: key, passcode: null };
   }
   const {
     data: { user },
@@ -46,7 +46,7 @@ export async function upsertNickname(display: string): Promise<NicknameRecord> {
   const { data, error } = await supabase
     .from('nicknames')
     .upsert(
-      { name: display, user_unique_key: key, user_id: user.id },
+      { name, user_unique_key: key, user_id: user.id },
       { onConflict: 'user_unique_key' }
     )
     .select('id, name, user_unique_key, passcode')

--- a/supabase/nicknames.sql
+++ b/supabase/nicknames.sql
@@ -1,37 +1,115 @@
--- 1) Columns: display_name + generated canonical (unique)
+-- 1) Columns: name + generated user key (unique)
 create extension if not exists pgcrypto;
 
 -- Ensure table exists (keep your existing id pk)
 create table if not exists public.nicknames (
   id bigserial primary key,
   user_id uuid unique,
-  display_name text not null,
-  name_canonical text generated always as (
-    lower(regexp_replace(display_name, '\s+', '', 'g'))
+  name text not null,
+  user_unique_key text generated always as (
+    lower(regexp_replace(name, '\\s+', '', 'g'))
   ) stored,
+  passcode int8,
   claim_code_hash text,
   created_at timestamptz not null default now()
 );
 
--- Backfill / migrate if you previously had "name"
+-- Migrate legacy columns to the new shape
 do $$
 begin
-  if exists (select 1 from information_schema.columns
-             where table_schema='public' and table_name='nicknames' and column_name='name') then
-    alter table public.nicknames
-      alter column name drop not null;
-    update public.nicknames set display_name = coalesce(display_name, name) where display_name is null;
-    alter table public.nicknames drop column if exists name;
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'nicknames'
+      and column_name = 'display_name'
+  ) then
+    alter table public.nicknames rename column display_name to name;
   end if;
-end $$;
+end
+$$;
 
--- Uniqueness on canonical
 do $$
 begin
-  if not exists (select 1 from pg_constraint where conname='nicknames_name_canonical_key') then
-    alter table public.nicknames add constraint nicknames_name_canonical_key unique (name_canonical);
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'nicknames'
+      and column_name = 'name_canonical'
+  ) then
+    alter table public.nicknames drop column name_canonical;
   end if;
-end $$;
+end
+$$;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'nicknames'
+      and column_name = 'user_unique_key'
+      and generation_expression is null
+  ) then
+    alter table public.nicknames drop column user_unique_key;
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'nicknames'
+      and column_name = 'user_unique_key'
+  ) then
+    execute $$
+      alter table public.nicknames
+      add column user_unique_key text generated always as (
+        lower(regexp_replace(name, '\\s+', '', 'g'))
+      ) stored
+    $$;
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'nicknames'
+      and column_name = 'passcode'
+  ) then
+    alter table public.nicknames add column passcode int8;
+  end if;
+end
+$$;
+
+-- Uniqueness on user_unique_key
+do $$
+begin
+  if exists (
+    select 1
+    from pg_constraint
+    where conname = 'nicknames_name_canonical_key'
+  ) then
+    alter table public.nicknames drop constraint nicknames_name_canonical_key;
+  end if;
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'nicknames_user_unique_key_key'
+  ) then
+    alter table public.nicknames add constraint nicknames_user_unique_key_key unique (user_unique_key);
+  end if;
+end
+$$;
 
 alter table public.nicknames enable row level security;
 
@@ -55,8 +133,8 @@ using (user_id = auth.uid());
 
 -- 2) RPCs aware of canonical
 
--- rotate_claim_code(display_name): returns plaintext code once
-create or replace function public.rotate_claim_code(p_display_name text)
+-- rotate_claim_code(name): returns plaintext code once
+create or replace function public.rotate_claim_code(p_name text)
 returns text
 language plpgsql security definer set search_path = public as $$
 declare code text;
@@ -65,7 +143,7 @@ begin
   update public.nicknames
      set claim_code_hash = crypt(code, gen_salt('bf'))
    where user_id = auth.uid()
-     and name_canonical = lower(regexp_replace(p_display_name, '\s+', '', 'g'));
+     and user_unique_key = lower(regexp_replace(p_name, '\\s+', '', 'g'));
   if not found then
     raise exception 'nickname not owned by caller';
   end if;
@@ -75,14 +153,14 @@ end $$;
 revoke all on function public.rotate_claim_code(text) from public;
 grant execute on function public.rotate_claim_code(text) to authenticated;
 
--- claim_nickname(display_name, code): transfer ownership by code
-create or replace function public.claim_nickname(p_display_name text, p_code text)
+-- claim_nickname(name, code): transfer ownership by code
+create or replace function public.claim_nickname(p_name text, p_code text)
 returns boolean
 language plpgsql security definer set search_path = public as $$
 begin
   update public.nicknames
      set user_id = auth.uid()
-   where name_canonical = lower(regexp_replace(p_display_name, '\s+', '', 'g'))
+   where user_unique_key = lower(regexp_replace(p_name, '\\s+', '', 'g'))
      and claim_code_hash is not null
      and crypt(p_code, claim_code_hash) = claim_code_hash;
   return found;


### PR DESCRIPTION
## Summary
- update AuthGate to use sanitized nickname data and show "Create new profile" when creating accounts
- rename nickname service helpers to reflect the canonical name column and ensure upserts rely on user_unique_key
- refresh Supabase nickname schema and RPC helpers to use name/user_unique_key columns and include passcode support

## Testing
- npm run lint *(fails: existing lint violations across untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68caae8dbc70832f8841b00c277ab4b0