### PR TITLE
Use canonical user keys for nickname persistence

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -118,13 +118,18 @@ function extractUserKey(result: unknown): string | null {
 }
 
 function createSession(nickname: string, userKey: string): Session {
+  const trimmedNickname = nickname.trim();
+  const storedNickname = trimmedNickname.length ? trimmedNickname : nickname;
+  const normalizedKeySource = userKey?.trim().length ? userKey.trim() : canonNickname(storedNickname);
+  const normalizedKey = canonNickname(normalizedKeySource);
+
   return {
-    user_unique_key: userKey,
-    nickname,
+    user_unique_key: normalizedKey,
+    nickname: storedNickname,
     authenticated_at: new Date().toISOString(),
     user: {
-      id: userKey,
-      nickname,
+      id: normalizedKey,
+      nickname: storedNickname,
       email: null,
     },
   };

--- a/src/lib/db/profiles.ts
+++ b/src/lib/db/profiles.ts
@@ -22,21 +22,21 @@ export async function ensureProfile(nickname: string): Promise<NicknameProfile |
 
   const { data: taken, error: takenError } = await supabase
     .from('nicknames')
-    .select('user_id')
+    .select('user_unique_key')
     .eq('user_unique_key', nicknameKey)
-    .maybeSingle<{ user_id: string | null }>();
+    .maybeSingle<{ user_unique_key: string | null }>();
 
   if (takenError && takenError.code !== 'PGRST116') {
     throw takenError;
   }
 
-  if (taken && taken.user_id && taken.user_id !== user.id) {
+  if (taken && taken.user_unique_key && taken.user_unique_key !== user.id) {
     throw { code: 'NICKNAME_TAKEN' };
   }
 
   const { data, error: upsertError } = await supabase
     .from('nicknames')
-    .upsert({ user_id: user.id, name: nickname }, { onConflict: 'user_id' })
+    .upsert({ user_unique_key: nicknameKey, name: nickname }, { onConflict: 'user_unique_key' })
     .select('id, name, user_unique_key, passcode')
     .maybeSingle<{ id: string | number; name: string; user_unique_key: string; passcode: number | null }>();
 


### PR DESCRIPTION
## Summary
- use canonical user_unique_key columns when verifying and upserting nickname profiles
- rely on passcode-authenticated sessions when upserting nicknames and surface conflicts via user_unique_key queries
- cache sanitized nickname sessions and derive/ensure user keys without relying on Supabase user_id

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb550113a8832fbb050783ae832fb9