### PR TITLE
Ensure nickname registration returns user key

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -215,9 +215,14 @@ export async function registerNicknameWithPasscode(
   if (error) {
     throw error;
   }
+  const noNickname =
+    data == null || (Array.isArray(data) && data.length === 0);
+  if (noNickname) {
+    throw new Error('Nickname not found.');
+  }
   const userKey = extractUserKey(data);
   if (!userKey) {
-    return null;
+    throw new Error('Failed to register nickname.');
   }
   const session = createSession(nickname, userKey);
   persistSession(session);

--- a/supabase/sql/2025-05-nickname-passcode.sql
+++ b/supabase/sql/2025-05-nickname-passcode.sql
@@ -20,13 +20,14 @@ create or replace function public.set_nickname_passcode(
     nickname text,
     passcode int8
 )
-returns void
+returns table(user_unique_key text)
 language sql
 security definer
 as $$
   update public.nicknames
   set passcode = set_nickname_passcode.passcode
-  where lower(replace(name,' ','')) = lower(replace(nickname,' ',''));
+  where lower(replace(name,' ','')) = lower(replace(nickname,' ',''))
+  returning user_unique_key;
 $$;
 
 grant execute on function public.verify_nickname_passcode(text, int8) to anon, authenticated;


### PR DESCRIPTION
## Summary
- return the updated user key from `set_nickname_passcode`
- use the returned key during nickname registration and throw if no nickname is found

## Testing
- npm run lint (fails: existing lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68cb5504aba0832f91b6c1ea01882917