### PR TITLE
Refactor nicknames schema for passcode-based access

### DIFF
--- a/supabase/nicknames.sql
+++ b/supabase/nicknames.sql
@@ -1,20 +1,17 @@
--- 1) Columns: name + generated user key (unique)
 create extension if not exists pgcrypto;
 
--- Ensure table exists (keep your existing id pk)
 create table if not exists public.nicknames (
   id bigserial primary key,
-  user_id uuid unique,
+  created_at timestamptz not null default now(),
   name text not null,
-  user_unique_key text generated always as (
-    lower(regexp_replace(name, '\\s+', '', 'g'))
-  ) stored,
   passcode int8,
-  claim_code_hash text,
-  created_at timestamptz not null default now()
+  user_unique_key text not null
 );
 
--- Migrate legacy columns to the new shape
+alter table public.nicknames drop column if exists user_id;
+alter table public.nicknames drop column if exists claim_code_hash;
+alter table public.nicknames drop column if exists claim_code;
+
 do $$
 begin
   if exists (
@@ -24,24 +21,34 @@ begin
       and table_name = 'nicknames'
       and column_name = 'display_name'
   ) then
-    alter table public.nicknames rename column display_name to name;
+    if not exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'nicknames'
+        and column_name = 'name'
+    ) then
+      alter table public.nicknames rename column display_name to name;
+    else
+      alter table public.nicknames drop column display_name;
+    end if;
   end if;
 end
 $$;
 
-do $$
-begin
-  if exists (
-    select 1
-    from information_schema.columns
-    where table_schema = 'public'
-      and table_name = 'nicknames'
-      and column_name = 'name_canonical'
-  ) then
-    alter table public.nicknames drop column name_canonical;
-  end if;
-end
-$$;
+alter table public.nicknames drop column if exists name_canonical;
+
+alter table public.nicknames
+  add column if not exists created_at timestamptz not null default now();
+
+alter table public.nicknames
+  add column if not exists name text;
+
+alter table public.nicknames
+  add column if not exists passcode int8;
+
+alter table public.nicknames
+  add column if not exists user_unique_key text;
 
 do $$
 begin
@@ -51,123 +58,84 @@ begin
     where table_schema = 'public'
       and table_name = 'nicknames'
       and column_name = 'user_unique_key'
-      and generation_expression is null
+      and generation_expression is not null
   ) then
+    alter table public.nicknames drop constraint if exists nicknames_user_unique_key_key;
+    alter table public.nicknames add column if not exists user_unique_key_tmp text;
+    update public.nicknames
+       set user_unique_key_tmp = lower(regexp_replace(name, '\\s+', '', 'g'));
     alter table public.nicknames drop column user_unique_key;
+    alter table public.nicknames rename column user_unique_key_tmp to user_unique_key;
   end if;
 end
 $$;
 
-do $$
-begin
-  if not exists (
-    select 1
-    from information_schema.columns
-    where table_schema = 'public'
-      and table_name = 'nicknames'
-      and column_name = 'user_unique_key'
-  ) then
-    execute $$
-      alter table public.nicknames
-      add column user_unique_key text generated always as (
-        lower(regexp_replace(name, '\\s+', '', 'g'))
-      ) stored
-    $$;
-  end if;
-end
+alter table public.nicknames
+  alter column user_unique_key set not null;
+
+alter table public.nicknames
+  alter column name set not null;
+
+-- Maintain canonical uniqueness on nickname key
+alter table public.nicknames drop constraint if exists nicknames_name_canonical_key;
+alter table public.nicknames drop constraint if exists nicknames_user_unique_key_key;
+alter table public.nicknames add constraint nicknames_user_unique_key_key unique (user_unique_key);
+
+-- Helper accessors for request-scoped claims
+create or replace function public.request_claim_text(claim_name text)
+returns text
+language sql
+stable
+as $$
+  select nullif(
+    (coalesce(nullif(current_setting('request.jwt.claims', true), ''), '{}')::jsonb ->> claim_name),
+    ''
+  );
 $$;
 
-do $$
-begin
-  if not exists (
-    select 1
-    from information_schema.columns
-    where table_schema = 'public'
-      and table_name = 'nicknames'
-      and column_name = 'passcode'
-  ) then
-    alter table public.nicknames add column passcode int8;
-  end if;
-end
-$$;
-
--- Uniqueness on user_unique_key
-do $$
-begin
-  if exists (
-    select 1
-    from pg_constraint
-    where conname = 'nicknames_name_canonical_key'
-  ) then
-    alter table public.nicknames drop constraint nicknames_name_canonical_key;
-  end if;
-  if not exists (
-    select 1
-    from pg_constraint
-    where conname = 'nicknames_user_unique_key_key'
-  ) then
-    alter table public.nicknames add constraint nicknames_user_unique_key_key unique (user_unique_key);
-  end if;
-end
+create or replace function public.request_claim_bigint(claim_name text)
+returns bigint
+language sql
+stable
+as $$
+  select case
+    when claim_txt ~ '^-?\\d+$' then claim_txt::bigint
+    else null
+  end
+  from (
+    select coalesce(public.request_claim_text(claim_name), '') as claim_txt
+  ) s;
 $$;
 
 alter table public.nicknames enable row level security;
 
--- Tight RLS (auth users can touch their row)
+-- Drop legacy auth-based policies
 drop policy if exists "nick_ins_upd_self" on public.nicknames;
-drop policy if exists "nick_upd_self"     on public.nicknames;
-drop policy if exists "nick_select_self"  on public.nicknames;
+drop policy if exists "nick_upd_self" on public.nicknames;
+drop policy if exists "nick_select_self" on public.nicknames;
 
-create policy "nick_ins_upd_self"
-on public.nicknames for insert to authenticated
-with check (user_id = auth.uid());
+drop policy if exists "nicknames_manage_by_claims" on public.nicknames;
 
-create policy "nick_upd_self"
-on public.nicknames for update to authenticated
-using (user_id = auth.uid())
-with check (user_id = auth.uid());
+drop function if exists public.rotate_claim_code(text);
+drop function if exists public.claim_nickname(text, text);
 
-create policy "nick_select_self"
-on public.nicknames for select to authenticated
-using (user_id = auth.uid());
+-- Passcode + user key based policies
+create policy "nicknames_manage_by_claims"
+on public.nicknames
+for all
+using (
+  public.request_claim_text('user_unique_key') = user_unique_key
+  and (
+    (passcode is null and public.request_claim_bigint('passcode') is null)
+    or (passcode is not null and public.request_claim_bigint('passcode') = passcode)
+  )
+)
+with check (
+  public.request_claim_text('user_unique_key') = user_unique_key
+  and (
+    (passcode is null and public.request_claim_bigint('passcode') is null)
+    or (passcode is not null and public.request_claim_bigint('passcode') = passcode)
+  )
+);
 
--- 2) RPCs aware of canonical
-
--- rotate_claim_code(name): returns plaintext code once
-create or replace function public.rotate_claim_code(p_name text)
-returns text
-language plpgsql security definer set search_path = public as $$
-declare code text;
-begin
-  code := lpad((floor(random()*1000000))::int::text, 6, '0');
-  update public.nicknames
-     set claim_code_hash = crypt(code, gen_salt('bf'))
-   where user_id = auth.uid()
-     and user_unique_key = lower(regexp_replace(p_name, '\\s+', '', 'g'));
-  if not found then
-    raise exception 'nickname not owned by caller';
-  end if;
-  return code;
-end $$;
-
-revoke all on function public.rotate_claim_code(text) from public;
-grant execute on function public.rotate_claim_code(text) to authenticated;
-
--- claim_nickname(name, code): transfer ownership by code
-create or replace function public.claim_nickname(p_name text, p_code text)
-returns boolean
-language plpgsql security definer set search_path = public as $$
-begin
-  update public.nicknames
-     set user_id = auth.uid()
-   where user_unique_key = lower(regexp_replace(p_name, '\\s+', '', 'g'))
-     and claim_code_hash is not null
-     and crypt(p_code, claim_code_hash) = claim_code_hash;
-  return found;
-end $$;
-
-revoke all on function public.claim_nickname(text, text) from public;
-grant execute on function public.claim_nickname(text, text) to authenticated;
-
--- refresh API cache
 notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- reshape the `public.nicknames` table so only id, created_at, name, passcode, and user_unique_key remain
- remove legacy claim-code helpers and replace RLS policies with passcode + user key checks
- add helper claim accessor functions to support the new row-level policies

## Testing
- not run (SQL changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cb5517f45c832fb85b90e5b75ae78b