### PR TITLE
Use edge function for nickname registration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,3 @@
 export const EDGE_BASE_URL = 'https://vijvcojvemkzgpzpowzh.functions.supabase.co';
 export const EXCHANGE_FN_URL = `${EDGE_BASE_URL}/nickname-passcode-exchange`;
+export const SET_NICKNAME_FN_URL = `${EDGE_BASE_URL}/set-nickname-passcode`;


### PR DESCRIPTION
## Summary
- add an edge function URL constant for nickname registration
- switch nickname registration to call the edge function and surface HTTP errors

## Testing
- npm run lint *(fails: repository has pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfbc01a7c832f852ebc010d8b5c75