### PR TITLE
Handle nickname lookup when verifying passcode

### DIFF
--- a/src/lib/customAuth.ts
+++ b/src/lib/customAuth.ts
@@ -19,6 +19,7 @@ export type ExchangeResponse = Record<string, unknown> & {
   nickname?: unknown;
   user_unique_key?: unknown;
   error?: unknown;
+  code?: unknown;
 };
 
 export function storeSessionFromExchange(response: ExchangeResponse): CustomSession {

--- a/supabase/sql/2025-05-nickname-passcode.sql
+++ b/supabase/sql/2025-05-nickname-passcode.sql
@@ -1,5 +1,14 @@
 set search_path = public;
 
+-- Helper to normalize nicknames consistently across lookups
+create or replace function public.normalize_nickname(input text)
+returns text
+language sql
+immutable
+as $$
+  select lower(replace(coalesce(input, ''), ' ', ''));
+$$;
+
 -- Verify nickname + passcode
 create or replace function public.verify_nickname_passcode(
     nickname text,
@@ -11,7 +20,7 @@ security definer
 as $$
   select n.user_unique_key
   from public.nicknames n
-  where lower(replace(n.name,' ','')) = lower(replace(nickname,' ',''))
+  where public.normalize_nickname(n.name) = public.normalize_nickname(nickname)
     and n.passcode = passcode;
 $$;
 
@@ -26,9 +35,24 @@ security definer
 as $$
   update public.nicknames
   set passcode = set_nickname_passcode.passcode
-  where lower(replace(name,' ','')) = lower(replace(nickname,' ',''))
+  where public.normalize_nickname(name) = public.normalize_nickname(nickname)
   returning user_unique_key;
+$$;
+
+-- Lookup a nickname using normalized comparison logic
+create or replace function public.find_nickname_by_normalized(
+    nickname text
+)
+returns table(user_unique_key text, name text)
+language sql
+security definer
+as $$
+  select n.user_unique_key, n.name
+  from public.nicknames n
+  where public.normalize_nickname(n.name) = public.normalize_nickname(nickname)
+  limit 1;
 $$;
 
 grant execute on function public.verify_nickname_passcode(text, int8) to anon, authenticated;
 grant execute on function public.set_nickname_passcode(text, int8) to anon, authenticated;
+grant execute on function public.find_nickname_by_normalized(text) to anon, authenticated;


### PR DESCRIPTION
## Summary
- add a reusable `normalize_nickname` helper and lookup RPC so all nickname comparisons ignore case and spaces
- teach the nickname-passcode exchange edge function to detect missing profiles and emit a `PROFILE_NOT_FOUND` error code
- update AuthGate to surface the new error by switching to the create-profile flow with the nickname prefilled while leaving incorrect-passcode handling unchanged

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68cf4f1d0e40832f84ae2649f5652b3a