### PR TITLE
Filter server due words by schedule date

### DIFF
--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -10,4 +10,6 @@ export type LearnedWord = {
   word_id: string;
   in_review_queue: boolean;
   learned_at?: string; // ISO timestamp
+  next_review_at?: string | null; // Date-only ISO timestamp
+  next_display_at?: string | null; // ISO timestamp
 };

--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -1,3 +1,4 @@
+import type { LearnedWord } from '@/core/models';
 import type { VocabularyWord } from '@/types/vocabulary';
 import type {
   DailySelection,
@@ -699,10 +700,19 @@ export class LearningProgressService {
       for (const row of rows ?? []) {
         if (!row || typeof row !== 'object') continue;
 
-        const inQueue = this.isInReviewQueue((row as { in_review_queue?: unknown }).in_review_queue);
+        const typed = row as LearnedWord;
+        const inQueue = this.isInReviewQueue(typed.in_review_queue);
         if (!inQueue) continue;
 
-        const wordIdValue = (row as { word_id?: unknown }).word_id;
+        const due = this.isDue({
+          nextReviewDate:
+            typeof typed.next_review_at === 'string' ? typed.next_review_at : undefined,
+          nextAllowedTime:
+            typeof typed.next_display_at === 'string' ? typed.next_display_at : undefined
+        });
+        if (!due) continue;
+
+        const wordIdValue = (typed as { word_id?: unknown }).word_id;
         if (typeof wordIdValue !== 'string') continue;
 
         const normalised = this.normaliseWordId(wordIdValue);


### PR DESCRIPTION
## Summary
- filter server-synced review queue entries to only include words scheduled for review on or before today
- extend the LearnedWord model to surface next_review_at and next_display_at timestamps for type-safe filtering
- update learning progress service tests to cover filtering future-dated server due words

## Testing
- npm test -- learningProgressServiceSelection

------
https://chatgpt.com/codex/tasks/task_e_68cf529dbe78832fbf1ecd2715532fd7