### PR TITLE
Adjust missing nickname sign-in message

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -159,15 +159,19 @@ export default function AuthGate() {
           passcodeInput,
         );
 
-        if (response.status === 404 && errorCode === 'PROFILE_NOT_FOUND') {
+        if (
+          response.status === 404 ||
+          errorCode === 'PROFILE_NOT_FOUND' ||
+          errorMessage === 'Profile not found'
+        ) {
           setS((p) => ({
             ...p,
             pending: false,
             nickname: sanitizedName,
             passcode: passcodeInput,
             mode: 'create',
-            error: undefined,
-            info: 'No profile found for that nickname. Create one to get started.',
+            error: 'Cannot find nickname. Please create a new profile.',
+            info: undefined,
           }));
           return;
         }


### PR DESCRIPTION
## Summary
- show a clearer error when a nickname lookup fails and prompt to create a profile
- broaden the detection of missing nickname responses from the passcode exchange endpoint

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf64034f88832f9426d7646e9e637b