### PR TITLE
feat: optimistic learned word caching

### DIFF
--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -8,3 +8,4 @@ export const DAILY_SELECTION_KEY = 'dailySelection';
 export const LAST_SELECTION_DATE_KEY = 'lastSelectionDate';
 export const TODAY_WORDS_KEY = 'todayWords';
 export const LAST_SYNC_DATE_KEY = 'lastSyncDate';
+export const LEARNED_WORDS_CACHE_KEY = 'learnedWordsCache';


### PR DESCRIPTION
## Summary
- optimistically seed the learned words list and cache before waiting for Supabase
- add learned word cache management in the learning progress service and merge remote snapshots
- hydrate learned summaries from the cached source so refreshes keep local counts accurate

## Testing
- npx vitest --run tests/markWordLearnedRemovesTodayWord.test.tsx *(hangs in this environment)*
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf626df2cc832fbd692c965a81576c