### PR TITLE
Update learned SRS state semantics

### DIFF
--- a/src/services/learningProgressService.ts
+++ b/src/services/learningProgressService.ts
@@ -304,7 +304,7 @@ export class LearningProgressService {
   private toSrsState(status?: StoredProgress['status']): string {
     switch (status) {
       case 'learned':
-        return 'graduated';
+        return 'learned';
       case 'due':
         return 'review';
       case 'not_due':

--- a/tests/learningProgressServiceSrsState.test.ts
+++ b/tests/learningProgressServiceSrsState.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { learningProgressService } from '@/services/learningProgressService';
+import { upsertLearned } from '@/lib/db/learned';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    const keys = Array.from(this.store.keys());
+    return keys[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+vi.mock('@/lib/db/learned', () => ({
+  getLearned: vi.fn().mockResolvedValue([]),
+  resetLearned: vi.fn().mockResolvedValue(undefined),
+  upsertLearned: vi.fn().mockResolvedValue(undefined)
+}));
+
+describe('learningProgressService markWordLearned', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: new MemoryStorage(),
+      configurable: true,
+      writable: true
+    });
+    vi.clearAllMocks();
+  });
+
+  it('returns a Supabase payload that uses the learned SRS state', async () => {
+    const result = await learningProgressService.markWordLearned('apple');
+
+    expect(result).not.toBeNull();
+    expect(result?.payload.srs_state).toBe('learned');
+
+    expect(upsertLearned).toHaveBeenCalled();
+    const [, payload] = vi.mocked(upsertLearned).mock.calls.at(-1)!;
+    expect(payload.srs_state).toBe('learned');
+  });
+});


### PR DESCRIPTION
## Summary
- return the literal `learned` SRS state for learned progress entries
- add a unit test that exercises `markWordLearned` and confirms the Supabase payload keeps the learned state

## Testing
- npm test -- --run tests/learningProgressServiceSrsState.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf626f7788832fbf7169e1e71e0294