### PR TITLE
Implement SRS sync for daily word selection

### DIFF
--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -9,7 +9,13 @@ export type UserPreferences = {
 export type LearnedWord = {
   word_id: string;
   in_review_queue: boolean;
-  learned_at?: string; // ISO timestamp
-  next_review_at?: string | null; // Date-only ISO timestamp
+  learned_at?: string | null; // ISO timestamp
+  review_count?: number | null;
+  last_review_at?: string | null;
+  next_review_at?: string | null; // ISO timestamp
   next_display_at?: string | null; // ISO timestamp
+  last_seen_at?: string | null;
+  srs_interval_days?: number | null;
+  srs_easiness?: number | null;
+  srs_state?: string | null;
 };

--- a/src/lib/db/learned.ts
+++ b/src/lib/db/learned.ts
@@ -3,6 +3,7 @@ import type { LearnedWord } from '@/core/models';
 import { ensureUserKey } from '@/lib/progress/srsSyncByUserKey';
 import { recalcProgressSummary } from '@/lib/progress/progressSummary';
 import { CUSTOM_AUTH_MODE } from '@/lib/customAuthMode';
+import { getActiveSession } from '@/lib/auth';
 
 export type LearnedWordUpsert = {
   in_review_queue: boolean;
@@ -48,6 +49,8 @@ function normaliseText(value?: string | null): string | null {
 }
 
 export async function getLearned(): Promise<LearnedWord[]> {
+  const session = await getActiveSession();
+  if (!session?.user_unique_key) return [];
   const supabase = getSupabaseClient();
   if (!supabase) return [];
   const user_unique_key = await ensureUserKey();
@@ -64,6 +67,8 @@ export async function upsertLearned(
   wordId: string,
   payload: LearnedWordUpsert
 ): Promise<void> {
+  const session = await getActiveSession();
+  if (!session?.user_unique_key) return;
   const supabase = getSupabaseClient();
   if (!supabase) return;
   const user_unique_key = await ensureUserKey();
@@ -87,7 +92,7 @@ export async function upsertLearned(
 
   const { error } = await supabase
     .from('learned_words')
-    .upsert(record, { onConflict: 'user_unique_key,word_id' });
+    .upsert(record, { onConflict: ['user_unique_key', 'word_id'] });
 
   if (error) {
     throw error;
@@ -97,6 +102,8 @@ export async function upsertLearned(
 }
 
 export async function resetLearned(wordId: string): Promise<void> {
+  const session = await getActiveSession();
+  if (!session?.user_unique_key) return;
   const supabase = getSupabaseClient();
   if (!supabase) return;
 

--- a/src/lib/progress/srsIntervals.ts
+++ b/src/lib/progress/srsIntervals.ts
@@ -1,0 +1,31 @@
+export const SRS_FIXED_INTERVALS_DAYS = [1, 3, 7, 14, 21, 30, 45, 60] as const;
+export const SRS_REPEAT_INTERVAL_DAYS = 20 as const;
+
+function toPositiveInteger(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  const int = Math.trunc(value);
+  return int > 0 ? int : null;
+}
+
+export function calculateNextIntervalDays(
+  reviewCount: number,
+  _previousInterval?: number | null
+): number {
+  const safeCount = toPositiveInteger(reviewCount);
+  if (!safeCount) {
+    return 1;
+  }
+
+  const index = safeCount - 1;
+  if (index < SRS_FIXED_INTERVALS_DAYS.length) {
+    return SRS_FIXED_INTERVALS_DAYS[index];
+  }
+
+  return SRS_REPEAT_INTERVAL_DAYS;
+}
+
+export function addIntervalDays(base: Date, days: number): Date {
+  const result = new Date(base);
+  result.setDate(result.getDate() + days);
+  return result;
+}


### PR DESCRIPTION
## Summary
- extend the learned word model and Supabase helpers to require an active session before syncing
- add reusable SRS interval utilities and update learning progress payloads to use the new spacing rules
- cache learned word rows and sync each daily selection to Supabase with updated review counts and scheduling

## Testing
- `npm run lint` *(fails: pre-existing lint violations throughout the project)*
- `npm test` *(fails: existing test suite errors and OOM during vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68cf628ce5a0832fb391e3a1d8c3868a