### PR TITLE
Refactor nickname/passcode auth to use Supabase edge API

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,1 @@
-export const EDGE_BASE_URL = 'https://vijvcojvemkzgpzpowzh.functions.supabase.co';
-export const EXCHANGE_FN_URL = `${EDGE_BASE_URL}/nickname-passcode-exchange`;
-export const SET_NICKNAME_FN_URL = `${EDGE_BASE_URL}/set-nickname-passcode`;
+export const EDGE_BASE_URL = 'https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1';

--- a/src/lib/customAuth.ts
+++ b/src/lib/customAuth.ts
@@ -1,156 +1,39 @@
-import { EXCHANGE_FN_URL } from '@/config';
-
-export type CustomSession = {
-  sessionToken: string;
-  expiresAt: number; // unix seconds
-  expiresIn: number; // seconds
+export type Session = {
+  session_token: string;
+  token_type: "bearer";
+  expires_in: number;
+  expires_at: number;
+  user_unique_key: string;
   nickname: string;
-  userKey: string; // user_unique_key
 };
 
-let _session: CustomSession | null = null;
-const LS_KEY = 'lazyVoca.session';
-const LEGACY_KEY = 'lazyVoca.auth';
+const LS_KEY = "lazyVoca.auth";
+let _session: Session | null = null;
 
-export type ExchangeResponse = Record<string, unknown> & {
-  session_token?: unknown;
-  expires_at?: unknown;
-  expires_in?: unknown;
-  nickname?: unknown;
-  user_unique_key?: unknown;
-  error?: unknown;
-  code?: unknown;
-};
-
-export function storeSessionFromExchange(response: ExchangeResponse): CustomSession {
-  if (typeof response.session_token !== 'string' || typeof response.expires_at !== 'number') {
-    throw new Error('Invalid authentication response');
-  }
-
-  const session: CustomSession = {
-    sessionToken: response.session_token,
-    expiresAt: response.expires_at,
-    expiresIn: typeof response.expires_in === 'number' ? response.expires_in : 0,
-    nickname: typeof response.nickname === 'string' ? response.nickname : '',
-    userKey: typeof response.user_unique_key === 'string' ? response.user_unique_key : '',
-  };
-
-  _session = session;
-
+export function loadSessionOnBoot() {
   try {
-    localStorage.setItem(LS_KEY, JSON.stringify(session));
-    localStorage.removeItem(LEGACY_KEY);
-  } catch {
-    /* ignore storage errors */
-  }
-
-  return session;
-}
-
-export function saveSession(response: ExchangeResponse): CustomSession {
-  return storeSessionFromExchange(response);
-}
-
-export function loadFromStorageOnBoot(): void {
-  try {
-    const stored = localStorage.getItem(LS_KEY);
-    const legacyStored = stored ? null : localStorage.getItem(LEGACY_KEY);
-    const raw = stored ?? legacyStored;
+    const raw = localStorage.getItem(LS_KEY);
     if (!raw) return;
-    const s = JSON.parse(raw) as Partial<CustomSession> & {
-      expires_at?: number;
-      session_token?: string;
-      user_unique_key?: string;
-    };
-    const expiresAt =
-      typeof s.expiresAt === 'number'
-        ? s.expiresAt
-        : typeof s.expires_at === 'number'
-          ? s.expires_at
-          : null;
-    const sessionToken =
-      typeof s.sessionToken === 'string'
-        ? s.sessionToken
-        : typeof s.session_token === 'string'
-          ? s.session_token
-          : null;
-    if (sessionToken && expiresAt) {
-      const hydrated: CustomSession = {
-        sessionToken,
-        expiresAt,
-        expiresIn:
-          typeof s.expiresIn === 'number'
-            ? s.expiresIn
-            : typeof s.expires_in === 'number'
-              ? s.expires_in
-              : 0,
-        nickname: typeof s.nickname === 'string' ? s.nickname : '',
-        userKey:
-          typeof s.userKey === 'string'
-            ? s.userKey
-            : typeof s.user_unique_key === 'string'
-              ? s.user_unique_key
-              : '',
-      };
-      _session = hydrated;
-      if (legacyStored) {
-        localStorage.removeItem(LEGACY_KEY);
-        localStorage.setItem(LS_KEY, JSON.stringify(hydrated));
-      }
-    }
+    const s = JSON.parse(raw) as Session;
+    if (s?.expires_at && Math.floor(Date.now() / 1000) < s.expires_at) _session = s;
   } catch {
-    /* ignore storage errors */
+    /* ignore */
   }
 }
-
-export function isExpired(skewSec = 30): boolean {
-  if (!_session) return true;
-  const now = Math.floor(Date.now() / 1000);
-  return now + skewSec >= _session.expiresAt;
-}
-
-export function getSession(): CustomSession | null {
-  if (!_session) return null;
-  if (isExpired()) return null;
-  return _session;
-}
-
-export function getAuthHeader(): Record<string, string> {
-  const session = getSession();
-  if (!session?.sessionToken) return {};
-  return { Authorization: `Bearer ${session.sessionToken}` };
-}
-
-export async function exchangeNicknamePasscode(
-  nickname: string,
-  passcode: string | number,
-): Promise<ExchangeResponse> {
-  const res = await fetch(EXCHANGE_FN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nickname, passcode }),
-  });
-  const json = (await res.json().catch(() => ({}))) as ExchangeResponse;
-  if (!res.ok) {
-    const errorMessage = typeof json.error === 'string' && json.error ? json.error : 'Sign-in failed';
-    const err = new Error(errorMessage) as Error & { status?: number };
-    err.status = res.status;
-    throw err;
-  }
-  return json;
-}
-
-export async function signIn(nickname: string, passcode: string | number): Promise<void> {
-  const exchange = await exchangeNicknamePasscode(nickname, passcode);
-  saveSession(exchange);
-}
-
-export function signOut(): void {
+export function getSession() { return _session; }
+export function signOut() {
   _session = null;
   try {
     localStorage.removeItem(LS_KEY);
-    localStorage.removeItem(LEGACY_KEY);
   } catch {
-    /* ignore storage errors */
+    /* ignore */
+  }
+}
+export function saveSession(s: Session) {
+  _session = s;
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(s));
+  } catch {
+    /* ignore */
   }
 }

--- a/src/lib/db/supabase.ts
+++ b/src/lib/db/supabase.ts
@@ -1,5 +1,5 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { getAuthHeader } from '@/lib/customAuth';
+import { getAuthHeader } from '@/lib/auth';
 
 let client: SupabaseClient | null = null;
 let hasShownMissingMessage = false;

--- a/src/lib/edgeApi.ts
+++ b/src/lib/edgeApi.ts
@@ -1,0 +1,24 @@
+export const SET_PROFILE_URL = "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1/set_nickname_passcode";
+export const EXCHANGE_URL    = "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1/nickname-passcode-exchange";
+
+async function postJson(url: string, body: Record<string, unknown>) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    // Important: do NOT send cookies
+    // credentials: "omit"
+    // mode: "cors"
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json?.error || `HTTP ${res.status}`);
+  return json;
+}
+
+export function setNicknamePasscode(nickname: string, passcode: string | number) {
+  return postJson(SET_PROFILE_URL, { nickname, passcode });
+}
+
+export function exchangeNicknamePasscode(nickname: string, passcode: string | number) {
+  return postJson(EXCHANGE_URL, { nickname, passcode });
+}

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,5 +1,5 @@
 import { EDGE_BASE_URL } from '@/config';
-import { getAuthHeader, signOut } from '@/lib/customAuth';
+import { clearStoredAuth, getAuthHeader } from '@/lib/auth';
 
 export async function apiFetchAbsolute(url: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers || {});
@@ -18,7 +18,7 @@ export async function apiFetchAbsolute(url: string, init: RequestInit = {}) {
 
   if (res.status === 401) {
     // Token invalid/expired → sign out locally
-    signOut();
+    clearStoredAuth({ keepPasscode: true });
   }
   return res;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
-import { loadFromStorageOnBoot } from '@/lib/customAuth'
+import { loadSessionOnBoot } from '@/lib/customAuth'
 
 // Disable console logs in production for better performance
 if (import.meta.env.PROD) {
@@ -11,7 +11,7 @@ if (import.meta.env.PROD) {
   console.info = () => {};
 }
 
-loadFromStorageOnBoot();
+loadSessionOnBoot();
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/src/services/nicknameService.ts
+++ b/src/services/nicknameService.ts
@@ -1,39 +1,16 @@
-import { SET_NICKNAME_FN_URL } from '@/config';
 import { canonNickname } from '@/core/nickname';
+import { setNicknamePasscode as callSetNicknamePasscode } from '@/lib/edgeApi';
 
-export type SetNicknamePasscodePayload = {
-  user_unique_key?: string;
-  nickname?: string;
-  error?: string;
-  code?: string;
-};
-
-export type SetNicknamePasscodeResult = {
-  response: Response;
-  payload: SetNicknamePasscodePayload;
-};
-
-// Lowercase + remove spaces for the unique key
 export function normalizeNickname(s: string) {
   return canonNickname(s);
 }
 
 const BLOCKED_NICKNAME_CHARS = /[<>"'`$(){}\u005B\u005D;]/g;
 
-// Optional: block risky nickname chars (doesn't affect key)
 export function sanitizeNickname(s: string) {
   return s.replace(BLOCKED_NICKNAME_CHARS, '').trim();
 }
 
-export async function setNicknamePasscode(
-  nickname: string,
-  passcode: string,
-): Promise<SetNicknamePasscodeResult> {
-  const response = await fetch(SET_NICKNAME_FN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nickname, passcode }),
-  });
-  const payload = (await response.json().catch(() => ({}))) as SetNicknamePasscodePayload;
-  return { response, payload };
+export function setNicknamePasscode(nickname: string, passcode: string | number) {
+  return callSetNicknamePasscode(nickname, passcode);
 }


### PR DESCRIPTION
## Summary
- add a shared Supabase edge API helper and update configuration to the new function URLs
- simplify the custom auth session store and rework auth utilities to rely on the helper
- update the AuthGate flow and related services to sign in with the edge functions and persist sessions without cookies

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ce3248cc832fb490d85569687264