### PR TITLE
Refactor edge API helpers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,1 @@
-export const EDGE_BASE_URL = 'https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1';
+export { EDGE_BASE as EDGE_BASE_URL } from './lib/edgeApi';

--- a/src/lib/edgeApi.ts
+++ b/src/lib/edgeApi.ts
@@ -1,24 +1,19 @@
-export const SET_PROFILE_URL = "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1/set_nickname_passcode";
-export const EXCHANGE_URL    = "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1/nickname-passcode-exchange";
+export const EDGE_BASE =
+  "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1";
+export const SET_PROFILE_URL = `${EDGE_BASE}/set_nickname_passcode`;
+export const EXCHANGE_URL = `${EDGE_BASE}/nickname-passcode-exchange`;
 
-async function postJson(url: string, body: Record<string, unknown>) {
+async function postJson(url: string, body: any) {
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    // Important: do NOT send cookies
-    // credentials: "omit"
-    // mode: "cors"
   });
   const json = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error(json?.error || `HTTP ${res.status}`);
   return json;
 }
-
-export function setNicknamePasscode(nickname: string, passcode: string | number) {
-  return postJson(SET_PROFILE_URL, { nickname, passcode });
-}
-
-export function exchangeNicknamePasscode(nickname: string, passcode: string | number) {
-  return postJson(EXCHANGE_URL, { nickname, passcode });
-}
+export const setNicknamePasscode = (n: string, p: string | number) =>
+  postJson(SET_PROFILE_URL, { nickname: n, passcode: p });
+export const exchangeNicknamePasscode = (n: string, p: string | number) =>
+  postJson(EXCHANGE_URL, { nickname: n, passcode: p });


### PR DESCRIPTION
## Summary
- define edge API helper constants and JSON POST wrapper for nickname/passcode flows
- update the config export to reuse the shared edge base URL constant

## Testing
- npm run lint *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d3048cbc832f803ba2155fde7149