### PR TITLE
Handle unknown nicknames by directing to profile creation

### DIFF
--- a/src/lib/edgeApi.ts
+++ b/src/lib/edgeApi.ts
@@ -1,7 +1,8 @@
 export const EDGE_BASE =
   "https://vijvcojvemkzgpzpowzh.supabase.co/functions/v1";
+
 export const SET_PROFILE_URL = `${EDGE_BASE}/set_nickname_passcode`;
-export const EXCHANGE_URL = `${EDGE_BASE}/nickname-passcode-exchange`;
+export const EXCHANGE_URL    = `${EDGE_BASE}/nickname-passcode-exchange`;
 
 async function postJson(url: string, body: any) {
   const res = await fetch(url, {
@@ -9,11 +10,20 @@ async function postJson(url: string, body: any) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok) throw new Error(json?.error || `HTTP ${res.status}`);
+  const text = await res.text();
+  let json: any = {};
+  try { json = text ? JSON.parse(text) : {}; } catch {}
+  if (!res.ok) {
+    const err: any = new Error(json?.error || `HTTP ${res.status}`);
+    err.status = res.status;
+    err.code = json?.code;
+    throw err;
+  }
   return json;
 }
-export const setNicknamePasscode = (n: string, p: string | number) =>
-  postJson(SET_PROFILE_URL, { nickname: n, passcode: p });
-export const exchangeNicknamePasscode = (n: string, p: string | number) =>
-  postJson(EXCHANGE_URL, { nickname: n, passcode: p });
+
+export const setNicknamePasscode = (nickname: string, passcode: string|number) =>
+  postJson(SET_PROFILE_URL, { nickname, passcode });
+
+export const exchangeNicknamePasscode = (nickname: string, passcode: string|number) =>
+  postJson(EXCHANGE_URL, { nickname, passcode });


### PR DESCRIPTION
## Summary
- replace the nickname exchange edge function so it returns structured error codes and continues to mint session tokens
- update the edge API helper to surface error status/code details to the client
- adjust the AuthGate sign-in flow to open profile creation with a friendly message when the nickname is missing and to show inline passcode errors

## Testing
- npm run lint *(fails: pre-existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d7fe9188832fbe0b97fb0ab700ad