### PR TITLE
Remove voice and debug sections from index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,6 @@
 
 import React from 'react';
 import VocabularyAppWithLearning from '@/components/VocabularyAppWithLearning';
-import VoiceDebugPanel from '@/components/VoiceDebugPanel';
-import DebugPanel from '@/components/DebugPanel';
 
 const Index = () => {
   return (
@@ -25,8 +23,6 @@ const Index = () => {
       <footer className="mt-6 text-center text-sm text-muted-foreground">
         <p>© 2025 Lazy Vocabulary - hoctusach@gmail.com</p>
       </footer>
-      <VoiceDebugPanel />
-      <DebugPanel />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the voice debug panel and playback debug panel from the index page to hide the diagnostic sections

## Testing
- npm run lint *(fails: numerous pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fbc79070832fbbde99b8249003a7