### PR TITLE
Add default vocabulary view and grants

### DIFF
--- a/supabase/sql/2025-01-local-to-db.sql
+++ b/supabase/sql/2025-01-local-to-db.sql
@@ -9,6 +9,21 @@ create table if not exists public.defaultVocabulary (
   count integer
 );
 
+create or replace view public.default_vocabulary as
+select
+  word,
+  category,
+  meaning,
+  example,
+  translation
+from public."defaultVocabulary";
+
+grant select on public.default_vocabulary to anon;
+grant select on public.default_vocabulary to authenticated;
+
+-- Row Level Security is not enabled on public."defaultVocabulary", so no view-specific
+-- policies are required to mirror table access.
+
 create table if not exists public.nicknames (
   id bigserial primary key,
   created_at timestamptz not null default now(),


### PR DESCRIPTION
## Summary
- add a default_vocabulary view that mirrors the defaultVocabulary table
- grant read access on the new view to anon and authenticated roles
- document that no additional RLS policies are required because RLS is not enabled on the base table

## Testing
- npx supabase db push *(fails: project is not linked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d12331b69c832f865051b506c82200