### PR TITLE
Use shared Supabase client with anon key

### DIFF
--- a/src/lib/db/learned.ts
+++ b/src/lib/db/learned.ts
@@ -1,4 +1,4 @@
-import { getSupabaseClient } from './supabase';
+import { getSupabaseClient } from '@/lib/supabaseClient';
 import type { LearnedWord } from '@/core/models';
 import { ensureUserKey } from '@/lib/progress/srsSyncByUserKey';
 import { recalcProgressSummary } from '@/lib/progress/progressSummary';

--- a/src/lib/db/supabase.ts
+++ b/src/lib/db/supabase.ts
@@ -1,7 +1,3 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { getAuthHeader } from '@/lib/auth';
-
-let client: SupabaseClient | null = null;
 let hasShownMissingMessage = false;
 
 type DevSupabaseSettings = {
@@ -499,7 +495,7 @@ function showMissingEnvMessage() {
   }
 }
 
-function resolveSupabaseConfig() {
+export function resolveSupabaseConfig() {
   let url = readImportMetaEnv('VITE_SUPABASE_URL') ?? readProcessEnv('NEXT_PUBLIC_SUPABASE_URL');
   let anon = readImportMetaEnv('VITE_SUPABASE_ANON_KEY') ?? readProcessEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
 
@@ -521,37 +517,4 @@ if (typeof window !== 'undefined') {
   if (!initialUrl || !initialAnon) {
     showMissingEnvMessage();
   }
-}
-
-const createAuthenticatedFetch = (): typeof fetch => {
-  return async (input, init) => {
-    const headers = new Headers(init?.headers ?? {});
-    const auth = getAuthHeader();
-    for (const [key, value] of Object.entries(auth)) {
-      if (value) {
-        headers.set(key, value);
-      }
-    }
-    return fetch(input, { ...init, headers });
-  };
-};
-
-export function getSupabaseClient(): SupabaseClient | null {
-  if (client) return client;
-  const { url, anon } = resolveSupabaseConfig();
-  if (!url || !anon) {
-    showMissingEnvMessage();
-    return null;
-  }
-  client = createClient(url, anon, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-      detectSessionInUrl: false,
-    },
-    global: {
-      fetch: createAuthenticatedFetch(),
-    },
-  });
-  return client;
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,16 +1,37 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { getSupabaseClient as getDbSupabaseClient } from './db/supabase';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-export function getSupabaseClient(): SupabaseClient | null {
-  return getDbSupabaseClient();
+import { resolveSupabaseConfig } from './db/supabase';
+
+let client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (client) return client;
+
+  const { url, anon } = resolveSupabaseConfig();
+
+  if (!url || !anon) {
+    console.error('[Supabase] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+    throw new Error('Supabase env vars missing');
+  }
+
+  if (!anon.startsWith('eyJ')) {
+    console.error(
+      '[Supabase] VITE_SUPABASE_ANON_KEY does not look like a JWT (should start with eyJ…)'
+    );
+    throw new Error('Invalid anon key');
+  }
+
+  client = createClient(url, anon, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+
+  return client;
 }
 
 export function requireSupabaseClient(): SupabaseClient {
-  const client = getDbSupabaseClient();
-  if (!client) {
-    throw new Error(
-      'Supabase credentials are missing. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable cloud sync.'
-    );
-  }
-  return client;
+  return getSupabaseClient();
 }


### PR DESCRIPTION
## Summary
- create a shared Supabase client that validates VITE_SUPABASE_* values and reuses a single instance
- remove the custom fetch wrapper that injected non-JWT Authorization headers and expose the resolved config for reuse
- update the learned-words DB module to pull the shared Supabase client

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d15def75e4832fbf9e54c16d9b04df