### PR TITLE
Ensure controls remain accessible when daily list is empty

### DIFF
--- a/src/components/vocabulary-app/ContentWithDataNew.tsx
+++ b/src/components/vocabulary-app/ContentWithDataNew.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
-import { VocabularyWord } from '@/types/vocabulary';
+import React from 'react';
+import type { ReadonlyWord } from '@/types/vocabulary';
 import VocabularyMainNew from './VocabularyMainNew';
 
 interface ContentWithDataNewProps {
-  displayWord: ReadonlyWord;
+  displayWord: ReadonlyWord | null;
   muted: boolean;
   paused: boolean;
   toggleMute: () => void;
@@ -17,6 +17,13 @@ interface ContentWithDataNewProps {
   onMarkWordLearned?: (word: string) => void;
   onOpenSearch: (word?: string) => void;
   additionalContent?: React.ReactNode;
+  emptyState?: {
+    word: string;
+    meaning: string;
+    example?: string;
+    translation?: string;
+    category?: string;
+  };
 }
 
 const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
@@ -33,13 +40,15 @@ const ContentWithDataNew: React.FC<ContentWithDataNewProps> = ({
   playCurrentWord,
   onMarkWordLearned,
   onOpenSearch,
-  additionalContent
+  additionalContent,
+  emptyState
 }) => {
   return (
     <>
       {/* Main vocabulary display */}
       <VocabularyMainNew
         currentWord={displayWord}
+        emptyState={emptyState}
         mute={muted}
         isPaused={paused}
         toggleMute={toggleMute}

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -96,31 +96,16 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({
     );
   }
 
-  if (!hasData) {
-    return (
-      <DebugInfoContext.Provider value={debugInfo}>
-        <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
-          <div className="space-y-4">
-            <UserInteractionManager
-              currentWord={currentWord}
-              playCurrentWord={playCurrentWord}
-              onInteractionUpdate={handleInteractionUpdate}
-            />
-            <VocabularyCardNew
-              word={`No words in "${currentCategory}" category`}
-              meaning="Try switching to another category"
-              example=""
-              backgroundColor="#F0F8FF"
-              isSpeaking={false}
-              category={currentCategory}
-            />
-          </div>
-        </VocabularyLayout>
-      </DebugInfoContext.Provider>
-    );
-  }
+  const emptyState = !hasData
+    ? {
+        word: `No words in "${currentCategory}" category`,
+        meaning: "Try switching categories or regenerate today's list",
+        example: '',
+        category: currentCategory || 'No Data'
+      }
+    : undefined;
 
-  if (!currentWord) {
+  if (!currentWord && hasData) {
     return (
       <DebugInfoContext.Provider value={debugInfo}>
         <VocabularyLayout showWordCard={true} hasData={true} onToggleView={() => {}}>
@@ -158,6 +143,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({
 
           <ContentWithDataNew
             displayWord={currentWord}
+            emptyState={emptyState}
             muted={isMuted}
             paused={isPaused}
             toggleMute={toggleMute}

--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -64,6 +64,10 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
   };
 
   const handleNextWord = () => {
+    if (!currentWord) {
+      toast.info('No words available in this category. Try switching categories or regenerate today\'s list.');
+      return;
+    }
     onNextWord();
     trackEvent('next_word', 'Next Word');
   };

--- a/src/components/vocabulary-app/VocabularyMainNew.tsx
+++ b/src/components/vocabulary-app/VocabularyMainNew.tsx
@@ -6,7 +6,7 @@ import { useBackgroundColor } from './useBackgroundColor';
 import VocabularyControlsColumn from './VocabularyControlsColumn';
 
 interface VocabularyMainNewProps {
-  currentWord: ReadonlyWord;
+  currentWord: ReadonlyWord | null;
   mute: boolean;
   isPaused: boolean;
   toggleMute: () => void;
@@ -20,6 +20,13 @@ interface VocabularyMainNewProps {
   playCurrentWord: () => void;
   onMarkWordLearned?: (word: string) => void;
   onOpenSearch: (word?: string) => void;
+  emptyState?: {
+    word: string;
+    meaning: string;
+    example?: string;
+    translation?: string;
+    category?: string;
+  };
 }
 
 const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
@@ -37,25 +44,33 @@ const VocabularyMainNew: React.FC<VocabularyMainNewProps> = ({
   playCurrentWord,
   onMarkWordLearned,
   onOpenSearch,
+  emptyState
   }) => {
   const { backgroundColor } = useBackgroundColor();
+
+  const wordToDisplay = currentWord?.word ?? emptyState?.word ?? 'No vocabulary available';
+  const meaningToDisplay = currentWord?.meaning ?? emptyState?.meaning ?? '';
+  const exampleToDisplay = currentWord?.example ?? emptyState?.example ?? '';
+  const translationToDisplay = currentWord?.translation ?? emptyState?.translation;
+  const categoryToDisplay = currentWord?.category ?? emptyState?.category ?? '';
+  const shouldShowWordCount = showWordCount && Boolean(currentWord);
 
   return (
     <div className="flex flex-row items-start gap-2 sm:gap-4 w-full max-w-5xl mx-auto">
       {/* Main card - takes most of the space */}
         <div className="flex-1 min-w-0">
           <VocabularyCardNew
-            word={currentWord.word}
-            meaning={currentWord.meaning}
-            example={currentWord.example}
-            translation={currentWord.translation}
+            word={wordToDisplay}
+            meaning={meaningToDisplay}
+            example={exampleToDisplay}
+            translation={translationToDisplay}
             backgroundColor={backgroundColor}
-            isSpeaking={isSoundPlaying}
-            category={currentWord.category || ''}
-            showWordCount={showWordCount}
+            isSpeaking={isSoundPlaying && Boolean(currentWord)}
+            category={categoryToDisplay}
+            showWordCount={shouldShowWordCount}
           />
         </div>
-      
+
       {/* Controls column - positioned on the right side */}
         <div className="flex-none flex flex-col justify-start items-end">
           <VocabularyControlsColumn


### PR DESCRIPTION
## Summary
- pass an empty-state description into the vocabulary content pipeline so the main card shows "No words" while controls stay visible
- update VocabularyMainNew to support null current words and render the placeholder messaging without hiding the action column
- guard the next-word action when no word is active to avoid errors while still allowing users to use the other controls

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d23abb2174832f8e5ebe8a7fbd7bf2