### PR TITLE
Show progress sections with default values when data missing

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -37,6 +37,19 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
     : 0;
   const [open, setOpen] = useState(false);
   const { totalHours } = useLearnerHours(learnerId);
+  const newWords = dailySelection?.newWords ?? [];
+  const reviewWords = dailySelection?.reviewWords ?? [];
+  const totalSelection = newWords.length + reviewWords.length;
+  const selectionSeverity = dailySelection?.severity ?? '—';
+  const selectionHasWords = totalSelection > 0;
+  const categoryBreakdown = selectionHasWords
+    ? Object.entries(
+        [...newWords, ...reviewWords].reduce((acc, word) => {
+          acc[word.category] = (acc[word.category] || 0) + 1;
+          return acc;
+        }, {} as Record<string, number>)
+      )
+    : [];
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -66,7 +79,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
                   <Button
                     variant="ghost"
                     size="icon"
-                    aria-label="How DUE REVIEW work?"
+                    aria-label="How does due review count work?"
                     className="h-10 w-10 text-gray-500 hover:text-gray-700"
                   >
                     <Info className="h-4 w-4" />
@@ -74,7 +87,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
                 </PopoverTrigger>
                 <PopoverContent className="max-w-xs text-left">
                   <div className="space-y-1">
-                    <p className="font-bold">How DUE REVIEW work?</p>
+                    <p className="font-bold">How does due review count work?</p>
                     <p>It goes with the Spaced Repetition Principle.</p>
                     <p>
                       Each correct review pushes the next one farther out: 2 → 3 → 5 → 7 → 10 → 14 → 21 → 28 → 35 days. After that, mastered items return every 60 days.
@@ -116,44 +129,38 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
         </div>
 
         {/* Daily Selection Info */}
-        {dailySelection && (
-          <div className="space-y-3">
-            <h4 className="font-semibold">Today's Selection</h4>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="secondary" className="border-0">
-                Total: {dailySelection.newWords.length + dailySelection.reviewWords.length}
-              </Badge>
-              <Badge variant="outline" className="text-green-600 border-0">
-                New: {dailySelection.newWords.length}
-              </Badge>
-              <Badge variant="outline" className="text-blue-600 border-0">
-                Review: {dailySelection.reviewWords.length}
-              </Badge>
-              <Badge variant="outline" className="border-0">
-                Level: {dailySelection.severity}
-              </Badge>
-            </div>
-            
-            {/* Category breakdown for all words in today's selection */}
-            {(dailySelection.newWords.length > 0 || dailySelection.reviewWords.length > 0) && (
-              <div className="text-sm">
-                <div className="font-medium mb-1">By Category:</div>
-                <div className="flex flex-wrap gap-1">
-                  {Object.entries(
-                    [...dailySelection.newWords, ...dailySelection.reviewWords].reduce((acc, word) => {
-                      acc[word.category] = (acc[word.category] || 0) + 1;
-                      return acc;
-                    }, {} as Record<string, number>)
-                  ).map(([category, count]) => (
-                    <Badge key={category} variant="outline" className="text-xs border-0">
-                      {category}: {count}
-                    </Badge>
-                  ))}
-                </div>
+        <div className="space-y-3">
+          <h4 className="font-semibold">Today's Selection</h4>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary" className="border-0">
+              Total: {totalSelection}
+            </Badge>
+            <Badge variant="outline" className="text-green-600 border-0">
+              New: {newWords.length}
+            </Badge>
+            <Badge variant="outline" className="text-blue-600 border-0">
+              Review: {reviewWords.length}
+            </Badge>
+            <Badge variant="outline" className="border-0">
+              Level: {selectionSeverity}
+            </Badge>
+          </div>
+
+          <div className="text-sm">
+            <div className="font-medium mb-1">By Category:</div>
+            {selectionHasWords ? (
+              <div className="flex flex-wrap gap-1">
+                {categoryBreakdown.map(([category, count]) => (
+                  <Badge key={category} variant="outline" className="text-xs border-0">
+                    {category}: {count}
+                  </Badge>
+                ))}
               </div>
+            ) : (
+              <div className="italic text-gray-500">No words selected yet.</div>
             )}
           </div>
-        )}
+        </div>
 
         {/* Generate Daily Selection */}
         <div className="space-y-3">

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -54,6 +54,9 @@ const VocabularyAppWithLearning: React.FC = () => {
   }, [markWordAsPlayed]);
 
   const learnedWordsList = Array.isArray(learnedWords) ? learnedWords : [];
+  const newWords = dailySelection?.newWords ?? [];
+  const reviewWords = dailySelection?.reviewWords ?? [];
+  const hasSelectionWords = newWords.length > 0 || reviewWords.length > 0;
 
   useEffect(() => {
     if (dailySelection) {
@@ -91,109 +94,118 @@ const VocabularyAppWithLearning: React.FC = () => {
         learnerId="default"
       />
 
-      {dailySelection && (
-        <Collapsible open={summaryOpen} onOpenChange={setSummaryOpen}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <CollapsibleTrigger className="flex items-center gap-2">
-                <h3 className="text-lg font-semibold">Word Summary</h3>
-                <span className="text-xs text-muted-foreground hidden sm:inline">
-                  Tap to show or hide details
-                </span>
-                <ChevronDown
-                  className={cn('h-4 w-4 transition-transform', summaryOpen && 'rotate-180')}
-                />
-              </CollapsibleTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="top">Click to expand or collapse the word summary.</TooltipContent>
-          </Tooltip>
-          <CollapsibleContent className="space-y-4">
-            <div className="grid gap-4 md:grid-cols-3">
-              {dailySelection.newWords.length > 0 && (
-                <div className="space-y-2">
-                  <h4 className="font-medium text-green-600">Today's New ({dailySelection.newWords.length})</h4>
-                  <div className="space-y-1 max-h-60 overflow-y-auto">
-                    {dailySelection.newWords.map((word, index) => (
-                      <div key={index} className="text-sm p-2 bg-green-50 rounded border">
-                        <div className="font-medium">{word.word}</div>
-                        <div className="text-xs text-gray-600">{word.category}</div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {dailySelection.reviewWords.length > 0 && (
-                <div className="space-y-2">
-                  <h4 className="font-medium text-red-600">
-                    Today's Due Review ({dailySelection.reviewWords.length})
-                  </h4>
-                  <div className="space-y-1 max-h-60 overflow-y-auto">
-                    {dailySelection.reviewWords.map((word, index) => (
-                      <div
-                        key={index}
-                        className="text-sm p-2 bg-red-50 rounded border"
-                      >
-                        <div className="font-medium">{word.word}</div>
-                        <div className="text-xs text-gray-600">
-                          {word.category} • Review #{word.reviewCount}
-                        </div>
-                        <div className="text-xs text-gray-500">
-                          Next review: {word.nextReviewDate}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              <div className="space-y-2">
-                <h4 className="font-medium text-gray-600">Learned ({learnedWordsList.length})</h4>
-                <div className="space-y-1 max-h-60 overflow-y-auto">
-                  {learnedWordsList.length > 0 ? (
-                    learnedWordsList.map((word, index) => (
-                      <div
-                        key={index}
-                        className="text-sm p-2 bg-gray-50 rounded border opacity-75 flex items-center justify-between"
-                      >
-                        <div>
-                          <div className="font-medium text-gray-700">{word.word}</div>
-                          <div className="text-xs text-gray-500">
-                            {word.category} • Learned {word.learnedDate}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <button
-                            aria-label="View Word"
-                            className="text-gray-400 hover:text-gray-600"
-                            onClick={() => openSearch(word.word)}
-                          >
-                            <Eye className="h-4 w-4" />
-                          </button>
-                          <button
-                            aria-label="Mark as New"
-                            className="text-gray-400 hover:text-gray-600"
-                            onClick={() => {
-                              setWordToReset(word.word);
-                              setIsMarkAsNewDialogOpen(true);
-                            }}
-                          >
-                            <RotateCcw className="h-4 w-4" />
-                          </button>
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
-                      No learned words
+      <Collapsible open={summaryOpen} onOpenChange={setSummaryOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <CollapsibleTrigger className="flex items-center gap-2">
+              <h3 className="text-lg font-semibold">Word Summary</h3>
+              <span className="text-xs text-muted-foreground hidden sm:inline">
+                Tap to show or hide details
+              </span>
+              <ChevronDown
+                className={cn('h-4 w-4 transition-transform', summaryOpen && 'rotate-180')}
+              />
+            </CollapsibleTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top">Click to expand or collapse the word summary.</TooltipContent>
+        </Tooltip>
+        <CollapsibleContent className="space-y-4">
+          {!hasSelectionWords && (
+            <div className="text-sm text-gray-500 italic">No daily selection available yet.</div>
+          )}
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <h4 className="font-medium text-green-600">Today's New ({newWords.length})</h4>
+              <div className="space-y-1 max-h-60 overflow-y-auto">
+                {newWords.length > 0 ? (
+                  newWords.map((word, index) => (
+                    <div key={index} className="text-sm p-2 bg-green-50 rounded border">
+                      <div className="font-medium">{word.word}</div>
+                      <div className="text-xs text-gray-600">{word.category}</div>
                     </div>
-                  )}
-                </div>
+                  ))
+                ) : (
+                  <div className="text-sm p-2 bg-green-50 rounded border text-gray-500 italic">
+                    No new words assigned
+                  </div>
+                )}
               </div>
             </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+
+            <div className="space-y-2">
+              <h4 className="font-medium text-red-600">
+                Today's Due Review ({reviewWords.length})
+              </h4>
+              <div className="space-y-1 max-h-60 overflow-y-auto">
+                {reviewWords.length > 0 ? (
+                  reviewWords.map((word, index) => (
+                    <div
+                      key={index}
+                      className="text-sm p-2 bg-red-50 rounded border"
+                    >
+                      <div className="font-medium">{word.word}</div>
+                      <div className="text-xs text-gray-600">
+                        {word.category} • Review #{word.reviewCount}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        Next review: {word.nextReviewDate}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-sm p-2 bg-red-50 rounded border text-gray-500 italic">
+                    No due reviews assigned
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <h4 className="font-medium text-gray-600">Learned ({learnedWordsList.length})</h4>
+              <div className="space-y-1 max-h-60 overflow-y-auto">
+                {learnedWordsList.length > 0 ? (
+                  learnedWordsList.map((word, index) => (
+                    <div
+                      key={index}
+                      className="text-sm p-2 bg-gray-50 rounded border opacity-75 flex items-center justify-between"
+                    >
+                      <div>
+                        <div className="font-medium text-gray-700">{word.word}</div>
+                        <div className="text-xs text-gray-500">
+                          {word.category} • Learned {word.learnedDate}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          aria-label="View Word"
+                          className="text-gray-400 hover:text-gray-600"
+                          onClick={() => openSearch(word.word)}
+                        >
+                          <Eye className="h-4 w-4" />
+                        </button>
+                        <button
+                          aria-label="Mark as New"
+                          className="text-gray-400 hover:text-gray-600"
+                          onClick={() => {
+                            setWordToReset(word.word);
+                            setIsMarkAsNewDialogOpen(true);
+                          }}
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-sm p-2 bg-gray-50 rounded border text-gray-500 italic">
+                    No learned words
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
       </div>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Summary
- show learning progress stats with default values when no daily selection data is available
- always render the word summary view with placeholders so the component remains visible when APIs return empty results

## Testing
- npx vitest run tests/LearningProgressPanel.test.tsx tests/vocabularyAppDueReviews.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d23aca9968832f802a6c6ac3dac353