### PR TITLE
Add debug logging for learning flow diagnostics

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -42,6 +42,12 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
   const totalSelection = newWords.length + reviewWords.length;
   const selectionSeverity = dailySelection?.severity ?? '—';
   const selectionHasWords = totalSelection > 0;
+  if (process.env.NEXT_PUBLIC_LAZYVOCA_DEBUG === '1') {
+    console.log('[LearningProgressPanel] rendering word list', {
+      itemsLength: totalSelection,
+      category: dailySelection?.category ?? null,
+    });
+  }
   const categoryBreakdown = selectionHasWords
     ? Object.entries(
         [...newWords, ...reviewWords].reduce((acc, word) => {

--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -85,6 +85,9 @@ export const useLearningProgress = () => {
     const init = async () => {
       const preparedKey = await prepareUserSession();
       if (!preparedKey || !isActive) return;
+      if (process.env.NEXT_PUBLIC_LAZYVOCA_DEBUG === '1') {
+        console.log('[useLearningProgress] prepareUserSession resolved', { userKey: preparedKey });
+      }
       setUserKey(preparedKey);
 
       await bootstrapLearnedFromServerByKey();


### PR DESCRIPTION
## Summary
- add environment-guarded debug logging when preparing user sessions and fetching daily selections
- capture cache and selection metrics during today-word retrieval
- report item counts when rendering the learning progress word list

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d24a32e5d8832f9995b846d0e1a806