### PR TITLE
Fix progress summary refresh and SRS column usage

### DIFF
--- a/src/lib/db/learned.ts
+++ b/src/lib/db/learned.ts
@@ -12,7 +12,7 @@ export type LearnedWordUpsert = {
   next_display_at?: string | null;
   last_seen_at?: string | null;
   srs_interval_days?: number | null;
-  srs_easiness?: number | null;
+  srs_ease?: number | null;
   srs_state?: string | null;
 };
 
@@ -78,7 +78,7 @@ export async function upsertLearned(
     next_display_at: normaliseISO(payload.next_display_at),
     last_seen_at: normaliseISO(payload.last_seen_at),
     srs_interval_days: normaliseNumber(payload.srs_interval_days),
-    srs_easiness: normaliseNumber(payload.srs_easiness),
+    srs_ease: normaliseNumber(payload.srs_ease),
     srs_state: normaliseText(payload.srs_state),
   };
 

--- a/src/types/vocabulary.ts
+++ b/src/types/vocabulary.ts
@@ -19,7 +19,7 @@ export type TodayWordSrs = {
   next_display_at?: string | null;
   last_seen_at?: string | null;
   srs_interval_days?: number | null;
-  srs_easiness?: number | null;
+  srs_ease?: number | null;
   srs_state?: string | null;
 };
 


### PR DESCRIPTION
## Summary
- switch progress summary refresh to call the refresh_user_progress_summary RPC and read the row instead of upserting
- update learning progress services to use the srs_ease column and new payload field names across client types
- replace the get_learned_words_by_key RPC usage with a direct learned_words select for SRS bootstrap and fetches

## Testing
- npm test -- --run *(fails: suite expects Supabase service singletons/mocks that are undefined in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da72846fdc832f887fb3c1f5d53035