### PR TITLE
Fix Supabase client queries for progress data

### DIFF
--- a/src/lib/progress/srsSyncByUserKey.ts
+++ b/src/lib/progress/srsSyncByUserKey.ts
@@ -9,6 +9,9 @@ export type ProgressSummary = {
   learned_count: number;
   learning_due_count: number;
   remaining_count: number;
+  learning_time: number;
+  learned_days: string[];
+  updated_at: string | null;
 };
 
 // Hard-coded total number of vocabulary words used for progress calculations
@@ -108,18 +111,22 @@ export async function markLearnedServerByKey(
     return null;
   }
 
-  if (data) {
-    persistProgressSummaryLocal({
-      learning_count: data.learning_count ?? 0,
-      learned_count: data.learned_count ?? 0,
-      learning_due_count: data.learning_due_count ?? 0,
-      remaining_count: data.remaining_count ?? Math.max(TOTAL_WORDS - (data.learned_count ?? 0), 0),
-      learning_time: data.learning_time ?? 0,
-      learned_days: Array.isArray(data.learned_days) ? data.learned_days : [],
-    });
+  if (!data) {
+    return null;
   }
 
-  return data as ProgressSummary;
+  const summary: ProgressSummary = {
+    learning_count: data.learning_count ?? 0,
+    learned_count: data.learned_count ?? 0,
+    learning_due_count: data.learning_due_count ?? 0,
+    remaining_count: data.remaining_count ?? Math.max(TOTAL_WORDS - (data.learned_count ?? 0), 0),
+    learning_time: data.learning_time ?? 0,
+    learned_days: Array.isArray(data.learned_days) ? data.learned_days : [],
+    updated_at: typeof data.updated_at === 'string' ? data.updated_at : null,
+  };
+
+  persistProgressSummaryLocal(summary);
+  return summary;
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace client-side learned words RPC usage with a direct select of the required SRS fields
- update progress summary helpers to read-only access with refresh RPC, include updated_at in cached data, and reuse local fallbacks
- extend progress sync types to persist the refreshed summary data returned from mark_word_learned_by_key

## Testing
- npm run lint *(fails: existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68db57c79b64832fad3079c9038c4b7a