### PR TITLE
Preserve RPC vocabulary metadata in daily selection

### DIFF
--- a/src/lib/db/supabase.ts
+++ b/src/lib/db/supabase.ts
@@ -102,6 +102,10 @@ export type DailySelectionV2Row = {
   word_id: string;
   category: string | null;
   is_due: boolean | null;
+  word?: string | null;
+  meaning?: string | null;
+  example?: string | null;
+  translation?: string | null;
 };
 
 export async function getDailySelectionV2(

--- a/src/types/vocabulary.ts
+++ b/src/types/vocabulary.ts
@@ -23,10 +23,16 @@ export type TodayWordSrs = {
   srs_state?: string | null;
 };
 
-export interface TodayWord extends VocabularyWord {
+export interface TodayWord {
   word_id: string;
+  word: string;
+  meaning: string;
+  example: string;
+  translation?: string;
+  count: number | string;
   category: string;
   is_due: boolean;
+  nextAllowedTime?: string;
   srs?: TodayWordSrs | null;
 }
 


### PR DESCRIPTION
## Summary
- extend the Supabase daily selection RPC types to expose the optional vocabulary metadata returned by the backend
- merge the RPC-provided fields while building today words, falling back to fetched vocabulary rows when needed and logging the normalized payload
- update the TodayWord shape so the enriched metadata is carried through learning progress state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfa8319d4832fbc5774ef14e121c5