### PR TITLE
Refactor local preference persistence

### DIFF
--- a/src/lib/localPreferences.ts
+++ b/src/lib/localPreferences.ts
@@ -1,12 +1,21 @@
-const SPEECH_RATE_KEY = 'lv_speech_rate';
+import {
+  hasLocalStorage,
+  readPreferencesFromStorage,
+  writePreferencesToStorage,
+} from '@/lib/preferences/localPreferences';
 
-const hasLocalStorage = (): boolean =>
-  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+const LEGACY_SPEECH_RATE_KEY = 'lv_speech_rate';
 
 export const getSpeechRate = (): number | null => {
+  const prefs = readPreferencesFromStorage();
+  if (prefs.speech_rate != null && Number.isFinite(prefs.speech_rate)) {
+    return prefs.speech_rate;
+  }
+
   if (!hasLocalStorage()) return null;
+
   try {
-    const raw = window.localStorage.getItem(SPEECH_RATE_KEY);
+    const raw = window.localStorage.getItem(LEGACY_SPEECH_RATE_KEY);
     if (raw === null) return null;
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? parsed : null;
@@ -16,11 +25,15 @@ export const getSpeechRate = (): number | null => {
 };
 
 export const setSpeechRate = (rate: number): void => {
-  if (!hasLocalStorage()) return;
   if (!Number.isFinite(rate)) return;
+
+  writePreferencesToStorage({ speech_rate: rate });
+
+  if (!hasLocalStorage()) return;
+
   try {
-    window.localStorage.setItem(SPEECH_RATE_KEY, String(rate));
+    window.localStorage.removeItem(LEGACY_SPEECH_RATE_KEY);
   } catch {
-    // ignore write errors
+    // ignore write errors when clearing legacy key
   }
 };

--- a/src/lib/preferences/localPreferences.ts
+++ b/src/lib/preferences/localPreferences.ts
@@ -2,6 +2,7 @@ import type { UserPreferences } from '@/core/models';
 
 const PREF_KEY = 'lv_preferences';
 const FAVORITE_VOICE_KEY = 'lv_favorite_voice';
+const LEGACY_SPEECH_RATE_KEY = 'lv_speech_rate';
 
 const defaultPrefs: UserPreferences = {
   favorite_voice: null,
@@ -11,61 +12,113 @@ const defaultPrefs: UserPreferences = {
   daily_option: null,
 };
 
-export async function getLocalPreferences(): Promise<UserPreferences> {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return { ...defaultPrefs };
-  }
+export const hasLocalStorage = (): boolean =>
+  typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const parseStoredPreferences = (): Partial<UserPreferences> => {
+  if (!hasLocalStorage()) return {};
 
   try {
     const raw = window.localStorage.getItem(PREF_KEY);
-    const stored = raw ? JSON.parse(raw) : {};
-    return { ...defaultPrefs, ...stored } as UserPreferences;
+    return raw ? (JSON.parse(raw) as Partial<UserPreferences>) : {};
   } catch (error) {
-    console.error('Error reading local preferences from localStorage', error);
-    return { ...defaultPrefs };
+    console.error('Error parsing local preferences from localStorage', error);
+    return {};
   }
-}
+};
 
-export async function saveLocalPreferences(prefs: Partial<UserPreferences>): Promise<void> {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+const applyLegacyFallbacks = (prefs: UserPreferences): UserPreferences => {
+  if (!hasLocalStorage()) {
+    return prefs;
+  }
+
+  const merged = { ...prefs };
+
+  try {
+    if (merged.favorite_voice == null) {
+      const legacyVoice = window.localStorage.getItem(FAVORITE_VOICE_KEY);
+      if (legacyVoice != null) {
+        merged.favorite_voice = legacyVoice;
+      }
+    }
+
+    if (merged.speech_rate == null) {
+      const legacyRate = window.localStorage.getItem(LEGACY_SPEECH_RATE_KEY);
+      if (legacyRate != null) {
+        const parsedRate = Number(legacyRate);
+        if (Number.isFinite(parsedRate)) {
+          merged.speech_rate = parsedRate;
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Error applying legacy preference fallbacks', error);
+    return merged;
+  }
+
+  return merged;
+};
+
+export const readPreferencesFromStorage = (): UserPreferences => {
+  const stored = parseStoredPreferences();
+  const merged = { ...defaultPrefs, ...stored } as UserPreferences;
+  return applyLegacyFallbacks(merged);
+};
+
+export const writePreferencesToStorage = (prefs: Partial<UserPreferences>): void => {
+  if (!hasLocalStorage()) {
     return;
   }
 
   try {
-    const current = await getLocalPreferences();
-    const merged = { ...current, ...prefs };
+    const current = readPreferencesFromStorage();
+    const merged = { ...current, ...prefs } as UserPreferences;
     window.localStorage.setItem(PREF_KEY, JSON.stringify(merged));
   } catch (error) {
-    console.error('Error saving local preferences to localStorage', error);
+    console.error('Error writing local preferences to localStorage', error);
+  }
+};
+
+export async function getLocalPreferences(): Promise<UserPreferences> {
+  return readPreferencesFromStorage();
+}
+
+export async function saveLocalPreferences(prefs: Partial<UserPreferences>): Promise<void> {
+  writePreferencesToStorage(prefs);
+
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  try {
+    if ('favorite_voice' in prefs) {
+      window.localStorage.removeItem(FAVORITE_VOICE_KEY);
+    }
+
+    if ('speech_rate' in prefs) {
+      window.localStorage.removeItem(LEGACY_SPEECH_RATE_KEY);
+    }
+  } catch (error) {
+    console.error('Error clearing legacy preference keys from localStorage', error);
   }
 }
 
 export function getFavoriteVoice(): string | null {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return null;
-  }
-
-  try {
-    return window.localStorage.getItem(FAVORITE_VOICE_KEY);
-  } catch (error) {
-    console.error('Error reading favorite voice from localStorage', error);
-    return null;
-  }
+  const prefs = readPreferencesFromStorage();
+  return prefs.favorite_voice;
 }
 
 export function setFavoriteVoice(name: string | null): void {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+  if (!hasLocalStorage()) {
     return;
   }
 
+  writePreferencesToStorage({ favorite_voice: name });
+
   try {
-    if (name) {
-      window.localStorage.setItem(FAVORITE_VOICE_KEY, name);
-    } else {
-      window.localStorage.removeItem(FAVORITE_VOICE_KEY);
-    }
+    window.localStorage.removeItem(FAVORITE_VOICE_KEY);
   } catch (error) {
-    console.error('Error saving favorite voice to localStorage', error);
+    console.error('Error clearing legacy favorite voice key from localStorage', error);
   }
 }
 

--- a/tests/localPreferencesStorage.test.ts
+++ b/tests/localPreferencesStorage.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getLocalPreferences,
+  saveLocalPreferences,
+  setFavoriteVoice,
+} from '@/lib/preferences/localPreferences';
+import { getSpeechRate, setSpeechRate } from '@/lib/localPreferences';
+
+const FAVORITE_VOICE_KEY = 'lv_favorite_voice';
+const SPEECH_RATE_KEY = 'lv_speech_rate';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+let mockStorage: MemoryStorage;
+let originalWindow: (Window & typeof globalThis) | undefined;
+
+beforeAll(() => {
+  originalWindow = (globalThis as { window?: Window & typeof globalThis }).window;
+  mockStorage = new MemoryStorage();
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: mockStorage },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterAll(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    delete (globalThis as { window?: Window & typeof globalThis }).window;
+  }
+});
+
+describe('local preferences storage', () => {
+  beforeEach(() => {
+    mockStorage.clear();
+  });
+
+  it('saves and reloads favorite voice and speech rate from consolidated preferences', async () => {
+    await saveLocalPreferences({ favorite_voice: 'Test Voice', speech_rate: 1.25 });
+
+    const prefs = await getLocalPreferences();
+    expect(prefs.favorite_voice).toBe('Test Voice');
+    expect(prefs.speech_rate).toBe(1.25);
+    expect(getSpeechRate()).toBe(1.25);
+  });
+
+  it('falls back to legacy keys when consolidated preferences lack values', async () => {
+    window.localStorage.setItem(FAVORITE_VOICE_KEY, 'Legacy Voice');
+    window.localStorage.setItem(SPEECH_RATE_KEY, '1.75');
+
+    const prefs = await getLocalPreferences();
+    expect(prefs.favorite_voice).toBe('Legacy Voice');
+    expect(prefs.speech_rate).toBe(1.75);
+    expect(getSpeechRate()).toBe(1.75);
+
+    setFavoriteVoice('Modern Voice');
+    setSpeechRate(1.1);
+
+    expect(window.localStorage.getItem(FAVORITE_VOICE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(SPEECH_RATE_KEY)).toBeNull();
+
+    const updatedPrefs = await getLocalPreferences();
+    expect(updatedPrefs.favorite_voice).toBe('Modern Voice');
+    expect(updatedPrefs.speech_rate).toBe(1.1);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared helpers for reading and writing consolidated local preferences while preserving legacy fallbacks
- update speech rate accessors to use the consolidated storage and clear legacy keys
- cover preference saves, legacy fallbacks, and migrations with unit tests

## Testing
- npm test -- --run tests/localPreferencesStorage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc0869f0e4832f8f6347386756d1cb