### PR TITLE
Persist edge sessions and forward auth headers

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 import { resolveSupabaseConfig } from './db/supabase';
+import { getAuthHeader } from './auth';
 
 let client: SupabaseClient | null = null;
 
@@ -21,11 +22,36 @@ export function getSupabaseClient(): SupabaseClient {
     throw new Error('Invalid anon key');
   }
 
+  const authorizedFetch: typeof fetch = async (input, init = {}) => {
+    const auth = getAuthHeader();
+    const headers = new Headers(
+      init.headers ?? (input instanceof Request ? input.headers : undefined) ?? {},
+    );
+
+    let applied = false;
+    for (const [key, value] of Object.entries(auth)) {
+      if (value?.length) {
+        headers.set(key, value);
+        applied = true;
+      }
+    }
+
+    if (!applied) {
+      return fetch(input, init);
+    }
+
+    const nextInit: RequestInit = { ...init, headers };
+    return fetch(input, nextInit);
+  };
+
   client = createClient(url, anon, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,
       detectSessionInUrl: false,
+    },
+    global: {
+      fetch: authorizedFetch,
     },
   });
 


### PR DESCRIPTION
## Summary
- store generated session tokens in public.user_sessions from the nickname/passcode exchange function
- wrap the Supabase browser client with a fetch that injects the current Authorization header so RPC calls include the bearer token

## Testing
- npm test *(fails: large portion of suite fails in current workspace due to missing mocks/services such as LearningProgressService)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd77f8f6c832f878f5b03070a4381