### PR TITLE
Fix auth header handling for Supabase and edge requests

### DIFF
--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -7,7 +7,20 @@ export async function apiFetchAbsolute(url: string, init: RequestInit = {}) {
   // Attach Authorization only for our Edge Functions
   if (url.startsWith(EDGE_BASE_URL)) {
     const auth = getAuthHeader();
-    for (const [k, v] of Object.entries(auth)) headers.set(k, v);
+    for (const [key, value] of Object.entries(auth)) {
+      const normalizedValue = value?.trim();
+      if (!normalizedValue) continue;
+
+      if (key.toLowerCase() === 'authorization') {
+        const token = normalizedValue.split(/\s+/).slice(-1)[0] ?? '';
+        const parts = token.split('.');
+        if (parts.length !== 3 || parts.some((part) => !part.length)) {
+          continue;
+        }
+      }
+
+      headers.set(key, normalizedValue);
+    }
   }
 
   if (!headers.has('Content-Type') && !(init.body instanceof FormData)) {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 import { resolveSupabaseConfig } from './db/supabase';
-import { getAuthHeader } from './auth';
 
 let client: SupabaseClient | null = null;
 
@@ -22,36 +21,11 @@ export function getSupabaseClient(): SupabaseClient {
     throw new Error('Invalid anon key');
   }
 
-  const authorizedFetch: typeof fetch = async (input, init = {}) => {
-    const auth = getAuthHeader();
-    const headers = new Headers(
-      init.headers ?? (input instanceof Request ? input.headers : undefined) ?? {},
-    );
-
-    let applied = false;
-    for (const [key, value] of Object.entries(auth)) {
-      if (value?.length) {
-        headers.set(key, value);
-        applied = true;
-      }
-    }
-
-    if (!applied) {
-      return fetch(input, init);
-    }
-
-    const nextInit: RequestInit = { ...init, headers };
-    return fetch(input, nextInit);
-  };
-
   client = createClient(url, anon, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,
       detectSessionInUrl: false,
-    },
-    global: {
-      fetch: authorizedFetch,
     },
   });
 


### PR DESCRIPTION
## Summary
- let the Supabase client rely on its built-in Authorization header so the anon key is preserved
- restrict apiFetchAbsolute to attach edge session Authorization headers only when they look like JWTs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd240f7500832f86b0a187d2d34a37