### PR TITLE
Add loading card for daily word selection

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -30,7 +30,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     markWordLearned: markCurrentWordLearned,
     markWordAsNew,
     todayWords,
-    learnedWords
+    learnedWords,
+    isDailySelectionLoading,
   } = useLearningProgress();
 
   // Track when words are played (integrate with existing word navigation)
@@ -212,6 +213,7 @@ const VocabularyAppWithLearning: React.FC = () => {
         <VocabularyAppContainerNew
           initialWords={todayWords}
           dailySelection={dailySelection}
+          isLoadingSelection={isDailySelectionLoading}
           onMarkWordLearned={(word) => {
             markCurrentWordLearned(word);
           }}

--- a/src/components/vocabulary-app/LoadingCard.css
+++ b/src/components/vocabulary-app/LoadingCard.css
@@ -1,0 +1,77 @@
+.lv-loading-card {
+  width: 100%;
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 2rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(236, 72, 153, 0.12));
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.lv-loading-card__inner {
+  font-family: 'Fira Code', 'Source Code Pro', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 1.05rem;
+  color: #0f172a;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lv-loading-card__text {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid rgba(15, 23, 42, 0.75);
+  letter-spacing: 0.02em;
+  animation: lv-typewriter 3s steps(36, end) 0.2s forwards;
+}
+
+.lv-loading-card__cursor {
+  width: 0.75rem;
+  height: 1.4rem;
+  background-color: rgba(15, 23, 42, 0.8);
+  border-radius: 2px;
+  animation: lv-caret-blink 0.9s steps(1) infinite;
+  margin-top: 0.2rem;
+}
+
+@keyframes lv-typewriter {
+  from {
+    width: 0;
+  }
+  to {
+    width: 36ch;
+  }
+}
+
+@keyframes lv-caret-blink {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .lv-loading-card {
+    min-height: 180px;
+    padding: 2rem 1.5rem;
+  }
+
+  .lv-loading-card__inner {
+    font-size: 0.95rem;
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .lv-loading-card__cursor {
+    margin-top: 0.6rem;
+    width: 0.6rem;
+    height: 1.1rem;
+  }
+}

--- a/src/components/vocabulary-app/LoadingCard.tsx
+++ b/src/components/vocabulary-app/LoadingCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './LoadingCard.css';
+
+const LoadingCard: React.FC = () => {
+  return (
+    <div className="lv-loading-card" role="status" aria-live="polite">
+      <div className="lv-loading-card__inner">
+        <span className="lv-loading-card__text">⌛ We’re preparing your daily words…</span>
+        <span className="lv-loading-card__cursor" aria-hidden="true" />
+      </div>
+    </div>
+  );
+};
+
+export default LoadingCard;

--- a/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
+++ b/src/components/vocabulary-app/VocabularyAppContainerNew.tsx
@@ -4,6 +4,7 @@ import VocabularyLayout from "@/components/VocabularyLayout";
 import ErrorDisplay from "./ErrorDisplay";
 import ContentWithDataNew from "./ContentWithDataNew";
 import VocabularyCardNew from "./VocabularyCardNew";
+import LoadingCard from "./LoadingCard";
 import UserInteractionManager from "./UserInteractionManager";
 import { useStableVocabularyState } from "@/hooks/vocabulary-app/useStableVocabularyState";
 import { useOptimizedAutoPlay } from "@/hooks/vocabulary-app/useOptimizedAutoPlay";
@@ -18,6 +19,7 @@ interface VocabularyAppContainerNewProps {
   additionalContent?: React.ReactNode;
   onOpenSearch: (word?: string) => void;
   dailySelection?: DailySelection | null;
+  isLoadingSelection?: boolean;
 }
 
 const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({
@@ -26,6 +28,7 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({
   additionalContent,
   onOpenSearch,
   dailySelection,
+  isLoadingSelection = false,
 }) => {
   // Use stable state management
   const {
@@ -71,6 +74,18 @@ const VocabularyAppContainerNew: React.FC<VocabularyAppContainerNewProps> = ({
     isPaused,
     currentWord: debugData
   }), [isMuted, selectedVoiceName, isPaused, debugData]);
+
+  if (isLoadingSelection) {
+    return (
+      <DebugInfoContext.Provider value={debugInfo}>
+        <VocabularyLayout showWordCard={true} hasData={false} onToggleView={() => {}}>
+          <div className="space-y-4">
+            <LoadingCard />
+          </div>
+        </VocabularyLayout>
+      </DebugInfoContext.Provider>
+    );
+  }
 
   if (!hasData && !vocabularyService.hasData()) {
     return (


### PR DESCRIPTION
## Summary
- add a dedicated loading state to the learning progress hook and player container so daily selections report their fetch progress
- render a reusable LoadingCard component with a typewriter animation while the word list request is in flight
- pass the loading flag through the learning-enabled app flow to cover reloads, existing users, and new profile creation

## Testing
- npm test -- --run *(fails: suite depends on LearningProgressService/Supabase singletons that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de249829a0832fb7aeceb75e150d9a