### PR TITLE
Align daily selection service with enriched Supabase RPC

### DIFF
--- a/src/lib/db/supabase.ts
+++ b/src/lib/db/supabase.ts
@@ -101,20 +101,33 @@ export function resolveSupabaseConfig() {
 export type DailySelectionV2Row = {
   word_id: string;
   category: string | null;
-  is_due: boolean | null;
+  is_today_selection?: boolean | null;
+  due_selected_today?: boolean | null;
+  new_selected_today?: boolean | null;
+  due_candidate_count?: number | null;
+  new_candidate_count?: number | null;
+  in_review_queue?: boolean | null;
+  review_count?: number | null;
+  learned_at?: string | null;
+  last_review_at?: string | null;
+  next_review_at?: string | null;
+  next_display_at?: string | null;
+  last_seen_at?: string | null;
+  srs_interval_days?: number | null;
+  srs_ease?: number | null;
+  srs_state?: string | null;
   word?: string | null;
   meaning?: string | null;
   example?: string | null;
   translation?: string | null;
-};
+} & Record<string, unknown>;
 
 export async function getDailySelectionV2(
   client: ReturnType<typeof createClient>,
-  params: { userKey: string; mode: string; count: number; category?: string | null }
+  params: { userKey: string; count: number; category?: string | null }
 ): Promise<DailySelectionV2Row[]> {
   const { data, error } = await client.rpc("generate_daily_selection_v2", {
     p_user_key: params.userKey,
-    p_mode: params.mode,
     p_count: params.count,
     p_category: params.category ?? null,
   });


### PR DESCRIPTION
## Summary
- align the Supabase daily selection helper with the updated RPC signature and expanded metadata
- map the RPC-provided SRS fields directly when building today words and remove the redundant learned words fetch
- update normalization and selection building so due/new categorisation uses the new selection flags

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de41782108832f88fafa051a589a99