### PR TITLE
Refresh daily words cache with server data

### DIFF
--- a/src/hooks/useLearningProgress.tsx
+++ b/src/hooks/useLearningProgress.tsx
@@ -135,7 +135,10 @@ export const useLearningProgress = () => {
       const mode = getModeForSeverity(preferredSeverity);
       const count = getCountForSeverity(preferredSeverity);
       const cached = loadTodayWordsFromLocal(preparedKey);
-      if (cached && isToday(cached.date) && matchesCurrentOptions(cached, { mode, count, category })) {
+      const hasUsableCache = Boolean(
+        cached && isToday(cached.date) && matchesCurrentOptions(cached, { mode, count, category })
+      );
+      if (hasUsableCache && cached) {
         if (!isActive) return;
         setDailySelection(cached.selection);
         setTodayWords(cached.words);
@@ -143,7 +146,7 @@ export const useLearningProgress = () => {
       }
 
       try {
-        if (!cached || !isToday(cached.date) || !matchesCurrentOptions(cached, { mode, count, category })) {
+        if (!hasUsableCache) {
           setIsDailySelectionLoading(true);
         }
         const result = await getOrCreateTodayWords(preparedKey, mode, count, category ?? null);
@@ -158,8 +161,8 @@ export const useLearningProgress = () => {
       } catch (error) {
         if (!isActive) return;
         console.warn('[useLearningProgress] Failed to load today\'s words', error);
-        setDailySelection(null);
-        if (!cached) {
+        if (!hasUsableCache) {
+          setDailySelection(null);
           setTodayWords([]);
         }
       } finally {


### PR DESCRIPTION
## Summary
- always refresh today's selection from the server while serving any cached payload for immediate display
- update useLearningProgress to present cached words first and swap in the refreshed selection when it arrives
- log and gracefully fall back to cached selections when the refresh RPC fails

## Testing
- npm test -- tests/useLearningProgressStats.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de4798a45c832f978c81739b95a5d2