### PR TITLE
Categorize learned words from RPC response

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -31,6 +31,8 @@ const VocabularyAppWithLearning: React.FC = () => {
     markWordAsNew,
     todayWords,
     learnedWords,
+    newTodayLearnedWords,
+    dueTodayLearnedWords,
     isDailySelectionLoading,
   } = useLearningProgress();
 
@@ -53,9 +55,10 @@ const VocabularyAppWithLearning: React.FC = () => {
   }, [markWordAsPlayed]);
 
   const learnedWordsList = Array.isArray(learnedWords) ? learnedWords : [];
-  const newWords = dailySelection?.newWords ?? [];
-  const reviewWords = dailySelection?.reviewWords ?? [];
-  const hasSelectionWords = newWords.length > 0 || reviewWords.length > 0;
+  const newTodayList = Array.isArray(newTodayLearnedWords) ? newTodayLearnedWords : [];
+  const dueTodayList = Array.isArray(dueTodayLearnedWords) ? dueTodayLearnedWords : [];
+  const hasSelectionWords =
+    newTodayList.length > 0 || dueTodayList.length > 0 || learnedWordsList.length > 0;
 
   useEffect(() => {
     if (dailySelection) {
@@ -111,53 +114,56 @@ const VocabularyAppWithLearning: React.FC = () => {
           )}
           <div className="grid gap-4 md:grid-cols-3">
             <div className="space-y-2">
-              <h4 className="font-medium text-green-600">Today's New ({newWords.length})</h4>
+              <h4 className="font-medium text-green-600">NEW TODAY ({newTodayList.length})</h4>
               <div className="space-y-1 max-h-60 overflow-y-auto">
-                {newWords.length > 0 ? (
-                  newWords.map((word, index) => (
-                    <div key={index} className="text-sm p-2 bg-green-50 rounded border">
+                {newTodayList.length > 0 ? (
+                  newTodayList.map((word, index) => (
+                    <div key={`${word.word}-${index}`} className="text-sm p-2 bg-green-50 rounded border">
                       <div className="font-medium">{word.word}</div>
-                      <div className="text-xs text-gray-600">{word.category}</div>
+                      {word.category && (
+                        <div className="text-xs text-gray-600">{word.category}</div>
+                      )}
+                      {word.lastReviewedAt && (
+                        <div className="text-xs text-gray-500">Last reviewed: {word.lastReviewedAt}</div>
+                      )}
                     </div>
                   ))
                 ) : (
                   <div className="text-sm p-2 bg-green-50 rounded border text-gray-500 italic">
-                    No new words assigned
+                    No new words assigned today
                   </div>
                 )}
               </div>
             </div>
 
             <div className="space-y-2">
-              <h4 className="font-medium text-red-600">
-                Today's Due Review ({reviewWords.length})
-              </h4>
+              <h4 className="font-medium text-red-600">DUE TODAY ({dueTodayList.length})</h4>
               <div className="space-y-1 max-h-60 overflow-y-auto">
-                {reviewWords.length > 0 ? (
-                  reviewWords.map((word, index) => (
+                {dueTodayList.length > 0 ? (
+                  dueTodayList.map((word, index) => (
                     <div
-                      key={index}
+                      key={`${word.word}-${index}`}
                       className="text-sm p-2 bg-red-50 rounded border"
                     >
                       <div className="font-medium">{word.word}</div>
-                      <div className="text-xs text-gray-600">
-                        {word.category} • Review #{word.reviewCount}
-                      </div>
-                      <div className="text-xs text-gray-500">
-                        Next review: {word.nextReviewDate}
-                      </div>
+                      {word.category && (
+                        <div className="text-xs text-gray-600">{word.category}</div>
+                      )}
+                      {word.lastReviewedAt && (
+                        <div className="text-xs text-gray-500">Last reviewed: {word.lastReviewedAt}</div>
+                      )}
                     </div>
                   ))
                 ) : (
                   <div className="text-sm p-2 bg-red-50 rounded border text-gray-500 italic">
-                    No due reviews assigned
+                    No due reviews today
                   </div>
                 )}
               </div>
             </div>
 
             <div className="space-y-2">
-              <h4 className="font-medium text-gray-600">Learned ({learnedWordsList.length})</h4>
+              <h4 className="font-medium text-gray-600">LEARNED ({learnedWordsList.length})</h4>
               <div className="space-y-1 max-h-60 overflow-y-auto">
                 {learnedWordsList.length > 0 ? (
                   learnedWordsList.map((word, index) => (

--- a/src/lib/progress/srsSyncByUserKey.ts
+++ b/src/lib/progress/srsSyncByUserKey.ts
@@ -212,6 +212,7 @@ function toLearnedWordRow(value: unknown): LearnedWordRow | null {
     word_id: typeof value.word_id === 'string' ? value.word_id : null,
     srs_state: typeof value.srs_state === 'string' ? value.srs_state : null,
     learned_at: typeof value.learned_at === 'string' ? value.learned_at : null,
+    mark_learned_at: typeof value.mark_learned_at === 'string' ? value.mark_learned_at : null,
     last_review_at: typeof value.last_review_at === 'string' ? value.last_review_at : null,
     next_review_at: typeof value.next_review_at === 'string' ? value.next_review_at : null,
     next_display_at: typeof value.next_display_at === 'string' ? value.next_display_at : null,
@@ -222,6 +223,14 @@ function toLearnedWordRow(value: unknown): LearnedWordRow | null {
     review_count: ensureNumber(value.review_count),
     srs_interval_days: ensureNumber(value.srs_interval_days),
     srs_ease: ensureNumber(value.srs_ease),
+    is_today_selection:
+      typeof value.is_today_selection === 'boolean'
+        ? value.is_today_selection
+        : null,
+    due_selected_today:
+      typeof value.due_selected_today === 'boolean'
+        ? value.due_selected_today
+        : null,
   };
 }
 

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -75,7 +75,11 @@ describe('useLearningProgress', () => {
     };
 
     fetchProgressSummaryMock.mockResolvedValue(initialSummary);
-    fetchLearnedWordSummariesMock.mockResolvedValue(overrideRows);
+    fetchLearnedWordSummariesMock.mockResolvedValue({
+      learnedWords: overrideRows,
+      newTodayWords: [],
+      dueTodayWords: [],
+    });
 
     const { result } = renderHook(() => useLearningProgress([]));
 


### PR DESCRIPTION
## Summary
- expand learned word normalization to include mark_learned_at plus today selection flags and derive NEW TODAY, DUE TODAY, and LEARNED buckets from the RPC payload
- persist the categorized lists in the learning progress hook/service and surface them to the vocabulary app UI
- refresh the summary panel to render the new buckets and adjust tests for the updated learned-word response shape

## Testing
- npm test -- tests/useLearningProgressStats.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de7d99c77c832fa1d17e3930b12ac1