### PR TITLE
Recompute dashboard progress from learned words

### DIFF
--- a/src/lib/progress/learnedWordStats.ts
+++ b/src/lib/progress/learnedWordStats.ts
@@ -1,5 +1,3 @@
-import type { ProgressSummaryFields } from './progressSummary';
-
 type Nullable<T> = T | null | undefined;
 
 export type LearnedWordRow = {
@@ -67,16 +65,11 @@ function matchesToday(value: Nullable<string>, today: Date): boolean {
 }
 
 function isDue(row: LearnedWordRow, now: Date): boolean {
-  const candidates: (Nullable<string>)[] = [row.next_review_at, row.next_display_at, row.learned_at];
-  for (const candidate of candidates) {
-    const iso = normaliseIso(candidate);
-    if (!iso) continue;
-    const parsed = Date.parse(iso);
-    if (!Number.isNaN(parsed) && parsed <= now.getTime()) {
-      return true;
-    }
-  }
-  return false;
+  const iso = normaliseIso(row.next_review_at);
+  if (!iso) return false;
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) return false;
+  return parsed <= now.getTime();
 }
 
 function toWordAndCategory(row: LearnedWordRow): { word: string; category?: string } | null {
@@ -140,10 +133,7 @@ export function computeLearnedWordStats(
   const learnedRows = safeRows.filter((row) => (row?.srs_state ?? '').toLowerCase() === 'learned');
   const learningRows = safeRows.filter((row) => (row?.srs_state ?? '').toLowerCase() === 'learning');
 
-  const newRows = learningRows.filter((row) => matchesToday(row.last_review_at, now));
-  const activeLearningRows = learningRows.filter((row) => !matchesToday(row.last_review_at, now));
-
-  const dueRows = activeLearningRows.filter((row) => isDue(row, now));
+  const dueRows = learningRows.filter((row) => isDue(row, now));
 
   const isTodaySelection = (row: LearnedWordRow) => Boolean(row?.is_today_selection);
   const isDueSelectedToday = (row: LearnedWordRow) => Boolean(row?.due_selected_today);
@@ -172,24 +162,15 @@ export function computeLearnedWordStats(
     .map(toLearnedSummary)
     .filter((value): value is LearnedWordSummary => value !== null);
 
+  const learnedCount = learnedRows.length;
+  const learningCount = learningRows.length;
   const summary: DerivedProgressSummary = {
-    learned: learnedRows.length,
-    learning: activeLearningRows.length,
-    new: newRows.length,
+    learned: learnedCount,
+    learning: learningCount,
+    new: Math.max(totalWords - learningCount, 0),
     due: dueRows.length,
-    remaining: Math.max(totalWords - learnedRows.length - activeLearningRows.length - newRows.length, 0),
+    remaining: Math.max(totalWords - learnedCount - learningCount, 0),
   };
 
   return { learnedWords, newTodayWords, dueTodayWords, summary };
-}
-
-export function legacySummaryToDerived(summary: ProgressSummaryFields | null): DerivedProgressSummary | null {
-  if (!summary) return null;
-  return {
-    learned: summary.learned_count ?? 0,
-    learning: summary.learning_count ?? 0,
-    new: summary.remaining_count ?? 0,
-    due: summary.learning_due_count ?? 0,
-    remaining: summary.remaining_count ?? 0,
-  };
 }

--- a/tests/useLearningProgressStats.test.tsx
+++ b/tests/useLearningProgressStats.test.tsx
@@ -4,7 +4,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { useLearningProgress } from '@/hooks/useLearningProgress';
-import { getLocalPreferences, saveLocalPreferences } from '@/lib/preferences/localPreferences';
+import { computeLearnedWordStats, type LearnedWordRow } from '@/lib/progress/learnedWordStats';
 
 const {
   fetchProgressSummaryMock,
@@ -52,26 +52,30 @@ describe('useLearningProgress', () => {
   });
 
   it('keeps learned stat aligned with learned summaries across refreshes', async () => {
+    const totalWords = 10;
     const initialSummary = {
-      learning_count: 2,
-      learned_count: 5,
-      learning_due_count: 1,
-      remaining_count: 3,
-      learning_time: 0,
-      learned_days: [],
-      updated_at: null,
+      learned: 5,
+      learning: 2,
+      new: totalWords - 2,
+      due: 1,
+      remaining: totalWords - 5 - 2,
     };
     const overrideRows = Array.from({ length: 6 }).map((_, index) => ({
       word: `word-${index}`,
     }));
+    const learnedSummary = {
+      learned: overrideRows.length,
+      learning: initialSummary.learning,
+      new: totalWords - initialSummary.learning,
+      due: initialSummary.due,
+      remaining: Math.max(totalWords - overrideRows.length - initialSummary.learning, 0),
+    };
     const refreshedSummary = {
-      learning_count: 4,
-      learned_count: 4,
-      learning_due_count: 4,
-      remaining_count: 10,
-      learning_time: 0,
-      learned_days: [],
-      updated_at: null,
+      learned: 4,
+      learning: 4,
+      new: totalWords - 4,
+      due: 2,
+      remaining: totalWords - 4 - 4,
     };
 
     fetchProgressSummaryMock.mockResolvedValue(initialSummary);
@@ -79,6 +83,7 @@ describe('useLearningProgress', () => {
       learnedWords: overrideRows,
       newTodayWords: [],
       dueTodayWords: [],
+      summary: learnedSummary,
     });
 
     const { result } = renderHook(() => useLearningProgress([]));
@@ -87,41 +92,114 @@ describe('useLearningProgress', () => {
       await result.current.refreshStats('user-key');
     });
     expect(result.current.progressStats).toMatchObject({
-      learning: initialSummary.learning_count,
-      new: initialSummary.remaining_count,
-      due: initialSummary.learning_due_count,
-      learned: initialSummary.learned_count,
-      total:
-        initialSummary.learned_count +
-        initialSummary.learning_count +
-        initialSummary.remaining_count,
+      learning: initialSummary.learning,
+      new: initialSummary.new,
+      due: initialSummary.due,
+      learned: initialSummary.learned,
+      total: totalWords,
     });
 
     await act(async () => {
       await result.current.refreshLearnedWords('user-key');
     });
     expect(result.current.progressStats.learned).toBe(overrideRows.length);
-    expect(result.current.progressStats.total).toBe(
-      overrideRows.length +
-        initialSummary.learning_count +
-        initialSummary.remaining_count
-    );
+    expect(result.current.progressStats.total).toBe(totalWords);
+    expect(result.current.progressStats.new).toBe(learnedSummary.new);
 
     fetchProgressSummaryMock.mockResolvedValue(refreshedSummary);
 
     await act(async () => {
       await result.current.refreshStats('user-key');
     });
-    expect(result.current.progressStats.learning).toBe(
-      refreshedSummary.learning_count
-    );
-    expect(result.current.progressStats.new).toBe(refreshedSummary.remaining_count);
-    expect(result.current.progressStats.due).toBe(refreshedSummary.learning_due_count);
+    expect(result.current.progressStats.learning).toBe(refreshedSummary.learning);
+    expect(result.current.progressStats.new).toBe(refreshedSummary.new);
+    expect(result.current.progressStats.due).toBe(refreshedSummary.due);
     expect(result.current.progressStats.learned).toBe(overrideRows.length);
-    expect(result.current.progressStats.total).toBe(
-      overrideRows.length +
-        refreshedSummary.learning_count +
-        refreshedSummary.remaining_count
-    );
+    expect(result.current.progressStats.total).toBe(totalWords);
+  });
+
+  it('derives counts from learned word rows when refreshing', async () => {
+    const now = new Date('2024-05-10T12:00:00Z');
+    const rows: LearnedWordRow[] = [
+      {
+        word_id: 'alpha::general',
+        srs_state: 'learned',
+        learned_at: now.toISOString(),
+        mark_learned_at: now.toISOString(),
+        last_review_at: now.toISOString(),
+        next_review_at: now.toISOString(),
+        next_display_at: null,
+        in_review_queue: true,
+        review_count: 3,
+        srs_interval_days: 3,
+        srs_ease: 2.5,
+        is_today_selection: true,
+        due_selected_today: false,
+      },
+      {
+        word_id: 'beta::general',
+        srs_state: 'learning',
+        learned_at: null,
+        mark_learned_at: null,
+        last_review_at: now.toISOString(),
+        next_review_at: new Date('2024-05-08T00:00:00Z').toISOString(),
+        next_display_at: null,
+        in_review_queue: true,
+        review_count: 1,
+        srs_interval_days: 1,
+        srs_ease: 2.3,
+        is_today_selection: true,
+        due_selected_today: true,
+      },
+      {
+        word_id: 'gamma::general',
+        srs_state: 'learning',
+        learned_at: null,
+        mark_learned_at: null,
+        last_review_at: new Date('2024-05-01T00:00:00Z').toISOString(),
+        next_review_at: new Date('2024-05-12T00:00:00Z').toISOString(),
+        next_display_at: null,
+        in_review_queue: true,
+        review_count: 2,
+        srs_interval_days: 2,
+        srs_ease: 2.2,
+        is_today_selection: false,
+        due_selected_today: false,
+      },
+    ];
+
+    const stats = computeLearnedWordStats(rows, { now, totalWords: 50 });
+
+    fetchProgressSummaryMock.mockResolvedValue(stats.summary);
+    fetchLearnedWordSummariesMock.mockResolvedValue({
+      ...stats,
+      summary: stats.summary,
+    });
+
+    const { result } = renderHook(() => useLearningProgress([]));
+
+    await act(async () => {
+      await result.current.refreshStats('user-key');
+    });
+
+    expect(result.current.progressStats).toMatchObject({
+      learned: stats.summary.learned,
+      learning: stats.summary.learning,
+      due: stats.summary.due,
+      new: stats.summary.new,
+      total: stats.summary.learned + stats.summary.learning + stats.summary.remaining,
+    });
+
+    await act(async () => {
+      await result.current.refreshLearnedWords('user-key');
+    });
+
+    expect(result.current.progressStats).toMatchObject({
+      learned: stats.learnedWords.length,
+      learning: stats.summary.learning,
+      due: stats.summary.due,
+      new: stats.summary.new,
+      total: stats.summary.learned + stats.summary.learning + stats.summary.remaining,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- derive learned, learning, due and new counters directly from Supabase learned_words rows
- expose the derived summary through the learningProgressService and refresh the hook with the computed stats
- add regression coverage to confirm the hook reports the correct counters after refreshes

## Testing
- npx vitest run tests/useLearningProgressStats.test.tsx --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68df2396a4ac832f924495f79d97d86e