### PR TITLE
Remove unused findFuzzyIndex utility

### DIFF
--- a/src/utils/text/findFuzzyIndex.ts
+++ b/src/utils/text/findFuzzyIndex.ts
@@ -1,5 +1,0 @@
-export const findFuzzyIndex = (list: string[], target: string): number => {
-  if (!target) return -1;
-  const lower = target.toLowerCase();
-  return list.findIndex(w => w.toLowerCase().startsWith(lower));
-};

--- a/tests/useVocabularyDataLoaderAllSheets.test.ts
+++ b/tests/useVocabularyDataLoaderAllSheets.test.ts
@@ -29,7 +29,6 @@ vi.mock('@/services/learningProgressService', () => ({
 }));
 
 vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
-vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
 vi.mock('@/lib/preferences/localPreferences', () => ({
   getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,

--- a/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
+++ b/tests/useVocabularyDataLoaderNextAllowedTime.test.ts
@@ -29,7 +29,6 @@ vi.mock('@/services/learningProgressService', () => ({
 }));
 
 vi.mock('@/utils/lastWordStorage', () => ({ getTodayLastWord: vi.fn() }));
-vi.mock('@/utils/text/findFuzzyIndex', () => ({ findFuzzyIndex: vi.fn() }));
 vi.mock('@/lib/preferences/localPreferences', () => ({
   getLocalPreferences: vi.fn().mockResolvedValue({
     favorite_voice: null,


### PR DESCRIPTION
## Summary
- delete the unused `findFuzzyIndex` text utility
- remove the leftover test mocks that referenced the deleted helper

## Testing
- npm test -- --run --passWithNoTests *(fails: pre-existing learning progress suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68df262068c0832f9189cbedede78743