### PR TITLE
Remove unused speech validation and control exports

### DIFF
--- a/src/utils/speech/core/modules/speechControl.ts
+++ b/src/utils/speech/core/modules/speechControl.ts
@@ -19,34 +19,9 @@ export const stopSpeaking = (): void => {
   }
 };
 
-export const pauseSpeaking = (): void => {
-  if (window.speechSynthesis && window.speechSynthesis.speaking) {
-    console.log('[ENGINE] Pausing speech');
-    window.speechSynthesis.pause();
-  }
-};
-
-export const resumeSpeaking = (): void => {
-  if (window.speechSynthesis && window.speechSynthesis.paused) {
-    console.log('[ENGINE] Resuming speech');
-    window.speechSynthesis.resume();
-  }
-};
-
 export const keepSpeechAlive = (): void => {
   if (window.speechSynthesis) {
     window.speechSynthesis.pause();
     window.speechSynthesis.resume();
-  }
-};
-
-export const resetSpeechEngine = (): void => {
-  if (!canPerformOperation()) {
-    return;
-  }
-  
-  if (window.speechSynthesis) {
-    console.log('[ENGINE] Resetting speech engine');
-    window.speechSynthesis.cancel();
   }
 };

--- a/src/utils/speech/core/modules/speechValidation.ts
+++ b/src/utils/speech/core/modules/speechValidation.ts
@@ -1,29 +1,8 @@
 
-export const waitForSpeechReadiness = async (): Promise<boolean> => {
-  return new Promise((resolve) => {
-    if (!window.speechSynthesis) {
-      console.error('[ENGINE] Speech synthesis not supported!');
-      resolve(false);
-      return;
-    }
-    console.log('[ENGINE] Waiting for speech readiness');
-    setTimeout(() => {
-      console.log('[ENGINE] Speech engine ready');
-      resolve(true);
-    }, 200); // Reduced delay for better responsiveness
-  });
-};
-
-export const validateCurrentSpeech = (): boolean => {
-  const isSpeaking = window.speechSynthesis ? window.speechSynthesis.speaking : false;
-  console.log(`[ENGINE] Speech validation - speaking: ${isSpeaking}, paused: ${window.speechSynthesis?.paused}`);
-  return isSpeaking;
-};
-
 export const ensureSpeechEngineReady = async (): Promise<void> => {
   if (window.speechSynthesis) {
     console.log('[ENGINE] Preparing speech engine');
-    
+
     // Only cancel if something is actually speaking
     if (window.speechSynthesis.speaking) {
       console.log('[ENGINE] Canceling existing speech');

--- a/src/utils/speech/core/speechEngine.ts
+++ b/src/utils/speech/core/speechEngine.ts
@@ -1,15 +1,10 @@
 // Main speech engine - re-exports all core functionality from focused modules
 export {
   stopSpeaking,
-  pauseSpeaking,
-  resumeSpeaking,
   keepSpeechAlive,
-  resetSpeechEngine,
 } from "./modules/speechControl";
 
 export {
-  waitForSpeechReadiness,
-  validateCurrentSpeech,
   ensureSpeechEngineReady,
   isSpeechSynthesisSupported,
 } from "./modules/speechValidation";

--- a/src/utils/speech/index.ts
+++ b/src/utils/speech/index.ts
@@ -3,12 +3,7 @@ import { calculateSpeechDuration } from "./durationUtils";
 import { speak } from "./core/speechPlayer";
 import {
   stopSpeaking,
-  pauseSpeaking,
-  resumeSpeaking,
   keepSpeechAlive,
-  waitForSpeechReadiness,
-  resetSpeechEngine,
-  validateCurrentSpeech,
   ensureSpeechEngineReady,
   isSpeechSynthesisSupported,
 } from "./core/speechEngine";
@@ -42,13 +37,8 @@ export {
   calculateSpeechDuration,
   isSpeechSynthesisSupported,
   stopSpeaking,
-  pauseSpeaking,
-  resumeSpeaking,
   checkSoundDisplaySync,
   keepSpeechAlive,
-  waitForSpeechReadiness,
-  resetSpeechEngine,
-  validateCurrentSpeech,
   forceResyncIfNeeded,
   ensureSpeechEngineReady,
   extractMainWord,


### PR DESCRIPTION
## Summary
- remove unused speech validation and control helpers along with their re-exports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df26161d34832f84779da5ca93a1c3