### PR TITLE
Remove unused speech text helpers

### DIFF
--- a/src/utils/speech/core/speechText.ts
+++ b/src/utils/speech/core/speechText.ts
@@ -19,18 +19,9 @@ export const prepareTextForSpeech = (text: string): string => {
   return prepared;
 };
 
-export const addPausesToText = (text: string): string => {
-  // Replace XML break tags with actual SSML pause marks that won't be read aloud
-  return text.replace(/\./g, '.');
-};
-
-export const checkSoundDisplaySync = (text: string, spokenText: string): boolean => {
-  return spokenText.toLowerCase().includes(text.toLowerCase());
-};
-
 export const forceResyncIfNeeded = (
-  currentWord: string, 
-  processedText: string, 
+  currentWord: string,
+  processedText: string,
   resyncCallback: () => void
 ): void => {
   if (!processedText.toLowerCase().includes(currentWord.toLowerCase())) {

--- a/src/utils/speech/index.ts
+++ b/src/utils/speech/index.ts
@@ -15,8 +15,6 @@ import {
 import {
   extractMainWord,
   prepareTextForSpeech,
-  addPausesToText,
-  checkSoundDisplaySync,
   forceResyncIfNeeded,
 } from "./core/speechText";
 import {
@@ -44,7 +42,6 @@ export {
   stopSpeaking,
   pauseSpeaking,
   resumeSpeaking,
-  checkSoundDisplaySync,
   keepSpeechAlive,
   waitForSpeechReadiness,
   resetSpeechEngine,
@@ -56,7 +53,6 @@ export {
   getSpeechPitch,
   getSpeechVolume,
   prepareTextForSpeech,
-  addPausesToText,
   splitTextIntoChunks,
   speakChunksInSequence,
   createSpeechMonitor,


### PR DESCRIPTION
## Summary
- remove unused pause and sync helpers from the speech text utilities
- update the speech module re-exports to drop the deleted helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df26140ec8832f9cbc604e5cd64f24