### PR TITLE
Remove sanitizeUserInput utility

### DIFF
--- a/src/utils/security/inputValidation.ts
+++ b/src/utils/security/inputValidation.ts
@@ -14,7 +14,7 @@ export {
 } from './validationTypes';
 
 // Export sanitization utilities
-export { sanitizeInput, sanitizeUserInput } from './sanitization';
+export { sanitizeInput } from './sanitization';
 
 // Export vocabulary validation functions from the new modular structure
 export { 

--- a/src/utils/security/sanitization.ts
+++ b/src/utils/security/sanitization.ts
@@ -54,25 +54,3 @@ export const sanitizeInput = (input: string): string => {
   return sanitized;
 };
 
-/**
- * More conservative sanitization for user input fields
- * Updated to be less aggressive while maintaining security
- */
-export const sanitizeUserInput = (input: string): string => {
-  if (!input || typeof input !== 'string') return '';
-  
-  console.log('[USER-SANITIZATION] Input received:', input);
-  
-  // Remove HTML tags but be more selective - preserve safe formatting
-  let sanitized = input.replace(/<(?!\/?(b|i|em|strong|span)\b)[^>]*>/gi, '');
-  
-  // Only remove the most dangerous characters, preserve linguistic notation
-  sanitized = sanitized.replace(/[<>]/g, '');
-  
-  // Apply standard sanitization
-  const result = sanitizeInput(sanitized);
-  
-  console.log('[USER-SANITIZATION] Output after sanitization:', result);
-  
-  return result;
-};


### PR DESCRIPTION
## Summary
- remove the unused sanitizeUserInput helper from the sanitization utilities
- stop re-exporting sanitizeUserInput via the input validation module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df260009b0832fafb54c2ea09602af