### PR TITLE
Remove unused category message label export

### DIFF
--- a/src/utils/categoryLabels.ts
+++ b/src/utils/categoryLabels.ts
@@ -7,20 +7,7 @@ export const CATEGORY_LABELS: Record<string, string> = {
   'word formation': 'Word formation',
 };
 
-export const CATEGORY_MESSAGE_LABELS: Record<string, string> = {
-  'phrasal verbs': 'Phrasal Verb',
-  'idioms': 'Idiom',
-  'topic vocab': 'Topic vocabulary',
-  'grammar': 'Grammar',
-  'phrases, collocations': 'Phrase - Collocation',
-  'word formation': 'Word formation',
-};
-
 export function getCategoryLabel(category: string): string {
   return CATEGORY_LABELS[category] ||
     category.charAt(0).toUpperCase() + category.slice(1);
-}
-
-export function getCategoryMessageLabel(category: string): string {
-  return CATEGORY_MESSAGE_LABELS[category] || getCategoryLabel(category);
 }


### PR DESCRIPTION
## Summary
- remove the unused `getCategoryMessageLabel` helper from `categoryLabels`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df25d26730832fbaee82921266d778