### PR TITLE
Remove unused session snapshot helper

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -346,6 +346,3 @@ export function storePasscode(passcode: string): void {
   rememberPasscode(passcode.trim());
 }
 
-export function getStoredSessionSnapshot(): Session | null {
-  return loadStoredSession();
-}


### PR DESCRIPTION
## Summary
- delete the unused `getStoredSessionSnapshot` export from the auth utilities
- confirm no modules import the helper so no additional clean up is needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df25a1f58c832f832a91f859ef6fc1