### PR TITLE
Remove unused speech chunk estimator

### DIFF
--- a/src/utils/speech/core/textChunker.ts
+++ b/src/utils/speech/core/textChunker.ts
@@ -47,9 +47,3 @@ export function splitTextIntoChunks(text: string): string[] {
   
   return chunks;
 }
-
-// Utility function to estimate the number of chunks needed for a text
-export function estimateChunkCount(text: string): number {
-  // Simple estimation: approximately one chunk per 200 characters
-  return Math.ceil(text.length / 200);
-}


### PR DESCRIPTION
## Summary
- remove the unused `estimateChunkCount` helper from the speech text chunker utilities
- ensure the helper is no longer exposed by rebuilding the project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df260a3acc832f90dc53e661a97021