### PR TITLE
Remove unused requireSupabaseClient export

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -67,6 +67,3 @@ export function getSupabaseClient(): SupabaseClient {
   return client;
 }
 
-export function requireSupabaseClient(): SupabaseClient {
-  return getSupabaseClient();
-}


### PR DESCRIPTION
## Summary
- remove the unused `requireSupabaseClient` helper
- confirm the file now only exposes `getSupabaseClient`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df25a5a1b4832f9152c8d27633e000