### PR TITLE
Remove unused nickname setter export

### DIFF
--- a/src/lib/nickname.ts
+++ b/src/lib/nickname.ts
@@ -4,10 +4,6 @@ export function getNicknameLocal(): string | null {
   try { return localStorage.getItem(NICKNAME_LS_KEY); } catch { return null; }
 }
 
-export function setNicknameLocal(v: string) {
-  try { localStorage.setItem(NICKNAME_LS_KEY, v); } catch {}
-}
-
 export function toCanonical(s: string): string {
   return s.normalize('NFKC').toLowerCase().replace(/\s+/g, '');
 }


### PR DESCRIPTION
## Summary
- remove the unused `setNicknameLocal` export from the nickname utilities

## Testing
- npm run lint *(fails: existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68df25b4b780832fb30e0962d8a0d61e