### PR TITLE
Remove unused debounce utility

### DIFF
--- a/src/lib/sync/debounce.ts
+++ b/src/lib/sync/debounce.ts
@@ -1,8 +1,0 @@
-export function debounce<T extends (...a: any[]) => any>(fn: T, ms = 1000) {
-  let t: any;
-  return (...a: Parameters<T>) => {
-    clearTimeout(t);
-    t = setTimeout(() => fn(...a), ms);
-  };
-}
-


### PR DESCRIPTION
## Summary
- delete the unused sync debounce utility to match the updated requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df25b7fae0832f84a025bafaafe46f