### PR TITLE
Remove unused nickname helpers

### DIFF
--- a/src/services/nicknameService.ts
+++ b/src/services/nicknameService.ts
@@ -1,16 +1,5 @@
-import { canonNickname } from '@/core/nickname';
-import { setNicknamePasscode as callSetNicknamePasscode } from '@/lib/edgeApi';
-
-export function normalizeNickname(s: string) {
-  return canonNickname(s);
-}
-
 const BLOCKED_NICKNAME_CHARS = /[<>"'`$(){}\u005B\u005D;]/g;
 
 export function sanitizeNickname(s: string) {
   return s.replace(BLOCKED_NICKNAME_CHARS, '').trim();
-}
-
-export function setNicknamePasscode(nickname: string, passcode: string | number) {
-  return callSetNicknamePasscode(nickname, passcode);
 }


### PR DESCRIPTION
## Summary
- remove unused nickname normalization and passcode helpers from the nickname service
- keep the service focused on sanitizing nicknames now that the helpers are redundant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df25c7775c832fb147c45603adf188