### PR TITLE
Remove passcode sign-up and clearing helpers

### DIFF
--- a/src/lib/auth/passcodeAuth.ts
+++ b/src/lib/auth/passcodeAuth.ts
@@ -68,29 +68,3 @@ export async function signInWithPasscode(
   }
 }
 
-export async function signUp(nickname: string, passcode: string): Promise<void> {
-  const trimmedPasscode = passcode.trim();
-  const key = canonNickname(nickname);
-  const store = readStore();
-  if (store[key]) {
-    throw new PasscodeAuthError('Nickname is already registered.', 'NICKNAME_TAKEN');
-  }
-  store[key] = trimmedPasscode;
-  writeStore(store);
-}
-
-export function clearStoredPasscode(nickname: string) {
-  try {
-    if (typeof window === 'undefined' || !('localStorage' in window)) return;
-    const key = canonNickname(nickname);
-    const raw = window.localStorage.getItem(PASSCODE_ACCOUNTS_KEY);
-    if (!raw) return;
-    const store = JSON.parse(raw) as PasscodeStore;
-    if (store[key]) {
-      delete store[key];
-      window.localStorage.setItem(PASSCODE_ACCOUNTS_KEY, JSON.stringify(store));
-    }
-  } catch {
-    // ignore failures
-  }
-}


### PR DESCRIPTION
## Summary
- remove the passcode sign-up helper
- drop the clearStoredPasscode helper that manipulated local storage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df25c970b0832f88fb460d96fc1200