### PR TITLE
Remove unused CSP header generator

### DIFF
--- a/src/utils/security/contentSecurity.ts
+++ b/src/utils/security/contentSecurity.ts
@@ -20,15 +20,6 @@ export const CSP_CONFIG = {
 };
 
 /**
- * Generates CSP header value
- */
-export const generateCSPHeader = (): string => {
-  return Object.entries(CSP_CONFIG)
-    .map(([directive, sources]) => `${directive} ${sources.join(' ')}`)
-    .join('; ');
-};
-
-/**
  * HTML encoding for XSS prevention
  */
 export const htmlEncode = (str: string): string => {


### PR DESCRIPTION
## Summary
- remove the unused `generateCSPHeader` export from the content security utilities
- verified that `CSP_CONFIG` is no longer referenced solely for header generation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df25f7da50832fb80f7e27bb7b8b0b