### PR TITLE
Allow spaces when typing in quick search

### DIFF
--- a/src/components/vocabulary-app/WordSearchModal.tsx
+++ b/src/components/vocabulary-app/WordSearchModal.tsx
@@ -172,6 +172,22 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose, init
     setQuery(value);
   };
 
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      return;
+    }
+
+    const isSpaceKey =
+      event.key === ' ' ||
+      event.key === 'Spacebar' ||
+      event.code === 'Space';
+
+    if (isSpaceKey) {
+      event.stopPropagation();
+    }
+  };
+
   const handleClose = () => {
     setQuery('');
     setDebouncedQuery('');
@@ -195,9 +211,7 @@ const WordSearchModal: React.FC<WordSearchModalProps> = ({ isOpen, onClose, init
             placeholder="Search word..."
             value={query}
             onChange={e => handleInputChange(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') e.preventDefault();
-            }}
+            onKeyDown={handleInputKeyDown}
           />
           <Button
             size="icon"


### PR DESCRIPTION
## Summary
- ensure the quick search modal input no longer loses space key presses by stopping them from bubbling to global handlers

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e332f77624832fb730ed88ec09eaee