### PR TITLE
Preserve newline formatting in vocabulary card text

### DIFF
--- a/src/components/VocabularyCard.tsx
+++ b/src/components/VocabularyCard.tsx
@@ -93,16 +93,16 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
             )}
           </div>
           
-          <div className="italic" style={{ color: '#2E7D32', fontSize: '1.25rem', textAlign: 'left' }}>
+          <div className="italic" style={{ color: '#2E7D32', fontSize: '1.25rem', textAlign: 'left', whiteSpace: 'pre-line' }}>
             <span style={{ color: '#2E7D32', fontStyle: 'italic' }}>* </span>{meaning}
           </div>
-          
-          <div className="italic" style={{ color: '#B71C1C', fontSize: '1rem', textAlign: 'left' }}>
+
+          <div className="italic" style={{ color: '#B71C1C', fontSize: '1rem', textAlign: 'left', whiteSpace: 'pre-line' }}>
             <span style={{ color: '#B71C1C', fontStyle: 'italic' }}>* </span>{example}
           </div>
 
           {translation && (
-            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left', whiteSpace: 'pre-line' }}>
               <em>* {translation}</em>
             </div>
           )}

--- a/src/components/vocabulary-app/VocabularyCard.tsx
+++ b/src/components/vocabulary-app/VocabularyCard.tsx
@@ -118,19 +118,19 @@ const VocabularyCard: React.FC<VocabularyCardProps> = ({
           {/* Meaning */}
           <div
             className="text-left text-base md:text-sm text-emerald-400 italic mb-2"
-            style={{ background: 'transparent', marginTop: 0 }}
+            style={{ background: 'transparent', marginTop: 0, whiteSpace: 'pre-line' }}
           >
             <span className="italic text-emerald-400">*</span> {meaning}
           </div>
           {/* Example */}
           <div
             className="text-left text-base md:text-sm text-red-600 italic"
-            style={{ background: 'transparent', marginTop: 0 }}
+            style={{ background: 'transparent', marginTop: 0, whiteSpace: 'pre-line' }}
           >
             <span className="italic text-red-600">*</span> {example}
           </div>
           {translation && (
-            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left', whiteSpace: 'pre-line' }}>
               <em>* {translation}</em>
             </div>
           )}

--- a/src/components/vocabulary-app/VocabularyCardNew.tsx
+++ b/src/components/vocabulary-app/VocabularyCardNew.tsx
@@ -63,16 +63,16 @@ const VocabularyCardNew: React.FC<VocabularyCardNewProps> = ({
           </div>
 
           {/* Meaning - transparent background, left-aligned, smaller font */}
-          <div style={{ color: '#2E7D32', fontSize: '1rem', textAlign: 'left', fontStyle: 'italic', borderRadius: '0.5rem', background: 'transparent' }}>
+          <div style={{ color: '#2E7D32', fontSize: '1rem', textAlign: 'left', fontStyle: 'italic', borderRadius: '0.5rem', background: 'transparent', whiteSpace: 'pre-line' }}>
             <span style={{ color: '#2E7D32', fontStyle: 'italic' }}>* </span>{meaning}
           </div>
 
           {/* Example - transparent background, left-aligned, smaller font */}
-          <div style={{ color: '#B71C1C', fontSize: '0.9rem', textAlign: 'left', fontStyle: 'italic', background: 'transparent' }}>
+          <div style={{ color: '#B71C1C', fontSize: '0.9rem', textAlign: 'left', fontStyle: 'italic', background: 'transparent', whiteSpace: 'pre-line' }}>
             <span style={{ color: '#B71C1C', fontStyle: 'italic' }}>* </span>{example}
           </div>
           {translation && (
-            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left' }}>
+            <div style={{ fontStyle: 'italic', fontSize: '0.9em', textAlign: 'left', whiteSpace: 'pre-line' }}>
               <em>* {translation}</em>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add `whiteSpace: 'pre-line'` styling to vocabulary card text fields so multiline content renders with the original line breaks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e47c82836c832f8ccfd9dc9488c676