### PR TITLE
Prevent empty voice preference persistence

### DIFF
--- a/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
+++ b/src/hooks/vocabulary-controller/core/useVocabularyDataLoader.ts
@@ -41,6 +41,10 @@ export const useVocabularyDataLoader = (
 
   // Persist selected voice whenever it changes
   useEffect(() => {
+    if (!selectedVoiceName) {
+      return;
+    }
+
     setFavoriteVoice(selectedVoiceName);
   }, [selectedVoiceName]);
 

--- a/tests/useVocabularyDataLoaderVoicePersistence.test.ts
+++ b/tests/useVocabularyDataLoaderVoicePersistence.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { useVocabularyDataLoader } from '@/hooks/vocabulary-controller/core/useVocabularyDataLoader';
+import { setFavoriteVoice } from '@/lib/preferences/localPreferences';
+
+vi.mock('@/lib/preferences/localPreferences', () => ({
+  setFavoriteVoice: vi.fn()
+}));
+
+vi.mock('@/utils/lastWordStorage', () => ({
+  getTodayLastWord: vi.fn(() => null)
+}));
+
+describe('useVocabularyDataLoader voice persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not persist empty voice selections', async () => {
+    const setFavoriteVoiceMock = setFavoriteVoice as unknown as vi.Mock;
+
+    const setWordList = vi.fn();
+    const setHasData = vi.fn();
+    const setCurrentIndex = vi.fn();
+    const clearAutoAdvanceTimer = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ voice }) =>
+        useVocabularyDataLoader(
+          setWordList,
+          setHasData,
+          setCurrentIndex,
+          0,
+          voice,
+          clearAutoAdvanceTimer,
+          []
+        ),
+      { initialProps: { voice: '' } }
+    );
+
+    await waitFor(() => {
+      expect(setFavoriteVoiceMock).not.toHaveBeenCalled();
+    });
+
+    rerender({ voice: 'Voice Prime' });
+
+    await waitFor(() => {
+      expect(setFavoriteVoiceMock).toHaveBeenCalledWith('Voice Prime');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- guard the vocabulary data loader from persisting empty voice names before the voice list is available
- add a regression test ensuring blank voice selections do not overwrite the stored favorite voice

## Testing
- npm run test -- useVocabularyDataLoaderVoicePersistence

------
https://chatgpt.com/codex/tasks/task_e_68e48cc73510832fad69e985f6bac78c