### PR TITLE
Fix speech rate persistence and add unit tests

### DIFF
--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,16 +1,26 @@
 import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
 import {
-  getSpeechRate as getStoredSpeechRate,
-  setSpeechRate as setStoredSpeechRate,
+  getSpeechRate as readSpeechRateFromPreferences,
+  setSpeechRate as writeSpeechRateToPreferences,
 } from '@/lib/localPreferences';
 
-let cachedRate = getStoredSpeechRate() ?? DEFAULT_SPEECH_RATE;
+let cachedRate: number | undefined;
 
-export const getSpeechRate = (): number => cachedRate;
+const resolveCachedRate = (): number => {
+  if (typeof cachedRate === 'number') {
+    return cachedRate;
+  }
+
+  const storedRate = readSpeechRateFromPreferences();
+  cachedRate = storedRate ?? DEFAULT_SPEECH_RATE;
+  return cachedRate;
+};
+
+export const getSpeechRate = (): number => resolveCachedRate();
 
 export const setSpeechRate = (rate: number): void => {
   cachedRate = rate;
-  setStoredSpeechRate(rate);
+  writeSpeechRateToPreferences(rate);
 };
 
 export const getSpeechPitch = (): number => 1.0;

--- a/tests/speechSettings.test.ts
+++ b/tests/speechSettings.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadSpeechRate = vi.fn<[], number | null>();
+const mockWriteSpeechRate = vi.fn<[number], void>();
+
+vi.mock('@/lib/localPreferences', () => ({
+  getSpeechRate: mockReadSpeechRate,
+  setSpeechRate: mockWriteSpeechRate,
+}));
+
+const importSpeechSettings = () =>
+  import('@/utils/speech/core/speechSettings');
+
+describe('speechSettings', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockReadSpeechRate.mockReset();
+    mockWriteSpeechRate.mockReset();
+  });
+
+  it('returns the stored speech rate when available', async () => {
+    mockReadSpeechRate.mockReturnValue(1.25);
+    const { getSpeechRate } = await importSpeechSettings();
+
+    expect(getSpeechRate()).toBe(1.25);
+    expect(getSpeechRate()).toBe(1.25);
+    expect(mockReadSpeechRate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the default rate when storage is empty', async () => {
+    mockReadSpeechRate.mockReturnValue(null);
+    const { getSpeechRate } = await importSpeechSettings();
+    const { DEFAULT_SPEECH_RATE } = await import('@/services/speech/core/constants');
+
+    expect(getSpeechRate()).toBe(DEFAULT_SPEECH_RATE);
+    expect(mockReadSpeechRate).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists and caches updates when the rate changes', async () => {
+    mockReadSpeechRate.mockReturnValue(0.8);
+    const { getSpeechRate, setSpeechRate } = await importSpeechSettings();
+
+    expect(getSpeechRate()).toBe(0.8);
+    mockReadSpeechRate.mockClear();
+
+    setSpeechRate(1.5);
+
+    expect(mockWriteSpeechRate).toHaveBeenCalledWith(1.5);
+    expect(getSpeechRate()).toBe(1.5);
+    // Should not re-read from storage after caching the new value
+    expect(mockReadSpeechRate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the speech settings module lazily loads the saved speech rate so user selections persist across reloads
- add targeted vitest coverage to confirm stored rates, default fallback, and cache updates

## Testing
- npx vitest run tests/speechSettings.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e48cefa6f0832fa3cf8ad48803e263