### PR TITLE
Normalize speech rate options and clamp stored values

### DIFF
--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '@/components/ui/popover';
+import { SPEECH_RATE_OPTIONS } from '@/services/speech/core/constants';
 import { Gauge } from 'lucide-react';
 
 interface SpeechRateControlProps {
   rate: number;
   onChange: (rate: number) => void;
 }
-
-const RATE_VALUES = [0, 0.2, 0.4, 0.6, 0.8, 1, 1.25, 1.5];
 
 const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange }) => {
   const [open, setOpen] = React.useState(false);
@@ -39,18 +38,21 @@ const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange })
       </PopoverTrigger>
       <PopoverContent className="w-44 p-2" side="right" align="start">
         <div className="grid grid-cols-4 gap-2">
-          {RATE_VALUES.map((v) => (
-            <PopoverClose asChild key={v}>
-              <Button
-                size="sm"
-                variant={rate === v ? 'default' : 'outline'}
-                className="h-7 px-2 text-xs"
-                onClick={() => handleChange(v)}
-              >
-                {v}x
-              </Button>
-            </PopoverClose>
-          ))}
+          {SPEECH_RATE_OPTIONS.map(v => {
+            const isActive = Math.abs(rate - v) < 0.001;
+            return (
+              <PopoverClose asChild key={v}>
+                <Button
+                  size="sm"
+                  variant={isActive ? 'default' : 'outline'}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => handleChange(v)}
+                >
+                  {v}x
+                </Button>
+              </PopoverClose>
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/hooks/useSpeechRate.tsx
+++ b/src/hooks/useSpeechRate.tsx
@@ -1,8 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import {
-  getSpeechRate as getStoredSpeechRate,
+  getSpeechRate,
   normalizeSpeechRate,
-  setSpeechRate as setStoredSpeechRate,
+  setSpeechRate as persistSpeechRate,
 } from '@/utils/speech/core/speechSettings';
 
 /**
@@ -13,17 +13,17 @@ import {
  */
 export const useSpeechRate = () => {
   // initialise from stored preference or fall back to default value from settings
-  const [speechRate, setSpeechRateState] = useState(() => getStoredSpeechRate());
+  const [speechRate, setSpeechRateState] = useState(() => getSpeechRate());
 
   // ensure state stays in sync with any external changes
   useEffect(() => {
-    setSpeechRateState(getStoredSpeechRate());
+    setSpeechRateState(getSpeechRate());
   }, []);
 
   const setSpeechRate = useCallback((rate: number) => {
     const normalized = normalizeSpeechRate(rate);
     setSpeechRateState(normalized);
-    setStoredSpeechRate(normalized);
+    persistSpeechRate(normalized);
   }, []);
 
   return { speechRate, setSpeechRate };

--- a/src/hooks/useSpeechRate.tsx
+++ b/src/hooks/useSpeechRate.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import {
   getSpeechRate as getStoredSpeechRate,
+  normalizeSpeechRate,
   setSpeechRate as setStoredSpeechRate,
 } from '@/utils/speech/core/speechSettings';
 
@@ -20,8 +21,9 @@ export const useSpeechRate = () => {
   }, []);
 
   const setSpeechRate = useCallback((rate: number) => {
-    setSpeechRateState(rate);
-    setStoredSpeechRate(rate);
+    const normalized = normalizeSpeechRate(rate);
+    setSpeechRateState(normalized);
+    setStoredSpeechRate(normalized);
   }, []);
 
   return { speechRate, setSpeechRate };

--- a/src/services/speech/core/constants.ts
+++ b/src/services/speech/core/constants.ts
@@ -2,3 +2,15 @@
  * Shared constants for speech services
  */
 export const DEFAULT_SPEECH_RATE = 0.8;
+
+/** Minimum rate that produces a reliable change in most browsers */
+export const MIN_SPEECH_RATE = 0.6;
+
+/** Maximum rate we currently expose in the UI */
+export const MAX_SPEECH_RATE = 2;
+
+/**
+ * Discrete rate options exposed to users. Keeping the list here avoids
+ * hard-coded duplicates between UI and business logic.
+ */
+export const SPEECH_RATE_OPTIONS = [0.6, 0.8, 1, 1.25, 1.5, 1.75, 2] as const;

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -21,11 +21,17 @@ let cachedRate: number | undefined;
 
 const resolveStoredSpeechRate = (): number => {
   const storedRate = readSpeechRateFromPreferences();
-  if (typeof storedRate !== 'number') {
+  if (typeof storedRate !== 'number' || !Number.isFinite(storedRate)) {
+    writeSpeechRateToPreferences(DEFAULT_SPEECH_RATE);
     return DEFAULT_SPEECH_RATE;
   }
 
-  return clampSpeechRate(storedRate);
+  const normalizedRate = clampSpeechRate(storedRate);
+  if (normalizedRate !== storedRate) {
+    writeSpeechRateToPreferences(normalizedRate);
+  }
+
+  return normalizedRate;
 };
 
 const resolveCachedRate = (): number => {

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,17 +1,33 @@
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import {
+  DEFAULT_SPEECH_RATE,
+  MAX_SPEECH_RATE,
+  MIN_SPEECH_RATE,
+} from '@/services/speech/core/constants';
 import {
   getSpeechRate as getStoredSpeechRate,
   setSpeechRate as setStoredSpeechRate,
 } from '@/lib/localPreferences';
 
-let cachedRate = getStoredSpeechRate() ?? DEFAULT_SPEECH_RATE;
+const clampSpeechRate = (rate: number | null | undefined): number => {
+  if (typeof rate !== 'number' || !Number.isFinite(rate)) {
+    return DEFAULT_SPEECH_RATE;
+  }
+
+  const clamped = Math.min(MAX_SPEECH_RATE, Math.max(MIN_SPEECH_RATE, rate));
+  return Math.round(clamped * 100) / 100;
+};
+
+let cachedRate = clampSpeechRate(getStoredSpeechRate());
 
 export const getSpeechRate = (): number => cachedRate;
 
 export const setSpeechRate = (rate: number): void => {
-  cachedRate = rate;
-  setStoredSpeechRate(rate);
+  const normalizedRate = clampSpeechRate(rate);
+  cachedRate = normalizedRate;
+  setStoredSpeechRate(normalizedRate);
 };
+
+export const normalizeSpeechRate = clampSpeechRate;
 
 export const getSpeechPitch = (): number => 1.0;
 export const getSpeechVolume = (): number => 1.0;

--- a/tests/speechSettings.test.ts
+++ b/tests/speechSettings.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_SPEECH_RATE,
+  MAX_SPEECH_RATE,
+  MIN_SPEECH_RATE,
+} from '@/services/speech/core/constants';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+let mockStorage: MemoryStorage;
+let originalWindow: (Window & typeof globalThis) | undefined;
+
+describe('speech settings', () => {
+  beforeAll(() => {
+    originalWindow = (globalThis as { window?: Window & typeof globalThis }).window;
+    mockStorage = new MemoryStorage();
+    Object.defineProperty(globalThis, 'window', {
+      value: { localStorage: mockStorage },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, 'window', {
+        value: originalWindow,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      delete (globalThis as { window?: Window & typeof globalThis }).window;
+    }
+  });
+
+  beforeEach(() => {
+    mockStorage.clear();
+    vi.resetModules();
+  });
+
+  it('normalizes arbitrary input values into the supported range', async () => {
+    const { normalizeSpeechRate } = await import('@/utils/speech/core/speechSettings');
+
+    expect(normalizeSpeechRate(null)).toBe(DEFAULT_SPEECH_RATE);
+    expect(normalizeSpeechRate(undefined)).toBe(DEFAULT_SPEECH_RATE);
+    expect(normalizeSpeechRate(NaN)).toBe(DEFAULT_SPEECH_RATE);
+    expect(normalizeSpeechRate(MIN_SPEECH_RATE - 0.5)).toBe(MIN_SPEECH_RATE);
+    expect(normalizeSpeechRate(MAX_SPEECH_RATE + 1)).toBe(MAX_SPEECH_RATE);
+    expect(normalizeSpeechRate(1.234)).toBe(1.23);
+  });
+
+  it('clamps stored rates above the supported maximum and persists the normalized value', async () => {
+    const localPreferences = await import('@/lib/localPreferences');
+    localPreferences.setSpeechRate(5);
+
+    const speechSettings = await import('@/utils/speech/core/speechSettings');
+    expect(speechSettings.getSpeechRate()).toBe(MAX_SPEECH_RATE);
+    expect(localPreferences.getSpeechRate()).toBe(MAX_SPEECH_RATE);
+  });
+
+  it('clamps stored rates below the supported minimum and persists the normalized value', async () => {
+    const localPreferences = await import('@/lib/localPreferences');
+    localPreferences.setSpeechRate(-4);
+
+    const speechSettings = await import('@/utils/speech/core/speechSettings');
+    expect(speechSettings.getSpeechRate()).toBe(MIN_SPEECH_RATE);
+    expect(localPreferences.getSpeechRate()).toBe(MIN_SPEECH_RATE);
+  });
+
+  it('falls back to the default rate when storage is empty or invalid', async () => {
+    const speechSettings = await import('@/utils/speech/core/speechSettings');
+
+    expect(speechSettings.getSpeechRate()).toBe(DEFAULT_SPEECH_RATE);
+
+    const localPreferences = await import('@/lib/localPreferences');
+    mockStorage.setItem('lv_preferences', '{"speech_rate":"invalid"}');
+
+    // reset cache before checking invalid scenario
+    vi.resetModules();
+    const reloadedSettings = await import('@/utils/speech/core/speechSettings');
+    expect(reloadedSettings.getSpeechRate()).toBe(DEFAULT_SPEECH_RATE);
+    expect(localPreferences.getSpeechRate()).toBe(DEFAULT_SPEECH_RATE);
+  });
+});


### PR DESCRIPTION
## Summary
- clamp stored speech rates to a safe browser-supported range and expose a normalizer
- share discrete speech-rate options between UI and core constants, adding 1.75x and 2x
- update the speech rate control to use the shared list and highlight the active rate more reliably

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e48d2d1b50832faee1f2c0c8282b3d