### PR TITLE
Sanitize speech text before playback

### DIFF
--- a/src/utils/speech/core/speechText.ts
+++ b/src/utils/speech/core/speechText.ts
@@ -5,17 +5,25 @@ export const extractMainWord = (word: string): string => {
   return word.split(/\s*\(/)[0].trim();
 };
 
+const cleanForSpeech = (text: string): string => {
+  return text
+    .replace(/^\s*\d+\.\s*/gm, '')
+    .replace(/\(.*?\)/g, '')
+    .replace(/\/.*?\//g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
 export const prepareTextForSpeech = (text: string): string => {
   if (!text || typeof text !== 'string') return '';
 
   console.log('[SPEECH-TEXT] Original text:', text.substring(0, 50) + '...');
 
-  const prepared = text.replace(/\s+/g, ' ').trim();
+  const prepared = cleanForSpeech(text);
 
-  
   console.log('[SPEECH-TEXT] Prepared for speech:', prepared.substring(0, 50) + '...');
   console.log('[SPEECH-TEXT] Length reduction:', text.length, '->', prepared.length);
-  
+
   return prepared;
 };
 


### PR DESCRIPTION
## Summary
- add a speech sanitization helper that strips numbering, parentheses, IPA notation, and extra whitespace
- run all speech playback through the cleaner so spoken text contains only natural words

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e48edcf438832f96a3ae006a69e0ef