### PR TITLE
Clamp speech rates and expand playback speed options

### DIFF
--- a/src/components/vocabulary-app/SpeechRateControl.tsx
+++ b/src/components/vocabulary-app/SpeechRateControl.tsx
@@ -8,7 +8,15 @@ interface SpeechRateControlProps {
   onChange: (rate: number) => void;
 }
 
-const RATE_VALUES = [0, 0.2, 0.4, 0.6, 0.8, 1, 1.25, 1.5];
+const RATE_OPTIONS = [
+  { value: 0.5, label: '0.5x' },
+  { value: 0.75, label: '0.75x' },
+  { value: 1, label: '1x' },
+  { value: 1.25, label: '1.25x' },
+  { value: 1.5, label: '1.5x' },
+  { value: 1.75, label: '1.75x' },
+  { value: 2, label: '2x' },
+];
 
 const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange }) => {
   const [open, setOpen] = React.useState(false);
@@ -39,18 +47,21 @@ const SpeechRateControl: React.FC<SpeechRateControlProps> = ({ rate, onChange })
       </PopoverTrigger>
       <PopoverContent className="w-44 p-2" side="right" align="start">
         <div className="grid grid-cols-4 gap-2">
-          {RATE_VALUES.map((v) => (
-            <PopoverClose asChild key={v}>
-              <Button
-                size="sm"
-                variant={rate === v ? 'default' : 'outline'}
-                className="h-7 px-2 text-xs"
-                onClick={() => handleChange(v)}
-              >
-                {v}x
-              </Button>
-            </PopoverClose>
-          ))}
+          {RATE_OPTIONS.map(({ value, label }) => {
+            const isActive = Math.abs(rate - value) < 0.001;
+            return (
+              <PopoverClose asChild key={value}>
+                <Button
+                  size="sm"
+                  variant={isActive ? 'default' : 'outline'}
+                  className="h-7 px-2 text-xs"
+                  onClick={() => handleChange(value)}
+                >
+                  {label}
+                </Button>
+              </PopoverClose>
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/services/speech/core/constants.ts
+++ b/src/services/speech/core/constants.ts
@@ -2,3 +2,5 @@
  * Shared constants for speech services
  */
 export const DEFAULT_SPEECH_RATE = 0.8;
+export const MIN_SPEECH_RATE = 0.5;
+export const MAX_SPEECH_RATE = 2;

--- a/src/utils/speech/core/speechSettings.ts
+++ b/src/utils/speech/core/speechSettings.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_SPEECH_RATE } from '@/services/speech/core/constants';
+import {
+  DEFAULT_SPEECH_RATE,
+  MIN_SPEECH_RATE,
+  MAX_SPEECH_RATE,
+} from '@/services/speech/core/constants';
 import {
   getSpeechRate as readSpeechRateFromPreferences,
   setSpeechRate as writeSpeechRateToPreferences,
@@ -6,21 +10,29 @@ import {
 
 let cachedRate: number | undefined;
 
+const clampRate = (rate: number): number => {
+  if (!Number.isFinite(rate)) {
+    return DEFAULT_SPEECH_RATE;
+  }
+  return Math.min(MAX_SPEECH_RATE, Math.max(MIN_SPEECH_RATE, rate));
+};
+
 const resolveCachedRate = (): number => {
   if (typeof cachedRate === 'number') {
     return cachedRate;
   }
 
   const storedRate = readSpeechRateFromPreferences();
-  cachedRate = storedRate ?? DEFAULT_SPEECH_RATE;
+  cachedRate = clampRate(storedRate ?? DEFAULT_SPEECH_RATE);
   return cachedRate;
 };
 
 export const getSpeechRate = (): number => resolveCachedRate();
 
 export const setSpeechRate = (rate: number): void => {
-  cachedRate = rate;
-  writeSpeechRateToPreferences(rate);
+  const sanitizedRate = clampRate(rate);
+  cachedRate = sanitizedRate;
+  writeSpeechRateToPreferences(sanitizedRate);
 };
 
 export const getSpeechPitch = (): number => 1.0;

--- a/tests/speechSettings.test.ts
+++ b/tests/speechSettings.test.ts
@@ -50,4 +50,22 @@ describe('speechSettings', () => {
     // Should not re-read from storage after caching the new value
     expect(mockReadSpeechRate).not.toHaveBeenCalled();
   });
+
+  it('clamps values read from storage into the supported range', async () => {
+    mockReadSpeechRate.mockReturnValue(0.1);
+    const { getSpeechRate } = await importSpeechSettings();
+    const { MIN_SPEECH_RATE } = await import('@/services/speech/core/constants');
+
+    expect(getSpeechRate()).toBe(MIN_SPEECH_RATE);
+  });
+
+  it('clamps values written to storage into the supported range', async () => {
+    mockReadSpeechRate.mockReturnValue(0.8);
+    const { setSpeechRate } = await importSpeechSettings();
+    const { MAX_SPEECH_RATE } = await import('@/services/speech/core/constants');
+
+    setSpeechRate(5);
+
+    expect(mockWriteSpeechRate).toHaveBeenCalledWith(MAX_SPEECH_RATE);
+  });
 });


### PR DESCRIPTION
## Summary
- clamp persisted speech rates to the supported 0.5x–2x range so the synthesizer always receives a valid value
- update the speech rate picker to offer curated speeds (including 1.75x and 2x) and robust active-state detection
- extend the speech settings unit tests to cover the new clamping behaviour

## Testing
- npm test -- speechSettings

------
https://chatgpt.com/codex/tasks/task_e_68e49f9c96a0832f87c3e2f3fed7191f