### PR TITLE
Show review metadata in daily summary lists

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -60,6 +60,32 @@ const VocabularyAppWithLearning: React.FC = () => {
   const hasSelectionWords =
     newTodayList.length > 0 || dueTodayList.length > 0 || learnedWordsList.length > 0;
 
+  const formatReviewCount = (count?: number) => {
+    if (typeof count !== 'number' || !Number.isFinite(count)) {
+      return '—';
+    }
+    const safeCount = Math.max(0, Math.trunc(count));
+    return `${safeCount}`;
+  };
+
+  const formatDateOnly = (value?: string) => {
+    if (!value) {
+      return '—';
+    }
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (!trimmed) {
+      return '—';
+    }
+    if (trimmed.length >= 10) {
+      return trimmed.slice(0, 10);
+    }
+    const parsed = Date.parse(trimmed);
+    if (Number.isNaN(parsed)) {
+      return trimmed;
+    }
+    return new Date(parsed).toISOString().slice(0, 10);
+  };
+
   useEffect(() => {
     if (dailySelection) {
       setSummaryOpen(true);
@@ -129,9 +155,10 @@ const VocabularyAppWithLearning: React.FC = () => {
                       {word.category && (
                         <div className="text-xs text-gray-600">{word.category}</div>
                       )}
-                      {word.lastReviewedAt && (
-                        <div className="text-xs text-gray-500">Last reviewed: {word.lastReviewedAt}</div>
-                      )}
+                      <div className="text-xs text-gray-500 space-y-0.5">
+                        <div>Review #{formatReviewCount(word.reviewCount)}</div>
+                        <div>Next review: {formatDateOnly(word.nextReviewAt)}</div>
+                      </div>
                     </div>
                   ))
                 ) : (
@@ -155,9 +182,10 @@ const VocabularyAppWithLearning: React.FC = () => {
                       {word.category && (
                         <div className="text-xs text-gray-600">{word.category}</div>
                       )}
-                      {word.lastReviewedAt && (
-                        <div className="text-xs text-gray-500">Last reviewed: {word.lastReviewedAt}</div>
-                      )}
+                      <div className="text-xs text-gray-500 space-y-0.5">
+                        <div>Review #{formatReviewCount(word.reviewCount)}</div>
+                        <div>Next review: {formatDateOnly(word.nextReviewAt)}</div>
+                      </div>
                     </div>
                   ))
                 ) : (

--- a/src/lib/progress/learnedWordStats.ts
+++ b/src/lib/progress/learnedWordStats.ts
@@ -26,6 +26,8 @@ export type TodayLearnedWordSummary = {
   word: string;
   category?: string;
   lastReviewedAt?: string;
+  nextReviewAt?: string;
+  reviewCount?: number;
   dueSelectedToday: boolean;
 };
 
@@ -101,9 +103,13 @@ function toTodaySummary(row: LearnedWordRow, dueSelectedToday: boolean): TodayLe
   const base = toWordAndCategory(row);
   if (!base) return null;
   const lastReviewedAt = normaliseIso(row.last_review_at) ?? undefined;
+  const nextReviewAt = normaliseIso(row.next_review_at) ?? undefined;
+  const reviewCount = typeof row.review_count === 'number' ? row.review_count : undefined;
   return {
     ...base,
     lastReviewedAt,
+    nextReviewAt,
+    reviewCount,
     dueSelectedToday,
   };
 }


### PR DESCRIPTION
## Summary
- display review count and next review date for the New Today and Due Today word summaries
- include reviewCount and nextReviewAt in today learned word summaries so the UI can render them

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bab90cb8832fa7b0ddf3b14975ff