### PR TITLE
Prevent speech synthesis from reading bracketed text

### DIFF
--- a/src/utils/speech/formatSpeechText.ts
+++ b/src/utils/speech/formatSpeechText.ts
@@ -8,13 +8,19 @@ export interface SpeechWord {
  * Format vocabulary word fields into SSML text with 300ms pauses between
  * segments. This ensures consistent pauses across platforms.
  */
+const sanitizeSegment = (segment: string): string => {
+  return segment
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/\/[^/]*\//g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
 export const formatSpeechText = ({ word, meaning = '', example = '' }: SpeechWord): string => {
-  const parts = [word.trim()];
-  if (meaning && meaning.trim().length > 0) {
-    parts.push(meaning.trim());
-  }
-  if (example && example.trim().length > 0) {
-    parts.push(example.trim());
-  }
-  return parts.filter(Boolean).join('<break time="300ms"/>');
+  const parts = [word, meaning, example]
+    .map((segment) => sanitizeSegment(segment ?? ''))
+    .filter((segment) => segment.length > 0);
+
+  return parts.join('<break time="300ms"/>');
 };


### PR DESCRIPTION
## Summary
- sanitize speech synthesis segments so that bracketed, parenthetical, or slash-delimited content is removed before playback

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c7055abc832fb008a13e1babec94