### PR TITLE
Format learned word dates without timezone

### DIFF
--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -208,7 +208,13 @@ const VocabularyAppWithLearning: React.FC = () => {
                       <div>
                         <div className="font-medium text-gray-700">{word.word}</div>
                         <div className="text-xs text-gray-500">
-                          {word.category} • Learned {word.learnedDate}
+                          {word.category ? (
+                            <>
+                              {word.category} • Learned {formatDateOnly(word.learnedDate)}
+                            </>
+                          ) : (
+                            <>Learned {formatDateOnly(word.learnedDate)}</>
+                          )}
                         </div>
                       </div>
                       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- display learned word timestamps without timezone by reusing the existing date-only formatter
- prevent the learned list from rendering an orphaned separator when no category is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c17985cc832fbecc86e6efc655c6