### PR TITLE
Randomize loading card status message

### DIFF
--- a/src/components/vocabulary-app/LoadingCard.tsx
+++ b/src/components/vocabulary-app/LoadingCard.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import './LoadingCard.css';
 
 const LoadingCard: React.FC = () => {
+  const messages = useMemo(
+    () => [
+      '⌛ We’re preparing your daily words…',
+      '✨ Loading your fun vocabulary picks…',
+      '📚 Gathering today’s wordy surprises…',
+      '🧠 Warming up your language neurons…',
+    ],
+    [],
+  );
+  const message = useMemo(
+    () => messages[Math.floor(Math.random() * messages.length)],
+    [messages],
+  );
   return (
     <div className="lv-loading-card" role="status" aria-live="polite">
       <div className="lv-loading-card__inner">
-        <span className="lv-loading-card__text">⌛ We’re preparing your daily words…</span>
+        <span className="lv-loading-card__text">{message}</span>
         <span className="lv-loading-card__cursor" aria-hidden="true" />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a set of playful loading messages for the loading card
- randomly select one message on each render to keep the experience fresh

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e59d68c278832f854de2703eb87e6c