### PR TITLE
Add footer greeting with sign-out link

### DIFF
--- a/src/components/UserGreeting.tsx
+++ b/src/components/UserGreeting.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState, type MouseEvent } from 'react';
+import { clearStoredAuth } from '@/lib/auth';
+import { getNicknameLocal, NICKNAME_LS_KEY } from '@/lib/nickname';
+import {
+  dispatchNicknameChange,
+  NICKNAME_EVENT_NAME,
+  type NicknameEventDetail,
+} from '@/lib/nicknameEvents';
+import { toast } from 'sonner';
+
+function normalizeNickname(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+const UserGreeting = () => {
+  const [nickname, setNickname] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const applyNickname = (value?: string | null) => {
+      if (typeof value === 'string') {
+        setNickname(normalizeNickname(value));
+      } else {
+        setNickname(normalizeNickname(getNicknameLocal()));
+      }
+    };
+
+    applyNickname(getNicknameLocal());
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== NICKNAME_LS_KEY) return;
+      applyNickname(event.newValue ?? null);
+    };
+
+    const handleNicknameEvent = (event: Event) => {
+      const detail = (event as CustomEvent<NicknameEventDetail>).detail;
+      applyNickname(detail?.nickname ?? null);
+    };
+
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener(NICKNAME_EVENT_NAME, handleNicknameEvent);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener(NICKNAME_EVENT_NAME, handleNicknameEvent);
+    };
+  }, []);
+
+  const handleSignOut = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      clearStoredAuth();
+      try {
+        localStorage.removeItem(NICKNAME_LS_KEY);
+      } catch {
+        /* ignore */
+      }
+      dispatchNicknameChange(null);
+      setNickname(null);
+      toast.success('Signed out successfully.');
+    },
+    [],
+  );
+
+  if (!nickname) {
+    return null;
+  }
+
+  return (
+    <p className="mt-2 text-center text-sm text-muted-foreground">
+      Hello <span className="font-semibold text-gray-900">{nickname}</span>,{' '}
+      <a
+        href="#sign-out"
+        onClick={handleSignOut}
+        className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+      >
+        Sign out
+      </a>
+    </p>
+  );
+};
+
+export default UserGreeting;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,7 @@ import {
   type Session as EdgeSession,
 } from '@/lib/customAuth';
 import { NICKNAME_LS_KEY } from '@/lib/nickname';
+import { dispatchNicknameChange } from '@/lib/nicknameEvents';
 
 export { exchangeNicknamePasscode } from '@/lib/edgeApi';
 export { saveEdgeSession as saveSession, getEdgeSession as getSession };
@@ -136,7 +137,9 @@ export function clearStoredAuth(options: { keepPasscode?: boolean } = {}): void 
   persistAuthState(null);
   if (!options.keepPasscode) {
     rememberPasscode(null);
+    removeFromStorage(NICKNAME_LS_KEY);
   }
+  dispatchNicknameChange(null);
   clearCachedUserKey();
   try {
     signOutEdge();

--- a/src/lib/nicknameEvents.ts
+++ b/src/lib/nicknameEvents.ts
@@ -1,0 +1,20 @@
+export const NICKNAME_EVENT_NAME = 'lazyVoca:nicknameChanged' as const;
+
+export type NicknameEventDetail = {
+  nickname: string | null;
+};
+
+export function dispatchNicknameChange(nickname: string | null): void {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+
+  try {
+    const event = new CustomEvent<NicknameEventDetail>(NICKNAME_EVENT_NAME, {
+      detail: { nickname },
+    });
+    window.dispatchEvent(event);
+  } catch {
+    // Ignore environments where CustomEvent isn't supported
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import VocabularyAppWithLearning from '@/components/VocabularyAppWithLearning';
+import UserGreeting from '@/components/UserGreeting';
 
 const Index = () => {
   return (
@@ -22,6 +23,7 @@ const Index = () => {
       
       <footer className="mt-6 text-center text-sm text-muted-foreground">
         <p>© 2025 Lazy Vocabulary - hoctusach@gmail.com</p>
+        <UserGreeting />
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a footer greeting component that shows the signed-in nickname with a Sign out link
- broadcast nickname changes so the greeting and AuthGate stay in sync across the app
- clear stored auth state updates to remove local nicknames and dispatch nickname change events

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a0bc7d98832fb5254d306d67b2f5