### PR TITLE
Remove reset button from vocabulary controls

### DIFF
--- a/src/components/vocabulary-app/VocabularyControlsColumn.tsx
+++ b/src/components/vocabulary-app/VocabularyControlsColumn.tsx
@@ -10,7 +10,6 @@ import {
   Speaker,
   Search,
   CheckCircle,
-  Trash2,
 } from 'lucide-react';
 import SpeechRateControl from './SpeechRateControl';
 import { useSpeechRate } from '@/hooks/useSpeechRate';
@@ -20,7 +19,6 @@ import { cn } from '@/lib/utils';
 import { useVoiceContext } from '@/hooks/useVoiceContext';
 import { unifiedSpeechController } from '@/services/speech/unifiedSpeechController';
 import { MarkAsLearnedDialog } from '@/components/MarkAsLearnedDialog';
-import { signOut } from '@/lib/customAuth';
 
 interface VocabularyControlsColumnProps {
   isMuted: boolean;
@@ -99,46 +97,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
     if (!isMuted && !isPaused) {
       playCurrentWord();
     }
-  };
-
-  const handleResetApp = () => {
-    if (typeof window === 'undefined') return;
-
-    const confirmed = window.confirm(
-      'Clearing all preferences in this device and sign out, your learning progress still can be accessible from this or other devices after re-login. Continue?',
-    );
-    if (!confirmed) return;
-
-    try {
-      signOut();
-    } catch (error) {
-      console.error('Reset:signOut', error);
-    }
-
-    try {
-      window.localStorage.clear();
-    } catch (error) {
-      console.error('Reset:localStorage', error);
-      toast.error('Unable to clear saved data. Please try again.');
-      return;
-    }
-
-    try {
-      window.sessionStorage?.clear();
-    } catch (error) {
-      console.error('Reset:sessionStorage', error);
-    }
-
-    trackEvent('reset_app', 'Reset App');
-    toast.success('All saved data cleared. Please sign in or register again.');
-
-    setTimeout(() => {
-      try {
-        window.location.reload();
-      } catch (error) {
-        console.error('Reset:reload', error);
-      }
-    }, 300);
   };
 
   const [isMarkAsLearnedDialogOpen, setIsMarkAsLearnedDialogOpen] = React.useState(false);
@@ -237,17 +195,6 @@ const VocabularyControlsColumn: React.FC<VocabularyControlsColumnProps> = ({
           <CheckCircle size={16} />
         </Button>
       )}
-
-      <Button
-        variant="destructive"
-        size="sm"
-        onClick={handleResetApp}
-        className="h-8 w-8 p-0"
-        title="Reset & Clear Saved Data"
-        aria-label="Reset & Clear Saved Data"
-      >
-        <Trash2 size={16} />
-      </Button>
 
       <MarkAsLearnedDialog
         isOpen={isMarkAsLearnedDialogOpen}


### PR DESCRIPTION
## Summary
- remove the destructive reset button from the vocabulary controls column
- drop the unused reset handler and associated authentication import

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5dd8729e8832f9a32b838497e0240