### PR TITLE
Remove close control from authentication popup

### DIFF
--- a/src/components/AuthGate.tsx
+++ b/src/components/AuthGate.tsx
@@ -344,24 +344,6 @@ export default function AuthGate() {
           position: 'relative',
         }}
       >
-        <button
-          type="button"
-          onClick={() => setS((p) => ({ ...p, show: false }))}
-          style={{
-            position: 'absolute',
-            top: 8,
-            right: 8,
-            border: 'none',
-            background: 'transparent',
-            fontSize: 20,
-            lineHeight: 1,
-            cursor: 'pointer',
-            color: '#666',
-          }}
-          aria-label="Close"
-        >
-          ×
-        </button>
         <h3 style={{ margin: 0 }}>{isCreateMode ? 'Create your profile' : 'Access your vocabulary'}</h3>
         <p style={{ marginTop: 6, color: '#555', fontSize: 14 }}>{modeDescription}</p>
         <label style={{ display: 'block', marginTop: 12, fontSize: 13, fontWeight: 600 }}>


### PR DESCRIPTION
## Summary
- remove the dismiss button from the auth gate overlay so users must sign in or create a profile before proceeding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5de0ecc98832fa1e0fe157d5f657b