### PR TITLE
Remove collapse toggle rotation effect

### DIFF
--- a/src/components/LearningProgressPanel.tsx
+++ b/src/components/LearningProgressPanel.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { ChevronDown, Info } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
-import { cn } from '@/lib/utils';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 
@@ -33,7 +32,7 @@ export const LearningProgressPanel: React.FC<LearningProgressPanelProps> = ({
           <div className="flex items-center justify-between">
             <CollapsibleTrigger className="flex items-center gap-2">
               <h3 className="text-lg font-semibold">Learning Progress</h3>
-              <ChevronDown className={cn('h-4 w-4 transition-transform', open && 'rotate-180')} />
+              <ChevronDown className="h-4 w-4" />
             </CollapsibleTrigger>
           </div>
           <CollapsibleContent className="space-y-4 pt-2">

--- a/src/components/VocabularyAppWithLearning.tsx
+++ b/src/components/VocabularyAppWithLearning.tsx
@@ -8,7 +8,6 @@ import ToastProvider from './vocabulary-app/ToastProvider';
 import { ChevronDown, RotateCcw, Eye } from 'lucide-react';
 import WordSearchModal from './vocabulary-app/WordSearchModal';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
-import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { MarkAsNewDialog } from './MarkAsNewDialog';
 import { useDailyUsageTracker } from '@/hooks/useDailyUsageTracker';
@@ -158,9 +157,7 @@ const VocabularyAppWithLearning: React.FC = () => {
               <span className="text-xs text-muted-foreground hidden sm:inline">
                 Tap to show or hide details
               </span>
-              <ChevronDown
-                className={cn('h-4 w-4 transition-transform', summaryOpen && 'rotate-180')}
-              />
+              <ChevronDown className="h-4 w-4" />
             </CollapsibleTrigger>
           </TooltipTrigger>
           <TooltipContent side="top">Click to expand or collapse the word summary.</TooltipContent>


### PR DESCRIPTION
## Summary
- remove the chevron rotation animation from the learning progress and word summary collapsible headers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef4e2bb948832fad0e0eb718d32b6c