### PR TITLE
Add italic hint below vocabulary card for replay guidance

### DIFF
--- a/src/components/vocabulary-container/VocabularyContainer.tsx
+++ b/src/components/vocabulary-container/VocabularyContainer.tsx
@@ -120,6 +120,12 @@ const VocabularyContainer: React.FC = () => {
         nextVoiceLabel={nextVoiceLabel}
         category={controllerState.currentWord.category}
       />
+      <p
+        className="mt-3 text-center italic text-sm"
+        style={{ color: 'var(--lv-text-secondary)' }}
+      >
+        Click Next to trigger voice if it is not played or stopped.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Provide unobtrusive guidance telling users to click Next to trigger voice playback when it didn't start or was stopped.

### Description
- Inserted a small centered italic helper paragraph under the `VocabularyCard` in `src/components/vocabulary-container/VocabularyContainer.tsx` with text "Click Next to trigger voice if it is not played or stopped." and styled with `className="mt-3 text-center italic text-sm"` and `style={{ color: 'var(--lv-text-secondary)' }}`.

### Testing
- Ran `npm run build` (completed successfully) and started the dev server with `npm run dev` and captured a Playwright screenshot to validate the UI (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f2613304832fbb32f08c3dde3eda)