### PR TITLE
Enhance leaderboard ranking and current-user display

### DIFF
--- a/src/components/vocabulary-app/LeaderboardPanel.tsx
+++ b/src/components/vocabulary-app/LeaderboardPanel.tsx
@@ -84,7 +84,7 @@ const LeaderboardRow: React.FC<{ entry: LeaderboardEntry; isStandaloneCurrentUse
           <span className="truncate font-medium" style={{ color: 'var(--lv-text)' }}>
             {entry.nickname}
           </span>
-          {entry.isCurrentUser && (
+          {entry.isCurrentUser && isStandaloneCurrentUser && (
             <span className="shrink-0 rounded-full bg-[var(--lv-accent)]/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--lv-accent)]">
               You
             </span>
@@ -224,7 +224,7 @@ const LeaderboardPanel: React.FC<LeaderboardPanelProps> = ({
             ))}
             {currentUserOutsideTop && (
               <>
-                <div className="px-2 text-center text-xs theme-muted-text">•••</div>
+                <div className="px-2 text-center text-xs theme-muted-text">...</div>
                 <LeaderboardRow entry={currentUserOutsideTop} isStandaloneCurrentUser />
               </>
             )}

--- a/src/lib/progress/leaderboard.ts
+++ b/src/lib/progress/leaderboard.ts
@@ -128,7 +128,8 @@ function learningMinutesFromHours(value: unknown): number | undefined {
 function sortLeaderboardEntries(entries: LeaderboardEntry[]): LeaderboardEntry[] {
   return [...entries].sort((a, b) => {
     if (b.learnedWords !== a.learnedWords) return b.learnedWords - a.learnedWords;
-    return (b.learningMinutes ?? 0) - (a.learningMinutes ?? 0);
+    if (b.learningWords !== a.learningWords) return b.learningWords - a.learningWords;
+    return a.nickname.localeCompare(b.nickname, undefined, { sensitivity: 'base' });
   });
 }
 
@@ -161,7 +162,7 @@ async function fetchLeaderboardRows(limit: number): Promise<LeaderboardRow[]> {
       .from('user_progress_summary')
       .select('user_unique_key, learned_count, learning_count, learning_due_count, learning_time, learned_days, updated_at')
       .order('learned_count', { ascending: false })
-      .order('learning_time', { ascending: false })
+      .order('learning_count', { ascending: false })
       .limit(limit);
 
     if (error) {
@@ -239,7 +240,7 @@ export async function getLeaderboardState(
   const limit = Math.max(1, Math.trunc(options.limit ?? DEFAULT_LIMIT));
   const { userKey, nickname } = await resolveCurrentIdentity();
   const rows = await fetchLeaderboardRows(limit);
-  const rankedEntries = applyRanks(rowsToEntries(rows, userKey));
+  let rankedEntries = applyRanks(rowsToEntries(rows, userKey));
 
   let currentUserEntry = rankedEntries.find((entry) => entry.isCurrentUser);
 
@@ -253,11 +254,10 @@ export async function getLeaderboardState(
       options.currentUserLearningCount,
       options.currentUserDueCount
     );
-
-    const entriesWithCurrentUser = applyRanks([...rankedEntries, currentUserEntry]);
-    currentUserEntry = entriesWithCurrentUser.find((entry) => entry.isCurrentUser) ?? currentUserEntry;
+    rankedEntries = applyRanks([...rankedEntries, currentUserEntry]);
+    currentUserEntry = rankedEntries.find((entry) => entry.isCurrentUser) ?? currentUserEntry;
   } else if (currentUserEntry && typeof options.currentUserLearnedCount === 'number') {
-    const entriesWithCurrentUser = applyRanks(
+    rankedEntries = applyRanks(
       rankedEntries.map((entry) =>
         entry.isCurrentUser
           ? {
@@ -269,13 +269,7 @@ export async function getLeaderboardState(
           : entry
       )
     );
-    currentUserEntry = entriesWithCurrentUser.find((entry) => entry.isCurrentUser) ?? currentUserEntry;
-    return {
-      timeframe: 'allTime',
-      entries: entriesWithCurrentUser.slice(0, limit),
-      currentUserEntry,
-      isLoading: false,
-    };
+    currentUserEntry = rankedEntries.find((entry) => entry.isCurrentUser) ?? currentUserEntry;
   }
 
   return {

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  rows: [] as Array<Record<string, unknown>>,
+  orderCalls: [] as Array<{ column: string; options: { ascending: boolean } }>,
+  activeSession: null as null | Record<string, unknown>,
+  progressSummary: null as null | Record<string, unknown>,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getActiveSession: vi.fn(async () => mocks.activeSession),
+}));
+
+vi.mock('@/lib/nickname', () => ({
+  getNicknameLocal: vi.fn(() => 'Local You'),
+}));
+
+vi.mock('@/lib/supabaseClient', () => ({
+  getSupabaseClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(function (this: unknown) {
+        return this;
+      }),
+      order: vi.fn(function (this: unknown, column: string, options: { ascending: boolean }) {
+        mocks.orderCalls.push({ column, options });
+        return this;
+      }),
+      limit: vi.fn(async () => ({ data: mocks.rows, error: null })),
+    })),
+  })),
+}));
+
+vi.mock('@/lib/progress/progressSummary', () => ({
+  getProgressSummary: vi.fn(async () => mocks.progressSummary),
+}));
+
+import { getLeaderboardState } from '@/lib/progress/leaderboard';
+
+describe('leaderboard state', () => {
+  beforeEach(() => {
+    mocks.rows = [];
+    mocks.orderCalls = [];
+    mocks.activeSession = null;
+    mocks.progressSummary = null;
+  });
+
+  it('ranks the top five by learned words and then learning count', async () => {
+    mocks.rows = [
+      row('beta', 8, 1),
+      row('alpha', 10, 2),
+      row('charlie', 10, 7),
+      row('delta', 9, 9),
+      row('echo', 7, 20),
+    ];
+
+    const state = await getLeaderboardState();
+
+    expect(mocks.orderCalls).toEqual([
+      { column: 'learned_count', options: { ascending: false } },
+      { column: 'learning_count', options: { ascending: false } },
+    ]);
+    expect(state.entries.map((entry) => [entry.rank, entry.userKey, entry.learnedWords, entry.learningWords])).toEqual([
+      [1, 'charlie', 10, 7],
+      [2, 'alpha', 10, 2],
+      [3, 'delta', 9, 9],
+      [4, 'beta', 8, 1],
+      [5, 'echo', 7, 20],
+    ]);
+  });
+
+  it('keeps an outside current user separate with current local counts', async () => {
+    mocks.activeSession = { user_unique_key: 'you', name: 'You' };
+    mocks.progressSummary = { learned_count: 1, learning_count: 1, learning_due_count: 0, learned_days: [] };
+    mocks.rows = [
+      row('first', 10, 1),
+      row('second', 9, 1),
+      row('third', 8, 1),
+      row('fourth', 7, 1),
+      row('fifth', 6, 1),
+    ];
+
+    const state = await getLeaderboardState({
+      currentUserLearnedCount: 3,
+      currentUserLearningCount: 4,
+      currentUserDueCount: 2,
+    });
+
+    expect(state.entries).toHaveLength(5);
+    expect(state.entries.some((entry) => entry.userKey === 'you')).toBe(false);
+    expect(state.currentUserEntry).toMatchObject({
+      userKey: 'you',
+      rank: 6,
+      learnedWords: 3,
+      learningWords: 4,
+      dueWords: 2,
+      isCurrentUser: true,
+    });
+  });
+
+  it('moves the current user into the top five when current counts qualify', async () => {
+    mocks.activeSession = { user_unique_key: 'you', name: 'You' };
+    mocks.rows = [
+      row('first', 10, 1),
+      row('second', 9, 1),
+      row('third', 8, 1),
+      row('fourth', 7, 1),
+      row('fifth', 6, 1),
+    ];
+
+    const state = await getLeaderboardState({
+      currentUserLearnedCount: 11,
+      currentUserLearningCount: 4,
+      currentUserDueCount: 2,
+    });
+
+    expect(state.entries).toHaveLength(5);
+    expect(state.entries[0]).toMatchObject({ userKey: 'you', rank: 1, learnedWords: 11, learningWords: 4 });
+    expect(state.entries.filter((entry) => entry.userKey === 'you')).toHaveLength(1);
+    expect(state.currentUserEntry?.rank).toBe(1);
+  });
+});
+
+function row(userKey: string, learnedCount: number, learningCount: number, dueCount = 0) {
+  return {
+    user_unique_key: userKey,
+    learned_count: learnedCount,
+    learning_count: learningCount,
+    learning_due_count: dueCount,
+    learning_time: 0,
+    learned_days: [],
+  };
+}


### PR DESCRIPTION
### Motivation
- Ensure the leaderboard ranks users by most learned words and breaks ties by learning counts so the top 5 reflect the intended ordering.
- Surface the current user’s live (local) counts without duplicating them in the top list and show the current user separately when they do not qualify for top-5.
- Make the UI numbers reflect the live/current counts and avoid misleading "You" badges when the user appears in the normal top list.

### Description
- Change sorting to order by `learnedWords` descending, then `learningWords` descending, then a stable `nickname` tie-breaker in `src/lib/progress/leaderboard.ts` and update the Supabase query to order by `learning_count` instead of `learning_time`.
- Rework ranking logic so the current user is re-ranked with provided live overrides and will be inserted into the top list only if their live counts qualify, otherwise the current user is appended as a standalone entry that follows an ellipsis; duplicates are avoided.
- Limit the `You` badge to the standalone current-user row in `src/components/vocabulary-app/LeaderboardPanel.tsx` and replace the visual separator with literal `...` before that row.
- Add unit tests `tests/leaderboard.test.ts` covering top-5 ordering by learned/learning counts, current-user-as-outside-row with local counts, and promotion of current user into the top 5 when qualifying.

### Testing
- Ran `npx vitest run tests/leaderboard.test.ts`, all new leaderboard tests passed (3 tests; ✅).
- Ran `npm run build`, production build completed successfully (✅).
- Ran `npm run lint`, which failed due to pre-existing lint errors elsewhere in the repository that are unrelated to these changes (❌).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc00381ce0832f93a9c0b864073a34)