### PR TITLE
Leaderboard: read learned_words and aggregate counts

### DIFF
--- a/src/lib/progress/leaderboard.ts
+++ b/src/lib/progress/leaderboard.ts
@@ -25,6 +25,13 @@ export type LeaderboardState = {
   error?: string;
 };
 
+type LearnedWordsLeaderboardRow = {
+  user_unique_key?: unknown;
+  srs_state?: unknown;
+  in_review_queue?: unknown;
+  next_review_at?: unknown;
+};
+
 type LeaderboardRow = {
   user_unique_key?: unknown;
   nickname?: unknown;
@@ -155,22 +162,71 @@ async function resolveCurrentIdentity(): Promise<{ userKey: string | null; nickn
   return { userKey, nickname: nickname || null };
 }
 
+function isDueFromTimestamp(value: unknown, now = Date.now()): boolean {
+  if (typeof value !== 'string') return false;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return false;
+  return parsed <= now;
+}
+
+function resolveLearningState(row: LearnedWordsLeaderboardRow): 'learned' | 'learning' | null {
+  const state = typeof row.srs_state === 'string' ? row.srs_state.trim().toLowerCase() : '';
+  if (state === 'learned' || state === 'learning') return state;
+  if (typeof row.in_review_queue === 'boolean') return row.in_review_queue ? 'learning' : 'learned';
+  return null;
+}
+
+function aggregateLearnedWordRows(rows: LearnedWordsLeaderboardRow[]): LeaderboardRow[] {
+  const byUser = new Map<string, { learned: number; learning: number; due: number }>();
+
+  rows.forEach((row) => {
+    const userKey = typeof row.user_unique_key === 'string' ? row.user_unique_key.trim() : '';
+    if (!userKey) return;
+
+    const state = resolveLearningState(row);
+    if (!state) return;
+
+    const counts = byUser.get(userKey) ?? { learned: 0, learning: 0, due: 0 };
+    if (state === 'learned') {
+      counts.learned += 1;
+    } else {
+      counts.learning += 1;
+      if (isDueFromTimestamp(row.next_review_at)) {
+        counts.due += 1;
+      }
+    }
+    byUser.set(userKey, counts);
+  });
+
+  return Array.from(byUser.entries()).map(([userKey, counts]) => ({
+    user_unique_key: userKey,
+    learned_count: counts.learned,
+    learning_count: counts.learning,
+    learning_due_count: counts.due,
+  }));
+}
+
 async function fetchLeaderboardRows(limit: number): Promise<LeaderboardRow[]> {
   try {
     const client = getSupabaseClient();
     const { data, error } = await client
-      .from('user_progress_summary')
-      .select('user_unique_key, learned_count, learning_count, learning_due_count, learning_time, learned_days, updated_at')
-      .order('learned_count', { ascending: false })
-      .order('learning_count', { ascending: false })
-      .limit(limit);
+      .from('learned_words')
+      .select('user_unique_key, srs_state, in_review_queue, next_review_at');
 
     if (error) {
       console.warn('leaderboard:fetchTop', error.message);
       return [];
     }
 
-    return Array.isArray(data) ? (data as LeaderboardRow[]) : [];
+    const learnedWordRows = Array.isArray(data) ? (data as LearnedWordsLeaderboardRow[]) : [];
+    return sortLeaderboardEntries(rowsToEntries(aggregateLearnedWordRows(learnedWordRows), null))
+      .slice(0, limit)
+      .map((entry) => ({
+        user_unique_key: entry.userKey,
+        learned_count: entry.learnedWords,
+        learning_count: entry.learningWords,
+        learning_due_count: entry.dueWords,
+      }));
   } catch (error) {
     console.warn('leaderboard:fetchTop', error);
     return [];

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   rows: [] as Array<Record<string, unknown>>,
-  orderCalls: [] as Array<{ column: string; options: { ascending: boolean } }>,
+  fromCalls: [] as string[],
   activeSession: null as null | Record<string, unknown>,
   progressSummary: null as null | Record<string, unknown>,
 }));
@@ -17,16 +17,12 @@ vi.mock('@/lib/nickname', () => ({
 
 vi.mock('@/lib/supabaseClient', () => ({
   getSupabaseClient: vi.fn(() => ({
-    from: vi.fn(() => ({
-      select: vi.fn(function (this: unknown) {
-        return this;
-      }),
-      order: vi.fn(function (this: unknown, column: string, options: { ascending: boolean }) {
-        mocks.orderCalls.push({ column, options });
-        return this;
-      }),
-      limit: vi.fn(async () => ({ data: mocks.rows, error: null })),
-    })),
+    from: vi.fn((table: string) => {
+      mocks.fromCalls.push(table);
+      return {
+        select: vi.fn(async () => ({ data: mocks.rows, error: null })),
+      };
+    }),
   })),
 }));
 
@@ -39,26 +35,24 @@ import { getLeaderboardState } from '@/lib/progress/leaderboard';
 describe('leaderboard state', () => {
   beforeEach(() => {
     mocks.rows = [];
-    mocks.orderCalls = [];
+    mocks.fromCalls = [];
     mocks.activeSession = null;
     mocks.progressSummary = null;
   });
 
-  it('ranks the top five by learned words and then learning count', async () => {
+  it('ranks the top five from learned_words counts by learned words and then learning count', async () => {
     mocks.rows = [
-      row('beta', 8, 1),
-      row('alpha', 10, 2),
-      row('charlie', 10, 7),
-      row('delta', 9, 9),
-      row('echo', 7, 20),
+      ...rows('beta', 8, 1),
+      ...rows('alpha', 10, 2),
+      ...rows('charlie', 10, 7),
+      ...rows('delta', 9, 9),
+      ...rows('echo', 7, 20),
+      ...rows('foxtrot', 6, 50),
     ];
 
     const state = await getLeaderboardState();
 
-    expect(mocks.orderCalls).toEqual([
-      { column: 'learned_count', options: { ascending: false } },
-      { column: 'learning_count', options: { ascending: false } },
-    ]);
+    expect(mocks.fromCalls).toEqual(['learned_words']);
     expect(state.entries.map((entry) => [entry.rank, entry.userKey, entry.learnedWords, entry.learningWords])).toEqual([
       [1, 'charlie', 10, 7],
       [2, 'alpha', 10, 2],
@@ -72,11 +66,11 @@ describe('leaderboard state', () => {
     mocks.activeSession = { user_unique_key: 'you', name: 'You' };
     mocks.progressSummary = { learned_count: 1, learning_count: 1, learning_due_count: 0, learned_days: [] };
     mocks.rows = [
-      row('first', 10, 1),
-      row('second', 9, 1),
-      row('third', 8, 1),
-      row('fourth', 7, 1),
-      row('fifth', 6, 1),
+      ...rows('first', 10, 1),
+      ...rows('second', 9, 1),
+      ...rows('third', 8, 1),
+      ...rows('fourth', 7, 1),
+      ...rows('fifth', 6, 1),
     ];
 
     const state = await getLeaderboardState({
@@ -100,11 +94,11 @@ describe('leaderboard state', () => {
   it('moves the current user into the top five when current counts qualify', async () => {
     mocks.activeSession = { user_unique_key: 'you', name: 'You' };
     mocks.rows = [
-      row('first', 10, 1),
-      row('second', 9, 1),
-      row('third', 8, 1),
-      row('fourth', 7, 1),
-      row('fifth', 6, 1),
+      ...rows('first', 10, 1),
+      ...rows('second', 9, 1),
+      ...rows('third', 8, 1),
+      ...rows('fourth', 7, 1),
+      ...rows('fifth', 6, 1),
     ];
 
     const state = await getLeaderboardState({
@@ -120,13 +114,19 @@ describe('leaderboard state', () => {
   });
 });
 
-function row(userKey: string, learnedCount: number, learningCount: number, dueCount = 0) {
-  return {
-    user_unique_key: userKey,
-    learned_count: learnedCount,
-    learning_count: learningCount,
-    learning_due_count: dueCount,
-    learning_time: 0,
-    learned_days: [],
-  };
+function rows(userKey: string, learnedCount: number, learningCount: number, dueCount = 0) {
+  return [
+    ...Array.from({ length: learnedCount }, (_, index) => ({
+      user_unique_key: userKey,
+      word_id: `${userKey}-learned-${index}`,
+      srs_state: 'learned',
+      next_review_at: null,
+    })),
+    ...Array.from({ length: learningCount }, (_, index) => ({
+      user_unique_key: userKey,
+      word_id: `${userKey}-learning-${index}`,
+      srs_state: 'learning',
+      next_review_at: index < dueCount ? '2020-01-01T00:00:00Z' : '2999-01-01T00:00:00Z',
+    })),
+  ];
 }


### PR DESCRIPTION
### Motivation
- The leaderboard previously queried `user_progress_summary` but needs raw per-word SRS rows to compute accurate learned/learning counts per user.
- Counting on `learned_words` ensures the leaderboard ranks users by actual learned rows and learning rows (and due) rather than relying on a summary table that can be out-of-date.

### Description
- Switch the leaderboard data source from `user_progress_summary` to `learned_words` and select the raw SRS fields (`user_unique_key, srs_state, in_review_queue, next_review_at`).
- Aggregate per-user counts from the `learned_words` rows to produce `learned_count`, `learning_count`, and `learning_due_count`, with a fallback to `in_review_queue` when `srs_state` is missing. (`src/lib/progress/leaderboard.ts`)
- Preserve ordering by `learned` first then `learning`, apply the top-5 limit after aggregation, and map aggregated results into existing leaderboard entry shapes.
- Update tests to assert the query now reads `learned_words` and to generate mock learned-word rows for verifying aggregation and ranking logic. (`tests/leaderboard.test.ts`)

### Testing
- Ran `npm test -- --run tests/leaderboard.test.ts`, and the leaderboard tests passed (3/3).
- Ran `npx tsc --noEmit` to verify type-checking, which succeeded.
- Ran `npm run lint`; linting failed due to existing, unrelated repository lint errors and not due to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc08043dac832fb0162154cf4dc049)