### PR TITLE
Fix word card auto-play after guard readiness

### DIFF
--- a/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
+++ b/src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts
@@ -117,13 +117,14 @@ export const useAutoPlay = (
     };
   }, [currentWord, muted, paused, playCurrentWord, guard, delayMs]);
 
-  // Reset tracking when word actually changes
+  // Reset tracking when the word disappears so the same word can auto-play
+  // again after data is reloaded. Do not mark a visible word as played here:
+  // composed guards (audio unlock, data readiness, etc.) may be false on the
+  // first render and become true later for the same word. The word is only
+  // recorded once an auto-play attempt is actually scheduled.
   useEffect(() => {
-    if (currentWord) {
-      const currentWordId = currentWord.word;
-      if (lastWordRef.current !== currentWordId) {
-        lastWordRef.current = currentWordId;
-      }
+    if (!currentWord) {
+      lastWordRef.current = null;
     }
   }, [currentWord]);
 };

--- a/tests/useAutoPlayResume.test.ts
+++ b/tests/useAutoPlayResume.test.ts
@@ -59,4 +59,27 @@ describe('useAutoPlay resume', () => {
     vi.advanceTimersByTime(500);
     expect(play).toHaveBeenCalledTimes(1);
   });
+
+  it('auto-plays current word when a composition guard becomes true', () => {
+    const play = vi.fn();
+    const guard = vi.fn((allowed: boolean) => allowed);
+    const { rerender } = renderHook(({ currentWord, allowed }) =>
+      useAutoPlay(currentWord, false, false, play, {
+        guard: () => guard(allowed),
+        delayMs: 100,
+      }),
+      { initialProps: { currentWord: word, allowed: false } }
+    );
+
+    vi.advanceTimersByTime(150);
+    expect(play).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ currentWord: word, allowed: true });
+    });
+
+    vi.advanceTimersByTime(150);
+    expect(play).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Auto-play could be incorrectly suppressed for the currently visible word when composed readiness guards (e.g. audio unlock, data load) were false on first render but became true later. 
- The change ensures the same visible word is allowed to auto-play once guard conditions become satisfied instead of being marked as already handled.

### Description
- Update `useAutoPlay` to stop marking a visible word as played and instead only reset `lastWordRef` when the `currentWord` becomes `null`, with an explanatory comment in `src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts`.
- Preserve the existing scheduling/coordination logic (timers, `unifiedSpeechController` registration, `hasUserInteracted` check and `speechController` activity checks) so behavior remains guarded by the same preconditions.
- Add a regression test to `tests/useAutoPlayResume.test.ts` that verifies an auto-play occurs when a composition `guard` flips from `false` to `true` for the same `currentWord`.

### Testing
- Ran `npm test -- --run tests/useAutoPlayResume.test.ts` and the test file passed (3 tests all green). 
- Ran `npm run build` and the production build completed successfully. 
- Ran `npx eslint src/hooks/vocabulary-playback/core/playback-states/useAutoPlay.ts` with no errors for the modified file. 
- Ran `npm run lint` which surfaced pre-existing lint errors elsewhere in the codebase and is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc56edfed8832f8c42ea884a40f1a1)